### PR TITLE
support boolean settings for alert notifications

### DIFF
--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -95,11 +95,23 @@ func ReadAlertNotification(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	settings := map[string]interface{}{}
+	for k, v := range alertNotification.Settings.(map[string]interface{}) {
+		boolVal, ok := v.(bool)
+		if ok && boolVal {
+			settings[k] = "true"
+		} else if ok && !boolVal {
+			settings[k] = "false"
+		} else {
+			settings[k] = v
+		}
+	}
+
 	d.Set("id", alertNotification.Id)
 	d.Set("is_default", alertNotification.IsDefault)
 	d.Set("name", alertNotification.Name)
 	d.Set("type", alertNotification.Type)
-	d.Set("settings", alertNotification.Settings)
+	d.Set("settings", settings)
 
 	return nil
 }
@@ -124,11 +136,23 @@ func makeAlertNotification(d *schema.ResourceData) (*gapi.AlertNotification, err
 		id, err = strconv.ParseInt(idStr, 10, 64)
 	}
 
+	settings := map[string]interface{}{}
+	for k, v := range d.Get("settings").(map[string]interface{}) {
+		strVal, ok := v.(string)
+		if ok && strVal == "true" {
+			settings[k] = true
+		} else if ok && strVal == "false" {
+			settings[k] = false
+		} else {
+			settings[k] = v
+		}
+	}
+
 	return &gapi.AlertNotification{
 		Id:        id,
 		Name:      d.Get("name").(string),
 		Type:      d.Get("type").(string),
 		IsDefault: d.Get("is_default").(bool),
-		Settings:  d.Get("settings").(interface{}),
+		Settings:  settings,
 	}, err
 }

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -85,6 +85,7 @@ resource "grafana_alert_notification" "test" {
     settings {
 			"addresses" = "foo@bar.test"
 			"uploadImage" = "false"
+			"autoResolve" = "true"
 		}
 }
 `

--- a/website/docs/r/alert_notification.html.md
+++ b/website/docs/r/alert_notification.html.md
@@ -34,6 +34,8 @@ The following arguments are supported:
 * `is_default` - (Optional) Is this the default channel for all your alerts.
 * `settings` - (Optional) Additional settings, for full reference lookup [Grafana HTTP API documentation](http://docs.grafana.org/http_api/alerting).
 
+**Note:** In `settings` the strings `"true"` and `"false"` are mapped to boolean `true` and `false` when sent to Grafana.
+
 ## Attributes Reference
 
 The resource exports the following attributes:


### PR DESCRIPTION
Currently it isn't possible to provide settings to Grafana alert notifiers that expect boolean parameters, because they are always sent as JSON strings rather than booleans.

Since Terraform does not support maps with mixed value types, this PR transforms the string "true" into boolean `true` and the string "false" into boolean `false` before assembling the JSON to send to Grafana.

It also transforms the boolean values returned by the Grafana API back into string values so that everything works correctly.

It's not the most graceful solution, but it does seem to work well.  Any suggestions for alternative approaches welcomed!

Fixes #35 