### PR TITLE
AWS cloudwatch data source support

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -228,8 +228,6 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		AuthType:      d.Get("json_data.0.auth_type").(string),
 		DefaultRegion: d.Get("json_data.0.default_region").(string),
 	}
-
-	return gapi.JSONData{}
 }
 
 func makeSecureJSONData(d *schema.ResourceData) gapi.SecureJSONData {
@@ -237,6 +235,4 @@ func makeSecureJSONData(d *schema.ResourceData) gapi.SecureJSONData {
 		AccessKey: d.Get("secure_json_data.0.access_key").(string),
 		SecretKey: d.Get("secure_json_data.0.secret_key").(string),
 	}
-
-	return gapi.SecureJSONData{}
 }

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -73,6 +73,40 @@ func ResourceDataSource() *schema.Resource {
 				Default:  "",
 			},
 
+			"json_data": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"default_region": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"secure_json_data": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_key": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"secret_key": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			"database_name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -223,7 +223,7 @@ func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
 	}, err
 }
 
-func makeJSONData(d *schema.ResourceData) (gapi.JSONData, error) {
+func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 	return gapi.JSONData{
 		AuthType:      d.Get("json_data.0.auth_type").(string),
 		DefaultRegion: d.Get("json_data.0.default_region").(string),
@@ -232,7 +232,7 @@ func makeJSONData(d *schema.ResourceData) (gapi.JSONData, error) {
 	return gapi.JSONData{}
 }
 
-func makeSecureJSONData(d *schema.ResourceData) (gapi.SecureJSONData, error) {
+func makeSecureJSONData(d *schema.ResourceData) gapi.SecureJSONData {
 	return gapi.SecureJSONData{
 		AccessKey: d.Get("secure_json_data.0.access_key").(string),
 		SecretKey: d.Get("secure_json_data.0.secret_key").(string),

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -218,5 +218,25 @@ func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
 		BasicAuth:         d.Get("basic_auth_enabled").(bool),
 		BasicAuthUser:     d.Get("basic_auth_username").(string),
 		BasicAuthPassword: d.Get("basic_auth_password").(string),
+		JSONData:          makeJSONData(d),
+		SecureJSONData:    makeSecureJSONData(d),
 	}, err
+}
+
+func makeJSONData(d *schema.ResourceData) (gapi.JSONData, error) {
+	return gapi.JSONData{
+		AuthType:      d.Get("json_data.0.auth_type").(string),
+		DefaultRegion: d.Get("json_data.0.default_region").(string),
+	}
+
+	return gapi.JSONData{}
+}
+
+func makeSecureJSONData(d *schema.ResourceData) (gapi.SecureJSONData, error) {
+	return gapi.SecureJSONData{
+		AccessKey: d.Get("secure_json_data.0.access_key").(string),
+		SecretKey: d.Get("secure_json_data.0.secret_key").(string),
+	}
+
+	return gapi.SecureJSONData{}
 }

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -122,6 +122,7 @@ func ResourceDataSource() *schema.Resource {
 	}
 }
 
+// CreateDataSource creates a Grafana datasource
 func CreateDataSource(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gapi.Client)
 
@@ -140,6 +141,7 @@ func CreateDataSource(d *schema.ResourceData, meta interface{}) error {
 	return ReadDataSource(d, meta)
 }
 
+// UpdateDataSource updates a Grafana datasource
 func UpdateDataSource(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gapi.Client)
 
@@ -151,6 +153,7 @@ func UpdateDataSource(d *schema.ResourceData, meta interface{}) error {
 	return client.UpdateDataSource(dataSource)
 }
 
+// ReadDataSource reads a Grafana datasource
 func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gapi.Client)
 
@@ -181,6 +184,7 @@ func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
+// DeleteDataSource deletes a Grafana datasource
 func DeleteDataSource(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gapi.Client)
 

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -23,12 +23,19 @@ func TestAccDataSource_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceCheckExists("grafana_data_source.test", &dataSource),
+					testAccDataSourceCheckExists("grafana_data_source.test_influxdb", &dataSource),
 					resource.TestCheckResourceAttr(
-						"grafana_data_source.test", "type", "influxdb",
+						"grafana_data_source.test_influxdb", "type", "influxdb",
 					),
 					resource.TestMatchResourceAttr(
-						"grafana_data_source.test", "id", regexp.MustCompile(`\d+`),
+						"grafana_data_source.test_influxdb", "id", regexp.MustCompile(`\d+`),
+					),
+					testAccDataSourceCheckExists("grafana_data_source.test_cloudwatch", &dataSource),
+					resource.TestCheckResourceAttr(
+						"grafana_data_source.test_cloudwatch", "type", "cloudwatch",
+					),
+					resource.TestMatchResourceAttr(
+						"grafana_data_source.test_cloudwatch", "id", regexp.MustCompile(`\d+`),
 					),
 				),
 			},
@@ -76,12 +83,26 @@ func testAccDataSourceCheckDestroy(dataSource *gapi.DataSource) resource.TestChe
 }
 
 const testAccDataSourceConfig_basic = `
-resource "grafana_data_source" "test" {
+resource "grafana_data_source" "test_influxdb" {
     type = "influxdb"
-    name = "terraform-acc-test"
-    database_name = "terraform-acc-test"
+    name = "terraform-acc-test-influxdb"
+    database_name = "terraform-acc-test-influxdb"
     url = "http://terraform-acc-test.invalid/"
     username = "terraform_user"
     password = "terraform_password"
+}
+
+resource "grafana_data_source" "test_cloudwatch" {
+    type = "cloudwatch"
+    name = "terraform-acc-test-cloudwatch"
+    url = "http://terraform-acc-test.invalid/"
+    json_data {
+			default_region = "us-east-1"
+			auth_type      = "keys"
+		}
+    secure_json_data {
+			access_key = "123"
+			secret_key = "456"
+		}
 }
 `

--- a/vendor/github.com/apparentlymart/go-grafana-api/README.md
+++ b/vendor/github.com/apparentlymart/go-grafana-api/README.md
@@ -1,2 +1,11 @@
 # grafana-api-golang-client
+
 Grafana HTTP API Client for Go
+
+## Tests
+
+To run the tests:
+
+```
+go test
+```

--- a/vendor/github.com/apparentlymart/go-grafana-api/client.go
+++ b/vendor/github.com/apparentlymart/go-grafana-api/client.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -46,11 +48,15 @@ func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request,
 	if c.key != "" {
 		req.Header.Add("Authorization", c.key)
 	}
-	if body == nil {
-		fmt.Println("request to ", url.String(), "with no body data")
-	} else {
-		fmt.Println("request to ", url.String(), "with body data", body.(*bytes.Buffer).String())
+
+	if os.Getenv("GF_LOG") != "" {
+		if body == nil {
+			log.Println("request to ", url.String(), "with no body data")
+		} else {
+			log.Println("request to ", url.String(), "with body data", body.(*bytes.Buffer).String())
+		}
 	}
+
 	req.Header.Add("Content-Type", "application/json")
 	return req, err
 }

--- a/vendor/github.com/apparentlymart/go-grafana-api/datasource.go
+++ b/vendor/github.com/apparentlymart/go-grafana-api/datasource.go
@@ -25,6 +25,21 @@ type DataSource struct {
 	BasicAuth         bool   `json:"basicAuth"`
 	BasicAuthUser     string `json:"basicAuthUser,omitempty"`
 	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
+
+	JSONData       JSONData       `json:"jsonData,omitempty"`
+	SecureJSONData SecureJSONData `json:"secureJsonData,omitempty"`
+}
+
+// JSONData is a representation of the datasource `jsonData` property
+type JSONData struct {
+	AuthType      string `json:"authType,omitempty"`
+	DefaultRegion string `json:"defaultRegion,omitempty"`
+}
+
+// SecureJSONData is a representation of the datasource `secureJsonData` property
+type SecureJSONData struct {
+	AccessKey string `json:"accessKey,omitempty"`
+	SecretKey string `json:"secretKey,omitempty"`
 }
 
 func (c *Client) NewDataSource(s *DataSource) (int64, error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -26,10 +26,10 @@
 			"revisionTime": "2017-04-18T07:21:50Z"
 		},
 		{
-			"checksumSHA1": "7pePgJHRok7HkNUzZqY9/wY72QQ=",
+			"checksumSHA1": "FIqC5wr3HVGaKdil+/xx3mnwL1Y=",
 			"path": "github.com/apparentlymart/go-grafana-api",
-			"revision": "086eb9b364680893a53f41fe6173a909ebd22e1d",
-			"revisionTime": "2017-08-15T16:18:14Z"
+			"revision": "35245a0ae5ef935eebb75de9bd8dfd94499f9b38",
+			"revisionTime": "2017-09-27T00:50:11Z"
 		},
 		{
 			"checksumSHA1": "+2yCNqbcf7VcavAptooQReTGiHY=",

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -61,6 +61,14 @@ The following arguments are supported:
 * `password` - (Required by some data source types) The password to use to
   authenticate to the data source.
 
+* `json_data` - (Required by some data source types) The default region
+  and authentication type to access the data source. `json_data` is documented
+  in more detail below.
+
+* `secure_json_data` - (Required by some data source types) The access and
+  secret keys required to access the data source. `secure_json_data` is
+  documented in more detail below.
+
 * `database_name` - (Required by some data source types) The name of the
   database to use on the selected data source server.
 
@@ -68,6 +76,22 @@ The following arguments are supported:
   application will access the data source. The default is "proxy", which means
   that the application will make requests via a proxy endpoint on the Grafana
   server.
+
+JSON Data (`json_data`) supports the following:
+
+* `auth_type` - (Required by some data source types) The authentication type
+  type used to access the data source.
+
+* `default` - (Required by some data source types) The default region for
+  the data source.
+
+Secure JSON Data (`secure_json_data`) supports the following:
+
+* `access_key` - (Required by some data source types) The access key required
+  to access the data source.
+
+* `secret_key` - (Required by some data source types) The secret key required
+  to access the data source.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This seeks to address issue #4, at least in the case of AWS cloudwatch data source support.

Note that it is dependent on [apparentlymart/go-grafana-api/pull/2](https://github.com/apparentlymart/go-grafana-api/pull/2).

Thanks!