### PR TITLE
Remove string interpolation in docs

### DIFF
--- a/website/docs/r/dashboard.html.md
+++ b/website/docs/r/dashboard.html.md
@@ -14,7 +14,7 @@ The dashboard resource allows a dashboard to be created on a Grafana server.
 
 ```hcl
 resource "grafana_dashboard" "metrics" {
-  config_json = "${file("grafana-dashboard.json")}"
+  config_json = file("grafana-dashboard.json")
 }
 ```
 

--- a/website/docs/r/data_source.html.md
+++ b/website/docs/r/data_source.html.md
@@ -28,7 +28,7 @@ resource "grafana_data_source" "metrics" {
   url           = "http://influxdb.example.net:8086/"
   username      = "myapp"
   password      = "foobarbaz"
-  database_name = "${influxdb_database.metrics.name}"
+  database_name = influxdb_database.metrics.name
 }
 ```
 

--- a/website/docs/r/folder.html.md
+++ b/website/docs/r/folder.html.md
@@ -18,7 +18,7 @@ resource "grafana_folder" "collection" {
 }
 
 resource "grafana_dashboard" "dashboard_in_folder" {
-  folder = "${grafana_folder.collection.id}"
+  folder = grafana_folder.collection.id
   ...
 }
 ```


### PR DESCRIPTION
Following https://github.com/grafana/terraform-provider-grafana/pull/176

Small thing I noticed while checking out the docs
Since the plugin now requires 0.12, the string interpolation can be updated
Other plugins such as the AWS one have updated their docs that way too