### PR TITLE
Fix `grafana_team` members reordering

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -34,7 +34,7 @@ resource "grafana_team" "test-team" {
 
 - **email** (String) An email address for the team.
 - **id** (String) The ID of this resource.
-- **members** (List of String) A list of email addresses corresponding to users who should be given membership
+- **members** (Set of String) A set of email addresses corresponding to users who should be given membership
 to the team. Note: users specified here must already exist in Grafana.
 
 ### Read-Only

--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -35,7 +35,6 @@ func ResourceTeam() *schema.Resource {
 * [Official documentation](https://grafana.com/docs/grafana/latest/manage-users/manage-teams/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
 `,
-
 		CreateContext: CreateTeam,
 		ReadContext:   ReadTeam,
 		UpdateContext: UpdateTeam,
@@ -62,7 +61,7 @@ func ResourceTeam() *schema.Resource {
 				Description: "An email address for the team.",
 			},
 			"members": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -195,7 +194,7 @@ func collectMembers(d *schema.ResourceData) (map[string]TeamMember, map[string]T
 
 	// Get the lists of team members read in from Grafana state (old) and configured (new)
 	state, config := d.GetChange("members")
-	for _, u := range state.([]interface{}) {
+	for _, u := range state.(*schema.Set).List() {
 		login := u.(string)
 		// Sanity check that a member isn't specified twice within a team
 		if _, ok := stateMembers[login]; ok {
@@ -203,7 +202,7 @@ func collectMembers(d *schema.ResourceData) (map[string]TeamMember, map[string]T
 		}
 		stateMembers[login] = TeamMember{0, login}
 	}
-	for _, u := range config.([]interface{}) {
+	for _, u := range config.(*schema.Set).List() {
 		login := u.(string)
 		// Sanity check that a member isn't specified twice within a team
 		if _, ok := configMembers[login]; ok {

--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -35,6 +35,7 @@ func ResourceTeam() *schema.Resource {
 * [Official documentation](https://grafana.com/docs/grafana/latest/manage-users/manage-teams/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
 `,
+
 		CreateContext: CreateTeam,
 		ReadContext:   ReadTeam,
 		UpdateContext: UpdateTeam,
@@ -67,7 +68,7 @@ func ResourceTeam() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Description: `
-A list of email addresses corresponding to users who should be given membership
+A set of email addresses corresponding to users who should be given membership
 to the team. Note: users specified here must already exist in Grafana.
 `,
 			},

--- a/grafana/resource_team_test.go
+++ b/grafana/resource_team_test.go
@@ -69,10 +69,31 @@ func TestAccTeam_Members(t *testing.T) {
 						"grafana_team.test", "name", "terraform-acc-test",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_team.test", "members.#", "1",
+						"grafana_team.test", "members.#", "2",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_team.test", "members.0", "john.doe@example.com",
+						"grafana_team.test", "members.0", "test-team-1@example.com",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_team.test", "members.1", "test-team-2@example.com",
+					),
+				),
+			},
+			{
+				Config: testAccTeamConfig_memberReorder,
+				Check: resource.ComposeTestCheckFunc(
+					testAccTeamCheckExists("grafana_team.test", &team),
+					resource.TestCheckResourceAttr(
+						"grafana_team.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_team.test", "members.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_team.test", "members.0", "test-team-1@example.com",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_team.test", "members.1", "test-team-2@example.com",
 					),
 				),
 			},
@@ -143,16 +164,47 @@ resource "grafana_team" "test" {
   email   = "teamEmailUpdate@example.com"
 }
 `
-const testAccTeamConfig_memberAdd = `
+const testAccTeam_users = `
+resource "grafana_user" "user_one" {
+	email    = "test-team-1@example.com"
+	name     = "Team Test User 1"
+	login    = "test-team-1"
+	password = "my-password"
+	is_admin = false
+}
+
+resource "grafana_user" "user_two" {
+	email    = "test-team-2@example.com"
+	name     = "Team Test User 2"
+	login    = "test-team-2"
+	password = "my-password"
+	is_admin = false
+}
+`
+
+const testAccTeamConfig_memberAdd = testAccTeam_users + `
 resource "grafana_team" "test" {
   name    = "terraform-acc-test"
   email   = "teamEmail@example.com"
   members = [
-    "john.doe@example.com",
+	grafana_user.user_one.email,
+	grafana_user.user_two.email,
   ]
 }
 `
-const testAccTeamConfig_memberRemove = `
+
+const testAccTeamConfig_memberReorder = testAccTeam_users + `
+resource "grafana_team" "test" {
+  name    = "terraform-acc-test"
+  email   = "teamEmail@example.com"
+  members = [
+	grafana_user.user_two.email,
+	grafana_user.user_one.email,
+	]
+}
+`
+
+const testAccTeamConfig_memberRemove = testAccTeam_users + `
 resource "grafana_team" "test" {
   name    = "terraform-acc-test"
   email   = "teamEmail@example.com"


### PR DESCRIPTION
It's managed as a set by the Grafana API (and client) but we have it as a list in the resource
This means that whenever the ordering change, it's not being pushed to the API and we have a drift (see issue for more info)

This makes the members attribute a set. Migration is not an issue since both lists and sets are represented as JSON lists in the state (I tested it)

Closes https://github.com/grafana/terraform-provider-grafana/issues/384