### PR TITLE
Change user lists to sets

### DIFF
--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -206,7 +206,7 @@ func collectUsers(d *schema.ResourceData) (map[string]OrgUser, map[string]OrgUse
 		roleName := strings.Title(role[:len(role)-1])
 		// Get the lists of users read in from Grafana state (old) and configured (new)
 		state, config := d.GetChange(role)
-		for _, u := range state.([]interface{}) {
+		for _, u := range state.(*schema.Set).List() {
 			email := u.(string)
 			// Sanity check that a user isn't specified twice within an organization
 			if _, ok := stateUsers[email]; ok {
@@ -214,7 +214,7 @@ func collectUsers(d *schema.ResourceData) (map[string]OrgUser, map[string]OrgUse
 			}
 			stateUsers[email] = OrgUser{0, email, roleName}
 		}
-		for _, u := range config.([]interface{}) {
+		for _, u := range config.(*schema.Set).List() {
 			email := u.(string)
 			// Sanity check that a user isn't specified twice within an organization
 			if _, ok := configUsers[email]; ok {

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -62,21 +62,21 @@ func ResourceOrganization() *schema.Resource {
 				Computed: true,
 			},
 			"admins": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"editors": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"viewers": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/grafana/resource_organization_test.go
+++ b/grafana/resource_organization_test.go
@@ -62,9 +62,6 @@ func TestAccOrganization_users(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "admins.#", "1",
 					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "admins.0", "john.doe@example.com",
-					),
 					resource.TestCheckNoResourceAttr(
 						"grafana_organization.test", "editors.#",
 					),
@@ -85,9 +82,6 @@ func TestAccOrganization_users(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "editors.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "editors.0", "john.doe@example.com",
 					),
 					resource.TestCheckNoResourceAttr(
 						"grafana_organization.test", "viewers.#",
@@ -137,9 +131,6 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "admins.#", "1",
 					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "admins.0", "john.doe@example.com",
-					),
 					resource.TestCheckNoResourceAttr(
 						"grafana_organization.test", "editors.#",
 					),
@@ -160,12 +151,6 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "admins.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "admins.0", "admin@localhost",
-					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "admins.1", "john.doe@example.com",
 					),
 					resource.TestCheckNoResourceAttr(
 						"grafana_organization.test", "editors.#",

--- a/website/docs/r/organization.html.md
+++ b/website/docs/r/organization.html.md
@@ -76,12 +76,6 @@ The following arguments are supported:
 A user can only be listed under one role-group for an organization, listing the
 same user under multiple roles will cause an error to be thrown.
 
-Note - Users specified for each role-group (`admins`, `editors`, `viewers`)
-should be listed in ascending alphabetical order (A-Z). By defining users in
-alphabetical order, Terraform is prevented from detecting unnecessary changes
-when comparing the list of defined users in the resource to the (ordered) list
-returned by the Grafana API.
-
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Users as lists may not be reported back from grafana in the same order - resulting in continually reported resource changes.

Treating the users as sets instead deals with this nicely.
