### PR TITLE
Team Resource Refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.0.0-20210719231312-127ddfdfd452
+	github.com/grafana/grafana-api-golang-client v0.0.0-20210720012848-3049c6914b86
 	github.com/grafana/synthetic-monitoring-agent v0.0.24
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.2
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.0.0-20210622232726-d2fbe458a0cf
+	github.com/grafana/grafana-api-golang-client v0.0.0-20210719231312-127ddfdfd452
 	github.com/grafana/synthetic-monitoring-agent v0.0.24
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.2
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210622232726-d2fbe458a0cf h1:WZsKxplmqdGhrFJ/KAY8DaeRVq6/jCeqeIoiXfM1UEo=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210622232726-d2fbe458a0cf/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210719231312-127ddfdfd452 h1:dMmz9CwnFXNFwyva1x5lcTdHe4zwAQz3zo4zj5eyJGw=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210719231312-127ddfdfd452/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/loki v1.6.1/go.mod h1:X+GvtCzAf2ok/xRLLvGB8kuWP1R+75nXnvjCEnenP0s=
 github.com/grafana/synthetic-monitoring-agent v0.0.23/go.mod h1:luWgdBaAQgOz9e6m/cGQCFFrPWkBTl+VZM/UC+75nSM=
 github.com/grafana/synthetic-monitoring-agent v0.0.24 h1:qfDFWIW2iPmffAsLO9WG/h8inAV+D/nXbQUQ4DTdL3E=

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210719231312-127ddfdfd452 h1:dMmz9CwnFXNFwyva1x5lcTdHe4zwAQz3zo4zj5eyJGw=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210719231312-127ddfdfd452/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210720012848-3049c6914b86 h1:Dmds3qEEVMuqH09VaIYSY9idLn4C8NMLyTmRfhW4ttM=
+github.com/grafana/grafana-api-golang-client v0.0.0-20210720012848-3049c6914b86/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/loki v1.6.1/go.mod h1:X+GvtCzAf2ok/xRLLvGB8kuWP1R+75nXnvjCEnenP0s=
 github.com/grafana/synthetic-monitoring-agent v0.0.23/go.mod h1:luWgdBaAQgOz9e6m/cGQCFFrPWkBTl+VZM/UC+75nSM=
 github.com/grafana/synthetic-monitoring-agent v0.0.24 h1:qfDFWIW2iPmffAsLO9WG/h8inAV+D/nXbQUQ4DTdL3E=

--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -87,6 +87,7 @@ func CreateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	}
 
 	d.SetId(strconv.FormatInt(teamID, 10))
+	d.Set("team_id", teamID)
 	if err = UpdateMembers(d, meta); err != nil {
 		return diag.FromErr(err)
 	}
@@ -107,7 +108,9 @@ func ReadTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 	d.Set("name", resp.Name)
-	d.Set("email", resp.Email)
+	if resp.Email != "" {
+		d.Set("email", resp.Email)
+	}
 	if err := ReadMembers(d, meta); err != nil {
 		return diag.FromErr(err)
 	}
@@ -236,12 +239,12 @@ func memberChanges(stateMembers, configMembers map[string]TeamMember) []MemberCh
 func addMemberIdsToChanges(meta interface{}, changes []MemberChange) ([]MemberChange, error) {
 	client := meta.(*client).gapi
 	gUserMap := make(map[string]int64)
-	gUsers, err := client.Users()
+	gUsers, err := client.OrgUsersCurrent()
 	if err != nil {
 		return nil, err
 	}
 	for _, u := range gUsers {
-		gUserMap[u.Email] = u.ID
+		gUserMap[u.Email] = u.UserID
 	}
 	var output []MemberChange
 


### PR DESCRIPTION
Depends on https://github.com/grafana/grafana-api-golang-client/pull/31.

* Use OrgUsersCurrent (GET /api/org/users) when reconciling team members.
  GET /api/users is not accessible on Grafana Cloud.
* Sets team_id on create. It's been left as null.
* Read only sets email if it's not a blank string. null vs. "" makes
  it appear that team resources are changed outside of Terraform.