### PR TITLE
Add full Stackdriver data source support

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -62,11 +62,23 @@ func ResourceDataSource() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"authentication_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"client_email": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"conn_max_lifetime": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 						"custom_metrics_namespaces": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"default_project": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -144,6 +156,10 @@ func ResourceDataSource() *schema.Resource {
 						},
 						"tls_skip_verify": {
 							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"token_uri": {
+							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"tsdb_resolution": {
@@ -343,8 +359,11 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 	return gapi.JSONData{
 		AssumeRoleArn:           d.Get("json_data.0.assume_role_arn").(string),
 		AuthType:                d.Get("json_data.0.auth_type").(string),
+		AuthenticationType:      d.Get("json_data.0.authentication_type").(string),
+		ClientEmail:             d.Get("json_data.0.client_email").(string),
 		ConnMaxLifetime:         int64(d.Get("json_data.0.conn_max_lifetime").(int)),
 		CustomMetricsNamespaces: d.Get("json_data.0.custom_metrics_namespaces").(string),
+		DefaultProject:          d.Get("json_data.0.default_project").(string),
 		DefaultRegion:           d.Get("json_data.0.default_region").(string),
 		Encrypt:                 d.Get("json_data.0.encrypt").(string),
 		EsVersion:               int64(d.Get("json_data.0.es_version").(int)),
@@ -364,6 +383,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		TLSAuth:                 d.Get("json_data.0.tls_auth").(bool),
 		TLSAuthWithCACert:       d.Get("json_data.0.tls_auth_with_ca_cert").(bool),
 		TLSSkipVerify:           d.Get("json_data.0.tls_skip_verify").(bool),
+		TokenURI:                d.Get("json_data.0.token_uri").(string),
 		TsdbResolution:          d.Get("json_data.0.tsdb_resolution").(string),
 		TsdbVersion:             d.Get("json_data.0.tsdb_version").(string),
 	}

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -263,15 +263,25 @@ resource "grafana_data_source" "testdata" {
 		resource "grafana_data_source" "stackdriver" {
 			type = "stackdriver"
 			name = "stackdriver"
+			json_data {
+				token_uri = "https://oauth2.googleapis.com/token"
+				authentication_type = "jwt"
+				default_project = "default-project"
+				client_email = "client-email@default-project.iam.gserviceaccount.com"
+			}			
 			secure_json_data {
 				private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
 			}
 		}
 		`,
 		map[string]string{
-			"type":                           "stackdriver",
-			"name":                           "stackdriver",
-			"secure_json_data.0.private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+			"type":                            "stackdriver",
+			"name":                            "stackdriver",
+			"json_data.0.token_uri":           "https://oauth2.googleapis.com/token",
+			"json_data.0.authentication_type": "jwt",
+			"json_data.0.default_project":     "default-project",
+			"json_data.0.client_email":        "client-email@default-project.iam.gserviceaccount.com",
+			"secure_json_data.0.private_key":  "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
 		},
 	},
 }

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -58,6 +58,13 @@ resource "grafana_data_source" "test_stackdriver" {
   type = "stackdriver"
   name = "sd-example"
 
+  json_data {
+    token_uri = "https://oauth2.googleapis.com/token"
+    authentication_type = "jwt"
+    default_project = "default-project"
+    client_email = "client-email@default-project.iam.gserviceaccount.com"
+  }
+
   secure_json_data {
     private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
   }
@@ -121,8 +128,12 @@ fields to operate properly.
 * `assume_role_arn` - (CloudWatch) The ARN of the role to be assumed by Grafana
   when using the CloudWatch data source.
 
-* `auth_type` - (CloudWatch) The authentication type type used to access the
+* `auth_type` - (CloudWatch) The authentication type used to access the
   data source.
+
+* `authentication_type` - (Stackdriver) The authentication type. 'jwt' or 'gce'
+
+* `client_email` - (Stackdriver) Email address associated with [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
 
 * `conn_max_lifetime` - (MySQL, PostgreSQL, and MSSQL) Maximum amount of time in
   seconds a connection may be reused (Grafana v5.4+).
@@ -130,6 +141,8 @@ fields to operate properly.
 * `custom_metrics_namespaces` - (CloudWatch)
   A comma-separated list of custom namespaces to be queried by the CloudWatch
   data source.
+
+* `default_project` - (Stackdriver) The default project for the data source.
 
 * `default_region` - (CloudWatch) The default region for the data source.
 
@@ -180,6 +193,8 @@ fields to operate properly.
 
 * `tls_skip_verify` - (All) Controls whether a client verifies the server’s
   certificate chain and host name.
+
+* `token_uri` - (Stackdriver) The token URI used, provided in the [service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
 
 * `tsdb_resolution` - (OpenTSDB) Resolution.
 


### PR DESCRIPTION
## What
Adds 4 new fields to JsonData in the data source management.

## Why
Closes issue #105 . As the issue states, the Cloud Monitoring/Stackdriver data source needs more fields in the jsonData portion in order to be configured and work.

Grafana Documentation:
https://grafana.com/docs/grafana/latest/datasources/cloudmonitoring/#configure-the-data-source-with-provisioning

## Verification
`make test` succeeds. I also compiled using `make build`, and used the new binary to create a new Stackdriver data source successfully in a local Grafana instance.