### PR TITLE
Mark secret_key in secure_json_data as sensitive

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -107,8 +107,9 @@ func ResourceDataSource() *schema.Resource {
 							Required: true,
 						},
 						"secret_key": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
 						},
 					},
 				},


### PR DESCRIPTION
As it contain sensitive information.

Currently there is a bug in Terraform, which ignores `Sensitive: true` on fields with type List.

See https://github.com/hashicorp/terraform-plugin-sdk/issues/76 for details.