### PR TITLE
Refactor Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,14 +1,18 @@
-Hi there,
-
-Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved for bug reports and feature requests. For general usage questions, please see: https://www.terraform.io/community.html.
+---
+name: Bug report
+about: Report a bug
+labels: 'bug'
+---
 
 ### Terraform Version
-Run `terraform -v` to show the version. If you are not running the latest version of Terraform, please upgrade because your issue may have already been fixed.
+* Terraform: ...
+* Terraform Grafana Provider: ...
+* Grafana: ...
 
 ### Affected Resource(s)
 Please list the resources as a list, for example:
-- opc_instance
-- opc_storage_volume
+* grafana_dashboard
+* grafana_folder
 
 If this issue appears to affect multiple resources, it may be an issue with Terraform's core, so please mention this.
 

--- a/.github/ISSUE_TEMPLATE/2-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.md
@@ -1,0 +1,5 @@
+---
+name: Feature request
+about: Suggest an idea for this provider
+labels: 'enhancement'
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+contact_links:
+  - name: 'Grafana #terraform Slack channel'
+    url: https://grafana.slack.com/archives/C017MUCFJUT


### PR DESCRIPTION
Split issue template into "Bug report" and "Feature request". This is GH's newer convention for issue templates. The existing one was only relevant to bugs. This provides a similar experience to https://github.com/grafana/grafana.

![image](https://user-images.githubusercontent.com/908409/115784885-f0220b80-a37b-11eb-8d9b-69ae46561e4b.png)