### PR TITLE
GoReleaser uses Go 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14
+        go-version: 1.16
     - name: Import GPG key
       id: import_gpg
       uses: hashicorp/ghaction-import-gpg@v2.1.0


### PR DESCRIPTION
[Go 1.16 adds support of 64-bit ARM architecture on macOS](https://golang.org/doc/go1.16#darwin). GoReleaser will create `terraform-provider-grafana_1.10.0_darwin_arm64.zip` on the next release. We'll be able to cloze https://github.com/grafana/terraform-provider-grafana/issues/179 at that time.