### PR TITLE
Add function to check semver for OSS tests

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -107,6 +107,7 @@ local pipeline(name, steps, services=[]) = {
         environment: {
           GRAFANA_URL: 'http://grafana:3000',
           GRAFANA_AUTH: 'admin:admin',
+          GRAFANA_VERSION: version,
           GRAFANA_ORG_ID: 1,
         },
       },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -108,6 +108,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 8.3.3
   image: golang:1.16
   name: tests
 trigger:
@@ -138,6 +139,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 8.2.7
   image: golang:1.16
   name: tests
 trigger:
@@ -168,6 +170,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 8.1.8
   image: golang:1.16
   name: tests
 trigger:
@@ -198,6 +201,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 8.0.7
   image: golang:1.16
   name: tests
 trigger:
@@ -228,6 +232,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 7.5.12
   image: golang:1.16
   name: tests
 trigger:
@@ -241,6 +246,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: ba529b1d151988f76e6b2f3be2b7da92877b62c205172ed799499ab9a3c461f2
+hmac: 3aa0d8e999b723753e800c9db22f793729847df3e246bdb40052266956af8833
 
 ...

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/terraform-provider-grafana
 go 1.16
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/grafana/grafana-api-golang-client v0.2.4
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RP
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -111,6 +112,22 @@ func CheckOSSTestsEnabled(t *testing.T) {
 	t.Helper()
 	if !accTestsEnabled(t, "TF_ACC_OSS") {
 		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
+	}
+}
+
+func CheckOSSTestsSemver(t *testing.T, semverConstraint string) {
+	t.Helper()
+
+	versionStr := os.Getenv("GRAFANA_VERSION")
+	if semverConstraint != "" && versionStr != "" {
+		version := semver.MustParse(versionStr)
+		c, err := semver.NewConstraint(semverConstraint)
+		if err != nil {
+			t.Fatalf("invalid constraint %s: %v", semverConstraint, err)
+		}
+		if !c.Check(version) {
+			t.Skipf("skipping test for Grafana version `%s`, constraint `%s`", versionStr, semverConstraint)
+		}
 	}
 }
 

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccDataSource_basic(t *testing.T) {
 	CheckOSSTestsEnabled(t)
+	CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var dataSource gapi.DataSource
 

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestAccDataSource_basic(t *testing.T) {
 	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var dataSource gapi.DataSource
 


### PR DESCRIPTION
Will be used for library panels: https://github.com/grafana/terraform-provider-grafana/pull/331. This is a feature from v8 so the tests on v7 shouldn't run
This line can be added to the test: `CheckOSSTestsSemver(t, ">=8.0.0")`
If a feature is deprecated from Grafana in the future, we can add a lower than semver