### PR TITLE
Reword docs about Synthetic Monitoring public config

### DIFF
--- a/docs/data-sources/synthetic_monitoring_probe.md
+++ b/docs/data-sources/synthetic_monitoring_probe.md
@@ -31,7 +31,7 @@ data "grafana_synthetic_monitoring_probe" "atlanta" {
 - **labels** (Map of String) Custom labels to be included with collected metrics and logs.
 - **latitude** (Number) Latitude coordinates.
 - **longitude** (Number) Longitude coordinates.
-- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. You must be an admin to set this to `true`.
+- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. This will be `true` for public probes, and `false` for Private probes
 - **region** (String) Region of the probe.
 - **tenant_id** (Number) The tenant ID of the probe.
 

--- a/docs/data-sources/synthetic_monitoring_probe.md
+++ b/docs/data-sources/synthetic_monitoring_probe.md
@@ -31,7 +31,7 @@ data "grafana_synthetic_monitoring_probe" "atlanta" {
 - **labels** (Map of String) Custom labels to be included with collected metrics and logs.
 - **latitude** (Number) Latitude coordinates.
 - **longitude** (Number) Longitude coordinates.
-- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. This will be `true` for public probes, and `false` for Private probes
+- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. Only Grafana Labs managed public probes will be set to `true`.
 - **region** (String) Region of the probe.
 - **tenant_id** (Number) The tenant ID of the probe.
 

--- a/docs/resources/synthetic_monitoring_probe.md
+++ b/docs/resources/synthetic_monitoring_probe.md
@@ -46,7 +46,7 @@ resource "grafana_synthetic_monitoring_probe" "main" {
 ### Optional
 
 - **labels** (Map of String) Custom labels to be included with collected metrics and logs.
-- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. Only Grafana Labs managed public probes will be set to `true`, should be set to `false`, and is `false` by default.
+- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. Only Grafana Labs managed public probes will be set to `true`. Defaults to `false`.
 
 ### Read-Only
 

--- a/docs/resources/synthetic_monitoring_probe.md
+++ b/docs/resources/synthetic_monitoring_probe.md
@@ -46,7 +46,7 @@ resource "grafana_synthetic_monitoring_probe" "main" {
 ### Optional
 
 - **labels** (Map of String) Custom labels to be included with collected metrics and logs.
-- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. You must be an admin to set this to `true`. Defaults to `false`.
+- **public** (Boolean) Public probes are run by Grafana Labs and can be used by all users. Only Grafana Labs managed public probes will be set to `true`, should be set to `false`, and is `false` by default.
 
 ### Read-Only
 

--- a/grafana/resource_synthetic_monitoring_probe.go
+++ b/grafana/resource_synthetic_monitoring_probe.go
@@ -79,7 +79,7 @@ Grafana Synthetic Monitoring Agent.
 				},
 			},
 			"public": {
-				Description: "Public probes are run by Grafana Labs and can be used by all users. You must be an admin to set this to `true`.",
+				Description: "Public probes are run by Grafana Labs and can be used by all users. Only Grafana Labs managed public probes will be set to `true`.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,


### PR DESCRIPTION
remove potential misleading line about public probes, and make it clear that public probes can only be created by Grafana Labs