### PR TITLE
Fix data source `grafana_user` description and `user_id`

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -4,7 +4,7 @@ page_title: "grafana_user Data Source - terraform-provider-grafana"
 subcategory: ""
 description: |-
   Official documentation https://grafana.com/docs/grafana/latest/manage-users/server-admin/server-admin-manage-users/HTTP API https://grafana.com/docs/grafana/latest/http_api/user/
-  This resource uses Grafana's admin APIs for creating and updating users which
+  This data source uses Grafana's admin APIs for reading users which
   does not currently work with API Tokens. You must use basic auth.
 ---
 
@@ -13,7 +13,7 @@ description: |-
 * [Official documentation](https://grafana.com/docs/grafana/latest/manage-users/server-admin/server-admin-manage-users/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
 
-This resource uses Grafana's admin APIs for creating and updating users which
+This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.
 
 ## Example Usage

--- a/grafana/data_source_user.go
+++ b/grafana/data_source_user.go
@@ -72,6 +72,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	d.SetId(fmt.Sprintf("%d", user.ID))
+	d.Set("user_id", user.ID)
 	d.Set("email", user.Email)
 	d.Set("name", user.Name)
 	d.Set("login", user.Login)

--- a/grafana/data_source_user.go
+++ b/grafana/data_source_user.go
@@ -15,7 +15,7 @@ func DatasourceUser() *schema.Resource {
 * [Official documentation](https://grafana.com/docs/grafana/latest/manage-users/server-admin/server-admin-manage-users/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
 
-This resource uses Grafana's admin APIs for creating and updating users which
+This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.
 `,
 		ReadContext: dataSourceUserRead,

--- a/grafana/data_source_user_test.go
+++ b/grafana/data_source_user_test.go
@@ -16,6 +16,9 @@ func TestAccDatasourceUser(t *testing.T) {
 	}
 	for _, rName := range []string{"from_email", "from_login", "from_id"} {
 		checks = append(checks,
+			resource.TestMatchResourceAttr(
+				"data.grafana_user."+rName, "user_id", idRegexp,
+			),
 			resource.TestCheckResourceAttr(
 				"data.grafana_user."+rName, "email", "test.datasource@example.com",
 			),


### PR DESCRIPTION
## Test terraform config

```tf
terraform {
  required_providers {
    grafana = {
      source = "grafana/grafana"
    }
  }
}

data "grafana_user" "admin" {
  login = "admin"
}

output "admin_id" {
  value = data.grafana_user.admin.user_id
}
```

## Before

```sh
$ terraform output
admin_id = -1
```

## After

```sh
$ terraform output
admin_id = 1
```