### PR TITLE
Update slack alert notification example usage

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -50,8 +50,8 @@ resource "grafana_alert_notification" "slack" {
   type = "slack"
 
   settings {
-    "slack" = "https://myteam.slack.com/hoook"
-    "recipient" = "@someguy"
+    "url"         = "https://hooks.slack.com/hoook"
+    "recipient"   = "@someguy"
     "uploadImage" = "false"
   }
 }


### PR DESCRIPTION
This PR updates the code example for the Slack `grafana_alert_notification` to match what the Grafana API expects to receive.