### PR TITLE
Warn If `es_version` is not a semantic version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/grafana/synthetic-monitoring-agent v0.0.24
 	github.com/grafana/synthetic-monitoring-api-go-client v0.0.2
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 )

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -3,9 +3,11 @@ package grafana
 import (
 	"context"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -121,6 +123,18 @@ source selected (via the 'type' argument).
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "(Elasticsearch) Elasticsearch semantic version (Grafana v8.0+).",
+							ValidateDiagFunc: func(v interface{}, p cty.Path) diag.Diagnostics {
+								var diags diag.Diagnostics
+								r := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+								if !r.MatchString(v.(string)) {
+									diags = append(diags, diag.Diagnostic{
+										Severity: diag.Warning,
+										Summary:  "Expected semantic version",
+										Detail:   "As of Grafana 8.0, the Elasticsearch plugin expects es_version to be set as a semantic version (E.g. 7.0.0, 7.6.1).",
+									})
+								}
+								return diags
+							},
 						},
 						"graphite_version": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
https://github.com/grafana/terraform-provider-grafana/pull/267 introduces a subtle breaking change.

When merged the `es_version` field will no longer be valid for Grafana versions 7.x and earlier. This warning will at least provide an indication that it's intended for use with Grafana 8+ instead of silently failing.

For Grafana 8+ users, it will provide an indication that they must update this field for it to actually work.

Example execution plan output:

```
╷
│ Warning: Expected semantic version
│
│   with grafana_data_source.elasticsearch,
│   on datasource.tf line 7, in resource "grafana_data_source" "elasticsearch":
│    7:     es_version                    = 70
│
│ As of Grafana 8.0, the Elasticsearch plugin expects es_version to be set as a semantic version (E.g. 7.0.0, 7.6.1).
│
```