### PR TITLE
Add UID to datasource reosurce and test

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -93,6 +93,7 @@ resource "grafana_data_source" "stackdriver" {
 - **json_data** (Block List) (Required by some data source types) (see [below for nested schema](#nestedblock--json_data))
 - **password** (String, Sensitive) (Required by some data source types) The password to use to authenticate to the data source. Defaults to ``.
 - **secure_json_data** (Block List) (see [below for nested schema](#nestedblock--secure_json_data))
+- **uid** (String) Unique identifier. If unset, this will be automatically generated.
 - **url** (String) The URL for the data source. The type of URL required varies depending on the chosen data source type.
 - **username** (String) (Required by some data source types) The username to use to authenticate to the data source. Defaults to ``.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
-	github.com/grafana/grafana-api-golang-client v0.1.1
+	github.com/grafana/grafana-api-golang-client v0.1.2
 	github.com/grafana/synthetic-monitoring-agent v0.3.3
 	github.com/grafana/synthetic-monitoring-api-go-client v0.3.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -454,6 +454,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grafana/grafana-api-golang-client v0.1.1 h1:qS/i3dxITGyDRqYuBLk679SjpSwPQ3VZyxuTsKq1Bas=
 github.com/grafana/grafana-api-golang-client v0.1.1/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.1.2 h1:dutE6hUVSJcpb4EtvjfSM8VQHh2kYxvGEeE8xVxUjWA=
+github.com/grafana/grafana-api-golang-client v0.1.2/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/synthetic-monitoring-agent v0.3.0/go.mod h1:P8WTBnw3SIZW5Nm5obOlSKvD887IxAfbrJkSnoZyIlA=
 github.com/grafana/synthetic-monitoring-agent v0.3.3 h1:/MM1vm/BwnbwQ2/aEwKbEpf01O4O3GhrcOofY4A0V9Q=
 github.com/grafana/synthetic-monitoring-agent v0.3.3/go.mod h1:qyo27gOTdj8K/dKkd+/SJ0M0zlnCV7t9nwVK+iLkVrk=

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -68,6 +68,12 @@ source selected (via the 'type' argument).
 				Default:     false,
 				Description: "Whether to set the data source as default. This should only be `true` to a single data source.",
 			},
+			"uid": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Unique identifier. If unset, this will be automatically generated.",
+			},
 			"json_data": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -439,6 +445,7 @@ func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 	d.Set("type", dataSource.Type)
 	d.Set("url", dataSource.URL)
 	d.Set("username", dataSource.User)
+	d.Set("uid", dataSource.UID)
 
 	// TODO: these fields should be migrated to SecureJSONData.
 	d.Set("basic_auth_enabled", dataSource.BasicAuth)
@@ -487,6 +494,7 @@ func makeDataSource(d *schema.ResourceData) (*gapi.DataSource, error) {
 		BasicAuth:         d.Get("basic_auth_enabled").(bool),
 		BasicAuthUser:     d.Get("basic_auth_username").(string),
 		BasicAuthPassword: d.Get("basic_auth_password").(string),
+		UID:               d.Get("uid").(string),
 		JSONData:          makeJSONData(d),
 		SecureJSONData:    makeSecureJSONData(d),
 	}, err

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -308,6 +308,11 @@ func TestAccDataSource_basic(t *testing.T) {
 				"id",
 				idRegexp,
 			),
+			resource.TestMatchResourceAttr(
+				test.resource,
+				"uid",
+				uidRegexp,
+			),
 		}
 
 		// Add custom checks for specified attribute values


### PR DESCRIPTION
This PR will add UID to the `grafana_data_source` resource.  This PR will fix [Issue 304](https://github.com/grafana/terraform-provider-grafana/issues/304)

The changes to JSON structure of Dashboards mean if you want to provision as code, you need to interpolate the Datasource UID (previously the Datasource name).