### PR TITLE
Updated dead link in documentation - data_sources

### DIFF
--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -17,7 +17,7 @@ source selected (via the `type` argument). The following examples are for
 InfluxDB, CloudWatch, and Google Stackdriver. See [Grafana's Data Sources Guides][datasources] for more details on
 the supported data source types and the arguments they use.
 
-[datasources]: https://grafana.com/docs/grafana/latest/features/datasources/
+[datasources]: https://grafana.com/docs/grafana/latest/datasources/#data-sources
 
 For an InfluxDB datasource:
 


### PR DESCRIPTION
The link referring to grafana's datasource docs in the terraform docs is dead and needs to be replaced.