### PR TITLE
Add import to the SM check documentation

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -614,4 +614,10 @@ Optional:
 - **max_unknown_hops** (Number) Maximum number of hosts to travers that give no response Defaults to `15`.
 - **ptr_lookup** (Boolean) Reverse lookup hostnames from IP addresses Defaults to `true`.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_synthetic_monitoring_check.check {{check-id}}
+```

--- a/templates/resources/synthetic_monitoring_check.md.tmpl
+++ b/templates/resources/synthetic_monitoring_check.md.tmpl
@@ -54,10 +54,8 @@ description: |-
 
 {{ .SchemaMarkdown | trimspace }}
 
-{{ if .HasImport -}}
 ## Import
 
 Import is supported using the following syntax:
 
-{{ printf "{{codefile \"shell\" %q}}" .ImportFile }}
-{{- end }}
+{{ codefile "shell" "examples/resources/grafana_synthetic_monitoring_check/import.sh" }}


### PR DESCRIPTION
It seems like the `{{ .ImportFile }}` stuff doesn't work in a custom template
Even removing the `{{ .HasImport }}` didn't work, the import file is just not detected