### PR TITLE
Bug fix: Add global field when updating a role.

### DIFF
--- a/grafana/resource_role.go
+++ b/grafana/resource_role.go
@@ -182,6 +182,7 @@ func UpdateRole(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		r := gapi.Role{
 			UID:         d.Id(),
 			Name:        d.Get("name").(string),
+			Global:      d.Get("global").(bool),
 			Description: desc,
 			Version:     int64(d.Get("version").(int)),
 			Permissions: permissions(d),


### PR DESCRIPTION
When updating a fine-grained access control role, Grafana checks if the role at question has global scope or not.
If global field is not specified in the role definition, Grafana will always assume that the role is not global,
which will result to failure when updating global roles.

**Note for the reviewers**

The role update is a Grafana Enterprise feature, [these code lines](https://github.com/grafana/grafana-enterprise/blob/main/src/pkg/extensions/accesscontrol/database/database.go#L219-L221) are the guardians which will cause the failure without the `global` flat set correctly. 