### PR TITLE
fix(Schema): Mark arguments containing secrets as sensitive

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -19,6 +19,7 @@ func Provider() terraform.ResourceProvider {
 			"auth": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
 				Description: "Credentials for accessing the Grafana API.",
 			},

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -39,8 +39,9 @@ func ResourceAlertNotification() *schema.Resource {
 			},
 
 			"settings": {
-				Type:     schema.TypeMap,
-				Optional: true,
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -30,6 +30,9 @@ func TestAccAlertNotification_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"grafana_alert_notification.test", "id", regexp.MustCompile(`\d+`),
 					),
+					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "settings.addresses", "foo@bar.test",
+					),
 				),
 			},
 		},

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -57,9 +57,10 @@ func ResourceDataSource() *schema.Resource {
 			},
 
 			"basic_auth_password": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+				Sensitive: true,
 			},
 
 			"username": &schema.Schema{
@@ -69,9 +70,10 @@ func ResourceDataSource() *schema.Resource {
 			},
 
 			"password": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+				Sensitive: true,
 			},
 
 			"json_data": &schema.Schema{
@@ -100,8 +102,9 @@ func ResourceDataSource() *schema.Resource {
 			},
 
 			"secure_json_data": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:      schema.TypeList,
+				Optional:  true,
+				Sensitive: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"access_key": &schema.Schema{

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -27,6 +27,12 @@ func TestAccDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"grafana_data_source.test_influxdb", "type", "influxdb",
 					),
+					resource.TestCheckResourceAttr(
+						"grafana_data_source.test_influxdb", "password", "terraform_password",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_data_source.test_influxdb", "basic_auth_password", "basic_password",
+					),
 					resource.TestMatchResourceAttr(
 						"grafana_data_source.test_influxdb", "id", regexp.MustCompile(`\d+`),
 					),
@@ -62,6 +68,9 @@ func TestAccDataSource_basicCloudwatch(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_data_source.test_cloudwatch", "json_data.0.default_region", "us-east-1",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_data_source.test_cloudwatch", "secure_json_data.0.access_key", "123",
 					),
 				),
 			},
@@ -110,12 +119,13 @@ func testAccDataSourceCheckDestroy(dataSource *gapi.DataSource) resource.TestChe
 
 const testAccDataSourceConfig_basic = `
 resource "grafana_data_source" "test_influxdb" {
-  type          = "influxdb"
-  name          = "terraform-acc-test-influxdb"
-  database_name = "terraform-acc-test-influxdb"
-  url           = "http://terraform-acc-test.invalid/"
-  username      = "terraform_user"
-  password      = "terraform_password"
+  type                = "influxdb"
+  name                = "terraform-acc-test-influxdb"
+  database_name       = "terraform-acc-test-influxdb"
+  url                 = "http://terraform-acc-test.invalid/"
+  username            = "terraform_user"
+  password            = "terraform_password"
+  basic_auth_password = "basic_password"
 }
 `
 const testAccDataSourceConfig_basicCloudwatch = `


### PR DESCRIPTION
There are a number of arguments used by this plugin which represent secret information,
such as authentication credentials. By marking these arguments as sensitive, terraform
will intelligently obfuscate those values in the output of a plan or apply.

For example, instead of printing secrets in plaintext it will instead show:

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + grafana_alert_notification.slack
      id:                 <computed>
      is_default:         "false"
      name:               "alert-channel"
      settings.%:         "2"
      settings.token:     <sensitive>
      settings.url:       <sensitive>
      type:               "slack"

  + grafana_data_source.influxdb
      id:                 <computed>
      access_mode:        "proxy"
      basic_auth_enabled: "false"
      database_name:      "status"
      is_default:         "true"
      name:               "influxdb"
      password:           <sensitive>
      type:               "influxdb"
      url:                "http://influxdb:8086/"
      username:           "root"

Plan: 3 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```

Additional tests were added to ensure the arguments now marked as sensitive
are still correctly used in the provider. This is the result of those tests:

```
➜  terraform-provider-grafana git:(sensitive-settings) GRAFANA_URL=http://localhost:3000 GRAFANA_AUTH=admin:admin make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-grafana       [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAlertNotification_basic
--- PASS: TestAccAlertNotification_basic (0.18s)
=== RUN   TestAccDashboard_basic
--- PASS: TestAccDashboard_basic (0.17s)
=== RUN   TestAccDashboard_disappear
--- PASS: TestAccDashboard_disappear (0.16s)
=== RUN   TestAccDataSource_basic
--- PASS: TestAccDataSource_basic (0.19s)
=== RUN   TestAccDataSource_basicCloudwatch
--- PASS: TestAccDataSource_basicCloudwatch (0.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-grafana/grafana       (cached)
```