### PR TITLE
Update Elasticsearch version to be string in grafana_data_source resource

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -110,7 +110,7 @@ Optional:
 - **default_project** (String) (Stackdriver) The default project for the data source.
 - **default_region** (String) (CloudWatch) The default region for the data source.
 - **encrypt** (String) (MSSQL) Connection SSL encryption handling: 'disable', 'false' or 'true'.
-- **es_version** (Number) (Elasticsearch) Elasticsearch version as a number (2/5/56/60/70).
+- **es_version** (String) (Elasticsearch) Elasticsearch semantic version (Grafana v8.0+).
 - **graphite_version** (String) (Graphite) Graphite version.
 - **http_method** (String) (Prometheus) HTTP method to use for making requests.
 - **interval** (String) (Elasticsearch) Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly'.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/grafana/synthetic-monitoring-agent v0.0.24
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.2
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.0.0-20210720012848-3049c6914b86
+	github.com/grafana/grafana-api-golang-client v0.0.0-20211005011003-c69abe946fa6
 	github.com/grafana/synthetic-monitoring-agent v0.0.24
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.2
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210720012848-3049c6914b86 h1:Dmds3qEEVMuqH09VaIYSY9idLn4C8NMLyTmRfhW4ttM=
-github.com/grafana/grafana-api-golang-client v0.0.0-20210720012848-3049c6914b86/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.0.0-20211005011003-c69abe946fa6 h1:B8YsmxR/o6nAJRPofr47bckY+MNGPj6Ejs8iAY4gXkI=
+github.com/grafana/grafana-api-golang-client v0.0.0-20211005011003-c69abe946fa6/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/loki v1.6.1/go.mod h1:X+GvtCzAf2ok/xRLLvGB8kuWP1R+75nXnvjCEnenP0s=
 github.com/grafana/synthetic-monitoring-agent v0.0.23/go.mod h1:luWgdBaAQgOz9e6m/cGQCFFrPWkBTl+VZM/UC+75nSM=
 github.com/grafana/synthetic-monitoring-agent v0.0.24 h1:qfDFWIW2iPmffAsLO9WG/h8inAV+D/nXbQUQ4DTdL3E=

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -118,9 +118,9 @@ source selected (via the 'type' argument).
 							Description: "(MSSQL) Connection SSL encryption handling: 'disable', 'false' or 'true'.",
 						},
 						"es_version": {
-							Type:        schema.TypeInt,
+							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "(Elasticsearch) Elasticsearch version as a number (2/5/56/60/70).",
+							Description: "(Elasticsearch) Elasticsearch semantic version (Grafana v8.0+).",
 						},
 						"graphite_version": {
 							Type:        schema.TypeString,
@@ -489,7 +489,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		DefaultProject:             d.Get("json_data.0.default_project").(string),
 		DefaultRegion:              d.Get("json_data.0.default_region").(string),
 		Encrypt:                    d.Get("json_data.0.encrypt").(string),
-		EsVersion:                  int64(d.Get("json_data.0.es_version").(int)),
+		EsVersion:                  d.Get("json_data.0.es_version").(string),
 		GraphiteVersion:            d.Get("json_data.0.graphite_version").(string),
 		HTTPMethod:                 d.Get("json_data.0.http_method").(string),
 		Interval:                   d.Get("json_data.0.interval").(string),

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -3,9 +3,11 @@ package grafana
 import (
 	"context"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -121,6 +123,18 @@ source selected (via the 'type' argument).
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "(Elasticsearch) Elasticsearch semantic version (Grafana v8.0+).",
+							ValidateDiagFunc: func(v interface{}, p cty.Path) diag.Diagnostics {
+								var diags diag.Diagnostics
+								r := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+								if !r.MatchString(v.(string)) {
+									diags = append(diags, diag.Diagnostic{
+										Severity: diag.Warning,
+										Summary:  "Expected semantic version",
+										Detail:   "As of Grafana 8.0, the Elasticsearch plugin expects es_version to be set as a semantic version (E.g. 7.0.0, 7.6.1).",
+									})
+								}
+								return diags
+							},
 						},
 						"graphite_version": {
 							Type:        schema.TypeString,

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -101,7 +101,7 @@ resource "grafana_data_source" "testdata" {
 		database_name = "[filebeat-]YYYY.MM.DD"
 		url 	        = "http://acc-test.invalid/"
 		json_data {
-			es_version        = 70
+			es_version        = "7.0.0"
 			interval          = "Daily"
 			time_field        = "@timestamp"
 			log_message_field = "message"
@@ -115,7 +115,7 @@ resource "grafana_data_source" "testdata" {
 			"name":                          "elasticsearch",
 			"database_name":                 "[filebeat-]YYYY.MM.DD",
 			"url":                           "http://acc-test.invalid/",
-			"json_data.0.es_version":        "70",
+			"json_data.0.es_version":        "7.0.0",
 			"json_data.0.interval":          "Daily",
 			"json_data.0.time_field":        "@timestamp",
 			"json_data.0.log_message_field": "message",


### PR DESCRIPTION
### Context

Grafana 8.0+ switched to use semantic versions instead of numeric values. The numeric usage is considered legacy and should not be used anymore and semantic versions are represented as string values. This PR updates the `es_version` attribute in the `json_data` for `grafana_data_source` resource.

Note that this change is only relevant for Grafana 8.0+ versions. Prior versions to 8.0 must still use the provider version which supports `es_version` as a numeric value.

### Impact

All `grafana_data_source` resources which are provisioning Elasticsearch datasource need to changed to use full semantic version of Elasticsearch. 

For example, instead of the following:

```
resource "grafana_data_source" "elasticsearch" {
  name = "elasticsearch"
  type = "elasticsearch"
  json_data {
    es_version = 70
  }
}
```
the following should be used

```
resource "grafana_data_source" "elasticsearch" {
  name = "elasticsearch"
  type = "elasticsearch"
  json_data {
    es_version = "7.0.0"
  }
}
```

### Fixes

https://github.com/grafana/terraform-provider-grafana/issues/243

### Note for reviewers

- Relevant [change in the grafana-api-go-client](https://github.com/grafana/grafana-api-golang-client/pull/34) is a prerequisite for this PR.
- There is an internal [escalation](https://github.com/grafana/support-escalations/issues/841) for this problem, so getting this fixed has some level of urgency.