### PR TITLE
Provider logging

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -38,8 +39,15 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	return gapi.New(
+	client, err := gapi.New(
 		d.Get("auth").(string),
 		d.Get("url").(string),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	client.Transport = logging.NewTransport("Grafana", client.Transport)
+
+	return client, nil
 }


### PR DESCRIPTION
~Blocked by https://github.com/nytm/go-grafana-api/pull/19~
~Blocked by https://github.com/terraform-providers/terraform-provider-grafana/pull/75~

This PR will need rebase.

---

This makes debugging for developers & users of this provider easier by exposing all requests & responses in the log (when >`DEBUG` severity is set).

Example:

```
---[ REQUEST ]---------------------------------------
POST /api/dashboards/db HTTP/1.1
Host: 127.0.0.1:3000
User-Agent: Go-http-client/1.1
Content-Length: 144
Authorization: Basic <redacted>
Content-Type: application/json
Accept-Encoding: gzip

{
 "meta": {
  "isStarred": false,
  "slug": "",
  "folderId": 0
 },
 "dashboard": {
  "title": "Terraform Acceptance Test",
  "version": 0
 },
 "folderId": 0,
 "Overwrite": false
}
-----------------------------------------------------
2019/02/23 09:06:47 [DEBUG] Grafana API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Content-Length: 139
Content-Type: application/json
Date: Sat, 23 Feb 2019 09:06:47 GMT

{
 "id": 1,
 "slug": "terraform-acceptance-test",
 "status": "success",
 "uid": "Grze1orik",
 "url": "/d/Grze1orik/terraform-acceptance-test",
 "version": 1
}
-----------------------------------------------------
```