### PR TITLE
Update the grafana version to 8.2.5 in tests

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,4 +1,4 @@
-local grafana = 'grafana/grafana:8.0.3';
+local grafana = 'grafana/grafana:8.2.5';
 local build = 'grafana/build-container:1.4.7';
 local goImage = 'golang:1.16-alpine';
 

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -55,7 +55,7 @@ platform:
 services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-  image: grafana/grafana:8.0.3
+  image: grafana/grafana:8.2.5
   name: grafana
 steps:
 - commands:
@@ -118,6 +118,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: d9dcbbdd0a9eedf0cc4a65dea61814a43023f96161a3363ef25357322c03fda3
+hmac: 1a3927e9946f0d8c6de54b49b1b74effa4c33beed747cc0f2ea637d147187aba
 
 ...

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= latest
+GRAFANA_VERSION ?= 8.2.5
 
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -146,6 +146,7 @@ func TestAccDashboard_folder(t *testing.T) {
 				Config: testAccExample(t, "resources/grafana_dashboard/_acc_folder.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
+					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
 					testAccDashboardCheckExistsInFolder(&dashboard, &folder),
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "folder"),
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "uid", "folder"),
@@ -204,9 +205,9 @@ func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.
 		if err == nil {
 			return fmt.Errorf("dashboard still exists")
 		}
-		_, err = client.Folder(folder.ID)
+		folder, err = client.Folder(folder.ID)
 		if err == nil {
-			return fmt.Errorf("folder still exists")
+			return fmt.Errorf("the following folder still exists: %s", folder.Title)
 		}
 		return nil
 	}


### PR DESCRIPTION
The `TestAccDashboard_folder` test would fail locally and I was wondering why
The `folder` variable in that test was never set and so the ID of that variable was always 0.
The `CheckDestroy` was always checking that the folder with ID 0 was destroyed
Something must have changed between 8.0.3 and 8.2.5 that affected folder IDs and that made the test fail

So the solution was adding the `testAccFolderCheckExists` from the `grafana_folder` tests. That function sets the folder variable after checking if the folder exists