### PR TITLE
Updating the access_mode setting description.

### DIFF
--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -94,9 +94,10 @@ The following arguments are supported:
   database to use on the selected data source server.
 
 * `access_mode` - (Optional) The method by which the browser-based Grafana
-  application will access the data source. The default is "proxy", which means
+  application will access the data source. The default is `proxy`, which means
   that the application will make requests via a proxy endpoint on the Grafana
-  server.
+  server. Proxy is displayed in the Grafana admin as Server. Another possible value is 
+  `direct` which is displayed in the Grafana admin as Browser.
 
 JSON Data (`json_data`) supports the following:
 


### PR DESCRIPTION
Access mode didn't list the possible values or an explanation to how that mapped to the Grafana Admin UI. Formatting to be like the other provider documentation. Closes #92