### PR TITLE
Update resource_builtin_role_assignment resource to ignore assignments defined in the server side

### DIFF
--- a/grafana/resource_builtin_role_assignment.go
+++ b/grafana/resource_builtin_role_assignment.go
@@ -108,9 +108,9 @@ func ReadBuiltInRole(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 	roles := make([]interface{}, 0)
 	for _, br := range brRole {
-		// It is possible on the server side there are roles assigned to the built-in role which were never in Terraform state,
-		// and are not now in the current configuration. To prevent unintended behaviour, such as destroying remove resources,
-		// the following check ensures to only consider roles which are either in the state or in the config.
+		// It is possible that in the server side there are roles assigned to the built-in role which were never in Terraform state,
+		// and are not in the current configuration. The following check ensures that we only consider roles which are either in the state or in the config.
+		// This prevents unintended behaviour, such as destroying the assignments which were never managed by Terraform.
 		_, isInState := stateRoles[br.UID]
 		_, isInConfig := configRoles[br.UID]
 		if !isInState && !isInConfig {

--- a/grafana/resource_builtin_role_assignment_test.go
+++ b/grafana/resource_builtin_role_assignment_test.go
@@ -48,6 +48,147 @@ func TestAccBuiltInRoleAssignment(t *testing.T) {
 	})
 }
 
+func TestAccBuiltInRoleAssignmentUpdate(t *testing.T) {
+	CheckEnterpriseTestsEnabled(t)
+
+	var br gapi.BuiltInRoleAssignment
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccBuiltInRoleAssignmentCheckDestroy(&br),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					err := prepareDefaultAssignments()
+					if err != nil {
+						t.Errorf("error when creating built-in role ssignments %s", err)
+					}
+				},
+				Config: builtInRoleAssignmentUpdatePreConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccBuiltInRoleAssignmentCheckExists("grafana_builtin_role_assignment.test_builtin_assignment"),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "builtin_role", "Viewer",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.0.uid", "viewer_test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.0.global", "true",
+					),
+				),
+			},
+			{
+				Config: builtInRoleAssignmentUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccBuiltInRoleAssignmentCheckExists("grafana_builtin_role_assignment.test_builtin_assignment"),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "builtin_role", "Viewer",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.0.uid", "viewer_test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.0.global", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.1.uid", "viewer_test_2",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_builtin_role_assignment.test_builtin_assignment", "roles.1.global", "true",
+					),
+					testAccBuiltInRoleAssignmentWereNotDestroyed(),
+				),
+			},
+		},
+	})
+}
+
+func prepareDefaultAssignments() error {
+	client := testAccProvider.Meta().(*client).gapi
+	r1 := gapi.Role{
+		UID:     "reportviewer",
+		Version: 1,
+		Name:    "Test Report Viewer",
+		Global:  true,
+		Permissions: []gapi.Permission{
+			{
+				Action: "reports:read",
+				Scope:  "reports:*",
+			},
+			{
+				Action: "users:create",
+			},
+		},
+	}
+	r2 := gapi.Role{
+		UID:     "createuser",
+		Version: 1,
+		Name:    "Test Create User",
+		Global:  true,
+		Permissions: []gapi.Permission{
+			{
+				Action: "users:create",
+			},
+		},
+	}
+	role1, err := client.NewRole(r1)
+	if err != nil {
+		return fmt.Errorf("error creating role: %s", err)
+	}
+	role2, err := client.NewRole(r2)
+	if err != nil {
+		return fmt.Errorf("error creating role: %s", err)
+	}
+	_, err = client.NewBuiltInRoleAssignment(gapi.BuiltInRoleAssignment{
+		BuiltinRole: "Viewer",
+		RoleUID:     role1.UID,
+		Global:      false,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating built-in role assigntment: %s", err)
+	}
+	_, err = client.NewBuiltInRoleAssignment(gapi.BuiltInRoleAssignment{
+		BuiltinRole: "Viewer",
+		RoleUID:     role2.UID,
+		Global:      false,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating built-in role assigntment: %s", err)
+	}
+	return nil
+}
+
+func testAccBuiltInRoleAssignmentWereNotDestroyed() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*client).gapi
+		assignments, err := client.GetBuiltInRoleAssignments()
+		if err != nil || assignments["Viewer"] == nil {
+			return fmt.Errorf("built-in assignments do not exist: %v", err)
+		}
+		roles := assignments["Viewer"]
+		contains := func(roles []*gapi.Role, uid string) bool {
+			for _, r := range roles {
+				if r.UID == uid {
+					return true
+				}
+			}
+			return false
+		}
+		if !contains(roles, "reportviewer") || !contains(roles, "createuser") {
+			return fmt.Errorf("built-in assignments do not exist for roles: %s and %s", "reportviewer", "createuser")
+		}
+		return nil
+	}
+}
+
 func testAccBuiltInRoleAssignmentCheckExists(rn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -121,5 +262,62 @@ resource "grafana_builtin_role_assignment" "test_assignment" {
 	uid = grafana_role.test_role_two.id
 	global = false
   }
+}
+`
+
+const builtInRoleAssignmentUpdatePreConfig = `
+resource "grafana_role" "viewer_test" {
+  name  = "viewer_test"
+  description = "test desc"
+  version = 1
+  uid = "viewer_test"
+  global = true 
+  permissions {
+	action = "users:create"
+  }
+}
+
+resource "grafana_builtin_role_assignment" "test_builtin_assignment" {
+  builtin_role  = "Viewer"
+  roles {
+	uid = grafana_role.viewer_test.id
+	global = true
+  } 
+}
+`
+
+const builtInRoleAssignmentUpdateConfig = `
+resource "grafana_role" "viewer_test" {
+  name  = "viewer_test"
+  description = "test desc"
+  version = 1
+  uid = "viewer_test"
+  global = true 
+  permissions {
+	action = "users:create"
+  }
+}
+
+resource "grafana_role" "viewer_test_2" {
+  name  = "viewer_test_2"
+  description = "test desc"
+  version = 1
+  uid = "viewer_test_2"
+  global = true 
+  permissions {
+	action = "users:create"
+  }
+}
+
+resource "grafana_builtin_role_assignment" "test_builtin_assignment" {
+  builtin_role  = "Viewer"
+  roles {
+	uid = grafana_role.viewer_test.id
+	global = true
+  } 
+  roles {
+	uid = grafana_role.viewer_test_2.id
+	global = true
+  } 
 }
 `

--- a/grafana/resource_builtin_role_assignment_test.go
+++ b/grafana/resource_builtin_role_assignment_test.go
@@ -221,7 +221,7 @@ func testAccBuiltInRoleAssignmentCheckDestroy(brAssignments *map[string][]*gapi.
 		}
 
 		if preservedRoleUIDs != nil {
-			for br, _ := range *brAssignments {
+			for br := range *brAssignments {
 				err := checkAssignmentsExists(bra[br], preservedRoleUIDs...)
 				if err != nil {
 					return fmt.Errorf("assignments were entirely destroyed, but expected to have roles with UID %v assigned to %s built-in role", preservedRoleUIDs, br)
@@ -230,7 +230,7 @@ func testAccBuiltInRoleAssignmentCheckDestroy(brAssignments *map[string][]*gapi.
 		}
 
 		if destroyedUIDs != nil {
-			for br, _ := range *brAssignments {
+			for br := range *brAssignments {
 				err := checkAssignmentsDoNotExist(bra[br], destroyedUIDs...)
 				if err != nil {
 					return fmt.Errorf("assignments were supped to destroyed, but have roles with UID %v assigned to %s built-in role", destroyedUIDs, br)


### PR DESCRIPTION
## Context

When Grafana starts, by default it creates built-in role assignments for fixed roles. Additionally, users can create built-in role assignments via API. In these scenarios, when the resource is not properly imported, terraform will try to destroy what is in server side, but not in the configuration.

The change ensures that this does not happen as it can cause unintended behaviour for users.

## Implementation details

The only workaround, with the given resources is to do in advance check to see if the fetched assignments has been ever in the state, or is present in the configuration, otherwise ignore it.

## Testing

I have manually tested the following scenarios:
- Having built-in role assignments in server, and creating a new assignment in terraform
- Updating the above created assignments after it's first time creation
- Removing roles from the above assignments
- Destroying entire resource -> in this scenario what has not been defined in the config, won't be destroyed from the backend.

Additionally, the newly added test covers the scenario mentioned in the issue.

## Related issues

Fixes https://github.com/grafana/terraform-provider-grafana/issues/362