### PR TITLE
Validate that there's exactly one SM check setting

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -413,7 +413,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 
 - **job** (String) Name used for job label.
 - **probes** (Set of Number) List of probe location IDs where this target will be checked from.
-- **settings** (Block Set, Min: 1, Max: 1) Check settings. (see [below for nested schema](#nestedblock--settings))
+- **settings** (Block Set, Min: 1, Max: 1) Check settings. Should contain exactly one nested block. (see [below for nested schema](#nestedblock--settings))
 - **target** (String) Hostname to ping.
 
 ### Optional

--- a/grafana/resource_synthetic_monitoring_check.go
+++ b/grafana/resource_synthetic_monitoring_check.go
@@ -523,7 +523,7 @@ multiple checks for a single endpoint to check different capabilities.
 				},
 			},
 			"settings": {
-				Description: "Check settings.",
+				Description: "Check settings. Should contain exactly one nested block.",
 				Type:        schema.TypeSet,
 				Required:    true,
 				MaxItems:    1,

--- a/grafana/resource_synthetic_monitoring_check.go
+++ b/grafana/resource_synthetic_monitoring_check.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -446,6 +447,7 @@ multiple checks for a single endpoint to check different capabilities.
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: resourceSyntheticMonitoringCheckCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -954,4 +956,27 @@ func makeCheckSettings(settings map[string]interface{}) sm.CheckSettings {
 	}
 
 	return cs
+}
+
+// Check if the user provider exactly one setting
+// Ideally, we'd use `ExactlyOneOf` here but it doesn't support TypeSet.
+// Also, TypeSet doesn't support ValidateFunc.
+// To maintain backwards compatibility, we do a custom validation in the CustomizeDiff function.
+func resourceSyntheticMonitoringCheckCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	settingsList := diff.Get("settings").(*schema.Set).List()
+	if len(settingsList) == 0 {
+		return fmt.Errorf("at least one check setting must be defined")
+	}
+	settings := settingsList[0].(map[string]interface{})
+
+	count := 0
+	for k := range syntheticMonitoringCheckSettings.Schema {
+		count += len(settings[k].(*schema.Set).List())
+	}
+
+	if count != 1 {
+		return fmt.Errorf("exactly one check setting must be defined, got %d", count)
+	}
+
+	return nil
 }

--- a/grafana/resource_synthetic_monitoring_check_test.go
+++ b/grafana/resource_synthetic_monitoring_check_test.go
@@ -239,3 +239,76 @@ func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckCloud(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceSyntheticMonitoringCheck_noSettings,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("at least one check setting must be defined"),
+			},
+		},
+	})
+}
+
+func TestAccResourceSyntheticMonitoringCheck_multiple(t *testing.T) {
+	CheckCloudTestsEnabled(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckCloud(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceSyntheticMonitoringCheck_multiple,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("exactly one check setting must be defined, got 2"),
+			},
+		},
+	})
+}
+
+const testAccResourceSyntheticMonitoringCheck_noSettings = `
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+resource "grafana_synthetic_monitoring_check" "no_settings" {
+  job       = "No Settings"
+  target    = "grafana.com"
+  enabled   = false
+  frequency = 120000
+  timeout   = 30000
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+  ]
+  labels = {
+    foo = "bar"
+  }
+  settings {
+
+  }
+}`
+
+const testAccResourceSyntheticMonitoringCheck_multiple = `
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+resource "grafana_synthetic_monitoring_check" "multiple" {
+  job       = "No Settings"
+  target    = "grafana.com"
+  enabled   = false
+  frequency = 120000
+  timeout   = 30000
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+  ]
+  labels = {
+    foo = "bar"
+  }
+  settings {
+	traceroute {}
+	http {}
+  }
+}`


### PR DESCRIPTION
Only one of `http`, `tcp`, `ping` or `traceroute` should be defined. This adds an error when none are defined (instead of a panic) or when multiple are defined (instead of a 400 error from the API on apply)
Fixes https://github.com/grafana/terraform-provider-grafana/issues/326