### PR TITLE
Settings is an argument not a block

### DIFF
--- a/website/docs/r/alert_notification.html.md
+++ b/website/docs/r/alert_notification.html.md
@@ -20,7 +20,7 @@ resource "grafana_alert_notification" "email_someteam" {
   send_reminder = true
   frequency = "24h"
 
-  settings {
+  settings = {
     addresses = "foo@example.net;bar@example.net"
     uploadImage = "false"
   }


### PR DESCRIPTION
Copying the example in the readme, fails with error

```
Error: Unsupported block type
```