### PR TITLE
datasource: add http headers support

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -88,6 +88,7 @@ resource "grafana_data_source" "stackdriver" {
 - **basic_auth_password** (String, Sensitive) Basic auth password. Defaults to ``.
 - **basic_auth_username** (String) Basic auth username. Defaults to ``.
 - **database_name** (String) (Required by some data source types) The name of the database to use on the selected data source server. Defaults to ``.
+- **http_headers** (Map of String, Sensitive) Custom HTTP headers
 - **id** (String) The ID of this resource.
 - **is_default** (Boolean) Whether to set the data source as default. This should only be `true` to a single data source. Defaults to `false`.
 - **json_data** (Block List) (Required by some data source types) (see [below for nested schema](#nestedblock--json_data))

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.1.3
+	github.com/grafana/grafana-api-golang-client v0.1.4-0.20220108024156-aae2f4216ddc
 	github.com/grafana/synthetic-monitoring-agent v0.4.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.3.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.1.4-0.20220108024156-aae2f4216ddc
+	github.com/grafana/grafana-api-golang-client v0.2.1
 	github.com/grafana/synthetic-monitoring-agent v0.4.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.3.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grafana/grafana-api-golang-client v0.1.3 h1:p0f8FB0/UlBX3nXv+Lt+dmms5p5cmp6hxuipio93lYc=
 github.com/grafana/grafana-api-golang-client v0.1.3/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.1.4-0.20220108024156-aae2f4216ddc h1:7b2sPwWzkkHt37hb3pnSMmIjA0F1mX6PnYIb0L7VTRY=
+github.com/grafana/grafana-api-golang-client v0.1.4-0.20220108024156-aae2f4216ddc/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/synthetic-monitoring-agent v0.3.0/go.mod h1:P8WTBnw3SIZW5Nm5obOlSKvD887IxAfbrJkSnoZyIlA=
 github.com/grafana/synthetic-monitoring-agent v0.4.1 h1:RiVOHi059tYIDixXPxmFQ2vCWCY4Vksslpfm5gNkgnQ=
 github.com/grafana/synthetic-monitoring-agent v0.4.1/go.mod h1:hcx3Pe76ixYsbjtM0eFpyE1bzPxiFgJIyXtdqgPeIkk=

--- a/go.sum
+++ b/go.sum
@@ -452,10 +452,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.1.3 h1:p0f8FB0/UlBX3nXv+Lt+dmms5p5cmp6hxuipio93lYc=
-github.com/grafana/grafana-api-golang-client v0.1.3/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
-github.com/grafana/grafana-api-golang-client v0.1.4-0.20220108024156-aae2f4216ddc h1:7b2sPwWzkkHt37hb3pnSMmIjA0F1mX6PnYIb0L7VTRY=
-github.com/grafana/grafana-api-golang-client v0.1.4-0.20220108024156-aae2f4216ddc/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.2.1 h1:5OizQpq+WP+A6t+wHoYCOrmbytWQMgnWwPfzXqSBGrI=
+github.com/grafana/grafana-api-golang-client v0.2.1/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/synthetic-monitoring-agent v0.3.0/go.mod h1:P8WTBnw3SIZW5Nm5obOlSKvD887IxAfbrJkSnoZyIlA=
 github.com/grafana/synthetic-monitoring-agent v0.4.1 h1:RiVOHi059tYIDixXPxmFQ2vCWCY4Vksslpfm5gNkgnQ=
 github.com/grafana/synthetic-monitoring-agent v0.4.1/go.mod h1:hcx3Pe76ixYsbjtM0eFpyE1bzPxiFgJIyXtdqgPeIkk=

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"regexp"
 	"strconv"
@@ -61,6 +62,15 @@ source selected (via the 'type' argument).
 				Optional:    true,
 				Default:     "",
 				Description: "(Required by some data source types) The name of the database to use on the selected data source server.",
+			},
+			"http_headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Custom HTTP headers",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"is_default": {
 				Type:        schema.TypeBool,
@@ -481,6 +491,11 @@ func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
 		id, err = strconv.ParseInt(idStr, 10, 64)
 	}
 
+	httpHeaders := make(map[string]string)
+	for key, value := range d.Get("http_headers").(map[string]interface{}) {
+		httpHeaders[key] = fmt.Sprintf("%v", value)
+	}
+
 	return &gapi.DataSource{
 		ID:                id,
 		Name:              d.Get("name").(string),
@@ -495,6 +510,7 @@ func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
 		BasicAuthUser:     d.Get("basic_auth_username").(string),
 		BasicAuthPassword: d.Get("basic_auth_password").(string),
 		UID:               d.Get("uid").(string),
+		HTTPHeaders:       httpHeaders,
 		JSONData:          makeJSONData(d),
 		SecureJSONData:    makeSecureJSONData(d),
 	}, err

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -11,292 +11,313 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var resourceTests = []struct {
-	resource   string
-	config     string
-	attrChecks map[string]string
-}{
-	{
-		"grafana_data_source.testdata",
-		`
-resource "grafana_data_source" "testdata" {
-	type                = "testdata"
-	name                = "testdata"
-	access_mode					= "direct"
-	basic_auth_enabled  = true
-	basic_auth_password = "ba_password"
-	basic_auth_username = "ba_username"
-	database_name       = "db_name"
-	is_default					= true
-	url                 = "http://acc-test.invalid/"
-	username            = "user"
-	password            = "pass"
-}
-`,
-		map[string]string{
-			"type":                "testdata",
-			"name":                "testdata",
-			"access_mode":         "direct",
-			"basic_auth_enabled":  "true",
-			"basic_auth_password": "ba_password",
-			"basic_auth_username": "ba_username",
-			"database_name":       "db_name",
-			"is_default":          "true",
-			"url":                 "http://acc-test.invalid/",
-			"username":            "user",
-			"password":            "pass",
-		},
-	},
-	{
-		"grafana_data_source.graphite",
-		`
-	resource "grafana_data_source" "graphite" {
-		type = "graphite"
-		name = "graphite"
-		url  = "http://acc-test.invalid/"
-		json_data {
-			graphite_version = "1.1"
-		}
-	}
-	`,
-		map[string]string{
-			"type":                         "graphite",
-			"name":                         "graphite",
-			"url":                          "http://acc-test.invalid/",
-			"json_data.0.graphite_version": "1.1",
-		},
-	},
-	{
-		"grafana_data_source.influx",
-		`
-	resource "grafana_data_source" "influx" {
-		type          = "influx"
-		name          = "influx"
-		database_name = "db_name"
-		username      = "user"
-		password      = "pass"
-		url           = "http://acc-test.invalid/"
-		json_data {
-			time_interval = "60s"
-		}
-	}
-	`,
-		map[string]string{
-			"type":                      "influx",
-			"name":                      "influx",
-			"database_name":             "db_name",
-			"username":                  "user",
-			"password":                  "pass",
-			"url":                       "http://acc-test.invalid/",
-			"json_data.0.time_interval": "60s",
-		},
-	},
-	{
-		"grafana_data_source.elasticsearch",
-		`
-	resource "grafana_data_source" "elasticsearch" {
-		type          = "elasticsearch"
-		name          = "elasticsearch"
-		database_name = "[filebeat-]YYYY.MM.DD"
-		url 	        = "http://acc-test.invalid/"
-		json_data {
-			es_version        = "7.0.0"
-			interval          = "Daily"
-			time_field        = "@timestamp"
-			log_message_field = "message"
-			log_level_field   = "fields.level"
-			max_concurrent_shard_requests = 8
-		}
-	}
-	`,
-		map[string]string{
-			"type":                          "elasticsearch",
-			"name":                          "elasticsearch",
-			"database_name":                 "[filebeat-]YYYY.MM.DD",
-			"url":                           "http://acc-test.invalid/",
-			"json_data.0.es_version":        "7.0.0",
-			"json_data.0.interval":          "Daily",
-			"json_data.0.time_field":        "@timestamp",
-			"json_data.0.log_message_field": "message",
-			"json_data.0.log_level_field":   "fields.level",
-			"json_data.0.max_concurrent_shard_requests": "8",
-		},
-	},
-	{
-		"grafana_data_source.opentsdb",
-		`
-	resource "grafana_data_source" "opentsdb" {
-		type = "opentsdb"
-		name = "opentsdb"
-		url	 = "http://acc-test.invalid/"
-		json_data {
-			tsdb_resolution = 1
-			tsdb_version    = 1
-		}
-	}
-	`,
-		map[string]string{
-			"type":                        "opentsdb",
-			"name":                        "opentsdb",
-			"url":                         "http://acc-test.invalid/",
-			"json_data.0.tsdb_resolution": "1",
-			"json_data.0.tsdb_version":    "1",
-		},
-	},
-	{
-		"grafana_data_source.cloudwatch",
-		`
-	resource "grafana_data_source" "cloudwatch" {
-		type = "cloudwatch"
-		name = "cloudwatch"
-		json_data {
-			default_region            = "us-east-1"
-			auth_type                 = "keys"
-			assume_role_arn           = "arn:aws:sts::*:assumed-role/*/*"
-			custom_metrics_namespaces = "foo"
-		}
-		secure_json_data {
-			access_key = "123"
-			secret_key = "456"
-		}
-	}
-	`,
-		map[string]string{
-			"type":                                  "cloudwatch",
-			"name":                                  "cloudwatch",
-			"json_data.0.default_region":            "us-east-1",
-			"json_data.0.auth_type":                 "keys",
-			"json_data.0.assume_role_arn":           "arn:aws:sts::*:assumed-role/*/*",
-			"json_data.0.custom_metrics_namespaces": "foo",
-			"secure_json_data.0.access_key":         "123",
-			"secure_json_data.0.secret_key":         "456",
-		},
-	},
-	{
-		"grafana_data_source.mssql",
-		`
-		resource "grafana_data_source" "mssql" {
-			type          = "mssql"
-			name          = "mssql"
-			database_name = "db"
-			url 	        = "acc-test.invalid:1433"
-			json_data {
-				max_open_conns    = 0
-				max_idle_conns    = 2
-				conn_max_lifetime = 14400
-				encrypt           = "yes"
-			}
-			secure_json_data {
-				password = "pass"
-			}
-		}
-		`,
-		map[string]string{
-			"type":                          "mssql",
-			"name":                          "mssql",
-			"database_name":                 "db",
-			"url":                           "acc-test.invalid:1433",
-			"json_data.0.max_open_conns":    "0",
-			"json_data.0.max_idle_conns":    "2",
-			"json_data.0.conn_max_lifetime": "14400",
-			"json_data.0.encrypt":           "yes",
-			"secure_json_data.0.password":   "pass",
-		},
-	},
-	{
-		"grafana_data_source.postgres",
-		`
-		resource "grafana_data_source" "postgres" {
-			type          = "postgres"
-			name          = "postgres"
-			database_name = "db"
-			url 	        = "acc-test.invalid:5432"
-			username      = "user"
-			json_data {
-				max_open_conns    = 0
-				max_idle_conns    = 2
-				conn_max_lifetime = 14400
-				postgres_version  = 905
-				timescaledb 			= false
-			}
-			secure_json_data {
-				password = "pass"
-			}
-		}
-		`,
-		map[string]string{
-			"type":                          "postgres",
-			"name":                          "postgres",
-			"database_name":                 "db",
-			"url":                           "acc-test.invalid:5432",
-			"json_data.0.max_open_conns":    "0",
-			"json_data.0.max_idle_conns":    "2",
-			"json_data.0.conn_max_lifetime": "14400",
-			"json_data.0.postgres_version":  "905",
-			"json_data.0.timescaledb":       "false",
-			"secure_json_data.0.password":   "pass",
-		},
-	},
-	{
-		"grafana_data_source.prometheus",
-		`
-		resource "grafana_data_source" "prometheus" {
-			type = "prometheus"
-			name = "prometheus"
-			url  = "http://acc-test.invalid:9090"
-			json_data {
-				http_method = "GET"
-				query_timeout = "1"
-				sigv4_auth   = true
-				sigv4_auth_type = "default"
-				sigv4_region    = "eu-west-1"
-			}
-		}
-		`,
-		map[string]string{
-			"type":                        "prometheus",
-			"name":                        "prometheus",
-			"url":                         "http://acc-test.invalid:9090",
-			"json_data.0.http_method":     "GET",
-			"json_data.0.query_timeout":   "1",
-			"json_data.0.sigv4_auth":      "true",
-			"json_data.0.sigv4_auth_type": "default",
-			"json_data.0.sigv4_region":    "eu-west-1",
-		},
-	},
-	{
-		"grafana_data_source.stackdriver",
-		`
-		resource "grafana_data_source" "stackdriver" {
-			type = "stackdriver"
-			name = "stackdriver"
-			json_data {
-				token_uri = "https://oauth2.googleapis.com/token"
-				authentication_type = "jwt"
-				default_project = "default-project"
-				client_email = "client-email@default-project.iam.gserviceaccount.com"
-			}
-			secure_json_data {
-				private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
-			}
-		}
-		`,
-		map[string]string{
-			"type":                            "stackdriver",
-			"name":                            "stackdriver",
-			"json_data.0.token_uri":           "https://oauth2.googleapis.com/token",
-			"json_data.0.authentication_type": "jwt",
-			"json_data.0.default_project":     "default-project",
-			"json_data.0.client_email":        "client-email@default-project.iam.gserviceaccount.com",
-			"secure_json_data.0.private_key":  "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
-		},
-	},
-}
-
 func TestAccDataSource_basic(t *testing.T) {
 	CheckOSSTestsEnabled(t)
 
 	var dataSource gapi.DataSource
+
+	var resourceTests = []struct {
+		resource         string
+		config           string
+		attrChecks       map[string]string
+		additionalChecks []resource.TestCheckFunc
+	}{
+		{
+			resource: "grafana_data_source.testdata",
+			config: `
+		resource "grafana_data_source" "testdata" {
+			type                = "testdata"
+			name                = "testdata"
+			access_mode					= "direct"
+			basic_auth_enabled  = true
+			basic_auth_password = "ba_password"
+			basic_auth_username = "ba_username"
+			database_name       = "db_name"
+			is_default					= true
+			url                 = "http://acc-test.invalid/"
+			username            = "user"
+			password            = "pass"
+		}
+		`,
+			attrChecks: map[string]string{
+				"type":                "testdata",
+				"name":                "testdata",
+				"access_mode":         "direct",
+				"basic_auth_enabled":  "true",
+				"basic_auth_password": "ba_password",
+				"basic_auth_username": "ba_username",
+				"database_name":       "db_name",
+				"is_default":          "true",
+				"url":                 "http://acc-test.invalid/",
+				"username":            "user",
+				"password":            "pass",
+			},
+		},
+		{
+			resource: "grafana_data_source.graphite",
+			config: `
+			resource "grafana_data_source" "graphite" {
+				type = "graphite"
+				name = "graphite"
+				url  = "http://acc-test.invalid/"
+				json_data {
+					graphite_version = "1.1"
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                         "graphite",
+				"name":                         "graphite",
+				"url":                          "http://acc-test.invalid/",
+				"json_data.0.graphite_version": "1.1",
+			},
+		},
+		{
+			resource: "grafana_data_source.influx",
+			config: `
+			resource "grafana_data_source" "influx" {
+				type          = "influx"
+				name          = "influx"
+				database_name = "db_name"
+				username      = "user"
+				password      = "pass"
+				url           = "http://acc-test.invalid/"
+				json_data {
+					time_interval = "60s"
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                      "influx",
+				"name":                      "influx",
+				"database_name":             "db_name",
+				"username":                  "user",
+				"password":                  "pass",
+				"url":                       "http://acc-test.invalid/",
+				"json_data.0.time_interval": "60s",
+			},
+		},
+		{
+			resource: "grafana_data_source.elasticsearch",
+			config: `
+			resource "grafana_data_source" "elasticsearch" {
+				type          = "elasticsearch"
+				name          = "elasticsearch"
+				database_name = "[filebeat-]YYYY.MM.DD"
+				url 	        = "http://acc-test.invalid/"
+				json_data {
+					es_version        = "7.0.0"
+					interval          = "Daily"
+					time_field        = "@timestamp"
+					log_message_field = "message"
+					log_level_field   = "fields.level"
+					max_concurrent_shard_requests = 8
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                          "elasticsearch",
+				"name":                          "elasticsearch",
+				"database_name":                 "[filebeat-]YYYY.MM.DD",
+				"url":                           "http://acc-test.invalid/",
+				"json_data.0.es_version":        "7.0.0",
+				"json_data.0.interval":          "Daily",
+				"json_data.0.time_field":        "@timestamp",
+				"json_data.0.log_message_field": "message",
+				"json_data.0.log_level_field":   "fields.level",
+				"json_data.0.max_concurrent_shard_requests": "8",
+			},
+		},
+		{
+			resource: "grafana_data_source.opentsdb",
+			config: `
+			resource "grafana_data_source" "opentsdb" {
+				type = "opentsdb"
+				name = "opentsdb"
+				url	 = "http://acc-test.invalid/"
+				json_data {
+					tsdb_resolution = 1
+					tsdb_version    = 1
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                        "opentsdb",
+				"name":                        "opentsdb",
+				"url":                         "http://acc-test.invalid/",
+				"json_data.0.tsdb_resolution": "1",
+				"json_data.0.tsdb_version":    "1",
+			},
+		},
+		{
+			resource: "grafana_data_source.cloudwatch",
+			config: `
+			resource "grafana_data_source" "cloudwatch" {
+				type = "cloudwatch"
+				name = "cloudwatch"
+				json_data {
+					default_region            = "us-east-1"
+					auth_type                 = "keys"
+					assume_role_arn           = "arn:aws:sts::*:assumed-role/*/*"
+					custom_metrics_namespaces = "foo"
+				}
+				secure_json_data {
+					access_key = "123"
+					secret_key = "456"
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                                  "cloudwatch",
+				"name":                                  "cloudwatch",
+				"json_data.0.default_region":            "us-east-1",
+				"json_data.0.auth_type":                 "keys",
+				"json_data.0.assume_role_arn":           "arn:aws:sts::*:assumed-role/*/*",
+				"json_data.0.custom_metrics_namespaces": "foo",
+				"secure_json_data.0.access_key":         "123",
+				"secure_json_data.0.secret_key":         "456",
+			},
+		},
+		{
+			resource: "grafana_data_source.mssql",
+			config: `
+				resource "grafana_data_source" "mssql" {
+					type          = "mssql"
+					name          = "mssql"
+					database_name = "db"
+					url 	        = "acc-test.invalid:1433"
+					json_data {
+						max_open_conns    = 0
+						max_idle_conns    = 2
+						conn_max_lifetime = 14400
+						encrypt           = "yes"
+					}
+					secure_json_data {
+						password = "pass"
+					}
+				}
+				`,
+			attrChecks: map[string]string{
+				"type":                          "mssql",
+				"name":                          "mssql",
+				"database_name":                 "db",
+				"url":                           "acc-test.invalid:1433",
+				"json_data.0.max_open_conns":    "0",
+				"json_data.0.max_idle_conns":    "2",
+				"json_data.0.conn_max_lifetime": "14400",
+				"json_data.0.encrypt":           "yes",
+				"secure_json_data.0.password":   "pass",
+			},
+		},
+		{
+			resource: "grafana_data_source.postgres",
+			config: `
+				resource "grafana_data_source" "postgres" {
+					type          = "postgres"
+					name          = "postgres"
+					database_name = "db"
+					url 	        = "acc-test.invalid:5432"
+					username      = "user"
+					json_data {
+						max_open_conns    = 0
+						max_idle_conns    = 2
+						conn_max_lifetime = 14400
+						postgres_version  = 905
+						timescaledb 			= false
+					}
+					secure_json_data {
+						password = "pass"
+					}
+				}
+				`,
+			attrChecks: map[string]string{
+				"type":                          "postgres",
+				"name":                          "postgres",
+				"database_name":                 "db",
+				"url":                           "acc-test.invalid:5432",
+				"json_data.0.max_open_conns":    "0",
+				"json_data.0.max_idle_conns":    "2",
+				"json_data.0.conn_max_lifetime": "14400",
+				"json_data.0.postgres_version":  "905",
+				"json_data.0.timescaledb":       "false",
+				"secure_json_data.0.password":   "pass",
+			},
+		},
+		{
+			resource: "grafana_data_source.prometheus",
+			config: `
+			resource "grafana_data_source" "prometheus" {
+				type = "prometheus"
+				name = "prometheus"
+				url  = "http://acc-test.invalid:9090"
+				json_data {
+					http_method = "GET"
+					query_timeout = "1"
+					sigv4_auth   = true
+					sigv4_auth_type = "default"
+					sigv4_region    = "eu-west-1"
+				}
+
+				http_headers = {
+					"header1" = "value1"
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                        "prometheus",
+				"name":                        "prometheus",
+				"url":                         "http://acc-test.invalid:9090",
+				"json_data.0.http_method":     "GET",
+				"json_data.0.query_timeout":   "1",
+				"json_data.0.sigv4_auth":      "true",
+				"json_data.0.sigv4_auth_type": "default",
+				"json_data.0.sigv4_region":    "eu-west-1",
+				"http_headers.header1":        "value1",
+			},
+			additionalChecks: []resource.TestCheckFunc{
+				func(s *terraform.State) error {
+					if dataSource.Name != "prometheus" {
+						return fmt.Errorf("bad name: %s", dataSource.Name)
+					}
+					if len(dataSource.HTTPHeaders) != 1 {
+						return fmt.Errorf("expected 1 http header, got %d", len(dataSource.HTTPHeaders))
+					}
+
+					if _, ok := dataSource.HTTPHeaders["header1"]; !ok {
+						return fmt.Errorf("http header header1 not found")
+					}
+					return nil
+				},
+			},
+		},
+		{
+			resource: "grafana_data_source.stackdriver",
+			config: `
+			resource "grafana_data_source" "stackdriver" {
+				type = "stackdriver"
+				name = "stackdriver"
+				json_data {
+					token_uri = "https://oauth2.googleapis.com/token"
+					authentication_type = "jwt"
+					default_project = "default-project"
+					client_email = "client-email@default-project.iam.gserviceaccount.com"
+				}
+				secure_json_data {
+					private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                            "stackdriver",
+				"name":                            "stackdriver",
+				"json_data.0.token_uri":           "https://oauth2.googleapis.com/token",
+				"json_data.0.authentication_type": "jwt",
+				"json_data.0.default_project":     "default-project",
+				"json_data.0.client_email":        "client-email@default-project.iam.gserviceaccount.com",
+				"secure_json_data.0.private_key":  "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+			},
+		},
+	}
 
 	// Iterate over the provided configurations for datasources
 	for _, test := range resourceTests {
@@ -332,7 +353,7 @@ func TestAccDataSource_basic(t *testing.T) {
 				{
 					Config: test.config,
 					Check: resource.ComposeAggregateTestCheckFunc(
-						checks...,
+						append(checks, test.additionalChecks...)...,
 					),
 				},
 			},


### PR DESCRIPTION
This PR adds support for HTTP headers with data_source ressource. It requires https://github.com/grafana/grafana-api-golang-client/pull/33 so an upgrade of client version should be done after merge of client PR.
It fixes #191 