### PR TITLE
Handle 404 response on Read

### DIFF
--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 
 	gapi "github.com/apparentlymart/go-grafana-api"
@@ -85,6 +86,11 @@ func ReadAlertNotification(d *schema.ResourceData, meta interface{}) error {
 
 	alertNotification, err := client.AlertNotification(id)
 	if err != nil {
+		if err.Error() == "404 Not Found" {
+			log.Printf("[WARN] removing datasource %s from state because it no longer exists in grafana", d.Get("name").(string))
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -160,11 +161,17 @@ func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 	idStr := d.Id()
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
+		if err.Error() == "404 Not Found" {
+			log.Printf("[WARN] removing datasource %s from state because it no longer exists in grafana", d.Get("name").(string))
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Invalid id: %#v", idStr)
 	}
 
 	dataSource, err := client.DataSource(id)
 	if err != nil {
+
 		return err
 	}
 


### PR DESCRIPTION
If a datasource or alert notification have been deleted out of band (not using Terraform) the Grafana API will return a 404 error. The standard behaviour in the scenario is to remove the resource from the Terraform state, by setting a blank ID.
This was already happening in the Dashboard resource.