### PR TITLE
fix slack hook URL parameter name, and sample URL typo

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -50,7 +50,7 @@ resource "grafana_alert_notification" "slack" {
   type = "slack"
 
   settings {
-    "slack" = "https://myteam.slack.com/hoook"
+    "url" = "https://myteam.slack.com/hook"
     "recipient" = "@someguy"
     "uploadImage" = "false"
   }


### PR DESCRIPTION
The parameter name is incorrect per grafana API. Although the [grafana API doc](http://docs.grafana.org/alerting/notifications/#slack) online does not seem to officially mention all the fields, but samples in the community forum show the proper fields:

https://community.grafana.com/t/slack-enable-image-via-curl/3521

https://community.grafana.com/t/how-can-i-add-send-on-all-alerts-and-include-image-option-while-creating-alert-notification-channel-using-api/2135

