### PR TITLE
Fix folder ID documentation

### DIFF
--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -31,12 +31,9 @@ resource "grafana_dashboard" "metrics" {
 
 - **title** (String) The title of the folder.
 
-### Optional
-
-- **id** (String) The ID of this resource.
-
 ### Read-Only
 
+- **id** (String) unique identifier for this folder.
 - **uid** (String) Unique identifier.
 
 ## Import

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -33,7 +33,7 @@ resource "grafana_dashboard" "metrics" {
 
 ### Read-Only
 
-- **id** (String) unique identifier for this folder.
+- **id** (String) Unique internal identifier.
 - **uid** (String) Unique identifier.
 
 ## Import

--- a/grafana/resource_folder.go
+++ b/grafana/resource_folder.go
@@ -32,7 +32,13 @@ func ResourceFolder() *schema.Resource {
 				Computed:    true,
 				Description: "Unique identifier.",
 			},
-
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Required:    false,
+				Optional:    false,
+				Description: "Unique internal identifier.",
+			},
 			"title": {
 				Type:        schema.TypeString,
 				Required:    true,


### PR DESCRIPTION
By adding the ID as a computed attribute it will show as a read-only attribute instead of the misleading comment that it might be possible to assign a value. This documentation seem to be generated automatically by the `tfplugindocs` tool, so we might need to either fix that or changing the way we generate the documentation.