### PR TITLE
Make secure_settings always pass values as string

### DIFF
--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -224,14 +224,10 @@ func makeAlertNotification(_ context.Context, d *schema.ResourceData) (*gapi.Ale
 	secureSettings := map[string]interface{}{}
 	for k, v := range d.Get("secure_settings").(map[string]interface{}) {
 		strVal, ok := v.(string)
-		switch {
-		case ok && strVal == "true":
-			secureSettings[k] = true
-		case ok && strVal == "false":
-			secureSettings[k] = false
-		default:
-			secureSettings[k] = v
+		if !ok {
+			return nil, errors.New("secure_settings must be a map of string")
 		}
+		secureSettings[k] = strVal
 	}
 
 	sendReminder := d.Get("send_reminder").(bool)

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -186,6 +186,9 @@ resource "grafana_alert_notification" "test" {
 			"uploadImage" = "false"
 			"autoResolve" = "true"
 		}
+	secure_settings = {
+		 "foo" = "true"
+	}
 }
 `
 


### PR DESCRIPTION
In #234 we have found that the secure settings for alert notifications must always be passed as a `map[string]string`, however for the case of `true` and `false` we were converting the values to booleans, which made Grafana HTTP API fail with a 400 Bad Request.

This change only removes the boolean conversions, so values are always passed as strings. A better fix that also involves the underlying API client would be to make this field a `map[string]string` instead of `map[string]interface`.