### PR TITLE
data_source: make URL field optional

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -35,7 +35,7 @@ func ResourceDataSource() *schema.Resource {
 
 			"url": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"is_default": &schema.Schema{

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -95,7 +95,6 @@ resource "grafana_data_source" "test_influxdb" {
 resource "grafana_data_source" "test_cloudwatch" {
     type = "cloudwatch"
     name = "terraform-acc-test-cloudwatch"
-    url = "http://terraform-acc-test.invalid/"
     json_data {
 			default_region = "us-east-1"
 			auth_type      = "keys"

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the data source within the Grafana
   server.
 
-* `url` - (Required) The URL for the data source. The type of URL required
+* `url` - (Optional) The URL for the data source. The type of URL required
   varies depending on the chosen data source type.
 
 * `is_default` - (Optional) If true, the data source will be the default

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -18,6 +18,8 @@ InfluxDB. See
 [Grafana's *Data Sources Guides*](http://docs.grafana.org/#data-sources-guides)
 for more details on the supported data source types and the arguments they use.
 
+For an InfluxDB datasource:
+
 ```hcl
 resource "grafana_data_source" "metrics" {
   type          = "influxdb"
@@ -26,6 +28,25 @@ resource "grafana_data_source" "metrics" {
   username      = "myapp"
   password      = "foobarbaz"
   database_name = "${influxdb_database.metrics.name}"
+}
+```
+
+For a CloudWatch datasource:
+
+```hcl
+resource "grafana_data_source" "test_cloudwatch" {
+  type = "cloudwatch"
+  name = "cw-example"
+
+  json_data {
+    default_region = "us-east-1"
+    auth_type      = "keys"
+  }
+
+  secure_json_data {
+    access_key = "123"
+    secret_key = "456"
+  }
 }
 ```
 


### PR DESCRIPTION
The CloudWatch datasource does not require the URL attribute via the API. This fixes #13.

With the changes cherry-picked from #17 tests pass.

```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-grafana	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAlertNotification_basic
--- PASS: TestAccAlertNotification_basic (0.62s)
=== RUN   TestAccDashboard_basic
--- PASS: TestAccDashboard_basic (0.42s)
=== RUN   TestAccDashboard_disappear
--- PASS: TestAccDashboard_disappear (0.36s)
=== RUN   TestAccDataSource_basic
--- PASS: TestAccDataSource_basic (0.74s)
PASS
ok  	github.com/terraform-providers/terraform-provider-grafana/grafana	(cached)
```