### PR TITLE
fix!: make alert_notification settings nonsensitive

### DIFF
--- a/docs/resources/alert_notification.md
+++ b/docs/resources/alert_notification.md
@@ -44,7 +44,7 @@ resource "grafana_alert_notification" "email_someteam" {
 - **is_default** (Boolean) Is this the default channel for all your alerts. Defaults to `false`.
 - **secure_settings** (Map of String, Sensitive) Additional secure settings, for full reference lookup [Grafana Supported Settings documentation](https://grafana.com/docs/grafana/latest/administration/provisioning/#supported-settings).
 - **send_reminder** (Boolean) Whether to send reminders for triggered alerts. Defaults to `false`.
-- **settings** (Map of String, Sensitive) Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).
+- **settings** (Map of String) Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).
 - **uid** (String) Unique identifier. If unset, this will be automatically generated.
 
 

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -67,7 +67,6 @@ func ResourceAlertNotification() *schema.Resource {
 			"settings": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				Sensitive:   true,
 				Description: "Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).",
 			},
 


### PR DESCRIPTION
Fixes #220.

As secure_settings should be used for sensitive settings, this marks the
alert_notification resource as insensitive by removing the sensitive
flag.

Suggest bumping the major version in order to avoid accidental "reveals"
of settings data that is sensitive.