### PR TITLE
Skip tests instead of using build tags

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,29 +3,31 @@ GRAFANA_VERSION ?= 8.2.5
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
-testacc-oss: TESTARGS+=-tags='oss'
-testacc-oss: testacc
+testacc-oss: 
+	TF_ACC_OSS=true make testacc
 
-testacc-enterprise: TESTARGS+=-tags='enterprise'
-testacc-enterprise: testacc
+testacc-enterprise:
+	TF_ACC_ENTERPRISE=true make testacc
 
-testacc-cloud: TESTARGS+=-tags='cloud'
-testacc-cloud: testacc
+testacc-cloud:
+	TF_ACC_CLOUD=true make testacc
 
 testacc-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
 		docker-compose \
 		-f ./docker-compose.yml \
-		run --rm grafana-provider \
-		make testacc TESTARGS="-tags='oss' $(TESTARGS)"
+		run --rm -e TESTARGS="$(TESTARGS)" \
+		grafana-provider \
+		make testacc-oss
 
 testacc-docker-tls:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
 		docker-compose \
 		-f ./docker-compose.yml \
 		-f ./docker-compose.tls.yml \
-		run --rm grafana-provider \
-		make testacc TESTARGS="-tags='oss' $(TESTARGS)"
+		run --rm -e TESTARGS="$(TESTARGS)" \
+		grafana-provider \
+		make testacc-oss
 
 changelog:
 	@test $${RELEASE_VERSION?Please set environment variable RELEASE_VERSION}

--- a/grafana/data_source_folder_test.go
+++ b/grafana/data_source_folder_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -12,6 +9,8 @@ import (
 )
 
 func TestAccDatasourceFolder(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var folder gapi.Folder
 	checks := []resource.TestCheckFunc{
 		testAccFolderCheckExists("grafana_folder.test", &folder),

--- a/grafana/data_source_synthetic_monitoring_probe_test.go
+++ b/grafana/data_source_synthetic_monitoring_probe_test.go
@@ -1,6 +1,3 @@
-//go:build cloud
-// +build cloud
-
 package grafana
 
 import (
@@ -10,6 +7,8 @@ import (
 )
 
 func TestAccDataSourceSyntheticMonitoringProbe(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/data_source_synthetic_monitoring_probes_test.go
+++ b/grafana/data_source_synthetic_monitoring_probes_test.go
@@ -1,6 +1,3 @@
-//go:build cloud
-// +build cloud
-
 package grafana
 
 import (
@@ -10,6 +7,8 @@ import (
 )
 
 func TestAccDataSourceSyntheticMonitoringProbes(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/data_source_user_test.go
+++ b/grafana/data_source_user_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -11,6 +8,8 @@ import (
 )
 
 func TestAccDatasourceUser(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var user gapi.User
 	checks := []resource.TestCheckFunc{
 		testAccUserCheckExists("grafana_user.test", &user),

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -78,8 +79,7 @@ func testAccPreCheck(t *testing.T) {
 	})
 }
 
-// testAccPreCheckCloud should be called by acceptance tests in files where the
-// "cloud" build tag is present.
+// testAccPreCheckCloud should be called by cloud acceptance tests
 func testAccPreCheckCloud(t *testing.T) {
 	testAccPreCheckEnv = append(testAccPreCheckEnv, "GRAFANA_SM_ACCESS_TOKEN")
 	testAccPreCheck(t)
@@ -93,4 +93,37 @@ func testAccExample(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return string(example)
+}
+
+func accTestsEnabled(t *testing.T, envVarName string) bool {
+	v, ok := os.LookupEnv(envVarName)
+	if !ok {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		t.Fatalf("%s must be set to a boolean value", envVarName)
+	}
+	return enabled
+}
+
+func CheckOSSTestsEnabled(t *testing.T) {
+	t.Helper()
+	if !accTestsEnabled(t, "TF_ACC_OSS") {
+		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
+	}
+}
+
+func CheckCloudTestsEnabled(t *testing.T) {
+	t.Helper()
+	if !accTestsEnabled(t, "TF_ACC_CLOUD") {
+		t.Skip("TF_ACC_CLOUD must be set to a truthy value for Cloud acceptance tests")
+	}
+}
+
+func CheckEnterpriseTestsEnabled(t *testing.T) {
+	t.Helper()
+	if !accTestsEnabled(t, "TF_ACC_ENTERPRISE") {
+		t.Skip("TF_ACC_ENTERPRISE must be set to a truthy value for Enterprise acceptance tests")
+	}
 }

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -16,6 +13,8 @@ import (
 )
 
 func TestAccAlertNotification_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
@@ -53,6 +52,8 @@ func TestAccAlertNotification_basic(t *testing.T) {
 }
 
 func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
@@ -90,6 +91,8 @@ func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
 }
 
 func TestAccAlertNotification_invalid_frequency(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
@@ -106,6 +109,8 @@ func TestAccAlertNotification_invalid_frequency(t *testing.T) {
 }
 
 func TestAccAlertNotification_reminder_no_frequency(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_api_key_test.go
+++ b/grafana/resource_api_key_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -28,6 +25,8 @@ resource "grafana_api_key" "bar" {
 `
 
 func TestAccGrafanaAuthKey(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/resource_builtin_role_assignment_test.go
+++ b/grafana/resource_builtin_role_assignment_test.go
@@ -1,6 +1,3 @@
-//go:build enterprise
-// +build enterprise
-
 package grafana
 
 import (
@@ -14,6 +11,8 @@ import (
 )
 
 func TestAccBuiltInRoleAssignment(t *testing.T) {
+	CheckEnterpriseTestsEnabled(t)
+
 	var br gapi.BuiltInRoleAssignment
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_dashboard_permission_test.go
+++ b/grafana/resource_dashboard_permission_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -13,6 +10,8 @@ import (
 )
 
 func TestAccDashboardPermission_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	dashboardID := int64(-1)
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -15,6 +12,8 @@ import (
 )
 
 func TestAccDashboard_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var dashboard gapi.Dashboard
 
 	resource.Test(t, resource.TestCase{
@@ -72,6 +71,8 @@ func TestAccDashboard_basic(t *testing.T) {
 }
 
 func TestAccDashboard_uid_unset(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var dashboard gapi.Dashboard
 
 	resource.Test(t, resource.TestCase{
@@ -115,6 +116,8 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 }
 
 func TestAccDashboard_computed_config(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var dashboard gapi.Dashboard
 
 	resource.Test(t, resource.TestCase{
@@ -135,6 +138,8 @@ func TestAccDashboard_computed_config(t *testing.T) {
 }
 
 func TestAccDashboard_folder(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var dashboard gapi.Dashboard
 	var folder gapi.Folder
 

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -298,6 +295,8 @@ resource "grafana_data_source" "testdata" {
 }
 
 func TestAccDataSource_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var dataSource gapi.DataSource
 
 	// Iterate over the provided configurations for datasources

--- a/grafana/resource_datasource_permission_test.go
+++ b/grafana/resource_datasource_permission_test.go
@@ -1,6 +1,3 @@
-//go:build cloud
-// +build cloud
-
 package grafana
 
 import (
@@ -13,6 +10,8 @@ import (
 )
 
 func TestAccDatasourcePermission_basic(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	datasourceID := int64(-1)
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_folder_permission_test.go
+++ b/grafana/resource_folder_permission_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -12,6 +9,8 @@ import (
 )
 
 func TestAccFolderPermission_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	folderUID := "uninitialized"
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -16,6 +13,8 @@ import (
 )
 
 func TestAccFolder_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var folder gapi.Folder
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_organization_test.go
+++ b/grafana/resource_organization_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -15,6 +12,8 @@ import (
 )
 
 func TestAccOrganization_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var org gapi.Org
 
 	resource.Test(t, resource.TestCase{
@@ -48,6 +47,8 @@ func TestAccOrganization_basic(t *testing.T) {
 }
 
 func TestAccOrganization_users(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var org gapi.Org
 
 	resource.Test(t, resource.TestCase{
@@ -114,6 +115,8 @@ func TestAccOrganization_users(t *testing.T) {
 }
 
 func TestAccOrganization_defaultAdmin(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var org gapi.Org
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_role_test.go
+++ b/grafana/resource_role_test.go
@@ -1,6 +1,3 @@
-//go:build enterprise
-// +build enterprise
-
 package grafana
 
 import (
@@ -14,6 +11,8 @@ import (
 )
 
 func TestAccRole(t *testing.T) {
+	CheckEnterpriseTestsEnabled(t)
+
 	var role gapi.Role
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_synthetic_monitoring_check_test.go
+++ b/grafana/resource_synthetic_monitoring_check_test.go
@@ -1,6 +1,3 @@
-//go:build cloud
-// +build cloud
-
 package grafana
 
 import (
@@ -11,6 +8,8 @@ import (
 )
 
 func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -61,6 +60,8 @@ func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -116,6 +117,8 @@ func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -152,6 +155,8 @@ func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/resource_synthetic_monitoring_probe_helper_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_helper_test.go
@@ -1,6 +1,3 @@
-//go:build cloud
-// +build cloud
-
 package grafana
 
 import (
@@ -11,6 +8,8 @@ import (
 )
 
 func TestImportProbeStateWithToken(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	testcases := map[string]struct {
 		input             string
 		expectError       bool

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -1,6 +1,3 @@
-//go:build cloud
-// +build cloud
-
 package grafana
 
 import (
@@ -10,6 +7,8 @@ import (
 )
 
 func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckCloud(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/resource_team_external_group_test.go
+++ b/grafana/resource_team_external_group_test.go
@@ -1,6 +1,3 @@
-//go:build enterprise
-// +build enterprise
-
 package grafana
 
 import (
@@ -13,6 +10,8 @@ import (
 )
 
 func TestAccTeamExternalGroup_basic(t *testing.T) {
+	CheckEnterpriseTestsEnabled(t)
+
 	teamID := int64(-1)
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_team_preferences_test.go
+++ b/grafana/resource_team_preferences_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -11,6 +8,8 @@ import (
 )
 
 func TestAccTeamPreferences_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/resource_team_test.go
+++ b/grafana/resource_team_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -15,6 +12,8 @@ import (
 )
 
 func TestAccTeam_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var team gapi.Team
 
 	resource.Test(t, resource.TestCase{
@@ -54,6 +53,8 @@ func TestAccTeam_basic(t *testing.T) {
 }
 
 func TestAccTeam_Members(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var team gapi.Team
 
 	resource.Test(t, resource.TestCase{

--- a/grafana/resource_user_test.go
+++ b/grafana/resource_user_test.go
@@ -1,6 +1,3 @@
-//go:build oss
-// +build oss
-
 package grafana
 
 import (
@@ -16,6 +13,8 @@ import (
 )
 
 func TestAccUser_basic(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
 	var user gapi.User
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },


### PR DESCRIPTION
The current way of working is annoying, I have to remove the build tags to make my IDE work
Instead, we can skip the tests that we don't want to run. It will write a small message for everyone of these but at least, it's very clear what's happening (why tests aren't running)