### PR TITLE
is_admin added to grafana_user.

### DIFF
--- a/grafana/resource_user.go
+++ b/grafana/resource_user.go
@@ -37,6 +37,11 @@ func ResourceUser() *schema.Resource {
 				Required:  true,
 				Sensitive: true,
 			},
+			"is_admin": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -52,6 +57,12 @@ func CreateUser(d *schema.ResourceData, meta interface{}) error {
 	id, err := client.CreateUser(user)
 	if err != nil {
 		return err
+	}
+	if d.HasChange("is_admin") {
+		err = client.UpdateUserPermissions(id, d.Get("is_admin").(bool))
+		if err != nil {
+			return err
+		}
 	}
 	d.SetId(strconv.FormatInt(id, 10))
 	return ReadUser(d, meta)
@@ -70,6 +81,7 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 	d.Set("email", user.Email)
 	d.Set("name", user.Name)
 	d.Set("login", user.Login)
+	d.Set("is_admin", user.IsAdmin)
 	return nil
 }
 
@@ -91,6 +103,12 @@ func UpdateUser(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("password") {
 		err = client.UpdateUserPassword(id, d.Get("password").(string))
+		if err != nil {
+			return err
+		}
+	}
+	if d.HasChange("is_admin") {
+		err = client.UpdateUserPermissions(id, d.Get("is_admin").(bool))
 		if err != nil {
 			return err
 		}

--- a/grafana/resource_user_test.go
+++ b/grafana/resource_user_test.go
@@ -56,6 +56,9 @@ func TestAccUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"grafana_user.test", "password", "zyx987",
 					),
+					resource.TestCheckResourceAttr(
+						"grafana_user.test", "is_admin", "true",
+					),
 				),
 			},
 		},
@@ -103,6 +106,7 @@ resource "grafana_user" "test" {
   name     = "Terraform Test"
   login    = "tt"
   password = "abc123"
+  is_admin = false
 }
 `
 
@@ -112,5 +116,6 @@ resource "grafana_user" "test" {
   name     = "Terraform Test Update"
   login    = "ttu"
   password = "zyx987"
+  is_admin = true
 }
 `

--- a/website/docs/r/user.html.md
+++ b/website/docs/r/user.html.md
@@ -22,6 +22,7 @@ resource "grafana_user" "staff" {
   name     = "Staff Name"
   login    = "staff"
   password = "my-password"
+  is_admin = false
 }
 ```
 
@@ -33,6 +34,7 @@ The following arguments are supported:
 * `name` - (Optional) The display name for the Grafana user.
 * `login` - (Optional) The username for the Grafana user.
 * `password` - (Optional) The password for the Grafana user.
+* `is_admin` - (Optional, default if `false`) The admin privileges for the Grafana user.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What
Added 1 new field (is_admin) to grafana_user to create grafana admin user.

### Why ?
Create admin user in the default organization.

### Verification
* `make testacc` passed.
* Tests in Grafana 7.3.6.