### PR TITLE
Adding profile field to JSON Data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-grafana
 go 1.14
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.0.0-20201222152747-e702fc8a9e99
+	github.com/grafana/grafana-api-golang-client v0.0.0-20210204123314-0aa501c4b8c4
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform v0.12.2

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grafana/grafana-api-golang-client v0.0.0-20201222152747-e702fc8a9e99 h1:c5NN7gvu2JGGd953dd37NVBG3Dmjx/C1IJp+Mpb0vF8=
 github.com/grafana/grafana-api-golang-client v0.0.0-20201222152747-e702fc8a9e99/go.mod h1:jFjwT3lvwl4JKqCw3guRJvlQ1/fmhER1h3Zgix3z7jw=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210204123314-0aa501c4b8c4 h1:nGHRqyz4r/wCtmT56QpeqPhL1GUGGjTU5T8F5Ux/pEc=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210204123314-0aa501c4b8c4/go.mod h1:jFjwT3lvwl4JKqCw3guRJvlQ1/fmhER1h3Zgix3z7jw=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,6 @@ github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01 h1:OgCNGSnEalfkR
 github.com/gophercloud/utils v0.0.0-20190128072930-fbb6ab446f01/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.0.0-20201222152747-e702fc8a9e99 h1:c5NN7gvu2JGGd953dd37NVBG3Dmjx/C1IJp+Mpb0vF8=
-github.com/grafana/grafana-api-golang-client v0.0.0-20201222152747-e702fc8a9e99/go.mod h1:jFjwT3lvwl4JKqCw3guRJvlQ1/fmhER1h3Zgix3z7jw=
 github.com/grafana/grafana-api-golang-client v0.0.0-20210204123314-0aa501c4b8c4 h1:nGHRqyz4r/wCtmT56QpeqPhL1GUGGjTU5T8F5Ux/pEc=
 github.com/grafana/grafana-api-golang-client v0.0.0-20210204123314-0aa501c4b8c4/go.mod h1:jFjwT3lvwl4JKqCw3guRJvlQ1/fmhER1h3Zgix3z7jw=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -126,6 +126,10 @@ func ResourceDataSource() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"profile": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"query_timeout": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -375,6 +379,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		MaxIdleConns:            int64(d.Get("json_data.0.max_idle_conns").(int)),
 		MaxOpenConns:            int64(d.Get("json_data.0.max_open_conns").(int)),
 		PostgresVersion:         int64(d.Get("json_data.0.postgres_version").(int)),
+		Profile:                 d.Get("json_data.0.profile").(string),
 		QueryTimeout:            d.Get("json_data.0.query_timeout").(string),
 		Sslmode:                 d.Get("json_data.0.ssl_mode").(string),
 		Timescaledb:             d.Get("json_data.0.timescaledb").(bool),

--- a/vendor/github.com/grafana/grafana-api-golang-client/datasource.go
+++ b/vendor/github.com/grafana/grafana-api-golang-client/datasource.go
@@ -56,6 +56,7 @@ type JSONData struct {
 	AssumeRoleArn           string `json:"assumeRoleArn,omitempty"`
 	DefaultRegion           string `json:"defaultRegion,omitempty"`
 	CustomMetricsNamespaces string `json:"customMetricsNamespaces,omitempty"`
+	Profile                 string `json:"profile,omitempty"`
 
 	// Used by OpenTSDB
 	TsdbVersion    string `json:"tsdbVersion,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/googleapis/gax-go/v2 v2.0.3
 github.com/googleapis/gax-go/v2
-# github.com/grafana/grafana-api-golang-client v0.0.0-20201222152747-e702fc8a9e99
+# github.com/grafana/grafana-api-golang-client v0.0.0-20210204123314-0aa501c4b8c4
 ## explicit
 github.com/grafana/grafana-api-golang-client
 # github.com/hashicorp/errwrap v1.0.0

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -173,6 +173,9 @@ fields to operate properly.
 * `postgres_version` - (PostgreSQL) Postgres version as a number
   (903/904/905/906/1000) meaning v9.3, v9.4, …, v10.
 
+* `profile` - (CloudWatch) The credentials profile name to use when authentication
+  type is set as 'Credentials file'.
+
 * `query_timeout` - (Prometheus) Timeout for queries made to the Prometheus
   data source in seconds.
 


### PR DESCRIPTION
## What

Adds "profile" field to JsonData in the data source management for CloudWatch.

## Why

In the latest version of Grafana, AWS CloudWatch datasources can be defined with "_Authentication Provider = Credentials file_" which stores the access and secret keys while it is possible to provide "_Credentials profile name_" to specify the name of the profile to use in _~/.aws/credentials_ file.

This pull-request adds support to set the profile name while creating CloudWatch datasources and depends on PR grafana/grafana-api-golang-client#22.

Fixes and closes #154. 