### PR TITLE
Do not delete dashboard uid fields

### DIFF
--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -135,8 +135,6 @@ func prepareDashboardModel(configJSON string) map[string]interface{} {
 	}
 
 	delete(configMap, "id")
-	// Only exists in 5.0+
-	delete(configMap, "uid")
 	configMap["version"] = 0
 
 	return configMap
@@ -166,8 +164,6 @@ func NormalizeDashboardConfigJSON(configI interface{}) string {
 	// significant when included in the JSON.
 	delete(configMap, "id")
 	delete(configMap, "version")
-	// Only exists in 5.0+
-	delete(configMap, "uid")
 
 	ret, err := json.Marshal(configMap)
 	if err != nil {

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -176,7 +176,8 @@ resource "grafana_dashboard" "test" {
 {
     "title": "Terraform Acceptance Test",
     "id": 12,
-    "version": "43"
+    "version": "43",
+    "uid": "someuid"
 }
 EOT
 }
@@ -188,7 +189,8 @@ const testAccDashboardConfig_update = `
 resource "grafana_dashboard" "test" {
 	config_json = <<EOT
 {
-	"title": "Updated Title"
+	"title": "Updated Title",
+	"uid": "someuid"
 }
 EOT
 }
@@ -206,7 +208,8 @@ resource "grafana_dashboard" "test_folder" {
 {
     "title": "Terraform Folder Test Dashboard",
     "id": 12,
-    "version": "43"
+    "version": "43",
+    "uid": "someuid"
 }
 EOT
 }
@@ -216,7 +219,8 @@ const testAccDashboardConfig_disappear = `
 resource "grafana_dashboard" "test" {
     config_json = <<EOT
 {
-    "title": "Terraform Disappear Test"
+    "title": "Terraform Disappear Test",
+    "uid": "someuid"
 }
 EOT
 }

--- a/grafana/resource_team_preferences_test.go
+++ b/grafana/resource_team_preferences_test.go
@@ -49,7 +49,8 @@ resource "grafana_dashboard" "test" {
 {
   "title": "Terraform Team Preferences Acceptance Test",
   "id": 13,
-  "version": "43"
+  "version": "43",
+  "uid": "someuid"
 }
 EOT
 }
@@ -71,7 +72,8 @@ resource "grafana_dashboard" "test" {
 {
   "title": "Terraform Team Preferences Acceptance Test",
   "id": 13,
-  "version": "43"
+  "version": "43",
+  "uid": "someuid"
 }
 EOT
 }


### PR DESCRIPTION
The purpose of the `uid` field is to allow migrating dashboards between Grafana instances and provisioning Grafana from configuration without breaking references. From my understanding this field is not instance-specific (such as `id`), therefore it should be preserved.

- https://grafana.com/docs/grafana/latest/administration/provisioning/#reusable-dashboard-urls