### PR TITLE
add org_id to the resource grafana_user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -42,6 +42,7 @@ resource "grafana_user" "staff" {
 - **is_admin** (Boolean) Whether to make user an admin. Defaults to `false`.
 - **login** (String) The username for the Grafana user.
 - **name** (String) The display name for the Grafana user.
+- **org_id** (Number) The organization ID to which the user must belong.
 
 ### Read-Only
 

--- a/grafana/resource_user.go
+++ b/grafana/resource_user.go
@@ -55,6 +55,11 @@ does not currently work with API Tokens. You must use basic auth.
 				Sensitive:   true,
 				Description: "The password for the Grafana user.",
 			},
+			"org_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The OrgID for the Grafana user.",
+			},
 			"is_admin": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -72,6 +77,7 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		Name:     d.Get("name").(string),
 		Login:    d.Get("login").(string),
 		Password: d.Get("password").(string),
+		OrgID:    int64(d.Get("org_id").(int)),
 	}
 	id, err := client.CreateUser(user)
 	if err != nil {


### PR DESCRIPTION
Currently, this version does not allow the resource "grafana_user" to assign the user to an organization.
This commit adds this feature.