### PR TITLE
Argument names must not be quoted

### DIFF
--- a/website/docs/r/alert_notification.html.md
+++ b/website/docs/r/alert_notification.html.md
@@ -19,8 +19,8 @@ resource "grafana_alert_notification" "email_someteam" {
   is_default = false
 
   settings {
-    "addresses" = "foo@example.net;bar@example.net"
-    "uploadImage" = "false"
+    addresses = "foo@example.net;bar@example.net"
+    uploadImage = "false"
   }
 }
 ```


### PR DESCRIPTION
Argument names must not be quoted in grafana_alert_notification settings