### PR TITLE
Updated vendored go-grafana-api client.

### DIFF
--- a/vendor/github.com/apparentlymart/go-grafana-api/client.go
+++ b/vendor/github.com/apparentlymart/go-grafana-api/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -38,9 +39,9 @@ func New(auth, baseURL string) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(method, requestPath string, body io.Reader) (*http.Request, error) {
 	url := c.baseURL
-	url.Path = path
+	url.Path = path.Join(url.Path, requestPath)
 	req, err := http.NewRequest(method, url.String(), body)
 	if err != nil {
 		return req, err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -26,10 +26,10 @@
 			"revisionTime": "2017-04-18T07:21:50Z"
 		},
 		{
-			"checksumSHA1": "FIqC5wr3HVGaKdil+/xx3mnwL1Y=",
+			"checksumSHA1": "ddOvRyJCJrcV3H6t1/hfxB8Vx/k=",
 			"path": "github.com/apparentlymart/go-grafana-api",
-			"revision": "35245a0ae5ef935eebb75de9bd8dfd94499f9b38",
-			"revisionTime": "2017-09-27T00:50:11Z"
+			"revision": "8003b0c560418e48c3da6edd6619accc0bcf648a",
+			"revisionTime": "2017-11-17T00:33:27Z"
 		},
 		{
 			"checksumSHA1": "+2yCNqbcf7VcavAptooQReTGiHY=",


### PR DESCRIPTION
This is to pull in this change: 
https://github.com/apparentlymart/go-grafana-api/pull/4

If the base URL includes a path component, don’t overwrite this with the
request path.
This is necessary when Grafana is running behind a reverse
proxy that is doing path based routing.