### PR TITLE
Allow to overwrite while creating dashboard from terraform

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -16,6 +16,7 @@ local pipeline(name, trigger) = {
       name: 'tests',
       image: golang,
       commands: [
+        'sleep 5', // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
         'make testacc',
       ],
       environment: {

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -30,6 +30,7 @@ resource "grafana_dashboard" "metrics" {
 
 - **folder** (Number) The id of the folder to save the dashboard in.
 - **id** (String) The ID of this resource.
+- **overwrite** (Boolean) Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.
 
 ### Read-Only
 

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -56,6 +56,12 @@ func ResourceDashboard() *schema.Resource {
 				ValidateFunc: ValidateDashboardConfigJSON,
 				Description:  "The complete dashboard model JSON.",
 			},
+
+			"overwrite": {
+				Type: schema.TypeBool,
+				Optional: true,
+				Description: "Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.",
+			},
 		},
 	}
 }
@@ -68,6 +74,8 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 	dashboard.Model = prepareDashboardModel(d.Get("config_json").(string))
 
 	dashboard.Folder = int64(d.Get("folder").(int))
+
+	dashboard.Overwrite = d.Get("overwrite").(bool)
 
 	resp, err := client.NewDashboard(dashboard)
 	if err != nil {


### PR DESCRIPTION
When dashboard already exists, creating it from terraform returns following error:

```
Error: status: 412, body: {"message":"The dashboard has been changed by someone else","status":"version-mismatch"}
```

I'd like to have a possibility to overwrite dashboards without importing them one by one.