### PR TITLE
Dashboard Resource Works with Grafana 8

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -30,6 +30,10 @@ local pipeline(name, trigger) = {
     {
       name: 'grafana',
       image: grafana,
+      environment: {
+        // Prevents error="database is locked"
+        GF_DATABASE_URL: 'sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL',
+      },
     },
   ],
   trigger: trigger,

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,5 +1,5 @@
 local golang = 'golang:1.16';
-local grafana = 'grafana/grafana:8.0.2';
+local grafana = 'grafana/grafana:8.0.3';
 
 // We'd like the same pipeline for testing pull requests as we do for building
 // master. The only difference is their names and triggers.

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,5 +1,5 @@
 local golang = 'golang:1.16';
-local grafana = 'grafana/grafana:7.4.2';
+local grafana = 'grafana/grafana:8.0.2';
 
 // We'd like the same pipeline for testing pull requests as we do for building
 // master. The only difference is their names and triggers.
@@ -16,7 +16,7 @@ local pipeline(name, trigger) = {
       name: 'tests',
       image: golang,
       commands: [
-        'sleep 5', // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
+        'sleep 5',  // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
         'make testacc',
       ],
       environment: {

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -3,10 +3,13 @@
 page_title: "grafana_dashboard Resource - terraform-provider-grafana"
 subcategory: ""
 description: |-
+  Manages Grafana dashboards.
   Official documentation https://grafana.com/docs/grafana/latest/dashboards/HTTP API https://grafana.com/docs/grafana/latest/http_api/dashboard/
 ---
 
 # grafana_dashboard (Resource)
+
+Manages Grafana dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
@@ -35,7 +38,9 @@ resource "grafana_dashboard" "metrics" {
 ### Read-Only
 
 - **dashboard_id** (Number) The numeric ID of the dashboard computed by Grafana.
-- **slug** (String) URL friendly version of the dashboard title.
+- **slug** (String, Deprecated) URL friendly version of the dashboard title. This field is deprecated, please use `uid` instead.
+- **uid** (String) The unique identifier of a dashboard. This is used to construct its URL. It’s automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs.
+- **version** (Number) Whenever you save a version of your dashboard, a copy of that version is saved so that previous versions of your dashboard are not lost.
 
 ## Import
 

--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -103,6 +103,7 @@ Optional:
 - **interval** (String) (Elasticsearch) Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly'.
 - **log_level_field** (String) (Elasticsearch) Which field should be used to indicate the priority of the log message.
 - **log_message_field** (String) (Elasticsearch) Which field should be used as the log message.
+- **max_concurrent_shard_requests** (Number) (Elasticsearch) Maximum number of concurrent shard requests.
 - **max_idle_conns** (Number) (MySQL, PostgreSQL and MSSQL) Maximum number of connections in the idle connection pool (Grafana v5.4+).
 - **max_open_conns** (Number) (MySQL, PostgreSQL and MSSQL) Maximum number of open connections to the database (Grafana v5.4+).
 - **postgres_version** (Number) (PostgreSQL) Postgres version as a number (903/904/905/906/1000) meaning v9.3, v9.4, etc.

--- a/examples/resources/grafana_dashboard/_acc_basic.tf
+++ b/examples/resources/grafana_dashboard/_acc_basic.tf
@@ -1,0 +1,14 @@
+# The "id" and "version" properties in the config below are there to test that
+# we correctly normalize them away. They are not actually used by this
+# resource, since it uses slugs for identification.
+#
+resource "grafana_dashboard" "test" {
+  config_json = <<EOD
+{
+  "title": "Terraform Acceptance Test",
+  "id": 12,
+  "uid": "basic",
+  "version": 34
+}
+EOD
+}

--- a/examples/resources/grafana_dashboard/_acc_basic_update.tf
+++ b/examples/resources/grafana_dashboard/_acc_basic_update.tf
@@ -1,0 +1,11 @@
+# this is used as an update on the basic resource above
+# NOTE: it leaves out id and version, as this is what
+# users will do when updating
+resource "grafana_dashboard" "test" {
+  config_json = <<EOD
+{
+  "title": "Updated Title",
+  "uid": "update"
+}
+EOD
+}

--- a/examples/resources/grafana_dashboard/_acc_folder.tf
+++ b/examples/resources/grafana_dashboard/_acc_folder.tf
@@ -1,0 +1,15 @@
+resource "grafana_folder" "test_folder" {
+  title = "Terraform Folder Test Folder"
+}
+
+resource "grafana_dashboard" "test_folder" {
+  folder      = grafana_folder.test_folder.id
+  config_json = <<EOD
+{
+  "title": "Terraform Folder Test Dashboard",
+  "id": 12,
+  "version": "43",
+  "uid": "folder"
+}
+EOD
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.0.0-20210609221621-5181ce3ac670
+	github.com/grafana/grafana-api-golang-client v0.0.0-20210617225133-8f4d217b96be
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.0-20210608014215-abcc28348a76
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-docs v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.0.0-20210617225133-8f4d217b96be
+	github.com/grafana/grafana-api-golang-client v0.0.0-20210618160844-e0f5ad352210
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.0-20210608014215-abcc28348a76
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-docs v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210617225133-8f4d217b96be h1:r/AZKMjlaLwHUnDtDNWArPpxRfxUCOm/KDmckbJK9GM=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210617225133-8f4d217b96be/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210618160844-e0f5ad352210 h1:UUJQQbVSM9ZVNQ8QcSvl82gmF4l25HrCYCwA89WTadA=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210618160844-e0f5ad352210/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/loki v1.5.0/go.mod h1:LoxeHyWIoFue9p8S5vwPqDNCet8u8uaKW2Dv7mPaly4=
 github.com/grafana/synthetic-monitoring-agent v0.0.22 h1:PKQfmCjSMz3qWhY54l7sTpjQOXhCnGbLTPOtrflwRkM=
 github.com/grafana/synthetic-monitoring-agent v0.0.22/go.mod h1:xKQ3cTCnHxONFXvw1OMTKD0K/VIXbWaISyAWEuPakAA=

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210609221621-5181ce3ac670 h1:cjCz+LJ0hKraDqWCRa9HnURt7eEbspcbjJWwSrOnVWI=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210609221621-5181ce3ac670/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210617225133-8f4d217b96be h1:r/AZKMjlaLwHUnDtDNWArPpxRfxUCOm/KDmckbJK9GM=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210617225133-8f4d217b96be/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/loki v1.5.0/go.mod h1:LoxeHyWIoFue9p8S5vwPqDNCet8u8uaKW2Dv7mPaly4=
 github.com/grafana/synthetic-monitoring-agent v0.0.22 h1:PKQfmCjSMz3qWhY54l7sTpjQOXhCnGbLTPOtrflwRkM=
 github.com/grafana/synthetic-monitoring-agent v0.0.22/go.mod h1:xKQ3cTCnHxONFXvw1OMTKD0K/VIXbWaISyAWEuPakAA=

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"sync"
@@ -77,8 +76,7 @@ func testAccPreCheck(t *testing.T) {
 // testAccExample returns an example config from the examples directory.
 // Examples are used for both documentation and acceptance tests.
 func testAccExample(t *testing.T, path string) string {
-	path = fmt.Sprintf("../examples/%s", path)
-	example, err := ioutil.ReadFile(path)
+	example, err := ioutil.ReadFile("../examples/" + path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -49,11 +49,8 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-// testAccPreCheck verifies required provider testing configuration
-//
-// This PreCheck function should be present in every acceptance test. It allows
-// test configurations to omit a provider configuration with region and ensures
-// testing functions that attempt to call AWS APIs are previously configured.
+// testAccPreCheck verifies required provider testing configuration. It should
+// be present in every acceptance test.
 //
 // These verifications and configuration are preferred at this level to prevent
 // provider developers from experiencing less clear errors for every test.

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -2,6 +2,8 @@ package grafana
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -73,4 +75,15 @@ func testAccPreCheck(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+// testAccExample returns an example config from the examples directory.
+// Examples are used for both documentation and acceptance tests.
+func testAccExample(t *testing.T, path string) string {
+	path = fmt.Sprintf("../examples/%s", path)
+	example, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(example)
 }

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -136,8 +136,13 @@ func resourceDashboardStateUpgradeV0(ctx context.Context, rawState map[string]in
 	if err != nil {
 		return nil, fmt.Errorf("Error attempting to migrate state. Grafana returned an error while searching for dashboard with ID %s: %s", params["dashboardIds"], err)
 	}
-	if len(resp) > 1 {
+	switch {
+	case len(resp) > 1:
+		// Search endpoint returned multiple dashboards. This is not likely.
 		return nil, fmt.Errorf("Error attempting to migrate state. Many dashboards returned by Grafana while searching for dashboard with ID, %s", params["dashboardIds"])
+	case len(resp) == 0:
+		// Dashboard does not exist. Let Terraform recreate it.
+		return rawState, nil
 	}
 	uid := resp[0].UID
 	rawState["id"] = uid

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -148,10 +148,13 @@ func resourceDashboardStateUpgradeV0(ctx context.Context, rawState map[string]in
 	rawState["id"] = uid
 	rawState["uid"] = uid
 	dashboard, err := client.DashboardByUID(uid)
-	if len(resp) > 1 {
-		return nil, fmt.Errorf("Error attempting to migrate state. Grafana returned an error while searching for dashboard with UID %s: %s", uid, err)
+	// Set version if we can.
+	// In the unlikely event that we don't get a dashboard back, we don't return
+	// an error because Terraform will be able to reconcile this field without
+	// much trouble.
+	if err == nil && dashboard != nil {
+		rawState["version"] = int64(dashboard.Model["version"].(float64))
 	}
-	rawState["version"] = int64(dashboard.Model["version"].(float64))
 	return rawState, nil
 }
 

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -94,32 +94,27 @@ func resourceDashboardV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"slug": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "URL friendly version of the dashboard title.",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"dashboard_id": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "The numeric ID of the dashboard computed by Grafana.",
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 			"folder": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The id of the folder to save the dashboard in.",
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
 			},
 			"config_json": {
 				Type:         schema.TypeString,
 				Required:     true,
 				StateFunc:    normalizeDashboardConfigJSON,
 				ValidateFunc: validateDashboardConfigJSON,
-				Description:  "The complete dashboard model JSON.",
 			},
 			"overwrite": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.",
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 		},
 	}

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -17,6 +17,8 @@ func ResourceDashboard() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
+Manages Grafana dashboards.
+
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
 `,
@@ -30,16 +32,33 @@ func ResourceDashboard() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+
+			"uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: "The unique identifier of a dashboard. This is used to construct its URL. " +
+					"It’s automatically generated if not provided when creating a dashboard. " +
+					"The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs. ",
+			},
+
 			"slug": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "URL friendly version of the dashboard title.",
+				Description: "URL friendly version of the dashboard title. This field is deprecated, please use `uid` instead.",
+				Deprecated:  "Use `uid` instead.",
 			},
 
 			"dashboard_id": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The numeric ID of the dashboard computed by Grafana.",
+			},
+
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Description: "Whenever you save a version of your dashboard, a copy of that version is saved " +
+					"so that previous versions of your dashboard are not lost.",
 			},
 
 			"folder": {
@@ -58,8 +77,8 @@ func ResourceDashboard() *schema.Resource {
 			},
 
 			"overwrite": {
-				Type: schema.TypeBool,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Optional:    true,
 				Description: "Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.",
 			},
 		},
@@ -68,39 +87,27 @@ func ResourceDashboard() *schema.Resource {
 
 func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*client).gapi
-
-	dashboard := gapi.Dashboard{}
-
-	dashboard.Model = prepareDashboardModel(d.Get("config_json").(string))
-
-	dashboard.Folder = int64(d.Get("folder").(int))
-
-	dashboard.Overwrite = d.Get("overwrite").(bool)
-
+	dashboard := makeDashboard(d)
 	resp, err := client.NewDashboard(dashboard)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(resp.Slug)
-
+	d.SetId(resp.UID)
 	return ReadDashboard(ctx, d, meta)
 }
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*client).gapi
-
-	slug := d.Id()
-
-	dashboard, err := client.Dashboard(slug)
+	uid := d.Id()
+	dashboard, err := client.DashboardByUID(uid)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "status: 404") {
-			log.Printf("[WARN] removing dashboard %s from state because it no longer exists in grafana", slug)
+			log.Printf("[WARN] removing dashboard %s from state because it no longer exists in grafana", uid)
 			d.SetId("")
-			return nil
+			return diag.FromErr(err)
+		} else {
+			return diag.FromErr(err)
 		}
-
-		return diag.FromErr(err)
 	}
 
 	configJSONBytes, err := json.Marshal(dashboard.Model)
@@ -110,58 +117,66 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 	configJSON := NormalizeDashboardConfigJSON(string(configJSONBytes))
 
-	d.SetId(dashboard.Meta.Slug)
+	d.SetId(dashboard.Model["uid"].(string))
+	d.Set("uid", dashboard.Model["uid"].(string))
 	d.Set("slug", dashboard.Meta.Slug)
 	d.Set("config_json", configJSON)
 	d.Set("folder", dashboard.Folder)
 	d.Set("dashboard_id", int64(dashboard.Model["id"].(float64)))
+	d.Set("version", int64(dashboard.Model["version"].(float64)))
 
 	return nil
 }
 
 func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*client).gapi
-
-	dashboard := gapi.Dashboard{}
-
-	dashboard.Model = prepareDashboardModel(d.Get("config_json").(string))
-
-	dashboard.Folder = int64(d.Get("folder").(int))
+	dashboard := makeDashboard(d)
 	dashboard.Overwrite = true
-
 	resp, err := client.NewDashboard(dashboard)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(resp.Slug)
-
+	d.SetId(resp.UID)
 	return ReadDashboard(ctx, d, meta)
 }
 
 func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*client).gapi
-
-	slug := d.Id()
-	if err := client.DeleteDashboard(slug); err != nil {
-		return diag.FromErr(err)
+	uid := d.Id()
+	err := client.DeleteDashboardByUID(uid)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "status: 404") {
+			log.Printf("[WARN] removing dashboard %s from state because it no longer exists in grafana", uid)
+			d.SetId("")
+			return diag.FromErr(err)
+		} else {
+			return diag.FromErr(err)
+		}
 	}
-
 	return diag.Diagnostics{}
 }
 
-func prepareDashboardModel(configJSON string) map[string]interface{} {
-	configMap := map[string]interface{}{}
-	err := json.Unmarshal([]byte(configJSON), &configMap)
+func makeDashboard(d *schema.ResourceData) gapi.Dashboard {
+
+	dashboard := gapi.Dashboard{
+		Folder:    int64(d.Get("folder").(int)),
+		Overwrite: d.Get("overwrite").(bool),
+	}
+
+	configJSON := d.Get("config_json").(string)
+
+	dashboardJSON := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &dashboardJSON)
 	if err != nil {
 		// The validate function should've taken care of this.
 		panic(fmt.Errorf("Invalid JSON got into prepare func"))
 	}
 
-	delete(configMap, "id")
-	configMap["version"] = 0
+	delete(dashboardJSON, "id")
+	delete(dashboardJSON, "version")
 
-	return configMap
+	dashboard.Model = dashboardJSON
+	return dashboard
 }
 
 func ValidateDashboardConfigJSON(configI interface{}, k string) ([]string, []error) {
@@ -188,7 +203,6 @@ func NormalizeDashboardConfigJSON(configI interface{}) string {
 	// significant when included in the JSON.
 	delete(configMap, "id")
 	delete(configMap, "version")
-	delete(configMap, "uid")
 
 	ret, err := json.Marshal(configMap)
 	if err != nil {

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -21,12 +21,11 @@ func TestAccDashboard_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// first step creates the resource
 			{
-				Config: testAccDashboardConfig_basic,
+				Config: testAccExample(t, "resources/grafana_dashboard/_acc_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
-					resource.TestMatchResourceAttr(
-						"grafana_dashboard.test", "id", regexp.MustCompile(`terraform-acceptance-test.*`),
-					),
+					resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "basic"),
+					resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "basic"),
 					resource.TestMatchResourceAttr(
 						"grafana_dashboard.test", "config_json", regexp.MustCompile(".*Terraform Acceptance Test.*"),
 					),
@@ -34,9 +33,11 @@ func TestAccDashboard_basic(t *testing.T) {
 			},
 			// second step updates it with a new title
 			{
-				Config: testAccDashboardConfig_update,
+				Config: testAccExample(t, "resources/grafana_dashboard/_acc_basic_update.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
+					resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "update"),
+					resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "update"),
 					resource.TestMatchResourceAttr(
 						"grafana_dashboard.test", "config_json", regexp.MustCompile(".*Updated Title.*"),
 					),
@@ -62,38 +63,16 @@ func TestAccDashboard_folder(t *testing.T) {
 		CheckDestroy:      testAccDashboardFolderCheckDestroy(&dashboard, &folder),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDashboardConfig_folder,
+				Config: testAccExample(t, "resources/grafana_dashboard/_acc_folder.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
-					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
 					testAccDashboardCheckExistsInFolder(&dashboard, &folder),
-					resource.TestMatchResourceAttr(
-						"grafana_dashboard.test_folder", "id", regexp.MustCompile(`terraform-folder-test-dashboard`),
-					),
+					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "folder"),
+					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "uid", "folder"),
 					resource.TestMatchResourceAttr(
 						"grafana_dashboard.test_folder", "folder", regexp.MustCompile(`\d+`),
 					),
 				),
-			},
-		},
-	})
-}
-
-func TestAccDashboard_disappear(t *testing.T) {
-	var dashboard gapi.Dashboard
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDashboardConfig_disappear,
-				Check: resource.ComposeTestCheckFunc(
-					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
-					testAccDashboardDisappear(&dashboard),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -105,19 +84,15 @@ func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.
 		if !ok {
 			return fmt.Errorf("resource not found: %s", rn)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-
 		client := testAccProvider.Meta().(*client).gapi
-		gotDashboard, err := client.Dashboard(rs.Primary.ID)
+		gotDashboard, err := client.DashboardByUID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting dashboard: %s", err)
 		}
-
 		*dashboard = *gotDashboard
-
 		return nil
 	}
 }
@@ -131,20 +106,10 @@ func testAccDashboardCheckExistsInFolder(dashboard *gapi.Dashboard, folder *gapi
 	}
 }
 
-func testAccDashboardDisappear(dashboard *gapi.Dashboard) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// At this point testAccDashboardCheckExists should have been called and
-		// dashboard should have been populated
-		client := testAccProvider.Meta().(*client).gapi
-		client.DeleteDashboard((*dashboard).Meta.Slug)
-		return nil
-	}
-}
-
 func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*client).gapi
-		_, err := client.Dashboard(dashboard.Meta.Slug)
+		_, err := client.DashboardByUID(dashboard.Model["uid"].(string))
 		if err == nil {
 			return fmt.Errorf("dashboard still exists")
 		}
@@ -155,7 +120,7 @@ func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard) resource.TestCheckF
 func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*client).gapi
-		_, err := client.Dashboard(dashboard.Meta.Slug)
+		_, err := client.Dashboard(dashboard.Model["uid"].(string))
 		if err == nil {
 			return fmt.Errorf("dashboard still exists")
 		}
@@ -166,62 +131,3 @@ func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.
 		return nil
 	}
 }
-
-// The "id" and "version" properties in the config below are there to test
-// that we correctly normalize them away. They are not actually used by this
-// resource, since it uses slugs for identification.
-const testAccDashboardConfig_basic = `
-resource "grafana_dashboard" "test" {
-    config_json = <<EOT
-{
-    "title": "Terraform Acceptance Test",
-    "id": 12,
-    "version": "43",
-    "uid": "someuid"
-}
-EOT
-}
-`
-
-// this is used as an update on the basic resource above
-// NOTE: it leaves out id and version, as this is what users will do when updating
-const testAccDashboardConfig_update = `
-resource "grafana_dashboard" "test" {
-	config_json = <<EOT
-{
-	"title": "Updated Title",
-	"uid": "someuid"
-}
-EOT
-}
-`
-
-const testAccDashboardConfig_folder = `
-
-resource "grafana_folder" "test_folder" {
-    title = "Terraform Folder Test Folder"
-}
-
-resource "grafana_dashboard" "test_folder" {
-    folder = "${grafana_folder.test_folder.id}"
-    config_json = <<EOT
-{
-    "title": "Terraform Folder Test Dashboard",
-    "id": 12,
-    "version": "43",
-    "uid": "someuid"
-}
-EOT
-}
-`
-
-const testAccDashboardConfig_disappear = `
-resource "grafana_dashboard" "test" {
-    config_json = <<EOT
-{
-    "title": "Terraform Disappear Test",
-    "uid": "someuid"
-}
-EOT
-}
-`

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -120,7 +120,7 @@ func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard) resource.TestCheckF
 func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*client).gapi
-		_, err := client.Dashboard(dashboard.Model["uid"].(string))
+		_, err := client.DashboardByUID(dashboard.Model["uid"].(string))
 		if err == nil {
 			return fmt.Errorf("dashboard still exists")
 		}


### PR DESCRIPTION
[Grafana 8 removed `slug` endpoints](https://github.com/grafana/grafana/blob/main/CHANGELOG.md#breaking-changes) that have been deprecated since Grafana 5. My proposed fix is to:

* Deprecate the `slug` field in the provider.
* Add `uid` and use it as we were using `slug`.
* Use the read and delete endpoints that have replaced the slug endpoints.

Other changes:

* Drone will run acceptance tests with Grafana 8.0.2.
* Test configurations were moved to `examples/`. This is a convention I'd like to propose we adopt for all acceptance test configuration files. Moving them into dedicated `.tf` files allows us to take advantage of `terrform fmt`, syntax highlighting, and use them in documentation. I've prefixed these particular examples with `_acc_` to indicate they are used in acceptance tests only because they would not make good examples for documentation.
* `version` was added as a computed (read only) field. This field is removed if set as a static value in `config_json`. It cannot be managed as a static value. Therefore we manage it in state and set it on read.
* `TestAccDashboard_disappear` removed. This does not seem useful.
* 404 on read and delete fixed. The error message read as if it were removing it from state, but instead it was throwing, `Error: status: 404, body: {"message":"Dashboard not found"}` without removing it. It now displays a warning error stating that Terraform will attempt to recreate it.
* `func prepareDashboardModel(configJSON string) map[string]interface{}` replaced with `func makeDashboard(d *schema.ResourceData) gapi.Dashboard`. This function name and signature is consistent with other resources in this provider.

Closes https://github.com/grafana/terraform-provider-grafana/issues/212