### PR TITLE
Update README, Test Target, and Vendoring

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,9 +10,7 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+	go test $(TEST) $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
@@ -38,7 +36,6 @@ fmtcheck:
 
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
-
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# Terraform Provider
+<a href="https://terraform.io">
+  <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" title="Terraform" align="right" height="50" />
+</a>
+
+# Terraform Provider for Grafana
 
 - Website: https://terraform.io
 - Documentation: https://www.terraform.io/docs/providers/grafana/index.html
 - Chat: [Terraform Gitter](https://gitter.im/hashicorp-terraform/Lobby)
 - Chat: [Grafana #terraform Slack channel](https://grafana.slack.com/archives/C017MUCFJUT)
 - Mailing List: [Google Groups](http://groups.google.com/group/terraform-tool)
-
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 # Terraform Provider for Grafana
 
-- Website: https://terraform.io
-- Documentation: https://www.terraform.io/docs/providers/grafana/index.html
-- Chat: [Terraform Gitter](https://gitter.im/hashicorp-terraform/Lobby)
-- Chat: [Grafana #terraform Slack channel](https://grafana.slack.com/archives/C017MUCFJUT)
-- Mailing List: [Google Groups](http://groups.google.com/group/terraform-tool)
+- Terraform website: https://terraform.io
+- Grafana website: https://grafana.com
+- Provider Documentation: https://www.terraform.io/docs/providers/grafana/index.html
+- Terraform Chat: [Terraform Gitter](https://gitter.im/hashicorp-terraform/Lobby)
+- Grafana Chat: [Grafana #terraform Slack channel](https://grafana.slack.com/archives/C017MUCFJUT)
+- Terraform Mailing List: [Google Groups](http://groups.google.com/group/terraform-tool)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,85 +1,39 @@
-Terraform Provider
-==================
+# Terraform Provider
 
-- Website: https://www.terraform.io
-- [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
-- Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
+- Website: https://terraform.io
+- Documentation: https://www.terraform.io/docs/providers/grafana/index.html
+- Chat: [Terraform Gitter](https://gitter.im/hashicorp-terraform/Lobby)
+- Chat: [Grafana #terraform Slack channel](https://grafana.slack.com/archives/C017MUCFJUT)
+- Mailing List: [Google Groups](http://groups.google.com/group/terraform-tool)
 
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 
-Requirements
-------------
+## Development
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
+If you're new to provider development, a good place to start is the [Extending
+Terraform](https://www.terraform.io/docs/extend/index.html) docs.
 
-Building The Provider
----------------------
+Set up your local environment by installing [Go](http://www.golang.org). Also
+recommended is [Docker](https://docs.docker.com/install/). Docker is not
+required, but it makes running a local Grafana instance for acceptance tests
+very easy.
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-grafana`
-
-```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-grafana
-```
-
-Enter the provider directory and build the provider
+Run [unit tests](https://www.terraform.io/docs/extend/testing/unit-testing.html):
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-grafana
-$ make build
+make test
 ```
 
-Developing the Provider
----------------------------
-
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
-
-To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+Run [acceptance tests](https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html):
 
 ```sh
-$ make bin
-...
-$ $GOPATH/bin/terraform-provider-grafana
-...
+# In one terminal, run a Grafana container.
+# You may optionally override the image tag...
+# GRAFANA_VERSION=7.1.1 \
+make test-serve
+
+# In another...
+GRAFANA_URL=http://localhost:3000 \
+GRAFANA_AUTH=admin:admin \
+make testacc
 ```
-
-In order to test the provider, you can simply run `make test`.
-
-```sh
-$ make test
-```
-
-In order to run the full suite of Acceptance tests, run `make testacc`. This should be
-performed before merging or opening pull requests.
-
-```sh
-$ GRAFANA_URL=http://localhost:3000 GRAFANA_AUTH=admin:admin make testacc
-```
-
-This requires a running Grafana server locally. This provider targets
-the latest version of Grafana, but older versions should be compatible where
-possible. In some cases, older versions of this provider will work with
-older versions of Grafana.
-
-If you have [Docker](https://docs.docker.com/install/) installed, you can
-run Grafana with the following command:
-
-```sh
-$ make test-serv
-```
-
-By default, this will use the latest version of Grafana based on their
-Docker repository. You can specify the version with the following:
-
-```sh
-$ GRAFANA_VERSION=3.1.1 make test-serv
-```
-
-This command will run attached and will stop the Grafana server when
-interrupted. Images will be cached locally by Docker so it is quicky to
-restart the server as necessary. The server will use the default port and
-credentials for the `GRAFANA_AUTH` and `GRAFANA_URL` environment variables.
-
-Nightly acceptance tests are run against the `latest` tag of the Grafana
-maintained Docker image.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ GRAFANA_URL=http://localhost:3000 \
 GRAFANA_AUTH=admin:admin \
 make testacc
 ```
+
+This codebase leverages
+[nytm/go-grafana-api](https://github.com/nytm/go-grafana-api) as its Grafana API
+client. All resources and data sources should leverage this.

--- a/vendor/github.com/nytm/go-grafana-api/.drone.yml
+++ b/vendor/github.com/nytm/go-grafana-api/.drone.yml
@@ -8,4 +8,4 @@ steps:
   image: golang
   commands:
   - go mod download
-  - go test
+  - go test -cover -race -vet all -mod readonly ./...

--- a/vendor/github.com/nytm/go-grafana-api/admin.go
+++ b/vendor/github.com/nytm/go-grafana-api/admin.go
@@ -11,6 +11,10 @@ import (
 func (c *Client) CreateUser(user User) (int64, error) {
 	id := int64(0)
 	data, err := json.Marshal(user)
+	if err != nil {
+		return id, err
+	}
+
 	req, err := c.newRequest("POST", "/api/admin/users", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return id, err

--- a/vendor/github.com/nytm/go-grafana-api/alertnotification.go
+++ b/vendor/github.com/nytm/go-grafana-api/alertnotification.go
@@ -10,6 +10,7 @@ import (
 
 type AlertNotification struct {
 	Id                    int64       `json:"id,omitempty"`
+	Uid                   string      `json:"uid"`
 	Name                  string      `json:"name"`
 	Type                  string      `json:"type"`
 	IsDefault             bool        `json:"isDefault"`

--- a/vendor/github.com/nytm/go-grafana-api/client.go
+++ b/vendor/github.com/nytm/go-grafana-api/client.go
@@ -31,7 +31,7 @@ func New(auth, baseURL string) (*Client, error) {
 	if strings.Contains(auth, ":") {
 		split := strings.SplitN(auth, ":", 2)
 		u.User = url.UserPassword(split[0], split[1])
-	} else {
+	} else if auth != "" {
 		key = fmt.Sprintf("Bearer %s", auth)
 	}
 	return &Client{

--- a/vendor/github.com/nytm/go-grafana-api/datasource.go
+++ b/vendor/github.com/nytm/go-grafana-api/datasource.go
@@ -78,6 +78,12 @@ type JSONData struct {
 	// Used by Prometheus
 	HttpMethod   string `json:"httpMethod,omitempty"`
 	QueryTimeout string `json:"queryTimeout,omitempty"`
+
+	// Used by Stackdriver
+	AuthenticationType string `json:"authenticationType,omitempty"`
+	ClientEmail        string `json:"clientEmail,omitempty"`
+	DefaultProject     string `json:"defaultProject,omitempty"`
+	TokenUri           string `json:"tokenUri,omitempty"`
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property
@@ -92,6 +98,9 @@ type SecureJSONData struct {
 	// Used by Cloudwatch
 	AccessKey string `json:"accessKey,omitempty"`
 	SecretKey string `json:"secretKey,omitempty"`
+
+	// Used by Stackdriver
+	PrivateKey string `json:"privateKey,omitempty"`
 }
 
 func (c *Client) NewDataSource(s *DataSource) (int64, error) {

--- a/vendor/github.com/nytm/go-grafana-api/folder.go
+++ b/vendor/github.com/nytm/go-grafana-api/folder.go
@@ -63,6 +63,9 @@ func (c *Client) NewFolder(title string) (Folder, error) {
 		"title": title,
 	}
 	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return folder, err
+	}
 	req, err := c.newRequest("POST", "/api/folders", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return folder, err
@@ -91,6 +94,9 @@ func (c *Client) UpdateFolder(id string, name string) error {
 		"name": name,
 	}
 	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return err
+	}
 	req, err := c.newRequest("PUT", fmt.Sprintf("/api/folders/%s", id), nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err

--- a/vendor/github.com/nytm/go-grafana-api/mock.go
+++ b/vendor/github.com/nytm/go-grafana-api/mock.go
@@ -1,0 +1,45 @@
+package gapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+type mockServer struct {
+	code   int
+	server *httptest.Server
+}
+
+func (m *mockServer) Close() {
+	m.server.Close()
+}
+
+func gapiTestTools(code int, body string) (*mockServer, *Client) {
+	mock := &mockServer{
+		code: code,
+	}
+
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(mock.code)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+
+	tr := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(mock.server.URL)
+		},
+	}
+
+	httpClient := &http.Client{Transport: tr}
+
+	url := url.URL{
+		Scheme: "http",
+		Host:   "my-grafana.com",
+	}
+
+	client := &Client{"my-key", url, httpClient}
+	return mock, client
+}

--- a/vendor/github.com/nytm/go-grafana-api/org_users.go
+++ b/vendor/github.com/nytm/go-grafana-api/org_users.go
@@ -46,6 +46,9 @@ func (c *Client) AddOrgUser(orgId int64, user, role string) error {
 		"role":         role,
 	}
 	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return err
+	}
 	req, err := c.newRequest("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err
@@ -65,6 +68,9 @@ func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
 		"role": role,
 	}
 	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return err
+	}
 	req, err := c.newRequest("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err

--- a/vendor/github.com/nytm/go-grafana-api/orgs.go
+++ b/vendor/github.com/nytm/go-grafana-api/orgs.go
@@ -78,11 +78,15 @@ func (c *Client) Org(id int64) (Org, error) {
 }
 
 func (c *Client) NewOrg(name string) (int64, error) {
+	id := int64(0)
+
 	dataMap := map[string]string{
 		"name": name,
 	}
 	data, err := json.Marshal(dataMap)
-	id := int64(0)
+	if err != nil {
+		return id, err
+	}
 	req, err := c.newRequest("POST", "/api/orgs", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return id, err
@@ -114,6 +118,9 @@ func (c *Client) UpdateOrg(id int64, name string) error {
 		"name": name,
 	}
 	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return err
+	}
 	req, err := c.newRequest("PUT", fmt.Sprintf("/api/orgs/%d", id), nil, bytes.NewBuffer(data))
 	if err != nil {
 		return err

--- a/vendor/github.com/nytm/go-grafana-api/playlist.go
+++ b/vendor/github.com/nytm/go-grafana-api/playlist.go
@@ -1,0 +1,134 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+)
+
+type PlaylistItem struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	Order int    `json:"order"`
+	Title string `json:"title"`
+}
+
+type Playlist struct {
+	Id       int            `json:"id"`
+	Name     string         `json:"name"`
+	Interval string         `json:"interval"`
+	Items    []PlaylistItem `json:"items"`
+}
+
+func (c *Client) Playlist(id int) (*Playlist, error) {
+	path := fmt.Sprintf("/api/playlists/%d", id)
+	req, err := c.newRequest("GET", path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, errors.New(resp.Status)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	playlist := &Playlist{}
+
+	err = json.Unmarshal(data, &playlist)
+	if err != nil {
+		return nil, err
+	}
+
+	return playlist, nil
+}
+
+func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
+	data, err := json.Marshal(playlist)
+	if err != nil {
+		return 0, err
+	}
+
+	req, err := c.newRequest("POST", "/api/playlists", nil, bytes.NewBuffer(data))
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, err
+	}
+
+	if resp.StatusCode != 200 {
+		return 0, errors.New(resp.Status)
+	}
+
+	data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	result := struct {
+		Id int
+	}{}
+
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.Id, nil
+}
+
+func (c *Client) UpdatePlaylist(playlist Playlist) error {
+	path := fmt.Sprintf("/api/playlists/%d", playlist.Id)
+	data, err := json.Marshal(playlist)
+	if err != nil {
+		return err
+	}
+
+	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}
+
+func (c *Client) DeletePlaylist(id int) error {
+	path := fmt.Sprintf("/api/playlists/%d", id)
+	req, err := c.newRequest("DELETE", path, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}

--- a/vendor/github.com/nytm/go-grafana-api/team.go
+++ b/vendor/github.com/nytm/go-grafana-api/team.go
@@ -1,0 +1,281 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+)
+
+type SearchTeam struct {
+	TotalCount int64   `json:"totalCount,omitempty"`
+	Teams      []*Team `json:"teams,omitempty"`
+	Page       int64   `json:"page,omitempty"`
+	PerPage    int64   `json:"perPage,omitempty"`
+}
+
+// Team consists of a get response
+// It's used in  Add and Update API
+type Team struct {
+	Id          int64  `json:"id,omitempty"`
+	OrgId       int64  `json:"orgId,omitempty"`
+	Name        string `json:"name"`
+	Email       string `json:"email,omitempty"`
+	AvatarUrl   string `json:"avatarUrl,omitempty"`
+	MemberCount int64  `json:"memberCount,omitempty"`
+	Permission  int64  `json:"permission,omitempty"`
+}
+
+// TeamMember
+type TeamMember struct {
+	OrgId      int64  `json:"orgId,omitempty"`
+	TeamId     int64  `json:"teamId,omitempty"`
+	UserId     int64  `json:"userId,omitempty"`
+	Email      string `json:"email,omitempty"`
+	Login      string `json:"login,omitempty"`
+	AvatarUrl  string `json:"avatarUrl,omitempty"`
+	Permission int64  `json:"permission,omitempty"`
+}
+
+type Preferences struct {
+	Theme           string `json:"theme"`
+	HomeDashboardId int64  `json:"homeDashboardId"`
+	Timezone        string `json:"timezone"`
+}
+
+func (c *Client) SearchTeam(query string) (*SearchTeam, error) {
+	var result SearchTeam
+
+	page := "1"
+	perPage := "1000"
+	path := "/api/teams/search"
+	queryValues := url.Values{}
+	queryValues.Set("page", page)
+	queryValues.Set("perPage", perPage)
+	queryValues.Set("query", query)
+
+	req, err := c.newRequest("GET", path, queryValues, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) Team(id int64) (*Team, error) {
+	var team Team
+
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &team); err != nil {
+		return nil, err
+	}
+	return &team, nil
+}
+
+// AddTeam makes a new team
+// email arg is an optional value.
+// If you don't want to set email, please set "" (empty string).
+func (c *Client) AddTeam(name string, email string) error {
+	path := fmt.Sprintf("/api/teams")
+	team := Team{
+		Name:  name,
+		Email: email,
+	}
+	data, err := json.Marshal(team)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest("POST", path, nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}
+
+func (c *Client) UpdateTeam(id int64, name string, email string) error {
+	path := fmt.Sprintf("/api/teams/%d", id)
+	team := Team{
+		Name: name,
+	}
+	// add param if email exists
+	if email != "" {
+		team.Email = email
+	}
+	data, err := json.Marshal(team)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}
+
+func (c *Client) DeleteTeam(id int64) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/teams/%d", id), nil, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}
+
+func (c *Client) TeamMembers(id int64) ([]*TeamMember, error) {
+	members := make([]*TeamMember, 0)
+
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/teams/%d/members", id), nil, nil)
+	if err != nil {
+		return members, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return members, err
+	}
+	if resp.StatusCode != 200 {
+		return members, fmt.Errorf(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return members, err
+	}
+	if err := json.Unmarshal(data, &members); err != nil {
+		return members, err
+	}
+	return members, nil
+}
+
+func (c *Client) AddTeamMember(id int64, userId int64) error {
+	path := fmt.Sprintf("/api/teams/%d/members", id)
+	member := TeamMember{UserId: userId}
+	data, err := json.Marshal(member)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest("POST", path, nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}
+
+func (c *Client) RemoveMemberFromTeam(id int64, userId int64) error {
+	path := fmt.Sprintf("/api/teams/%d/members/%d", id, userId)
+
+	req, err := c.newRequest("DELETE", path, nil, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}
+
+func (c *Client) TeamPreferences(id int64) (*Preferences, error) {
+	var preferences Preferences
+
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/teams/%d/preferences", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &preferences); err != nil {
+		return nil, err
+	}
+	return &preferences, nil
+}
+
+func (c *Client) UpdateTeamPreferences(id int64, theme string, homeDashboardId int64, timezone string) error {
+	path := fmt.Sprintf("/api/teams/%d", id)
+	preferences := Preferences{
+		Theme:           theme,
+		HomeDashboardId: homeDashboardId,
+		Timezone:        timezone,
+	}
+	data, err := json.Marshal(preferences)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -198,7 +198,7 @@ github.com/mitchellh/hashstructure
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
-# github.com/nytm/go-grafana-api v0.3.1
+# github.com/nytm/go-grafana-api v0.5.0
 ## explicit
 github.com/nytm/go-grafana-api
 # github.com/oklog/run v1.0.0


### PR DESCRIPTION
README updates:

* Removes parts related to `GOPATH`. These aren't really relevant anymore since Go modules is used.
* Additional links - Grafana website, Grafana Slack, provider docs.
* H2 sections consolidated into "Development".
* Reduce Terraform logo size, align on top right (borrowed from the [aws provider readme](https://github.com/terraform-providers/terraform-provider-aws/blob/818942acfd59940af2295587cca2b81a6aa4e895/README.md)).

It'd be great to also document the release process, however, I'm not yet familiar with it. I'm hoping we can document this during the [1.6.0](https://github.com/terraform-providers/terraform-provider-grafana/issues/106) release.

The `test` Make target is simplified. Per the commit message:
> No need to call 'go test' with -i first. The -i flag installs packages
> that are dependencies of the test, but does not run the tests. This
> isn't useful since dependencies are vendored.
> 
> This will also fail if the user executing the command does not have
> write permission on the Go installation.

Sync dependencies with `go mod vendor`. `go test` on master fails with:

```
▸ go test ./...
go: inconsistent vendoring in /Users/trott/code/github.com/terraform-providers/terraform-provider-grafana:
        github.com/nytm/go-grafana-api@v0.5.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/nytm/go-grafana-api@v0.3.1: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
```