### PR TITLE
resource/data_source: add support for stackdriver privatekey

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -188,6 +188,11 @@ func ResourceDataSource() *schema.Resource {
 							Optional:  true,
 							Sensitive: true,
 						},
+						"private_key": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
 						"secret_key": {
 							Type:      schema.TypeString,
 							Optional:  true,
@@ -369,6 +374,7 @@ func makeSecureJSONData(d *schema.ResourceData) gapi.SecureJSONData {
 		AccessKey:         d.Get("secure_json_data.0.access_key").(string),
 		BasicAuthPassword: d.Get("secure_json_data.0.basic_auth_password").(string),
 		Password:          d.Get("secure_json_data.0.password").(string),
+		PrivateKey:        d.Get("secure_json_data.0.private_key").(string),
 		SecretKey:         d.Get("secure_json_data.0.secret_key").(string),
 		TlsCACert:         d.Get("secure_json_data.0.tls_ca_cert").(string),
 		TlsClientCert:     d.Get("secure_json_data.0.tls_client_cert").(string),

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -257,6 +257,23 @@ resource "grafana_data_source" "testdata" {
 			"json_data.0.query_timeout": "1",
 		},
 	},
+	{
+		"grafana_data_source.stackdriver",
+		`
+		resource "grafana_data_source" "stackdriver" {
+			type = "stackdriver"
+			name = "stackdriver"
+			secure_json_data {
+				private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
+			}
+		}
+		`,
+		map[string]string{
+			"type":                           "stackdriver",
+			"name":                           "stackdriver",
+			"secure_json_data.0.private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+		},
+	},
 }
 
 func TestAccDataSource_basic(t *testing.T) {

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -13,8 +13,8 @@ The data source resource allows a data source to be created on a Grafana server.
 ## Example Usage
 
 The required arguments for this resource vary depending on the type of data
-source selected (via the `type` argument). The following example is for
-InfluxDB. See [Grafana's Data Sources Guides][datasources] for more details on
+source selected (via the `type` argument). The following examples are for
+InfluxDB, CloudWatch, and Google Stackdriver. See [Grafana's Data Sources Guides][datasources] for more details on
 the supported data source types and the arguments they use.
 
 [datasources]: https://grafana.com/docs/grafana/latest/features/datasources/
@@ -47,6 +47,19 @@ resource "grafana_data_source" "test_cloudwatch" {
   secure_json_data {
     access_key = "123"
     secret_key = "456"
+  }
+}
+```
+
+For a Stackdriver datasource:
+
+```hcl
+resource "grafana_data_source" "test_stackdriver" {
+  type = "stackdriver"
+  name = "sd-example"
+
+  secure_json_data {
+    private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
   }
 }
 ```
@@ -182,6 +195,8 @@ fields to operate properly.
 * `basic_auth_password` - (All) Password to use for basic authentication.
 
 * `password` - (All) Password to use for authentication.
+
+* `private_key` - (Stackdriver) The [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) `private_key` to use to access the data source.
 
 * `tls_ca_cert` - (All) CA cert for out going requests.
 


### PR DESCRIPTION
Closes #91 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-grafana/blob/master/CHANGELOG.md):
```release-note
resource/data_source: add private_key attribute for stackdriver data_sources
```

Output of acceptance tests:
```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAlertNotification_basic
--- PASS: TestAccAlertNotification_basic (0.18s)
=== RUN   TestAccAlertNotification_invalid_frequence
--- PASS: TestAccAlertNotification_invalid_frequence (0.04s)
=== RUN   TestAccAlertNotification_reminder_no_frequence
--- PASS: TestAccAlertNotification_reminder_no_frequence (0.03s)
=== RUN   TestAccDashboard_basic
--- PASS: TestAccDashboard_basic (0.33s)
=== RUN   TestAccDashboard_folder
--- PASS: TestAccDashboard_folder (0.34s)
=== RUN   TestAccDashboard_disappear
--- PASS: TestAccDashboard_disappear (0.16s)
=== RUN   TestAccDataSource_basic
--- PASS: TestAccDataSource_basic (1.97s)
=== RUN   TestAccFolder_basic
--- PASS: TestAccFolder_basic (0.18s)
=== RUN   TestAccOrganization_basic
--- PASS: TestAccOrganization_basic (0.48s)
=== RUN   TestAccOrganization_users
--- PASS: TestAccOrganization_users (0.74s)
=== RUN   TestAccOrganization_defaultAdmin
--- PASS: TestAccOrganization_defaultAdmin (0.49s)
```