### PR TITLE
typo in grafana_dashboard_permission docs

### DIFF
--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -27,7 +27,7 @@ resource "grafana_dashboard" "metrics" {
 }
 
 resource "grafana_dashboard_permission" "collectionPermission" {
-  dashboard_id = grafana_dashboard.metrics.dashboard_id
+  dashboard_uid = grafana_dashboard.metrics.dashboard_id
   permissions {
     role       = "Editor"
     permission = "Edit"

--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -27,7 +27,7 @@ resource "grafana_dashboard" "metrics" {
 }
 
 resource "grafana_dashboard_permission" "collectionPermission" {
-  dashboard_uid = grafana_dashboard.metrics.dashboard_id
+  dashboard_id = grafana_dashboard.metrics.dashboard_id
   permissions {
     role       = "Editor"
     permission = "Edit"

--- a/examples/resources/grafana_dashboard_permission/resource.tf
+++ b/examples/resources/grafana_dashboard_permission/resource.tf
@@ -11,7 +11,7 @@ resource "grafana_dashboard" "metrics" {
 }
 
 resource "grafana_dashboard_permission" "collectionPermission" {
-  dashboard_uid = grafana_dashboard.metrics.dashboard_id
+  dashboard_id = grafana_dashboard.metrics.dashboard_id
   permissions {
     role       = "Editor"
     permission = "Edit"


### PR DESCRIPTION
self explanatory 

```
╷
│ Error: Missing required argument
│ 
│   on main.tf line 20, in resource "grafana_dashboard_permission" "this":
│   20: resource "grafana_dashboard_permission" "this" {
│ 
│ The argument "dashboard_id" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 21, in resource "grafana_dashboard_permission" "this":
│   21:   dashboard_uid = grafana_dashboard.this.dashboard_id
│ 
│ An argument named "dashboard_uid" is not expected here. Did you mean "dashboard_id"?
╵
```