### PR TITLE
Add support for 'External ID' in AWS-based datasources (Cloudwatch, Athena)

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -115,6 +115,7 @@ Optional:
 - **default_region** (String) (CloudWatch, Athena) The default region for the data source.
 - **encrypt** (String) (MSSQL) Connection SSL encryption handling: 'disable', 'false' or 'true'.
 - **es_version** (String) (Elasticsearch) Elasticsearch semantic version (Grafana v8.0+).
+- **external_id** (String) (CloudWatch, Athena) If you are assuming a role in another account, that has been created with an external ID, specify the external ID here.
 - **github_url** (String) (Github) Github URL
 - **graphite_version** (String) (Graphite) Graphite version.
 - **http_method** (String) (Prometheus) HTTP method to use for making requests.

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -162,6 +162,11 @@ source selected (via the 'type' argument).
 								return diags
 							},
 						},
+						"external_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "(CloudWatch, Athena) If you are assuming a role in another account, that has been created with an external ID, specify the external ID here.",
+						},
 						"github_url": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -561,6 +566,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		DefaultRegion:              d.Get("json_data.0.default_region").(string),
 		Encrypt:                    d.Get("json_data.0.encrypt").(string),
 		EsVersion:                  d.Get("json_data.0.es_version").(string),
+		ExternalID:                 d.Get("json_data.0.external_id").(string),
 		GraphiteVersion:            d.Get("json_data.0.graphite_version").(string),
 		HTTPMethod:                 d.Get("json_data.0.http_method").(string),
 		Interval:                   d.Get("json_data.0.interval").(string),

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -160,6 +160,7 @@ func TestAccDataSource_basic(t *testing.T) {
 					auth_type                 = "keys"
 					assume_role_arn           = "arn:aws:sts::*:assumed-role/*/*"
 					custom_metrics_namespaces = "foo"
+					external_id               = "abc123"
 				}
 				secure_json_data {
 					access_key = "123"
@@ -174,6 +175,7 @@ func TestAccDataSource_basic(t *testing.T) {
 				"json_data.0.auth_type":                 "keys",
 				"json_data.0.assume_role_arn":           "arn:aws:sts::*:assumed-role/*/*",
 				"json_data.0.custom_metrics_namespaces": "foo",
+				"json_data.0.external_id":               "abc123",
 				"secure_json_data.0.access_key":         "123",
 				"secure_json_data.0.secret_key":         "456",
 			},
@@ -348,6 +350,7 @@ func TestAccDataSource_basic(t *testing.T) {
 					default_region            = "us-east-1"
 					auth_type                 = "keys"
 					assume_role_arn           = "arn:aws:sts::*:assumed-role/*/*"
+					external_id               = "abc123"
 					catalog                   = "my-catalog"
 					workgroup                 = "my-workgroup"
 					database                  = "my-database"
@@ -365,6 +368,7 @@ func TestAccDataSource_basic(t *testing.T) {
 				"json_data.0.default_region":    "us-east-1",
 				"json_data.0.auth_type":         "keys",
 				"json_data.0.assume_role_arn":   "arn:aws:sts::*:assumed-role/*/*",
+				"json_data.0.external_id":       "abc123",
 				"json_data.0.catalog":           "my-catalog",
 				"json_data.0.workgroup":         "my-workgroup",
 				"json_data.0.database":          "my-database",


### PR DESCRIPTION
https://github.com/grafana/terraform-provider-grafana/issues/308