### PR TITLE
Fix json_data field types for opentsdb datasource

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -146,8 +146,8 @@ Optional:
 - **tls_auth_with_ca_cert** (Boolean) (All) Enable TLS authentication using CA cert.
 - **tls_skip_verify** (Boolean) (All) Controls whether a client verifies the server’s certificate chain and host name.
 - **token_uri** (String) (Stackdriver) The token URI used, provided in the service account key.
-- **tsdb_resolution** (String) (OpenTSDB) Resolution.
-- **tsdb_version** (String) (OpenTSDB) Version.
+- **tsdb_resolution** (Number) (OpenTSDB) Resolution.
+- **tsdb_version** (Number) (OpenTSDB) Version.
 - **version** (String) (InfluxDB) InfluxQL or Flux.
 - **workgroup** (String) (Athena) Workgroup to use.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/grafana/grafana-api-golang-client v0.3.1
+	github.com/grafana/grafana-api-golang-client v0.4.0
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.6.2
 	github.com/grafana/synthetic-monitoring-api-go-client v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.3.1 h1:QrHv0RKrYmhVvDN3Pyr+KcoPWY5HG2FEJDz+6fh7y9Y=
-github.com/grafana/grafana-api-golang-client v0.3.1/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.4.0 h1:lUaTh8G4vHtG3mKg4bkZrZsYvraWq8nTeKXWLAY+CoA=
+github.com/grafana/grafana-api-golang-client v0.4.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
 github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.6.2 h1:JGTdlcu8y/ujwGQwTs1q9b1RLAQUr5oV1v4r7Cz5O9g=

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -318,12 +318,12 @@ source selected (via the 'type' argument).
 							Description: "(Stackdriver) The token URI used, provided in the service account key.",
 						},
 						"tsdb_resolution": {
-							Type:        schema.TypeString,
+							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "(OpenTSDB) Resolution.",
 						},
 						"tsdb_version": {
-							Type:        schema.TypeString,
+							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "(OpenTSDB) Version.",
 						},
@@ -622,8 +622,8 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		TLSAuthWithCACert:          d.Get("json_data.0.tls_auth_with_ca_cert").(bool),
 		TLSSkipVerify:              d.Get("json_data.0.tls_skip_verify").(bool),
 		TokenURI:                   d.Get("json_data.0.token_uri").(string),
-		TsdbResolution:             d.Get("json_data.0.tsdb_resolution").(string),
-		TsdbVersion:                d.Get("json_data.0.tsdb_version").(string),
+		TsdbResolution:             int64(d.Get("json_data.0.tsdb_resolution").(int)),
+		TsdbVersion:                int64(d.Get("json_data.0.tsdb_version").(int)),
 		Version:                    d.Get("json_data.0.version").(string),
 		Workgroup:                  d.Get("json_data.0.workgroup").(string),
 	}


### PR DESCRIPTION
Supersedes https://github.com/grafana/terraform-provider-grafana/pull/141
Closes https://github.com/grafana/terraform-provider-grafana/issues/140

`tsdb_resolution` and `tsdb_version` were declared as strings though
those fields are integers.