### PR TITLE
Fix missing `org_id` of resource `grafana_organization`

### DIFF
--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -155,6 +155,7 @@ func ReadOrganization(ctx context.Context, d *schema.ResourceData, meta interfac
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	d.Set("org_id", resp.ID)
 	d.Set("name", resp.Name)
 	if err := ReadUsers(d, meta); err != nil {
 		return diag.FromErr(err)

--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -140,7 +140,7 @@ func CreateOrganization(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	return diag.Diagnostics{}
+	return ReadOrganization(ctx, d, meta)
 }
 
 func ReadOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/grafana/resource_organization_test.go
+++ b/grafana/resource_organization_test.go
@@ -28,6 +28,9 @@ func TestAccOrganization_basic(t *testing.T) {
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
 					resource.TestMatchResourceAttr(
+						"grafana_organization.test", "org_id", idRegexp,
+					),
+					resource.TestMatchResourceAttr(
 						"grafana_organization.test", "id", idRegexp,
 					),
 				),


### PR DESCRIPTION
## Test terraform config

```tf
terraform {
  required_providers {
    grafana = {
      source = "grafana/grafana"
    }
  }
}

resource "grafana_organization" "org_2" {
  name = "org_2"
}

output "org_id" {
  value = grafana_organization.org_2.org_id
}
```

## Before

```sh
$ terraform output
╷
│ Warning: No outputs found
│ 
│ The state file either has no outputs defined, or all the defined outputs are empty. Please define an output in your configuration with the `output` keyword and run `terraform refresh` for it to become available. If you are
│ using interpolation, please verify the interpolated value is not empty. You can use the `terraform console` command to assist.
╵
```

## After

```sh
$ terraform output
org_id = 2
```