### PR TITLE
Targets/Docs for Releases and Changelog Generation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,3 +44,19 @@ test-compile:
 		exit 1; \
 	fi
 	go test -c $(TEST) $(TESTARGS)
+
+changelog:
+	@test $${RELEASE_VERSION?Please set environment variable RELEASE_VERSION}
+	@test $${CHANGELOG_GITHUB_TOKEN?Please set environment variable CHANGELOG_GITHUB_TOKEN}
+	@docker run -it --rm \
+		-v $$PWD:/usr/local/src/your-app \
+		-e CHANGELOG_GITHUB_TOKEN=$$CHANGELOG_GITHUB_TOKEN \
+		ferrarimarco/github-changelog-generator \
+		--user grafana \
+		--project terraform-provider-grafana \
+		--future-release $$RELEASE_VERSION
+	@git add CHANGELOG.md && git commit -m "Release $$RELEASE_VERSION"
+
+release: changelog
+	@git tag $$RELEASE_VERSION
+	@git push origin $$RELEASE_VERSION

--- a/README.md
+++ b/README.md
@@ -44,3 +44,25 @@ make testacc
 This codebase leverages
 [grafana/grafana-api-golang-client](https://github.com/grafana/grafana-api-golang-client) as its Grafana API
 client. All resources and data sources should leverage this.
+
+## Releasing
+
+Builds and releases are automated with GitHub Actions and
+[GoReleaser](https://github.com/goreleaser/goreleaser/). The changelog is
+managed with
+[github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
+
+Create a new release with the `release` Make target:
+
+```
+RELEASE_VERSION=v... \
+CHANGELOG_GITHUB_TOKEN=... \
+make release
+```
+
+Once the command exits, you can monitor the rest of the process on the [Actions
+UI](https://github.com/grafana/terraform-provider-grafana/actions?query=workflow%3Arelease).
+
+The Action creates the release, but leaves it in "draft" state. Open it up in a
+[browser](https://github.com/grafana/terraform-provider-grafana/releases) and if
+all looks well, mash the publish button.


### PR DESCRIPTION
Adds `changelog` and `release` targets to remove some manual steps in the release process.

The changelog is generated with [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator). This [gist](https://gist.github.com/trotttrotttrott/2b0eab82225f47bd71189ba03fe3c9fc) is a preview of the output. The generation and committing of the changelog should likely move to CI as a followup.