### PR TITLE
Add support for providing additional HTTP headers

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -1,6 +1,9 @@
 package grafana
 
 import (
+	"encoding/json"
+	"os"
+
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -24,6 +27,14 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
 				Description: "Credentials for accessing the Grafana API.",
 			},
+			"headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Sensitive:   true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Optional. HTTP headers mapping keys to values used for accessing the Grafana API.",
+				DefaultFunc: EnvDefaultJsonFunc("GRAFANA_HTTP_HEADERS", nil),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -39,9 +50,28 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	headersObj := d.Get("headers").(map[string]interface{})
+	if headersObj != nil && len(headersObj) == 0 {
+		// Workaround for a bug when DefaultFunc returns a TypeMap
+		headersObjAbs, _ := EnvDefaultJsonFunc("GRAFANA_HTTP_HEADERS", nil)()
+		headersObj = headersObjAbs.(map[string]interface{})
+	}
+
+	// Convert headers from map[string]interface{} to map[string]string
+	headers := make(map[string]string)
+	if headersObj != nil {
+		for k, v := range headersObj {
+			switch v := v.(type) {
+			case string:
+				headers[k] = v
+			}
+		}
+	}
+
 	client, err := gapi.New(
 		d.Get("auth").(string),
 		d.Get("url").(string),
+		headers,
 	)
 	if err != nil {
 		return nil, err
@@ -50,4 +80,21 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	client.Transport = logging.NewTransport("Grafana", client.Transport)
 
 	return client, nil
+}
+
+// EnvDefaultJsonFunc is a helper function that parses the given environment
+// variable as a JSON object, or returns the default value otherwise.
+func EnvDefaultJsonFunc(k string, dv interface{}) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if valStr := os.Getenv(k); valStr != "" {
+			var valObj map[string]interface{}
+			err := json.Unmarshal([]byte(valStr), &valObj)
+			if err != nil {
+				return nil, err
+			}
+			return valObj, nil
+		}
+
+		return dv, nil
+	}
 }


### PR DESCRIPTION
Sometimes the Grafana server is behind a proxy or application firewall and it is necessary to provide additional HTTP headers to establish a connection, such as authentication tokens or cookies. In general sense these are represented as key-value pairs of strings. To also add support to provide these using an environment variable `GRAFANA_HTTP_HEADERS` it should contain a JSON-encoded values.

Usage:

```
provider "grafana" {
  url  = "http://172.17.0.1:3000"
  auth = "admin:admin"
  headers = {
    "Cookies" = "foo=bar"
  }
}
```

```bash
$ GRAFANA_HTTP_HEADERS='{"Cookies":"foo=bar"}' terraform plan
```

Depends on PR https://github.com/nytm/go-grafana-api/pull/63.