### PR TITLE
Fix probes datasource tests

### DIFF
--- a/grafana/data_source_synthetic_monitoring_probes_test.go
+++ b/grafana/data_source_synthetic_monitoring_probes_test.go
@@ -15,16 +15,12 @@ func TestAccDataSourceSyntheticMonitoringProbes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/data-source.tf"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Seol"),
-					resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta", "1"),
-				),
+				Check:  resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta", "1"),
 			},
 			{
 				Config: testAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/with-deprecated.tf"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Seol", "9"),
-				),
+				// We're not checking for deprecated probes here because there may not be any, causing tests to fail.
+				Check: resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta", "1"),
 			},
 		},
 	})


### PR DESCRIPTION
The `Seol` probe was deleted, causing our tests to fail.
I don't think our tests can rely on deprecated probes in a clean way. It's fine to have a test gap for this IMO