### PR TITLE
Leverage SDK v2 context-aware schema functions and diagnostics

### DIFF
--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -99,8 +99,7 @@ func UpdateAlertNotification(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	err = client.UpdateAlertNotification(alertNotification)
-	if err != nil {
+	if err = client.UpdateAlertNotification(alertNotification); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -160,8 +159,7 @@ func DeleteAlertNotification(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("Invalid id: %#v", idStr)
 	}
 
-	err = client.DeleteAlertNotification(id)
-	if err != nil {
+	if err = client.DeleteAlertNotification(id); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -157,7 +157,7 @@ func DeleteAlertNotification(ctx context.Context, d *schema.ResourceData, meta i
 	idStr := d.Id()
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return diag.Errorf("Invalid id: %#v, error: %v", idStr, err)
+		return diag.Errorf("Invalid id: %#v", idStr)
 	}
 
 	err = client.DeleteAlertNotification(id)

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -1,13 +1,14 @@
 package grafana
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"log"
 	"strconv"
 	"time"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -17,10 +18,10 @@ var (
 
 func ResourceAlertNotification() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateAlertNotification,
-		Update: UpdateAlertNotification,
-		Delete: DeleteAlertNotification,
-		Read:   ReadAlertNotification,
+		CreateContext: CreateAlertNotification,
+		UpdateContext: UpdateAlertNotification,
+		DeleteContext: DeleteAlertNotification,
+		ReadContext:   ReadAlertNotification,
 
 		Schema: map[string]*schema.Schema{
 			"type": {
@@ -72,42 +73,47 @@ func ResourceAlertNotification() *schema.Resource {
 	}
 }
 
-func CreateAlertNotification(d *schema.ResourceData, meta interface{}) error {
+func CreateAlertNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
-	alertNotification, err := makeAlertNotification(d)
+	alertNotification, err := makeAlertNotification(ctx, d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	id, err := client.NewAlertNotification(alertNotification)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(id, 10))
 
-	return ReadAlertNotification(d, meta)
+	return ReadAlertNotification(ctx, d, meta)
 }
 
-func UpdateAlertNotification(d *schema.ResourceData, meta interface{}) error {
+func UpdateAlertNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
-	alertNotification, err := makeAlertNotification(d)
+	alertNotification, err := makeAlertNotification(ctx, d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return client.UpdateAlertNotification(alertNotification)
+	err = client.UpdateAlertNotification(alertNotification)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
-func ReadAlertNotification(d *schema.ResourceData, meta interface{}) error {
+func ReadAlertNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	idStr := d.Id()
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("Invalid id: %#v", idStr)
+		return diag.Errorf("Invalid id: %#v", idStr)
 	}
 
 	alertNotification, err := client.AlertNotification(id)
@@ -117,7 +123,7 @@ func ReadAlertNotification(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	settings := map[string]interface{}{}
@@ -145,19 +151,24 @@ func ReadAlertNotification(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func DeleteAlertNotification(d *schema.ResourceData, meta interface{}) error {
+func DeleteAlertNotification(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	idStr := d.Id()
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("Invalid id: %#v", idStr)
+		return diag.Errorf("Invalid id: %#v, error: %v", idStr, err)
 	}
 
-	return client.DeleteAlertNotification(id)
+	err = client.DeleteAlertNotification(id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
-func makeAlertNotification(d *schema.ResourceData) (*gapi.AlertNotification, error) {
+func makeAlertNotification(ctx context.Context, d *schema.ResourceData) (*gapi.AlertNotification, error) {
 	idStr := d.Id()
 	var id int64
 	var err error

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -1,11 +1,13 @@
 package grafana
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -13,10 +15,10 @@ import (
 
 func ResourceDashboard() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateDashboard,
-		Read:   ReadDashboard,
-		Update: UpdateDashboard,
-		Delete: DeleteDashboard,
+		CreateContext: CreateDashboard,
+		ReadContext:   ReadDashboard,
+		UpdateContext: UpdateDashboard,
+		DeleteContext: DeleteDashboard,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -48,7 +50,7 @@ func ResourceDashboard() *schema.Resource {
 	}
 }
 
-func CreateDashboard(d *schema.ResourceData, meta interface{}) error {
+func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	dashboard := gapi.Dashboard{}
@@ -59,15 +61,15 @@ func CreateDashboard(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := client.NewDashboard(dashboard)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(resp.Slug)
 
-	return ReadDashboard(d, meta)
+	return ReadDashboard(ctx, d, meta)
 }
 
-func ReadDashboard(d *schema.ResourceData, meta interface{}) error {
+func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	slug := d.Id()
@@ -80,12 +82,12 @@ func ReadDashboard(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
-		return err
+		return diag.FromErr(err)
 	}
 
 	configJSONBytes, err := json.Marshal(dashboard.Model)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	configJSON := NormalizeDashboardConfigJSON(string(configJSONBytes))
@@ -99,7 +101,7 @@ func ReadDashboard(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func UpdateDashboard(d *schema.ResourceData, meta interface{}) error {
+func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	dashboard := gapi.Dashboard{}
@@ -111,19 +113,24 @@ func UpdateDashboard(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := client.NewDashboard(dashboard)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(resp.Slug)
 
-	return ReadDashboard(d, meta)
+	return ReadDashboard(ctx, d, meta)
 }
 
-func DeleteDashboard(d *schema.ResourceData, meta interface{}) error {
+func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	slug := d.Id()
-	return client.DeleteDashboard(slug)
+	err := client.DeleteDashboard(slug)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
 func prepareDashboardModel(configJSON string) map[string]interface{} {

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -20,7 +20,7 @@ func ResourceDashboard() *schema.Resource {
 		UpdateContext: UpdateDashboard,
 		DeleteContext: DeleteDashboard,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthroughContext,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -20,7 +20,7 @@ func ResourceDashboard() *schema.Resource {
 		UpdateContext: UpdateDashboard,
 		DeleteContext: DeleteDashboard,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -125,8 +125,7 @@ func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 	client := meta.(*gapi.Client)
 
 	slug := d.Id()
-	err := client.DeleteDashboard(slug)
-	if err != nil {
+	if err := client.DeleteDashboard(slug); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -282,8 +282,7 @@ func UpdateDataSource(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.FromErr(err)
 	}
 
-	err = client.UpdateDataSource(dataSource)
-	if err != nil {
+	if err = client.UpdateDataSource(dataSource); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -336,8 +335,7 @@ func DeleteDataSource(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("Invalid id: %#v", idStr)
 	}
 
-	err = client.DeleteDataSource(id)
-	if err != nil {
+	if err = client.DeleteDataSource(id); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -1,10 +1,11 @@
 package grafana
 
 import (
-	"fmt"
+	"context"
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -12,10 +13,10 @@ import (
 
 func ResourceDataSource() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateDataSource,
-		Update: UpdateDataSource,
-		Delete: DeleteDataSource,
-		Read:   ReadDataSource,
+		CreateContext: CreateDataSource,
+		UpdateContext: UpdateDataSource,
+		DeleteContext: DeleteDataSource,
+		ReadContext:   ReadDataSource,
 
 		Schema: map[string]*schema.Schema{
 			"access_mode": {
@@ -254,44 +255,49 @@ func ResourceDataSource() *schema.Resource {
 }
 
 // CreateDataSource creates a Grafana datasource
-func CreateDataSource(d *schema.ResourceData, meta interface{}) error {
+func CreateDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	dataSource, err := makeDataSource(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	id, err := client.NewDataSource(dataSource)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(id, 10))
 
-	return ReadDataSource(d, meta)
+	return ReadDataSource(ctx, d, meta)
 }
 
 // UpdateDataSource updates a Grafana datasource
-func UpdateDataSource(d *schema.ResourceData, meta interface{}) error {
+func UpdateDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	dataSource, err := makeDataSource(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return client.UpdateDataSource(dataSource)
+	err = client.UpdateDataSource(dataSource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
 // ReadDataSource reads a Grafana datasource
-func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
+func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	idStr := d.Id()
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("Invalid id: %#v", idStr)
+		return diag.Errorf("Invalid id: %#v", idStr)
 	}
 
 	dataSource, err := client.DataSource(id)
@@ -301,7 +307,7 @@ func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(dataSource.ID, 10))
@@ -321,16 +327,21 @@ func ReadDataSource(d *schema.ResourceData, meta interface{}) error {
 }
 
 // DeleteDataSource deletes a Grafana datasource
-func DeleteDataSource(d *schema.ResourceData, meta interface{}) error {
+func DeleteDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
 	idStr := d.Id()
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("Invalid id: %#v", idStr)
+		return diag.Errorf("Invalid id: %#v", idStr)
 	}
 
-	return client.DeleteDataSource(id)
+	err = client.DeleteDataSource(id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
 func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {

--- a/grafana/resource_folder.go
+++ b/grafana/resource_folder.go
@@ -85,8 +85,7 @@ func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func DeleteFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 
-	err := client.DeleteFolder(d.Get("uid").(string))
-	if err != nil {
+	if err := client.DeleteFolder(d.Get("uid").(string)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_folder.go
+++ b/grafana/resource_folder.go
@@ -20,7 +20,7 @@ func ResourceFolder() *schema.Resource {
 		DeleteContext: DeleteFolder,
 		ReadContext:   ReadFolder,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthroughContext,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/grafana/resource_folder.go
+++ b/grafana/resource_folder.go
@@ -20,7 +20,7 @@ func ResourceFolder() *schema.Resource {
 		DeleteContext: DeleteFolder,
 		ReadContext:   ReadFolder,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -33,13 +35,13 @@ const (
 
 func ResourceOrganization() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateOrganization,
-		Read:   ReadOrganization,
-		Update: UpdateOrganization,
-		Delete: DeleteOrganization,
-		Exists: ExistsOrganization,
+		CreateContext: CreateOrganization,
+		ReadContext:   ReadOrganization,
+		UpdateContext: UpdateOrganization,
+		DeleteContext: DeleteOrganization,
+		Exists:        ExistsOrganization,
 		Importer: &schema.ResourceImporter{
-			State: ImportOrganization,
+			StateContext: ImportOrganization,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -86,21 +88,26 @@ func ResourceOrganization() *schema.Resource {
 	}
 }
 
-func CreateOrganization(d *schema.ResourceData, meta interface{}) error {
+func CreateOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	name := d.Get("name").(string)
 	orgId, err := client.NewOrg(name)
 	if err != nil && err.Error() == "409 Conflict" {
-		return errors.New(fmt.Sprintf("Error: A Grafana Organization with the name '%s' already exists.", name))
+		return diag.Errorf("Error: A Grafana Organization with the name '%s' already exists.", name)
 	}
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.SetId(strconv.FormatInt(orgId, 10))
-	return UpdateUsers(d, meta)
+	err = UpdateUsers(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
-func ReadOrganization(d *schema.ResourceData, meta interface{}) error {
+func ReadOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
 	resp, err := client.Org(orgId)
@@ -110,32 +117,42 @@ func ReadOrganization(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.Set("name", resp.Name)
 	if err := ReadUsers(d, meta); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	return nil
 }
 
-func UpdateOrganization(d *schema.ResourceData, meta interface{}) error {
+func UpdateOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
 	if d.HasChange("name") {
 		name := d.Get("name").(string)
 		err := client.UpdateOrg(orgId, name)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
-	return UpdateUsers(d, meta)
+	err := UpdateUsers(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
-func DeleteOrganization(d *schema.ResourceData, meta interface{}) error {
+func DeleteOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
-	return client.DeleteOrg(orgId)
+	err := client.DeleteOrg(orgId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
 func ExistsOrganization(d *schema.ResourceData, meta interface{}) (bool, error) {
@@ -151,15 +168,15 @@ func ExistsOrganization(d *schema.ResourceData, meta interface{}) (bool, error) 
 	return true, err
 }
 
-func ImportOrganization(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func ImportOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	exists, err := ExistsOrganization(d, meta)
 	if err != nil || !exists {
 		return nil, errors.New(fmt.Sprintf("Error: Unable to import Grafana Organization: %s.", err))
 	}
 	d.Set("admin_user", "admin")
 	d.Set("create_users", "true")
-	err = ReadOrganization(d, meta)
-	if err != nil {
+	diags := ReadOrganization(ctx, d, meta)
+	if diags != nil {
 		return nil, err
 	}
 	return []*schema.ResourceData{d}, nil

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -99,8 +99,7 @@ func CreateOrganization(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 	d.SetId(strconv.FormatInt(orgId, 10))
-	err = UpdateUsers(d, meta)
-	if err != nil {
+	if err = UpdateUsers(d, meta); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -136,8 +135,7 @@ func UpdateOrganization(ctx context.Context, d *schema.ResourceData, meta interf
 			return diag.FromErr(err)
 		}
 	}
-	err := UpdateUsers(d, meta)
-	if err != nil {
+	if err := UpdateUsers(d, meta); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -147,8 +145,7 @@ func UpdateOrganization(ctx context.Context, d *schema.ResourceData, meta interf
 func DeleteOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	orgId, _ := strconv.ParseInt(d.Id(), 10, 64)
-	err := client.DeleteOrg(orgId)
-	if err != nil {
+	if err := client.DeleteOrg(orgId); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -41,7 +41,7 @@ func ResourceOrganization() *schema.Resource {
 		DeleteContext: DeleteOrganization,
 		Exists:        ExistsOrganization,
 		Importer: &schema.ResourceImporter{
-			StateContext: ImportOrganization,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -163,20 +163,6 @@ func ExistsOrganization(d *schema.ResourceData, meta interface{}) (bool, error) 
 		return false, err
 	}
 	return true, err
-}
-
-func ImportOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	exists, err := ExistsOrganization(d, meta)
-	if err != nil || !exists {
-		return nil, errors.New(fmt.Sprintf("Error: Unable to import Grafana Organization: %s.", err))
-	}
-	d.Set("admin_user", "admin")
-	d.Set("create_users", "true")
-	diags := ReadOrganization(ctx, d, meta)
-	if diags != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }
 
 func ReadUsers(d *schema.ResourceData, meta interface{}) error {

--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -75,8 +75,7 @@ func CreateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	}
 
 	d.SetId(strconv.FormatInt(teamID, 10))
-	err = UpdateMembers(d, meta)
-	if err != nil {
+	if err = UpdateMembers(d, meta); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -114,8 +113,7 @@ func UpdateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 			return diag.FromErr(err)
 		}
 	}
-	err := UpdateMembers(d, meta)
-	if err != nil {
+	if err := UpdateMembers(d, meta); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -125,8 +123,7 @@ func UpdateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func DeleteTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	teamID, _ := strconv.ParseInt(d.Id(), 10, 64)
-	err := client.DeleteTeam(teamID)
-	if err != nil {
+	if err := client.DeleteTeam(teamID); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -38,7 +38,7 @@ func ResourceTeam() *schema.Resource {
 		DeleteContext: DeleteTeam,
 		Exists:        ExistsTeam,
 		Importer: &schema.ResourceImporter{
-			StateContext: ImportTeam,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -141,18 +141,6 @@ func ExistsTeam(d *schema.ResourceData, meta interface{}) (bool, error) {
 		return false, err
 	}
 	return true, err
-}
-
-func ImportTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	exists, err := ExistsTeam(d, meta)
-	if err != nil || !exists {
-		return nil, errors.New(fmt.Sprintf("Error: Unable to import Grafana Team: %s.", err))
-	}
-	diags := ReadTeam(ctx, d, meta)
-	if diags != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }
 
 func ReadMembers(d *schema.ResourceData, meta interface{}) error {

--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -30,13 +32,13 @@ const (
 
 func ResourceTeam() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateTeam,
-		Read:   ReadTeam,
-		Update: UpdateTeam,
-		Delete: DeleteTeam,
-		Exists: ExistsTeam,
+		CreateContext: CreateTeam,
+		ReadContext:   ReadTeam,
+		UpdateContext: UpdateTeam,
+		DeleteContext: DeleteTeam,
+		Exists:        ExistsTeam,
 		Importer: &schema.ResourceImporter{
-			State: ImportTeam,
+			StateContext: ImportTeam,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -63,20 +65,25 @@ func ResourceTeam() *schema.Resource {
 	}
 }
 
-func CreateTeam(d *schema.ResourceData, meta interface{}) error {
+func CreateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	name := d.Get("name").(string)
 	email := d.Get("email").(string)
 	teamID, err := client.AddTeam(name, email)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(teamID, 10))
-	return UpdateMembers(d, meta)
+	err = UpdateMembers(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
-func ReadTeam(d *schema.ResourceData, meta interface{}) error {
+func ReadTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	teamID, _ := strconv.ParseInt(d.Id(), 10, 64)
 	resp, err := client.Team(teamID)
@@ -86,17 +93,17 @@ func ReadTeam(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.Set("name", resp.Name)
 	d.Set("email", resp.Email)
 	if err := ReadMembers(d, meta); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	return nil
 }
 
-func UpdateTeam(d *schema.ResourceData, meta interface{}) error {
+func UpdateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	teamID, _ := strconv.ParseInt(d.Id(), 10, 64)
 	if d.HasChange("name") || d.HasChange("email") {
@@ -104,16 +111,26 @@ func UpdateTeam(d *schema.ResourceData, meta interface{}) error {
 		email := d.Get("email").(string)
 		err := client.UpdateTeam(teamID, name, email)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
-	return UpdateMembers(d, meta)
+	err := UpdateMembers(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
-func DeleteTeam(d *schema.ResourceData, meta interface{}) error {
+func DeleteTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	teamID, _ := strconv.ParseInt(d.Id(), 10, 64)
-	return client.DeleteTeam(teamID)
+	err := client.DeleteTeam(teamID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
 func ExistsTeam(d *schema.ResourceData, meta interface{}) (bool, error) {
@@ -129,13 +146,13 @@ func ExistsTeam(d *schema.ResourceData, meta interface{}) (bool, error) {
 	return true, err
 }
 
-func ImportTeam(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func ImportTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	exists, err := ExistsTeam(d, meta)
 	if err != nil || !exists {
 		return nil, errors.New(fmt.Sprintf("Error: Unable to import Grafana Team: %s.", err))
 	}
-	err = ReadTeam(d, meta)
-	if err != nil {
+	diags := ReadTeam(ctx, d, meta)
+	if diags != nil {
 		return nil, err
 	}
 	return []*schema.ResourceData{d}, nil

--- a/grafana/resource_user.go
+++ b/grafana/resource_user.go
@@ -124,8 +124,7 @@ func DeleteUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = client.DeleteUser(id)
-	if err != nil {
+	if err = client.DeleteUser(id); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_user.go
+++ b/grafana/resource_user.go
@@ -1,23 +1,25 @@
 package grafana
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func ResourceUser() *schema.Resource {
 	return &schema.Resource{
-		Create: CreateUser,
-		Read:   ReadUser,
-		Update: UpdateUser,
-		Delete: DeleteUser,
-		Exists: ExistsUser,
+		CreateContext: CreateUser,
+		ReadContext:   ReadUser,
+		UpdateContext: UpdateUser,
+		DeleteContext: DeleteUser,
+		Exists:        ExistsUser,
 		Importer: &schema.ResourceImporter{
-			State: ImportUser,
+			StateContext: ImportUser,
 		},
 		Schema: map[string]*schema.Schema{
 			"email": {
@@ -46,7 +48,7 @@ func ResourceUser() *schema.Resource {
 	}
 }
 
-func CreateUser(d *schema.ResourceData, meta interface{}) error {
+func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	user := gapi.User{
 		Email:    d.Get("email").(string),
@@ -56,27 +58,27 @@ func CreateUser(d *schema.ResourceData, meta interface{}) error {
 	}
 	id, err := client.CreateUser(user)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if d.HasChange("is_admin") {
 		err = client.UpdateUserPermissions(id, d.Get("is_admin").(bool))
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	d.SetId(strconv.FormatInt(id, 10))
-	return ReadUser(d, meta)
+	return ReadUser(ctx, d, meta)
 }
 
-func ReadUser(d *schema.ResourceData, meta interface{}) error {
+func ReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	user, err := client.User(id)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.Set("email", user.Email)
 	d.Set("name", user.Name)
@@ -85,11 +87,11 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func UpdateUser(d *schema.ResourceData, meta interface{}) error {
+func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	u := gapi.User{
 		ID:    id,
@@ -99,30 +101,35 @@ func UpdateUser(d *schema.ResourceData, meta interface{}) error {
 	}
 	err = client.UserUpdate(u)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if d.HasChange("password") {
 		err = client.UpdateUserPassword(id, d.Get("password").(string))
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if d.HasChange("is_admin") {
 		err = client.UpdateUserPermissions(id, d.Get("is_admin").(bool))
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
-	return ReadUser(d, meta)
+	return ReadUser(ctx, d, meta)
 }
 
-func DeleteUser(d *schema.ResourceData, meta interface{}) error {
+func DeleteUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gapi.Client)
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	return client.DeleteUser(id)
+	err = client.DeleteUser(id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
 }
 
 func ExistsUser(d *schema.ResourceData, meta interface{}) (bool, error) {
@@ -135,13 +142,13 @@ func ExistsUser(d *schema.ResourceData, meta interface{}) (bool, error) {
 	return true, nil
 }
 
-func ImportUser(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func ImportUser(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	exists, err := ExistsUser(d, meta)
 	if err != nil || !exists {
 		return nil, errors.New(fmt.Sprintf("Error: Unable to import Grafana User: %s.", err))
 	}
-	err = ReadUser(d, meta)
-	if err != nil {
+	diags := ReadUser(ctx, d, meta)
+	if diags != nil {
 		return nil, err
 	}
 	return []*schema.ResourceData{d}, nil

--- a/grafana/resource_user.go
+++ b/grafana/resource_user.go
@@ -2,8 +2,6 @@ package grafana
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strconv"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -19,7 +17,7 @@ func ResourceUser() *schema.Resource {
 		DeleteContext: DeleteUser,
 		Exists:        ExistsUser,
 		Importer: &schema.ResourceImporter{
-			StateContext: ImportUser,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"email": {
@@ -139,16 +137,4 @@ func ExistsUser(d *schema.ResourceData, meta interface{}) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-func ImportUser(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	exists, err := ExistsUser(d, meta)
-	if err != nil || !exists {
-		return nil, errors.New(fmt.Sprintf("Error: Unable to import Grafana User: %s.", err))
-	}
-	diags := ReadUser(ctx, d, meta)
-	if diags != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
Leverage support for [context-aware schema functions](https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#more-support-for-context-context) and [diagnostics](https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#support-for-diagnostics), which were made available in Terraform Plugin SDK v2.

Closes https://github.com/grafana/terraform-provider-grafana/issues/175.