### PR TITLE
add-tls-skip-verify

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -198,7 +198,6 @@ func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 	d.Set("type", dataSource.Type)
 	d.Set("url", dataSource.URL)
 	d.Set("username", dataSource.User)
-	d.Set("skip_tls_verify", dataSource.User)
 
 	return nil
 }

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -71,6 +71,12 @@ func ResourceDataSource() *schema.Resource {
 				Sensitive: true,
 			},
 
+			"tls_skip_verify": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  "",
+			},
+
 			"json_data": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -192,6 +198,7 @@ func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 	d.Set("type", dataSource.Type)
 	d.Set("url", dataSource.URL)
 	d.Set("username", dataSource.User)
+	d.Set("skip_tls_verify", dataSource.User)
 
 	return nil
 }
@@ -241,6 +248,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		DefaultRegion:           d.Get("json_data.0.default_region").(string),
 		CustomMetricsNamespaces: d.Get("json_data.0.custom_metrics_namespaces").(string),
 		AssumeRoleArn:           d.Get("json_data.0.assume_role_arn").(string),
+		TlsSkipVerify:           d.Get("tls_skip_verify").(bool),
 	}
 }
 

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -86,6 +86,9 @@ The following arguments are supported:
   and authentication type to access the data source. `json_data` is documented
   in more detail below.
 
+* `tls_skip_verify` - Optional boolean value indicating if verification of 
+  tls should be skipped.
+
 * `secure_json_data` - (Required by some data source types) The access and
   secret keys required to access the data source. `secure_json_data` is
   documented in more detail below.

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -87,7 +87,7 @@ The following arguments are supported:
   in more detail below.
 
 * `tls_skip_verify` - Optional boolean value indicating if verification of 
-  tls should be skipped.
+  TLS should be skipped.
 
 * `secure_json_data` - (Required by some data source types) The access and
   secret keys required to access the data source. `secure_json_data` is


### PR DESCRIPTION
Currently, tls-skip-verify is not available as a main level option. This modification adds the ability to set the tls-skip-verify option.