### PR TITLE
Add support for providing additional HTTP headers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ provider "grafana" {
 - **ca_cert** (String) Certificate CA bundle to use to verify the Grafana server's certificate. May alternatively be set via the `GRAFANA_CA_CERT` environment variable.
 - **cloud_api_key** (String, Sensitive) API key for Grafana Cloud. May alternatively be set via the `GRAFANA_CLOUD_API_KEY` environment variable.
 - **cloud_api_url** (String) Grafana Cloud's API URL. May alternatively be set via the `GRAFANA_CLOUD_API_URL` environment variable.
+- **http_headers** (Map of String, Sensitive) Optional. HTTP headers mapping keys to values used for accessing the Grafana API. May alternatively be set via the `GRAFANA_HTTP_HEADERS` environment variable in JSON format.
 - **insecure_skip_verify** (Boolean) Skip TLS certificate verification. May alternatively be set via the `GRAFANA_INSECURE_SKIP_VERIFY` environment variable.
 - **org_id** (Number) The organization id to operate on within grafana. May alternatively be set via the `GRAFANA_ORG_ID` environment variable.
 - **retries** (Number) The amount of retries to use for Grafana API calls. May alternatively be set via the `GRAFANA_RETRIES` environment variable.


### PR DESCRIPTION
Sometimes the Grafana server is behind a proxy or application firewall and it is necessary to provide additional HTTP headers to establish a connection, such as authentication tokens or cookies. In general sense these are represented as key-value pairs of strings. To also add support to provide these using an environment variable `GRAFANA_HTTP_HEADERS`, this PR assumes it contains a JSON-encoded map.

Usage:

```
provider "grafana" {
  url  = "http://172.17.0.1:3000"
  auth = "admin:admin"
  headers = {
    "Cookies" = "foo=bar"
  }
}
```

```bash
$ GRAFANA_HTTP_HEADERS='{"Cookies":"foo=bar"}' terraform plan
```

This PR is based on https://github.com/grafana/terraform-provider-grafana/pull/119 and depends on PR https://github.com/grafana/grafana-api-golang-client/pull/16.