### PR TITLE
Delete UID in NormalizeDashboardConfigJSON

### DIFF
--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -164,6 +164,7 @@ func NormalizeDashboardConfigJSON(configI interface{}) string {
 	// significant when included in the JSON.
 	delete(configMap, "id")
 	delete(configMap, "version")
+	delete(configMap, "uid")
 
 	ret, err := json.Marshal(configMap)
 	if err != nil {


### PR DESCRIPTION
This partially rolls back https://github.com/grafana/terraform-provider-grafana/pull/136.

If `uid` is not set, Grafana generates a random value. The provider will want to remove the generated value on every execution plan. Removing it here eliminates this problem.

Fixes https://github.com/grafana/terraform-provider-grafana/issues/151.
Fixes https://github.com/grafana/terraform-provider-grafana/issues/152.