### PR TITLE
r/grafana_alert_notification Add disable_resolve_message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM golang:1.14
-
-ENV GOFLAGS=-mod=readonly
-
-WORKDIR /go/src/github.com/terraform-providers/terraform-provider-grafana
-
-COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.14
+
+ENV GOFLAGS=-mod=readonly
+
+WORKDIR /go/src/github.com/terraform-providers/terraform-provider-grafana
+
+COPY . .

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,10 +4,18 @@ WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=grafana
 GRAFANA_VERSION ?= "latest"
 
+DOCKER_COMPOSE_DEVELOP=GRAFANA_VERSION=$(GRAFANA_VERSION) docker-compose -f ./docker-compose.yml -f ./docker-compose.develop.yml
+
 default: build
 
 build: fmtcheck
 	go install
+
+develop-docker:
+	@$(DOCKER_COMPOSE_DEVELOP) run --rm grafana-provider bash; $(DOCKER_COMPOSE_DEVELOP) down -v
+
+testacc-docker:
+	@$(DOCKER_COMPOSE_DEVELOP) run --rm grafana-provider make testacc; $(DOCKER_COMPOSE_DEVELOP) down -v
 
 test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=30s -parallel=4

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ make test
 Run [acceptance tests](https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html):
 
 ```sh
+You could run the acceptance tests inside docker or outside of docker
+
+make testacc-docker.
+
+Alternatively,
+
 # In one terminal, run a Grafana container.
 # You may optionally override the image tag...
 # GRAFANA_VERSION=7.3.4 \

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  grafana-provider:
+    command: bash
+    volumes:
+      - .:/go/src/github.com/terraform-providers/terraform-provider-grafana

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -3,5 +3,6 @@ version: '3.8'
 services:
   grafana-provider:
     command: bash
+    working_dir: /go/src/github.com/terraform-providers/terraform-provider-grafana
     volumes:
       - .:/go/src/github.com/terraform-providers/terraform-provider-grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,12 @@ version: '3.8'
 
 services:
   grafana-provider:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    image: terraform-provider-grafana
+    image: golang:1.14
     environment:
       - GRAFANA_URL=http://grafana:3000
       - GRAFANA_AUTH=admin:admin
       - GRAFANA_ORG_ID=1
+      - GOFLAGS=-mod=vendor
     depends_on:
     - grafana
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  grafana-provider:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    image: terraform-provider-grafana
+    environment:
+      - GRAFANA_URL=http://grafana:3000
+      - GRAFANA_AUTH=admin:admin
+      - GRAFANA_ORG_ID=1
+    depends_on:
+    - grafana
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION}
+

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -62,6 +62,12 @@ func ResourceAlertNotification() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"disable_resolve_message": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -132,6 +138,9 @@ func ReadAlertNotification(d *schema.ResourceData, meta interface{}) error {
 	d.Set("type", alertNotification.Type)
 	d.Set("settings", settings)
 	d.Set("uid", alertNotification.UID)
+	d.Set("disable_resolve_message", alertNotification.DisableResolveMessage)
+	d.Set("send_reminder", alertNotification.SendReminder)
+	d.Set("frequency", alertNotification.Frequency)
 
 	return nil
 }

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -191,13 +191,14 @@ func makeAlertNotification(d *schema.ResourceData) (*gapi.AlertNotification, err
 	}
 
 	return &gapi.AlertNotification{
-		ID:           id,
-		Name:         d.Get("name").(string),
-		Type:         d.Get("type").(string),
-		IsDefault:    d.Get("is_default").(bool),
-		UID:          d.Get("uid").(string),
-		SendReminder: sendReminder,
-		Frequency:    frequency,
-		Settings:     settings,
+		ID:                    id,
+		Name:                  d.Get("name").(string),
+		Type:                  d.Get("type").(string),
+		IsDefault:             d.Get("is_default").(bool),
+		DisableResolveMessage: d.Get("disable_resolve_message").(bool),
+		UID:                   d.Get("uid").(string),
+		SendReminder:          sendReminder,
+		Frequency:             frequency,
+		Settings:              settings,
 	}, err
 }

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -38,6 +38,46 @@ func TestAccAlertNotification_basic(t *testing.T) {
 						"grafana_alert_notification.test", "frequency", "12h",
 					),
 					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "disable_resolve_message", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "settings.addresses", "foo@bar.test",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
+	var alertNotification gapi.AlertNotification
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAlertNotificationCheckDestroy(&alertNotification),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertNotificationConfig_disable_resolve_message,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlertNotificationCheckExists("grafana_alert_notification.test", &alertNotification),
+					testAccAlertNotificationDefinition(&alertNotification),
+					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "type", "email",
+					),
+					resource.TestMatchResourceAttr(
+						"grafana_alert_notification.test", "id", regexp.MustCompile(`\d+`),
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "send_reminder", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "frequency", "12h",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_alert_notification.test", "disable_resolve_message", "true",
+					),
+					resource.TestCheckResourceAttr(
 						"grafana_alert_notification.test", "settings.addresses", "foo@bar.test",
 					),
 				),
@@ -133,6 +173,21 @@ resource "grafana_alert_notification" "test" {
     name = "terraform-acc-test"
 		send_reminder = true
 		frequency = "12h"
+    settings = {
+			"addresses" = "foo@bar.test"
+			"uploadImage" = "false"
+			"autoResolve" = "true"
+		}
+}
+`
+
+const testAccAlertNotificationConfig_disable_resolve_message = `
+resource "grafana_alert_notification" "test" {
+    type = "email"
+    name = "terraform-acc-test"
+		send_reminder = true
+		frequency = "12h"
+		disable_resolve_message = true
     settings = {
 			"addresses" = "foo@bar.test"
 			"uploadImage" = "false"

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -38,7 +38,7 @@ func TestAccAlertNotification_basic(t *testing.T) {
 						"grafana_alert_notification.test", "frequency", "12h",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_alert_notification.test", "disable_resolve_message", "true",
+						"grafana_alert_notification.test", "disable_resolve_message", "false",
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_alert_notification.test", "settings.addresses", "foo@bar.test",

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -95,7 +95,7 @@ func TestAccAlertNotification_invalid_frequence(t *testing.T) {
 		CheckDestroy: testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
 			{
-				ExpectError: regexp.MustCompile("invalid duration \"hi\""),
+				ExpectError: regexp.MustCompile("time: invalid duration hi"),
 				Config:      testAccAlertNotificationConfig_invalid_frequency,
 			},
 		},

--- a/website/docs/r/alert_notification.html.md
+++ b/website/docs/r/alert_notification.html.md
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `is_default` - (Optional) Is this the default channel for all your alerts.
 * `send_reminder` - (Optional) Whether to send reminders for triggered alerts.
 * `frequency` - (Optional) Frequency of alert reminders. Frequency must be set if reminders are enabled.
+* `disable_resolve_message` - (Optional) Whether to disable sending resolve messages.
 * `settings` - (Optional) Additional settings, for full reference lookup [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).
 
 **Note:** In `settings` the strings `"true"` and `"false"` are mapped to boolean `true` and `false` when sent to Grafana.


### PR DESCRIPTION
closes #62 

```bash
root@8321e8aa53b6:/go/src/github.com/terraform-providers/terraform-provider-grafana# make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-grafana	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAlertNotification_basic
--- PASS: TestAccAlertNotification_basic (0.27s)
=== RUN   TestAccAlertNotification_disableResolveMessage
--- PASS: TestAccAlertNotification_disableResolveMessage (0.40s)
=== RUN   TestAccAlertNotification_invalid_frequence
--- PASS: TestAccAlertNotification_invalid_frequence (0.07s)
=== RUN   TestAccAlertNotification_reminder_no_frequence
--- PASS: TestAccAlertNotification_reminder_no_frequence (0.07s)
=== RUN   TestAccDashboard_basic
--- PASS: TestAccDashboard_basic (0.51s)
=== RUN   TestAccDashboard_folder
--- PASS: TestAccDashboard_folder (0.47s)
=== RUN   TestAccDashboard_disappear
--- PASS: TestAccDashboard_disappear (0.24s)
=== RUN   TestAccDataSource_basic
--- PASS: TestAccDataSource_basic (2.88s)
=== RUN   TestAccFolderPermission_basic
--- PASS: TestAccFolderPermission_basic (0.98s)
=== RUN   TestAccFolder_basic
--- PASS: TestAccFolder_basic (0.28s)
=== RUN   TestAccOrganization_basic
--- PASS: TestAccOrganization_basic (0.61s)
=== RUN   TestAccOrganization_users
--- PASS: TestAccOrganization_users (0.97s)
=== RUN   TestAccOrganization_defaultAdmin
--- PASS: TestAccOrganization_defaultAdmin (0.63s)
=== RUN   TestAccTeamPreferences_basic
--- PASS: TestAccTeamPreferences_basic (0.82s)
=== RUN   TestAccTeam_basic
--- PASS: TestAccTeam_basic (0.61s)
=== RUN   TestAccTeam_Members
--- PASS: TestAccTeam_Members (0.61s)
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (0.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-grafana/grafana	(cached)
```