### PR TITLE
fix(resource_alert_notification): safeguard against a nil value for AlertNotification.SecureFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ GRAFANA_ORG_ID=1 \
 make testacc
 ```
 
+#### Limiting an acceptance test run to specific tests
+
+The tests run by a target can be filtered by specifying an additional `run` argument:
+
+```sh
+TESTARGS='--run=TestAccDataSource_basic' make testacc-docker
+```
+
+The value passed to `run` supports regular expressions:
+
+```sh
+TESTARGS='--run=TestAccDataSource_.*' make testacc-docker
+```
+
 #### Running enterprise tests
 
 To run tests for resources which are available only for Grafana Enterprise, running instance of Grafana Enterprise is required.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - GRAFANA_URL=http://grafana:3000
       - GRAFANA_AUTH=admin:admin
       - GRAFANA_ORG_ID=1
+      - TESTARGS=${TESTARGS}
     working_dir: /go/src/github.com/grafana/terraform-provider-grafana
     volumes:
       - .:/go/src/github.com/grafana/terraform-provider-grafana

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -160,15 +160,17 @@ func ReadAlertNotification(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	secureSettings := map[string]interface{}{}
 
-	for k, v := range alertNotification.SecureFields.(map[string]interface{}) {
-		boolVal, ok := v.(bool)
-		switch {
-		case ok && boolVal:
-			secureSettings[k] = "true"
-		case ok && !boolVal:
-			secureSettings[k] = "false"
-		default:
-			secureSettings[k] = v
+	if f, ok := alertNotification.SecureFields.(map[string]interface{}); ok {
+		for k, v := range f {
+			boolVal, ok := v.(bool)
+			switch {
+			case ok && boolVal:
+				secureSettings[k] = "true"
+			case ok && !boolVal:
+				secureSettings[k] = "false"
+			default:
+				secureSettings[k] = v
+			}
 		}
 	}
 	d.Set("secure_settings", secureSettings)


### PR DESCRIPTION
Resolves #280 

I haven't been able to reproduce this with an acceptance test, but my local instance of grafana is not returning a `secureFields` field when reading an alert notification resource.  This is crashing the provider during a plan phase:
https://gist.github.com/ctrombley/4cdfa01b110d85bc28c88890815351b0

This PR safeguards against this scenario with a type assertion test.  

- Grafana `7.1.0-beta-2`
- Provider `1.14.0`
- Terraform `0.15.5`

I also added some instructions to the README for filtering tests during a test run when using docker.