### PR TITLE
renames the `terraform-providers` module organization to `grafana`

### DIFF
--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -3,6 +3,6 @@ version: '3.8'
 services:
   grafana-provider:
     command: bash
-    working_dir: /go/src/github.com/terraform-providers/terraform-provider-grafana
+    working_dir: /go/src/github.com/grafana/terraform-provider-grafana
     volumes:
-      - .:/go/src/github.com/terraform-providers/terraform-provider-grafana
+      - .:/go/src/github.com/grafana/terraform-provider-grafana

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-grafana
+module github.com/grafana/terraform-provider-grafana
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/grafana/terraform-provider-grafana/grafana"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-grafana/grafana"
 )
 
 func main() {


### PR DESCRIPTION
This repository has moved to a new organization. This change reflects the move in the `go.mod` file and `main.go` imports.