### PR TITLE
Resource Organization

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -19,7 +19,6 @@ func Provider() terraform.ResourceProvider {
 			"auth": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
 				Description: "Credentials for accessing the Grafana API.",
 			},
@@ -29,6 +28,7 @@ func Provider() terraform.ResourceProvider {
 			"grafana_alert_notification": ResourceAlertNotification(),
 			"grafana_dashboard":          ResourceDashboard(),
 			"grafana_data_source":        ResourceDataSource(),
+			"grafana_organization":       ResourceOrganization(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -19,6 +19,7 @@ func Provider() terraform.ResourceProvider {
 			"auth": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
 				Description: "Credentials for accessing the Grafana API.",
 			},

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -225,15 +225,20 @@ func changes(stateUsers, configUsers map[string]OrgUser) []UserChange {
 	for _, user := range configUsers {
 		sUser, ok := stateUsers[user.Email]
 		if !ok {
+			// User doesn't exist in Grafana's state for the organization, should be added.
 			changes = append(changes, UserChange{Add, user})
 			continue
 		}
 		if sUser.Role != user.Role {
+			// Update the user as they're configured with a different role than
+			// what is in Grafana's state.
 			changes = append(changes, UserChange{Update, user})
 		}
 	}
 	for _, user := range stateUsers {
 		if _, ok := configUsers[user.Email]; !ok {
+			// User exists in Grafana's state for the organization, but isn't
+			// present in the organization configuration, should be removed.
 			changes = append(changes, UserChange{Remove, user})
 		}
 	}

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -263,7 +263,7 @@ func addIdsToChanges(d *schema.ResourceData, meta interface{}, changes []UserCha
 			return nil, errors.New(fmt.Sprintf("Error adding user %s. User does not exist in Grafana.", change.User.Email))
 		}
 		if !ok && create {
-			id, err := createUser(meta, change.User.Email)
+			id, err = createUser(meta, change.User.Email)
 			if err != nil {
 				return nil, err
 			}

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -258,11 +258,10 @@ func addIds(d *schema.ResourceData, meta interface{}, changes []UserChange) ([]U
 			return nil, errors.New(fmt.Sprintf("Error adding user %s. User does not exist in Grafana.", change.User.Email))
 		}
 		if !ok && create {
-			user, err := createUser(meta, change.User.Email)
+			id, err := createUser(meta, change.User.Email)
 			if err != nil {
 				return nil, err
 			}
-			id = user
 		}
 		change.User.Id = id
 		output = append(output, change)

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -191,7 +191,7 @@ func UpdateUsers(d *schema.ResourceData, meta interface{}) error {
 	}
 	changes := changes(stateUsers, configUsers)
 	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
-	changes, err = addIds(d, meta, changes)
+	changes, err = addIdsToChanges(d, meta, changes)
 	if err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func changes(stateUsers, configUsers map[string]OrgUser) []UserChange {
 	return changes
 }
 
-func addIds(d *schema.ResourceData, meta interface{}, changes []UserChange) ([]UserChange, error) {
+func addIdsToChanges(d *schema.ResourceData, meta interface{}, changes []UserChange) ([]UserChange, error) {
 	client := meta.(*gapi.Client)
 	gUserMap := make(map[string]int64)
 	gUsers, err := client.Users()

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -206,7 +206,12 @@ func collectUsers(d *schema.ResourceData) (map[string]OrgUser, map[string]OrgUse
 		// Get the lists of users read in from Grafana state (old) and configured (new)
 		state, config := d.GetChange(role)
 		for _, u := range state.([]interface{}) {
-			stateUsers[u.(string)] = OrgUser{0, u.(string), roleName}
+			email := u.(string)
+			// Sanity check that a user isn't specified twice within an organization
+			if _, ok := stateUsers[email]; ok {
+				return nil, nil, errors.New(fmt.Sprintf("Error: User '%s' cannot be specified multiple times.", email))
+			}
+			stateUsers[email] = OrgUser{0, email, roleName}
 		}
 		for _, u := range config.([]interface{}) {
 			email := u.(string)

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -39,28 +39,18 @@ func ResourceOrganization() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The name of the Grafana organization.",
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"admin_user": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "admin",
-				Description: `The name of the Grafana admin user, defaulting to
-"admin". Grafana adds this user to all organizations automatically, and this
-will keep Terraform from removing them from managed organizations. Specifying a
-blank string here will cause Terraform to remove the default admin user from the
-organization.`,
 			},
 			"create_users": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				Description: `When set to true (the default if unspecified) users
-will be created for any specified organization user not already registered in
-Grafana. This is particularly userful for authentication integrations such as
-google_auth and github_auth.`,
 			},
 			"org_id": &schema.Schema{
 				Type:     schema.TypeInt,
@@ -72,9 +62,6 @@ google_auth and github_auth.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Description: `A list containing email addresses of users who
-should be given the role 'Admin' within this organization. Note: users specified
-here must already exist in Grafana.`,
 			},
 			"editors": &schema.Schema{
 				Type:     schema.TypeList,
@@ -82,9 +69,6 @@ here must already exist in Grafana.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Description: `A list containing email addresses of users who
-should have the role 'Editor' within this organization. Note: users specified
-here must already exist in Grafana.`,
 			},
 			"viewers": &schema.Schema{
 				Type:     schema.TypeList,
@@ -92,9 +76,6 @@ here must already exist in Grafana.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Description: `A list containing email addresses of users who
-should have the role 'Viewer' within this organization. Note: users specified
-here must already exist in Grafana.`,
 			},
 		},
 	}

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -1,0 +1,324 @@
+package grafana
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	gapi "github.com/nytm/go-grafana-api"
+	"log"
+	"strconv"
+	"strings"
+)
+
+type OrgUser struct {
+	Id    int64
+	Email string
+	Role  string
+}
+
+const UserAdd = 10
+const UserUpdate = 20
+const UserRemove = 30
+
+type UserChange struct {
+	Type int8
+	User OrgUser
+}
+
+func ResourceOrganization() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateOrganization,
+		Read:   ReadOrganization,
+		Update: UpdateOrganization,
+		Delete: DeleteOrganization,
+		Exists: ExistsOrganization,
+		Importer: &schema.ResourceImporter{
+			State: ImportOrganization,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the Grafana organization.",
+			},
+			"admin_user": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "admin",
+				Description: `The name of the Grafana admin user, defaulting to
+"admin". Grafana adds this user to all organizations automatically, and this
+will keep Terraform from removing them from managed organizations. Specifying a
+blank string here will cause Terraform to remove the default admin user from the
+organization.`,
+			},
+			"create_users": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: `When set to true (the default if unspecified) users
+will be created for any specified organization user not already registered in
+Grafana. This is particularly userful for authentication integrations such as
+google_auth and github_auth.`,
+			},
+			"org_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"admins": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: `A list containing email addresses of users who
+should be given the role 'Admin' within this organization. Note: users specified
+here must already exist in Grafana.`,
+			},
+			"editors": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: `A list containing email addresses of users who
+should have the role 'Editor' within this organization. Note: users specified
+here must already exist in Grafana.`,
+			},
+			"viewers": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: `A list containing email addresses of users who
+should have the role 'Viewer' within this organization. Note: users specified
+here must already exist in Grafana.`,
+			},
+		},
+	}
+}
+
+func CreateOrganization(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+	name := d.Get("name").(string)
+	orgId, err := client.NewOrg(name)
+	if err != nil && err.Error() == "409 Conflict" {
+		return errors.New(fmt.Sprintf("Error: A Grafana Organization with the name '%s' already exists.", name))
+	}
+	if err != nil {
+		log.Printf("[DEBUG] creating Grafana organization %s", name)
+		return err
+	}
+	d.SetId(strconv.FormatInt(orgId, 10))
+	return UpdateUsers(d, meta)
+}
+
+func ReadOrganization(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
+	resp, err := client.Org(orgId)
+	if err != nil {
+		if err.Error() == "404 Not Found" {
+			log.Printf("[WARN] removing organization %s from state because it no longer exists in grafana", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	d.Set("name", resp.Name)
+	if err := ReadUsers(d, meta); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpdateOrganization(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		log.Printf("[DEBUG] org name has been updated from %s to %s", oldName.(string), newName.(string))
+		name := d.Get("name").(string)
+		err := client.UpdateOrg(orgId, name)
+		if err != nil {
+			return err
+		}
+	}
+	return UpdateUsers(d, meta)
+}
+
+func DeleteOrganization(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
+	return client.DeleteOrg(orgId)
+}
+
+func ExistsOrganization(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*gapi.Client)
+	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
+	_, err := client.Org(orgId)
+	if err != nil && err.Error() == "404 Not Found" {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, err
+}
+
+func ImportOrganization(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	exists, err := ExistsOrganization(d, meta)
+	if err != nil || !exists {
+		return nil, errors.New("Error Importing Grafana Organization")
+	}
+	d.Set("admin_user", "admin")
+	d.Set("create_users", "true")
+	err = ReadOrganization(d, meta)
+	if err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func ReadUsers(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gapi.Client)
+	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
+	orgUsers, err := client.OrgUsers(orgId)
+	if err != nil {
+		return err
+	}
+	roleMap := map[string][]string{"Admin": nil, "Editor": nil, "Viewer": nil}
+	grafAdmin := d.Get("admin_user")
+	for _, orgUser := range orgUsers {
+		if orgUser.Login != grafAdmin {
+			roleMap[orgUser.Role] = append(roleMap[orgUser.Role], orgUser.Email)
+		}
+	}
+	for k, v := range roleMap {
+		d.Set(fmt.Sprintf("%ss", strings.ToLower(k)), v)
+	}
+	return nil
+}
+
+func UpdateUsers(d *schema.ResourceData, meta interface{}) error {
+	oldUsers, newUsers := collectUsers(d)
+	changes := changes(oldUsers, newUsers)
+	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
+	changes, err := addIds(d, meta, changes)
+	if err != nil {
+		return err
+	}
+	return applyChanges(meta, orgId, changes)
+}
+
+func collectUsers(d *schema.ResourceData) (map[string]OrgUser, map[string]OrgUser) {
+	roles := []string{"admins", "editors", "viewers"}
+	oldUsers, newUsers := make(map[string]OrgUser), make(map[string]OrgUser)
+	for _, role := range roles {
+		roleName := strings.Title(role[:len(role)-1])
+		old, new := d.GetChange(role)
+		for _, u := range old.([]interface{}) {
+			oldUsers[u.(string)] = OrgUser{0, u.(string), roleName}
+		}
+		for _, u := range new.([]interface{}) {
+			newUsers[u.(string)] = OrgUser{0, u.(string), roleName}
+		}
+	}
+	return oldUsers, newUsers
+}
+
+func changes(oldUsers, newUsers map[string]OrgUser) map[string]UserChange {
+	changes := make(map[string]UserChange)
+	for _, user := range newUsers {
+		oUser, ok := oldUsers[user.Email]
+		if !ok {
+			changes[user.Email] = UserChange{UserAdd, user}
+			continue
+		}
+		if oUser.Role != user.Role {
+			changes[user.Email] = UserChange{UserUpdate, user}
+		}
+	}
+	for _, user := range oldUsers {
+		if _, ok := newUsers[user.Email]; !ok {
+			changes[user.Email] = UserChange{UserRemove, user}
+		}
+	}
+	return changes
+}
+
+func addIds(d *schema.ResourceData, meta interface{}, changes map[string]UserChange) (map[string]UserChange, error) {
+	client := meta.(*gapi.Client)
+	gUserMap := make(map[string]int64)
+	gUsers, err := client.Users()
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range gUsers {
+		gUserMap[u.Email] = u.Id
+	}
+	output := make(map[string]UserChange)
+	create := d.Get("create_users").(bool)
+	for _, change := range changes {
+		id, ok := gUserMap[change.User.Email]
+		if !ok && !create {
+			return nil, errors.New(fmt.Sprintf("Error adding user %s. User does not exist in Grafana.", change.User.Email))
+		}
+		if !ok && create {
+			log.Printf("[DEBUG] Creating user '%s'. User is not known to Grafana.", change.User.Email)
+			user, err := createUser(meta, change.User.Email)
+			if err != nil {
+				return nil, err
+			}
+			id = user
+		}
+		change.User.Id = id
+		output[change.User.Email] = change
+	}
+	return output, nil
+}
+
+func createUser(meta interface{}, user string) (int64, error) {
+	client := meta.(*gapi.Client)
+	id, n := int64(0), 64
+	bytes := make([]byte, n)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return id, err
+	}
+	pass := string(bytes[:n])
+	log.Printf("[DEBUG] creating user %s with random password", user)
+	u := gapi.User{
+		Name:     user,
+		Login:    user,
+		Email:    user,
+		Password: pass,
+	}
+	id, err = client.CreateUser(u)
+	if err != nil {
+		return id, err
+	}
+	return id, err
+}
+
+func applyChanges(meta interface{}, orgId int64, changes map[string]UserChange) error {
+	var err error
+	client := meta.(*gapi.Client)
+	for _, change := range changes {
+		u := change.User
+		switch change.Type {
+		case UserAdd:
+			err = client.AddOrgUser(orgId, u.Email, u.Role)
+		case UserUpdate:
+			err = client.UpdateOrgUser(orgId, u.Id, u.Role)
+		case UserRemove:
+			err = client.RemoveOrgUser(orgId, u.Id)
+		}
+		if err != nil && err.Error() != "409 Conflict" {
+			return err
+		}
+	}
+	return nil
+}

--- a/grafana/resource_organization_test.go
+++ b/grafana/resource_organization_test.go
@@ -1,0 +1,280 @@
+package grafana
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	gapi "github.com/nytm/go-grafana-api"
+)
+
+func TestAccOrganization_basic(t *testing.T) {
+	var org gapi.Org
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrganizationCheckDestroy(&org),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOrganizationConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestMatchResourceAttr(
+						"grafana_organization.test", "id", regexp.MustCompile(`\d+`),
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOrganizationConfig_updateName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test-update",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrganization_users(t *testing.T) {
+	var org gapi.Org
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrganizationCheckDestroy(&org),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOrganizationConfig_usersCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.0", "john.doe@example.com",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "editors.#",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "viewers.#",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOrganizationConfig_usersUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "editors.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "editors.0", "john.doe@example.com",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "viewers.#", "0",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOrganizationConfig_usersRemove,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "editors.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "viewers.#", "0",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrganization_defaultAdmin(t *testing.T) {
+	var org gapi.Org
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOrganizationCheckDestroy(&org),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOrganizationConfig_defaultAdminNormal,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admin_user", "admin",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.0", "john.doe@example.com",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "editors.#",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "viewers.#",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccOrganizationConfig_defaultAdminChange,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admin_user", "nobody",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.0", "admin@localhost",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.1", "john.doe@example.com",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "editors.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "viewers.#", "0",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrganizationCheckExists(rn string, a *gapi.Org) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+		tmp, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		id := int64(tmp)
+		if err != nil {
+			return fmt.Errorf("resource id is malformed")
+		}
+
+		client := testAccProvider.Meta().(*gapi.Client)
+		org, err := client.Org(id)
+		if err != nil {
+			return fmt.Errorf("error getting data source: %s", err)
+		}
+
+		*a = org
+
+		return nil
+	}
+}
+
+func testAccOrganizationCheckDestroy(a *gapi.Org) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*gapi.Client)
+		org, err := client.Org(a.Id)
+		if err == nil && org.Name != "" {
+			return fmt.Errorf("organization still exists")
+		}
+		return nil
+	}
+}
+
+const testAccOrganizationConfig_basic = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+}
+`
+const testAccOrganizationConfig_updateName = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test-update"
+}
+`
+
+const testAccOrganizationConfig_usersCreate = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+    admin_user = "admin"
+    create_users = true
+    admins = [
+        "john.doe@example.com",
+    ]
+}
+`
+const testAccOrganizationConfig_usersUpdate = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+    admin_user = "admin"
+    create_users = false
+    editors = [
+        "john.doe@example.com",
+    ]
+}
+`
+const testAccOrganizationConfig_usersRemove = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+    admin_user = "admin"
+    create_users = false
+}
+`
+
+const testAccOrganizationConfig_defaultAdminNormal = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+    admin_user = "admin"
+    create_users = false
+    admins = [
+        "john.doe@example.com"
+    ]
+}
+`
+const testAccOrganizationConfig_defaultAdminChange = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+    admin_user = "nobody"
+    create_users = false
+    admins = [
+        "admin@localhost",
+        "john.doe@example.com"
+    ]
+}
+`

--- a/vendor/github.com/nytm/go-grafana-api/alertnotification.go
+++ b/vendor/github.com/nytm/go-grafana-api/alertnotification.go
@@ -9,16 +9,16 @@ import (
 )
 
 type AlertNotification struct {
-	Id          int64       `json:"id,omitempty"`
-	Name        string      `json:"name"`
-	Type        string      `json:"type"`
-	IsDefault   bool        `json:"isDefault"`
-	Settings    interface{} `json:"settings"`
+	Id        int64       `json:"id,omitempty"`
+	Name      string      `json:"name"`
+	Type      string      `json:"type"`
+	IsDefault bool        `json:"isDefault"`
+	Settings  interface{} `json:"settings"`
 }
 
 func (c *Client) AlertNotification(id int64) (*AlertNotification, error) {
 	path := fmt.Sprintf("/api/alert-notifications/%d", id)
-	req, err := c.newRequest("GET", path, nil)
+	req, err := c.newRequest("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (c *Client) NewAlertNotification(a *AlertNotification) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	req, err := c.newRequest("POST", "/api/alert-notifications", bytes.NewBuffer(data))
+	req, err := c.newRequest("POST", "/api/alert-notifications", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
 	}
@@ -77,7 +77,7 @@ func (c *Client) UpdateAlertNotification(a *AlertNotification) error {
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PUT", path, bytes.NewBuffer(data))
+	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (c *Client) UpdateAlertNotification(a *AlertNotification) error {
 
 func (c *Client) DeleteAlertNotification(id int64) error {
 	path := fmt.Sprintf("/api/alert-notifications/%d", id)
-	req, err := c.newRequest("DELETE", path, nil)
+	req, err := c.newRequest("DELETE", path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/nytm/go-grafana-api/client.go
+++ b/vendor/github.com/nytm/go-grafana-api/client.go
@@ -39,9 +39,10 @@ func New(auth, baseURL string) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) newRequest(method, requestPath string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(method, requestPath string, query url.Values, body io.Reader) (*http.Request, error) {
 	url := c.baseURL
 	url.Path = path.Join(url.Path, requestPath)
+	url.RawQuery = query.Encode()
 	req, err := http.NewRequest(method, url.String(), body)
 	if err != nil {
 		return req, err

--- a/vendor/github.com/nytm/go-grafana-api/dashboard.go
+++ b/vendor/github.com/nytm/go-grafana-api/dashboard.go
@@ -33,7 +33,7 @@ func (c *Client) SaveDashboard(model map[string]interface{}, overwrite bool) (*D
 	if err != nil {
 		return nil, err
 	}
-	req, err := c.newRequest("POST", "/api/dashboards/db", bytes.NewBuffer(data))
+	req, err := c.newRequest("POST", "/api/dashboards/db", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) SaveDashboard(model map[string]interface{}, overwrite bool) (*D
 
 func (c *Client) Dashboard(slug string) (*Dashboard, error) {
 	path := fmt.Sprintf("/api/dashboards/db/%s", slug)
-	req, err := c.newRequest("GET", path, nil)
+	req, err := c.newRequest("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (c *Client) Dashboard(slug string) (*Dashboard, error) {
 
 func (c *Client) DeleteDashboard(slug string) error {
 	path := fmt.Sprintf("/api/dashboards/db/%s", slug)
-	req, err := c.newRequest("DELETE", path, nil)
+	req, err := c.newRequest("DELETE", path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/nytm/go-grafana-api/datasource.go
+++ b/vendor/github.com/nytm/go-grafana-api/datasource.go
@@ -49,7 +49,7 @@ func (c *Client) NewDataSource(s *DataSource) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	req, err := c.newRequest("POST", "/api/datasources", bytes.NewBuffer(data))
+	req, err := c.newRequest("POST", "/api/datasources", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
 	}
@@ -80,7 +80,7 @@ func (c *Client) UpdateDataSource(s *DataSource) error {
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PUT", path, bytes.NewBuffer(data))
+	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (c *Client) UpdateDataSource(s *DataSource) error {
 
 func (c *Client) DataSource(id int64) (*DataSource, error) {
 	path := fmt.Sprintf("/api/datasources/%d", id)
-	req, err := c.newRequest("GET", path, nil)
+	req, err := c.newRequest("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (c *Client) DataSource(id int64) (*DataSource, error) {
 
 func (c *Client) DeleteDataSource(id int64) error {
 	path := fmt.Sprintf("/api/datasources/%d", id)
-	req, err := c.newRequest("DELETE", path, nil)
+	req, err := c.newRequest("DELETE", path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/nytm/go-grafana-api/org_users.go
+++ b/vendor/github.com/nytm/go-grafana-api/org_users.go
@@ -1,0 +1,95 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+)
+
+type OrgUser struct {
+	OrgId  int64  `json:"orgId"`
+	UserId int64  `json:"userId"`
+	Email  string `json:"email"`
+	Login  string `json:"login"`
+	Role   string `json:"role"`
+}
+
+func (c *Client) OrgUsers(orgId int64) ([]OrgUser, error) {
+	users := make([]OrgUser, 0)
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, nil)
+	if err != nil {
+		return users, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return users, err
+	}
+	if resp.StatusCode != 200 {
+		return users, errors.New(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return users, err
+	}
+	err = json.Unmarshal(data, &users)
+	if err != nil {
+		return users, err
+	}
+	return users, err
+}
+
+func (c *Client) AddOrgUser(orgId int64, user, role string) error {
+	dataMap := map[string]string{
+		"loginOrEmail": user,
+		"role":         role,
+	}
+	data, err := json.Marshal(dataMap)
+	req, err := c.newRequest("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+	return err
+}
+
+func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
+	dataMap := map[string]string{
+		"role": role,
+	}
+	data, err := json.Marshal(dataMap)
+	req, err := c.newRequest("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+	return err
+}
+
+func (c *Client) RemoveOrgUser(orgId, userId int64) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+	return err
+}

--- a/vendor/github.com/nytm/go-grafana-api/orgs.go
+++ b/vendor/github.com/nytm/go-grafana-api/orgs.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Org struct {
-	Id   int64
-	Name string
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 func (c *Client) Orgs() ([]Org, error) {
 	orgs := make([]Org, 0)
 
-	req, err := c.newRequest("GET", "/api/orgs/", nil)
+	req, err := c.newRequest("GET", "/api/orgs/", nil, nil)
 	if err != nil {
 		return orgs, err
 	}
@@ -35,12 +35,86 @@ func (c *Client) Orgs() ([]Org, error) {
 	return orgs, err
 }
 
-func (c *Client) NewOrg(name string) error {
-	settings := map[string]string{
+func (c *Client) OrgByName(name string) (Org, error) {
+	org := Org{}
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/orgs/name/%s", name), nil, nil)
+	if err != nil {
+		return org, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return org, err
+	}
+	if resp.StatusCode != 200 {
+		return org, errors.New(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return org, err
+	}
+	err = json.Unmarshal(data, &org)
+	return org, err
+}
+
+func (c *Client) Org(id int64) (Org, error) {
+	org := Org{}
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/orgs/%d", id), nil, nil)
+	if err != nil {
+		return org, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return org, err
+	}
+	if resp.StatusCode != 200 {
+		return org, errors.New(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return org, err
+	}
+	err = json.Unmarshal(data, &org)
+	return org, err
+}
+
+func (c *Client) NewOrg(name string) (int64, error) {
+	dataMap := map[string]string{
 		"name": name,
 	}
-	data, err := json.Marshal(settings)
-	req, err := c.newRequest("POST", "/api/orgs", bytes.NewBuffer(data))
+	data, err := json.Marshal(dataMap)
+	id := int64(0)
+	req, err := c.newRequest("POST", "/api/orgs", nil, bytes.NewBuffer(data))
+	if err != nil {
+		return id, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return id, err
+	}
+	if resp.StatusCode != 200 {
+		return id, errors.New(resp.Status)
+	}
+	data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return id, err
+	}
+	tmp := struct {
+		Id int64 `json:"orgId"`
+	}{}
+	err = json.Unmarshal(data, &tmp)
+	if err != nil {
+		return id, err
+	}
+	id = tmp.Id
+	return id, err
+}
+
+func (c *Client) UpdateOrg(id int64, name string) error {
+	dataMap := map[string]string{
+		"name": name,
+	}
+	data, err := json.Marshal(dataMap)
+	req, err := c.newRequest("PUT", fmt.Sprintf("/api/orgs/%d", id), nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}
@@ -55,7 +129,7 @@ func (c *Client) NewOrg(name string) error {
 }
 
 func (c *Client) DeleteOrg(id int64) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/orgs/%d", id), nil)
+	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/orgs/%d", id), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/nytm/go-grafana-api/user.go
+++ b/vendor/github.com/nytm/go-grafana-api/user.go
@@ -4,19 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"net/url"
 )
 
 type User struct {
-	Id      int64
-	Email   string
-	Name    string
-	Login   string
-	IsAdmin bool
+	Id       int64  `json:"id,omitempty"`
+	Email    string `json:"email,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Login    string `json:"login,omitempty"`
+	Password string `json:"password,omitempty"`
+	IsAdmin  bool   `json:"isAdmin,omitempty"`
 }
 
 func (c *Client) Users() ([]User, error) {
 	users := make([]User, 0)
-	req, err := c.newRequest("GET", "/api/users", nil)
+	req, err := c.newRequest("GET", "/api/users", nil, nil)
 	if err != nil {
 		return users, err
 	}
@@ -36,4 +38,39 @@ func (c *Client) Users() ([]User, error) {
 		return users, err
 	}
 	return users, err
+}
+
+func (c *Client) UserByEmail(email string) (User, error) {
+	user := User{}
+	query := url.Values{}
+	query.Add("loginOrEmail", email)
+	req, err := c.newRequest("GET", "/api/users/lookup", query, nil)
+	if err != nil {
+		return user, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return user, err
+	}
+	if resp.StatusCode != 200 {
+		return user, errors.New(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return user, err
+	}
+	tmp := struct {
+		Id       int64  `json:"id,omitempty"`
+		Email    string `json:"email,omitempty"`
+		Name     string `json:"name,omitempty"`
+		Login    string `json:"login,omitempty"`
+		Password string `json:"password,omitempty"`
+		IsAdmin  bool   `json:"isGrafanaAdmin,omitempty"`
+	}{}
+	err = json.Unmarshal(data, &tmp)
+	if err != nil {
+		return user, err
+	}
+	user = User(tmp)
+	return user, err
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -603,10 +603,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "OgmfBdtCPdeO09SfnpuJJ4KJqe0=",
+			"checksumSHA1": "Qw8GWOuQ1rq1SpxMREDMJ8NwSzM=",
 			"path": "github.com/nytm/go-grafana-api",
-			"revision": "cf649e058be2ac31c638f743cad7b2009a441853",
-			"revisionTime": "2018-06-27T19:47:26Z"
+			"revision": "d769eac759956916df08aaea55dc69f64bf3b5d5",
+			"revisionTime": "2018-07-13T13:50:26Z"
 		},
 		{
 			"checksumSHA1": "pvg8L4xN+zO9HLJislpVeHPPLjM=",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -56,4 +56,20 @@ resource "grafana_alert_notification" "slack" {
   }
 }
 
+resource "grafana_organization" "org" {
+    name         = "Grafana Organization
+    admin_user   = "admin"
+    create_users = true
+    admins       = [
+        "admin@example.com"
+    ]
+    editors      = [
+        "editor-01@example.com",
+        "editor-02@example.com"
+    ]
+    viewers      = [
+        "viewer-01@example.com",
+        "viewer-02@example.com"
+    ]
+}
 ```

--- a/website/docs/r/organization.html.md
+++ b/website/docs/r/organization.html.md
@@ -73,6 +73,9 @@ The following arguments are supported:
   should be given `viewer` access to the organization. Note: users specified
   here must already exist in Grafana unless 'create_users' is set to true.
 
+A user can only be listed under one role-group for an organization, listing the
+same user under multiple roles will cause an error to be thrown.
+
 Note - Users specified for each role-group (`admins`, `editors`, `viewers`)
 should be listed in ascending alphabetical order (A-Z). By defining users in
 alphabetical order, Terraform is prevented from detecting unnecessary changes

--- a/website/docs/r/organization.html.md
+++ b/website/docs/r/organization.html.md
@@ -1,0 +1,95 @@
+---
+layout: "grafana"
+page_title: "Grafana: grafana_organization"
+sidebar_current: "docs-grafana-resource-organization"
+description: |-
+  The grafana_organization resource allows a Grafana organization to be created.
+---
+
+# grafana\_organization
+
+The organization resource allows Grafana organizations and their membership to
+be created and managed.
+
+## Example Usage
+
+```hcl
+# Create a Grafana organization with defined membership, creating placeholder
+# accounts for users that don't exist.
+resource "grafana_organization" "test-org" {
+    name         = "Test Organization
+    admin_user   = "admin"
+    create_users = true
+    admins       = [
+        "admin@example.com"
+    ]
+    editors      = [
+        "editor-01@example.com",
+        "editor-02@example.com"
+    ]
+    viewers      = [
+        "viewer-01@example.com",
+        "viewer-02@example.com"
+    ]
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The display name for the Grafana organization created.
+
+* `admin_user` - (Optional) The login name of the configured
+  [default admin user](http://docs.grafana.org/installation/configuration/#admin-user)
+  for the Grafana installation. If unset, this value defaults to `admin`, the
+  Grafana default. Grafana adds the default admin user to all organizations
+  automatically upon creation, and this parameter keeps Terraform from removing
+  it from organizations.
+
+* `create_users` - (Optional) Whether or not to create Grafana users specified
+  in the organization's membership if they don't already exist in Grafana. If
+  unspecified, this parameter defaults to `true`, creating placeholder users
+  with the `name`, `login`, and `email` set to the email of the user, and a
+  random password. Setting this option to `false` will cause an error to be
+  thrown for any users that do not already exist in Grafana.
+
+  This option is particularly useful when integrating Grafana with external
+  authentication services such as
+  [`auth.github`](http://docs.grafana.org/installation/configuration/#auth-github)
+  and
+  [`auth.google`](http://docs.grafana.org/installation/configuration/#auth-google).
+
+* `admins` - (Optional) A list of email addresses corresponding to users who
+  should be given `admin` access to the organization. Note: users specified
+  here must already exist in Grafana unless 'create_users' is set to true.
+
+* `editors` - (Optional) A list of email addresses corresponding to users who
+  should be given `editor` access to the organization. Note: users specified
+  here must already exist in Grafana unless 'create_users' is set to true.
+
+* `viewers` - (Optional) A list of email addresses corresponding to users who
+  should be given `viewer` access to the organization. Note: users specified
+  here must already exist in Grafana unless 'create_users' is set to true.
+
+Note - Users specified for each role-group (`admins`, `editors`, `viewers`)
+should be listed in ascending alphabetical order (A-Z). By defining users in
+alphabetical order, Terraform is prevented from detecting unnecessary changes
+when comparing the list of defined users in the resource to the (ordered) list
+returned by the Grafana API.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `org_id` - The organization id assigned to this organization by Grafana.
+
+## Import
+
+Existing organizations can be imported using the organization id obtained from
+the Grafana Web UI under 'Server Admin'.
+
+```
+$ terraform import grafana_organization.org_name {org_id}
+```

--- a/website/grafana.erb
+++ b/website/grafana.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-grafana-resource-data-source") %>>
               <a href="/docs/providers/grafana/r/data_source.html">grafana_data_source</a>
             </li>
+            <li<%= sidebar_current("docs-grafana-resource-organization") %>>
+              <a href="/docs/providers/grafana/r/organization.html">grafana_organization</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
Adds support for creating and managing Grafana organizations and their membership with the addition of the `grafana_organization` resource.

This PR also adds acceptance tests and website documentation for the new resource, as well as updating the vendored version of the `go-grafana-api`.