### PR TITLE
Allow dependabot to check github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
This change allows dependabot to check any GitHub actions which this project uses and submit pull requests with version bumps in order to keep packages up-to-date.