### PR TITLE
Crash when config_json will be known after apply #246

### DIFF
--- a/examples/resources/grafana_dashboard/_acc_computed.tf
+++ b/examples/resources/grafana_dashboard/_acc_computed.tf
@@ -1,0 +1,19 @@
+# Creating a dashboard with a random uid.
+# We'd like to ensure that using a computed configuration works.
+
+resource "grafana_dashboard" "test" {
+  config_json = <<EOD
+{
+  "title": "Terraform Acceptance Test"
+}
+EOD
+}
+
+resource "grafana_dashboard" "test-computed" {
+  config_json = <<EOD
+{
+  "title": "Terraform Acceptance Test Computed",
+	"tags": ["${grafana_dashboard.test.uid}"]
+}
+EOD
+}


### PR DESCRIPTION
Following discussion in #246

I have the same issue in acc tests with a computed value in config_json attribute like :
```
# main.tf
resource "grafana_dashboard" "test" {
  config_json = <<EOD
{
  "title": "Terraform Acceptance Test",
  "id": ${substr(uuid(), 0, 6)},
  "uid": "basic",
  "version": 34
}
EOD
}
```

Despite it's a new plan (without state file), Terraform call the StateFunc `normalizeDashboardConfigJSON` with the default value 
 `UnknownVariableValue` (74D93920-ED26-11E3-AC10-0800200C9A66) which cause the unmashal error.
https://github.com/hashicorp/terraform-plugin-sdk/blob/112e2164c381d80e8ada3170dac9a8a5db01079a/internal/configs/hcl2shim/values.go#L16

I suggest to return an error during unmashall instead of terminate the program using `panic()`, and then skip the normalizeDashboardConfigJSON if the `config_json` doesn't have the expected format.

To reproduce in tests, I created 2 dashboards (one with the minimal configuration and a second with a configuration attribute defined by the first one)
