### PR TITLE
Format Terraform files in examples/

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -14,8 +14,8 @@ Data source for Grafana Stack
 
 ```terraform
 resource "grafana_cloud_stack" "test" {
-  name   = "gcloudstacktest"
-  slug   = "gcloudstacktest"
+  name        = "gcloudstacktest"
+  slug        = "gcloudstacktest"
   region_slug = "eu"
   description = "Test Grafana Cloud Stack"
 }

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -16,14 +16,14 @@ description: |-
 
 ```terraform
 resource "grafana_dashboard" "test" {
-  config_json      = jsonencode({
-    id             = 12345,
-    title          = "Production Overview",
-    tags           = [ "templated" ],
-    timezone       = "browser",
-    schemaVersion  = 16,
-    version        = 0,
-    refresh        = "25s"
+  config_json = jsonencode({
+    id            = 12345,
+    title         = "Production Overview",
+    tags          = ["templated"],
+    timezone      = "browser",
+    schemaVersion = 16,
+    version       = 0,
+    refresh       = "25s"
   })
 }
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -22,14 +22,14 @@ resource "grafana_api_key" "foo" {
 }
 
 resource "grafana_api_key" "bar" {
-  name = "key_bar"
-  role = "Admin"
+  name            = "key_bar"
+  role            = "Admin"
   seconds_to_live = 30
 }
 
 
 output "api_key_foo_key_only" {
-  value = grafana_api_key.foo.key
+  value     = grafana_api_key.foo.key
   sensitive = true
 }
 

--- a/docs/resources/builtin_role_assignment.md
+++ b/docs/resources/builtin_role_assignment.md
@@ -20,11 +20,11 @@ description: |-
 resource "grafana_builtin_role_assignment" "viewer" {
   builtin_role = "Viewer"
   roles {
-    uid = "firstuid"
+    uid    = "firstuid"
     global = false
   }
   roles {
-    uid = "seconduid"
+    uid    = "seconduid"
     global = true
   }
 }

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -14,8 +14,8 @@ description: |-
 
 ```terraform
 resource "grafana_cloud_stack" "test" {
-  name   = "gcloudstacktest"
-  slug   = "gcloudstacktest"
+  name        = "gcloudstacktest"
+  slug        = "gcloudstacktest"
   region_slug = "eu"
   description = "Test Grafana Cloud Stack"
 }

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -18,11 +18,11 @@ Manages Grafana library panels.
 
 ```terraform
 resource "grafana_library_panel" "test" {
-  name          = "updated name"
-  model_json    = jsonencode({
-    title       = "updated name",
-    id          = 12,
-    version     = 35
+  name = "updated name"
+  model_json = jsonencode({
+    title   = "updated name",
+    id      = 12,
+    version = 35
   })
 }
 ```

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -18,18 +18,18 @@ description: |-
 
 ```terraform
 resource "grafana_role" "super_user" {
-  name = "Super User"
+  name        = "Super User"
   description = "My Super User description"
-  uid = "superuseruid"
-  version = 1
-  global = true
+  uid         = "superuseruid"
+  version     = 1
+  global      = true
 
   permissions {
     action = "users:create"
   }
   permissions {
     action = "users:read"
-    scope = "global:users:*"
+    scope  = "global:users:*"
   }
 }
 ```

--- a/docs/resources/team_external_group.md
+++ b/docs/resources/team_external_group.md
@@ -15,7 +15,7 @@ description: |-
 
 ```terraform
 resource "grafana_team_external_group" "test-team-group" {
-  team_id  = 1
+  team_id = 1
   groups = [
     "test-group-1",
     "test-group-2"

--- a/examples/data-sources/grafana_cloud_stack/data-source.tf
+++ b/examples/data-sources/grafana_cloud_stack/data-source.tf
@@ -1,6 +1,6 @@
 resource "grafana_cloud_stack" "test" {
-  name   = "gcloudstacktest"
-  slug   = "gcloudstacktest"
+  name        = "gcloudstacktest"
+  slug        = "gcloudstacktest"
   region_slug = "eu"
   description = "Test Grafana Cloud Stack"
 }

--- a/examples/data-sources/grafana_dashboard/bad-ExactlyOneOf.tf
+++ b/examples/data-sources/grafana_dashboard/bad-ExactlyOneOf.tf
@@ -1,16 +1,16 @@
 resource "grafana_dashboard" "test_bad_inputs" {
-  config_json      = jsonencode({
-    id             = 12345,
-    title          = "Production Overview",
-    tags           = [ "templated" ],
-    timezone       = "browser",
-    schemaVersion  = 16,
-    version        = 0,
-    refresh        = "25s"
+  config_json = jsonencode({
+    id            = 12345,
+    title         = "Production Overview",
+    tags          = ["templated"],
+    timezone      = "browser",
+    schemaVersion = 16,
+    version       = 0,
+    refresh       = "25s"
   })
 }
 
 data "grafana_dashboard" "bad_from_uid_id" {
-  uid           = grafana_dashboard.test_bad_inputs.id
-  dashboard_id  = grafana_dashboard.test_bad_inputs.dashboard_id
+  uid          = grafana_dashboard.test_bad_inputs.id
+  dashboard_id = grafana_dashboard.test_bad_inputs.dashboard_id
 }

--- a/examples/data-sources/grafana_dashboard/data-source.tf
+++ b/examples/data-sources/grafana_dashboard/data-source.tf
@@ -1,12 +1,12 @@
 resource "grafana_dashboard" "test" {
-  config_json      = jsonencode({
-    id             = 12345,
-    title          = "Production Overview",
-    tags           = [ "templated" ],
-    timezone       = "browser",
-    schemaVersion  = 16,
-    version        = 0,
-    refresh        = "25s"
+  config_json = jsonencode({
+    id            = 12345,
+    title         = "Production Overview",
+    tags          = ["templated"],
+    timezone      = "browser",
+    schemaVersion = 16,
+    version       = 0,
+    refresh       = "25s"
   })
 }
 

--- a/examples/resources/grafana_api_key/resource.tf
+++ b/examples/resources/grafana_api_key/resource.tf
@@ -4,14 +4,14 @@ resource "grafana_api_key" "foo" {
 }
 
 resource "grafana_api_key" "bar" {
-  name = "key_bar"
-  role = "Admin"
+  name            = "key_bar"
+  role            = "Admin"
   seconds_to_live = 30
 }
 
 
 output "api_key_foo_key_only" {
-  value = grafana_api_key.foo.key
+  value     = grafana_api_key.foo.key
   sensitive = true
 }
 

--- a/examples/resources/grafana_builtin_role_assignment/resource.tf
+++ b/examples/resources/grafana_builtin_role_assignment/resource.tf
@@ -1,11 +1,11 @@
 resource "grafana_builtin_role_assignment" "viewer" {
   builtin_role = "Viewer"
   roles {
-    uid = "firstuid"
+    uid    = "firstuid"
     global = false
   }
   roles {
-    uid = "seconduid"
+    uid    = "seconduid"
     global = true
   }
 }

--- a/examples/resources/grafana_cloud_stack/resource.tf
+++ b/examples/resources/grafana_cloud_stack/resource.tf
@@ -1,6 +1,6 @@
 resource "grafana_cloud_stack" "test" {
-  name   = "gcloudstacktest"
-  slug   = "gcloudstacktest"
+  name        = "gcloudstacktest"
+  slug        = "gcloudstacktest"
   region_slug = "eu"
   description = "Test Grafana Cloud Stack"
 }

--- a/examples/resources/grafana_library_panel/_acc_basic.tf
+++ b/examples/resources/grafana_library_panel/_acc_basic.tf
@@ -3,10 +3,10 @@
 # computed fields.
 #
 resource "grafana_library_panel" "test" {
-  name        = "basic"
-  folder_id   = 0
-  model_json  = jsonencode({
-    title     = "basic",
-    version   = 34,
+  name      = "basic"
+  folder_id = 0
+  model_json = jsonencode({
+    title   = "basic",
+    version = 34,
   })
 }

--- a/examples/resources/grafana_library_panel/_acc_basic_update.tf
+++ b/examples/resources/grafana_library_panel/_acc_basic_update.tf
@@ -1,9 +1,9 @@
 # This is used to test that we can update _acc_basic.tf
 resource "grafana_library_panel" "test" {
-  name          = "updated name"
-  model_json    = jsonencode({
-    title       = "updated name",
-    id          = 12,
-    version     = 35
+  name = "updated name"
+  model_json = jsonencode({
+    title   = "updated name",
+    id      = 12,
+    version = 35
   })
 }

--- a/examples/resources/grafana_library_panel/_acc_basic_update_uid.tf
+++ b/examples/resources/grafana_library_panel/_acc_basic_update_uid.tf
@@ -2,9 +2,9 @@
 #
 # it a point to ensure explicit changes to `uid` are noticed.
 resource "grafana_library_panel" "test" {
-  name          = "basic_update_uid"
-  folder_id     = 0
-  model_json    = jsonencode({
+  name      = "basic_update_uid"
+  folder_id = 0
+  model_json = jsonencode({
     description = "basic_update_uid",
   })
 }

--- a/examples/resources/grafana_library_panel/_acc_computed.tf
+++ b/examples/resources/grafana_library_panel/_acc_computed.tf
@@ -2,19 +2,19 @@
 # We'd like to ensure that using a computed configuration works.
 
 resource "grafana_library_panel" "test" {
-  name          = "computed"
-  folder_id     = 0
-  model_json    = jsonencode({
-    title       = "computed"
-    id          = 12,
-    version     = 35
+  name      = "computed"
+  folder_id = 0
+  model_json = jsonencode({
+    title   = "computed"
+    id      = 12,
+    version = 35
   })
 }
 
 resource "grafana_library_panel" "test-computed" {
-  name          = "computed-uid"
-  folder_id     = 0
-  model_json    = jsonencode({
+  name      = "computed-uid"
+  folder_id = 0
+  model_json = jsonencode({
     title       = "computed-uid"
     description = "test computed UID",
     type        = "test",

--- a/examples/resources/grafana_library_panel/_acc_folder.tf
+++ b/examples/resources/grafana_library_panel/_acc_folder.tf
@@ -3,11 +3,11 @@ resource "grafana_folder" "test_folder" {
 }
 
 resource "grafana_library_panel" "test_folder" {
-  name          = "test-folder"
-  folder_id     = grafana_folder.test_folder.id
-  model_json    = jsonencode({
-    title       = "test-folder",
-    id          = 12,
-    version     = 43,
+  name      = "test-folder"
+  folder_id = grafana_folder.test_folder.id
+  model_json = jsonencode({
+    title   = "test-folder",
+    id      = 12,
+    version = 43,
   })
 }

--- a/examples/resources/grafana_library_panel/resource.tf
+++ b/examples/resources/grafana_library_panel/resource.tf
@@ -1,8 +1,8 @@
 resource "grafana_library_panel" "test" {
-  name          = "updated name"
-  model_json    = jsonencode({
-    title       = "updated name",
-    id          = 12,
-    version     = 35
+  name = "updated name"
+  model_json = jsonencode({
+    title   = "updated name",
+    id      = 12,
+    version = 35
   })
 }

--- a/examples/resources/grafana_role/resource.tf
+++ b/examples/resources/grafana_role/resource.tf
@@ -1,15 +1,15 @@
 resource "grafana_role" "super_user" {
-  name = "Super User"
+  name        = "Super User"
   description = "My Super User description"
-  uid = "superuseruid"
-  version = 1
-  global = true
+  uid         = "superuseruid"
+  version     = 1
+  global      = true
 
   permissions {
     action = "users:create"
   }
   permissions {
     action = "users:read"
-    scope = "global:users:*"
+    scope  = "global:users:*"
   }
 }

--- a/examples/resources/grafana_team_external_group/resource.tf
+++ b/examples/resources/grafana_team_external_group/resource.tf
@@ -1,5 +1,5 @@
 resource "grafana_team_external_group" "test-team-group" {
-  team_id  = 1
+  team_id = 1
   groups = [
     "test-group-1",
     "test-group-2"


### PR DESCRIPTION
Ran `terraform fmt -recursive examples/` to get format-valid Terraform files. We should add a CI check for not introducing format-invalid files in the future.