### PR TITLE
Add importer to alert notification

### DIFF
--- a/docs/resources/alert_notification.md
+++ b/docs/resources/alert_notification.md
@@ -47,4 +47,10 @@ resource "grafana_alert_notification" "email_someteam" {
 - **settings** (Map of String) Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).
 - **uid** (String) Unique identifier. If unset, this will be automatically generated.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_alert_notification.alert_notification_name {{alert_notification_id}}
+```

--- a/examples/resources/grafana_alert_notification/import.sh
+++ b/examples/resources/grafana_alert_notification/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_alert_notification.alert_notification_name {{alert_notification_id}}

--- a/grafana/resource_alert_notification.go
+++ b/grafana/resource_alert_notification.go
@@ -29,6 +29,9 @@ func ResourceAlertNotification() *schema.Resource {
 		UpdateContext: UpdateAlertNotification,
 		DeleteContext: DeleteAlertNotification,
 		ReadContext:   ReadAlertNotification,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"type": {


### PR DESCRIPTION
**Use Case**

We have more than 200 alert notifications which are used by hundreds of alert rules. We need the ability to import these existing alert notifications. Destroying and recreating is not an option as we would have to manually update hundreds of alert rules.

