### PR TITLE
Run cloud tests in CI

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,9 +1,20 @@
 local grafana = 'grafana/grafana:8.0.3';
-local build = 'grafana/build-container:1.4.1';
+local build = 'grafana/build-container:1.4.7';
 
-// We'd like the same pipeline for testing pull requests as we do for building
-// master. The only difference is their names and triggers.
-local pipeline(name, trigger) = {
+local secret(name, vaultPath, vaultKey) = {
+  kind: 'secret',
+  name: name,
+  get: {
+    path: vaultPath,
+    name: vaultKey,
+  },
+
+  fromSecret:: { from_secret: name },
+};
+local apiToken = secret('grafana-api-token', 'infra/data/ci/terraform-provider-grafana/cloud', 'api-key');
+local smToken = secret('grafana-sm-token', 'infra/data/ci/terraform-provider-grafana/cloud', 'sm-access-token');
+
+local pipeline(name, steps, services=[]) = {
   kind: 'pipeline',
   type: 'docker',
   name: name,
@@ -11,42 +22,74 @@ local pipeline(name, trigger) = {
     os: 'linux',
     arch: 'amd64',
   },
-  steps: [
-    {
-      name: 'tests',
-      image: build,
-      commands: [
-        'sleep 5',  // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
-        'golangci-lint --version',
-        'golangci-lint run ./...',
-        'make testacc',
-      ],
-      environment: {
-        GRAFANA_URL: 'http://grafana:3000',
-        GRAFANA_AUTH: 'admin:admin',
-        GRAFANA_ORG_ID: 1,
-      },
-    },
-  ],
-  services: [
-    {
-      name: 'grafana',
-      image: grafana,
-      environment: {
-        // Prevents error="database is locked"
-        GF_DATABASE_URL: 'sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL',
-      },
-    },
-  ],
-  trigger: trigger,
+  steps: steps,
+  services: services,
+  trigger: {
+    branch: ['master'],
+    event: ['pull_request', 'push'],
+  },
 };
 
 [
-  pipeline('test-pr', {
-    event: ['pull_request'],
-  }),
-  pipeline('build-master', {
-    branch: ['master'],
-    event: ['push'],
-  }),
+  pipeline(
+    'lint', steps=[
+      {
+        name: 'lint',
+        image: build,
+        commands: [
+          'golangci-lint --version',
+          'golangci-lint run ./...',
+        ],
+      },
+    ]
+  ),
+
+  pipeline(
+    'oss tests',
+    steps=[
+      {
+        name: 'tests',
+        image: build,
+        commands: [
+          'sleep 5',  // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
+          'make testacc-oss',
+        ],
+        environment: {
+          GRAFANA_URL: 'http://grafana:3000',
+          GRAFANA_AUTH: 'admin:admin',
+          GRAFANA_ORG_ID: 1,
+        },
+      },
+    ],
+    services=[
+      {
+        name: 'grafana',
+        image: grafana,
+        environment: {
+          // Prevents error="database is locked"
+          GF_DATABASE_URL: 'sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL',
+        },
+      },
+    ],
+  ),
+
+  pipeline(
+    'cloud tests',
+    steps=[
+      {
+        name: 'tests',
+        image: build,
+        commands: ['make testacc-cloud'],
+        environment: {
+          GRAFANA_URL: 'https://terraformprovidergrafana.grafana.net/',
+          GRAFANA_AUTH: apiToken.fromSecret,
+          GRAFANA_SM_ACCESS_TOKEN: smToken.fromSecret,
+          GRAFANA_ORG_ID: 1,
+        },
+      },
+    ]
+  ),
+
+  apiToken,
+  smToken,
 ]

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -1,71 +1,91 @@
 ---
 kind: pipeline
-type: docker
-name: test-pr
-
+name: lint
 platform:
-  os: linux
   arch: amd64
-
+  os: linux
+services: []
 steps:
-- name: tests
-  image: grafana/build-container:1.4.1
-  commands:
-  - sleep 5
+- commands:
   - golangci-lint --version
   - golangci-lint run ./...
-  - make testacc
-  environment:
-    GRAFANA_AUTH: admin:admin
-    GRAFANA_ORG_ID: 1
-    GRAFANA_URL: http://grafana:3000
-
-services:
-- name: grafana
-  image: grafana/grafana:8.0.3
-  environment:
-    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-
-trigger:
-  event:
-  - pull_request
-
----
-kind: pipeline
-type: docker
-name: build-master
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: tests
-  image: grafana/build-container:1.4.1
-  commands:
-  - sleep 5
-  - golangci-lint --version
-  - golangci-lint run ./...
-  - make testacc
-  environment:
-    GRAFANA_AUTH: admin:admin
-    GRAFANA_ORG_ID: 1
-    GRAFANA_URL: http://grafana:3000
-
-services:
-- name: grafana
-  image: grafana/grafana:8.0.3
-  environment:
-    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-
+  image: grafana/build-container:1.4.7
+  name: lint
 trigger:
   branch:
   - master
   event:
+  - pull_request
   - push
-
+type: docker
+---
+kind: pipeline
+name: oss tests
+platform:
+  arch: amd64
+  os: linux
+services:
+- environment:
+    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
+  image: grafana/grafana:8.0.3
+  name: grafana
+steps:
+- commands:
+  - sleep 5
+  - make testacc-oss
+  environment:
+    GRAFANA_AUTH: admin:admin
+    GRAFANA_ORG_ID: 1
+    GRAFANA_URL: http://grafana:3000
+  image: grafana/build-container:1.4.7
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+---
+kind: pipeline
+name: cloud tests
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - make testacc-cloud
+  environment:
+    GRAFANA_AUTH:
+      from_secret: grafana-api-token
+    GRAFANA_ORG_ID: 1
+    GRAFANA_SM_ACCESS_TOKEN:
+      from_secret: grafana-sm-token
+    GRAFANA_URL: https://terraformprovidergrafana.grafana.net/
+  image: grafana/build-container:1.4.7
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+---
+get:
+  name: api-key
+  path: infra/data/ci/terraform-provider-grafana/cloud
+kind: secret
+name: grafana-api-token
+---
+get:
+  name: sm-access-token
+  path: infra/data/ci/terraform-provider-grafana/cloud
+kind: secret
+name: grafana-sm-token
 ---
 kind: signature
-hmac: e720237ec519da396e1c93fba1b538353b1df9d3965095a3230ff640ae5b4bdd
+hmac: 89fe5fce8f18f6fea07e8250974711c58f963bea1f33947247691c48d3a1f858
 
 ...

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,9 @@ GRAFANA_VERSION ?= latest
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
+testacc-oss: TESTARGS+=-tags='oss'
+testacc-oss: testacc
+
 testacc-enterprise: TESTARGS+=-tags='enterprise'
 testacc-enterprise: testacc
 
@@ -14,7 +17,7 @@ testacc-docker:
 		docker-compose \
 		-f ./docker-compose.yml \
 		run --rm grafana-provider \
-		make testacc TESTARGS="$(TESTARGS)"
+		make testacc TESTARGS="-tags='oss' $(TESTARGS)"
 
 testacc-docker-tls:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
@@ -22,7 +25,7 @@ testacc-docker-tls:
 		-f ./docker-compose.yml \
 		-f ./docker-compose.tls.yml \
 		run --rm grafana-provider \
-		make testacc TESTARGS="$(TESTARGS)"
+		make testacc TESTARGS="-tags='oss' $(TESTARGS)"
 
 changelog:
 	@test $${RELEASE_VERSION?Please set environment variable RELEASE_VERSION}
@@ -42,6 +45,6 @@ release:
 	@git push origin $$RELEASE_VERSION
 
 drone:
-	drone jsonnet --stream --source .drone/drone.jsonnet --target .drone/drone.yml
+	drone jsonnet --stream --source .drone/drone.jsonnet --target .drone/drone.yml --format
 	drone lint .drone/drone.yml
 	drone sign --save grafana/terraform-provider-grafana .drone/drone.yml

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,18 +40,18 @@ provider "grafana" {
 
 ## Authentication
 
-### auth
+### `auth`
 
 This can be a Grafana API key, basic auth `username:password`, or a
-[Grafana Cloud API key](https://grafana.com/docs/grafana-cloud/cloud-portal/create-api-key/).
+[Grafana API key](https://grafana.com/docs/grafana/latest/http_api/create-api-tokens-for-org/).
 
-### sm\_access\_token
+### `sm_access_token`
 
 [Synthetic Monitoring](https://grafana.com/docs/grafana-cloud/synthetic-monitoring/)
 endpoints require a dedicated access token. You may obtain an access token with its
 [Registration API](https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md#registration-api).
 
-```
+```console
 curl \
   -X POST \
   -H 'Content-type: application/json; charset=utf-8' \
@@ -74,19 +74,19 @@ the portal. First you need to create a Stack by clicking "Add Stack". When it's
 created you will be taken to its landing page on the portal. Get your `stackId`
 from the URL in your browser:
 
-```
+```http
 https://grafana.com/orgs/<org-slug>/stacks/<stack-id>
 ```
 
 Next, go to "Details" for Prometheus. Again, get `metricsInstanceId` from your URL:
 
-```
+```http
 https://grafana.com/orgs/<org-slug>/hosted-metrics/<metrics-instance-id>
 ```
 
 Finally, go back to your stack page, and go to "Details" for Loki to get
 `logsInstanceId`.
 
-```
+```http
 https://grafana.com/orgs/<org-slug>/hosted-logs/<logs-instance-id>
 ```

--- a/docs/resources/synthetic_monitoring_probe.md
+++ b/docs/resources/synthetic_monitoring_probe.md
@@ -60,4 +60,5 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import grafana_synthetic_monitoring_probe.probe {{probe-id}}
+terraform import grafana_synthetic_monitoring_probe.probe {{probe-id}}:{{auth_token}}
 ```

--- a/grafana/data_source_synthetic_monitoring_probe_test.go
+++ b/grafana/data_source_synthetic_monitoring_probe_test.go
@@ -1,3 +1,4 @@
+//go:build cloud
 // +build cloud
 
 package grafana

--- a/grafana/data_source_synthetic_monitoring_probes_test.go
+++ b/grafana/data_source_synthetic_monitoring_probes_test.go
@@ -1,3 +1,4 @@
+//go:build cloud
 // +build cloud
 
 package grafana

--- a/grafana/data_source_user_test.go
+++ b/grafana/data_source_user_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_builtin_role_assignment_test.go
+++ b/grafana/resource_builtin_role_assignment_test.go
@@ -1,3 +1,4 @@
+//go:build enterprise
 // +build enterprise
 
 package grafana

--- a/grafana/resource_dashboard_permission_test.go
+++ b/grafana/resource_dashboard_permission_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_folder_permission_test.go
+++ b/grafana/resource_folder_permission_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_organization_test.go
+++ b/grafana/resource_organization_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_role_test.go
+++ b/grafana/resource_role_test.go
@@ -1,3 +1,4 @@
+//go:build enterprise
 // +build enterprise
 
 package grafana

--- a/grafana/resource_synthetic_monitoring_check_test.go
+++ b/grafana/resource_synthetic_monitoring_check_test.go
@@ -1,3 +1,4 @@
+//go:build cloud
 // +build cloud
 
 package grafana

--- a/grafana/resource_synthetic_monitoring_probe_helper_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_helper_test.go
@@ -1,3 +1,6 @@
+//go:build cloud
+// +build cloud
+
 package grafana
 
 import (

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -1,3 +1,4 @@
+//go:build cloud
 // +build cloud
 
 package grafana

--- a/grafana/resource_team_external_group_test.go
+++ b/grafana/resource_team_external_group_test.go
@@ -1,3 +1,4 @@
+//go:build enterprise
 // +build enterprise
 
 package grafana

--- a/grafana/resource_team_preferences_test.go
+++ b/grafana/resource_team_preferences_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_team_test.go
+++ b/grafana/resource_team_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/grafana/resource_user_test.go
+++ b/grafana/resource_user_test.go
@@ -1,3 +1,6 @@
+//go:build oss
+// +build oss
+
 package grafana
 
 import (

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -18,18 +18,18 @@ The Grafana provider provides configuration management resources for
 
 ## Authentication
 
-### auth
+### `auth`
 
 This can be a Grafana API key, basic auth `username:password`, or a
-[Grafana Cloud API key](https://grafana.com/docs/grafana-cloud/cloud-portal/create-api-key/).
+[Grafana API key](https://grafana.com/docs/grafana/latest/http_api/create-api-tokens-for-org/).
 
-### sm\_access\_token
+### `sm_access_token`
 
 [Synthetic Monitoring](https://grafana.com/docs/grafana-cloud/synthetic-monitoring/)
 endpoints require a dedicated access token. You may obtain an access token with its
 [Registration API](https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md#registration-api).
 
-```
+```console
 curl \
   -X POST \
   -H 'Content-type: application/json; charset=utf-8' \
@@ -52,19 +52,19 @@ the portal. First you need to create a Stack by clicking "Add Stack". When it's
 created you will be taken to its landing page on the portal. Get your `stackId`
 from the URL in your browser:
 
-```
+```http
 https://grafana.com/orgs/<org-slug>/stacks/<stack-id>
 ```
 
 Next, go to "Details" for Prometheus. Again, get `metricsInstanceId` from your URL:
 
-```
+```http
 https://grafana.com/orgs/<org-slug>/hosted-metrics/<metrics-instance-id>
 ```
 
 Finally, go back to your stack page, and go to "Details" for Loki to get
 `logsInstanceId`.
 
-```
+```http
 https://grafana.com/orgs/<org-slug>/hosted-logs/<logs-instance-id>
 ```


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/226

- Add `oss` build tag. Not all oss tests are runnable in the cloud. For example, tests that manage users cannot run in the cloud. For that reason, `oss` was added. There are now three tags: `cloud`, `enterprise` and `oss`, they each have their own tests
- Related to previous point, make all build tag headers consistent. My vscode plugin is proposing me to add `//go:build` everywhere, not sure if it's needed, but it works either way
- For now the test stack for cloud is static but I'd like if it was created automatically before tests

Once this is merged we can merge dependabot bumps with confidence: https://github.com/grafana/terraform-provider-grafana/pull/288 + https://github.com/grafana/terraform-provider-grafana/pull/282