### PR TITLE
alert_notification/dashboard: fix compatibility with grafana 5.0

### DIFF
--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -67,8 +67,8 @@ func testAccAlertNotificationCheckExists(rn string, a *gapi.AlertNotification) r
 func testAccAlertNotificationCheckDestroy(a *gapi.AlertNotification) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*gapi.Client)
-		_, err := client.AlertNotification(a.Id)
-		if err == nil {
+		alert, err := client.AlertNotification(a.Id)
+		if err == nil && alert != nil {
 			return fmt.Errorf("alert-notification still exists")
 		}
 		return nil

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -94,6 +94,8 @@ func prepareDashboardModel(configJSON string) map[string]interface{} {
 	}
 
 	delete(configMap, "id")
+	// Only exists in 5.0+
+	delete(configMap, "uid")
 	configMap["version"] = 0
 
 	return configMap
@@ -123,6 +125,8 @@ func NormalizeDashboardConfigJSON(configI interface{}) string {
 	// significant when included in the JSON.
 	delete(configMap, "id")
 	delete(configMap, "version")
+	// Only exists in 5.0+
+	delete(configMap, "uid")
 
 	ret, err := json.Marshal(configMap)
 	if err != nil {


### PR DESCRIPTION
This strips the new `uid` field, soon to be replacing `slug`, to fix #15. I would note I believe should eventually migrate to this new UID field as [described in their release notes](http://docs.grafana.org/guides/whats-new-in-v5/#dashboard-model-persistent-url-s-and-api-changes) for 5.0 in place of `slug` which is currently used as the identifier.

Additionally, it adds a check for a null 200 OK response for alert notifications by checking both the content of the response and the presence of errors. This maybe is something we'd want to change
in the client library but seems like an easy approach to getting the tests passing.

Here's an example of the 200 OK null response API behavior:

```
$ curl -s -i -X GET https://$AUTH@$URL/api/alert-notifications/10
HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Length: 4
Content-Type: application/json
Date: Sat, 24 Mar 2018 16:49:02 GMT
Expires: -1
Pragma: no-cache

null
```

And version / test output:

```
$ curl -s https://$AUTH@$URL/api/frontend/settings | jq  '.buildInfo'
{
  "buildstamp": 1521216676,
  "commit": "91162f3",
  "env": "production",
  "hasUpdate": false,
  "latestVersion": "5.0.0",
  "version": "5.0.3"
}
```

```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-grafana	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAlertNotification_basic
--- PASS: TestAccAlertNotification_basic (0.72s)
=== RUN   TestAccDashboard_basic
--- PASS: TestAccDashboard_basic (0.43s)
=== RUN   TestAccDashboard_disappear
--- PASS: TestAccDashboard_disappear (0.38s)
=== RUN   TestAccDataSource_basic
--- PASS: TestAccDataSource_basic (0.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-grafana/grafana	(cached)
```

Both changes should be backwards compatible with older versions of Grafana.