### PR TITLE
Add provider configure unit test

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -71,6 +71,19 @@ local pipeline(name, steps, services=[]) = {
   ),
 
   pipeline(
+    'unit tests',
+    steps=[
+      {
+        name: 'tests',
+        image: images.go,
+        commands: [
+          'go test ./...',
+        ],
+      },
+    ]
+  ),
+
+  pipeline(
     'cloud tests',
     steps=[
       {

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -49,6 +49,27 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
+name: unit tests
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - go test ./...
+  image: golang:1.16
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+workspace:
+  path: /drone/terraform-provider-grafana
+---
+kind: pipeline
 name: cloud tests
 platform:
   arch: amd64
@@ -252,6 +273,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: 21722dfbb237f702dd2e062347c7adfeb8a15a7cf103670928142a975d743d33
+hmac: da6ac4bfbcd28b5ba91a57b10128a0bae335bf46b1bc0ca08ea59326eae3ed16
 
 ...

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -346,5 +346,4 @@ func getJSONMap(k string) (map[string]interface{}, error) {
 		return valObj, nil
 	}
 	return nil, nil
-
 }

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -181,7 +181,6 @@ func TestProviderConfigure(t *testing.T) {
 				},
 				Steps: []resource.TestStep{test},
 			})
-
 		})
 	}
 }

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -46,8 +49,140 @@ func init() {
 }
 
 func TestProvider(t *testing.T) {
+	IsUnitTest(t)
+
 	if err := Provider("dev")().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProviderConfigure(t *testing.T) {
+	IsUnitTest(t)
+
+	// Helper for header tests
+	checkHeaders := func(t *testing.T, provider *schema.Provider) {
+		gotHeaders := provider.Meta().(*client).gapiConfig.HTTPHeaders
+		if len(gotHeaders) != 2 {
+			t.Errorf("expected 2 HTTP header, got %d", len(gotHeaders))
+		}
+		if gotHeaders["Authorization"] != "Bearer test" {
+			t.Errorf("expected HTTP header Authorization to be \"Bearer test\", got %q", gotHeaders["Authorization"])
+		}
+		if gotHeaders["X-Custom-Header"] != "custom-value" {
+			t.Errorf("expected HTTP header X-Custom-Header to be \"custom-value\", got %q", gotHeaders["X-Custom-Header"])
+		}
+	}
+
+	envBackup := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, v := range envBackup {
+			kv := strings.SplitN(v, "=", 2)
+			os.Setenv(kv[0], kv[1])
+		}
+	}()
+
+	cases := []struct {
+		name        string
+		config      map[string]interface{}
+		env         map[string]string
+		expectedErr string
+		check       func(t *testing.T, provider *schema.Provider)
+	}{
+		{
+			name:        "no config",
+			env:         map[string]string{},
+			expectedErr: "\"auth\": one of `auth,cloud_api_key,sm_access_token` must be specified",
+		},
+		{
+			name: "grafana config from env",
+			env: map[string]string{
+				"GRAFANA_AUTH": "admin:admin",
+				"GRAFANA_URL":  "https://test.com",
+			},
+		},
+		{
+			name: "header config",
+			env: map[string]string{
+				"GRAFANA_AUTH": "admin:admin",
+				"GRAFANA_URL":  "https://test.com",
+			},
+			config: map[string]interface{}{
+				"http_headers": map[string]interface{}{
+					"Authorization":   "Bearer test",
+					"X-Custom-Header": "custom-value",
+				},
+			},
+			check: checkHeaders,
+		},
+		{
+			name: "header config from env",
+			env: map[string]string{
+				"GRAFANA_AUTH":         "admin:admin",
+				"GRAFANA_URL":          "https://test.com",
+				"GRAFANA_HTTP_HEADERS": `{"X-Custom-Header": "custom-value", "Authorization": "Bearer test"}`,
+			},
+			check: checkHeaders,
+		},
+		{
+			name: "invalid header",
+			env: map[string]string{
+				"GRAFANA_AUTH":         "admin:admin",
+				"GRAFANA_URL":          "https://test.com",
+				"GRAFANA_HTTP_HEADERS": `blabla`,
+			},
+			expectedErr: "invalid http_headers config: invalid character 'b' looking for beginning of value",
+		},
+		{
+			name: "grafana cloud config from env",
+			env: map[string]string{
+				"GRAFANA_CLOUD_API_KEY": "testtest",
+			},
+		},
+		{
+			name: "grafana sm config from env",
+			env: map[string]string{
+				"GRAFANA_SM_ACCESS_TOKEN": "testtest",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range tc.env {
+				os.Setenv(k, v)
+			}
+
+			test := resource.TestStep{
+				// Resource is irrelevant, it's just there to test the provider being configured
+				// Terraform will "validate" the provider, but not actually use it when planning
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Config: `resource "grafana_folder" "test" {
+					title = "test"
+				}`,
+			}
+
+			if tc.expectedErr != "" {
+				test.ExpectError = regexp.MustCompile(tc.expectedErr)
+			}
+
+			// Configure the provider and check it
+			provider := Provider("dev")()
+			provider.Configure(context.Background(), terraform.NewResourceConfigRaw(tc.config))
+			if tc.check != nil {
+				tc.check(t, provider)
+			}
+			// Run the plan to check for validation errors
+			resource.UnitTest(t, resource.TestCase{
+				Providers: map[string]*schema.Provider{
+					"grafana": provider,
+				},
+				Steps: []resource.TestStep{test},
+			})
+
+		})
 	}
 }
 
@@ -112,6 +247,14 @@ func accTestsEnabled(t *testing.T, envVarName string) bool {
 		t.Fatalf("%s must be set to a boolean value", envVarName)
 	}
 	return enabled
+}
+
+func IsUnitTest(t *testing.T) {
+	t.Helper()
+
+	if accTestsEnabled(t, "TF_ACC") {
+		t.Skip("Skipping acceptance tests")
+	}
 }
 
 func CheckOSSTestsEnabled(t *testing.T) {

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -236,6 +236,8 @@ func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.
 }
 
 func Test_normalizeDashboardConfigJSON(t *testing.T) {
+	IsUnitTest(t)
+
 	type args struct {
 		config interface{}
 	}

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -568,6 +568,8 @@ func TestAccDataSource_basic(t *testing.T) {
 }
 
 func TestDatasourceMigrationV0(t *testing.T) {
+	IsUnitTest(t)
+
 	cases := []struct {
 		name     string
 		state    map[string]interface{}


### PR DESCRIPTION
Following https://github.com/grafana/terraform-provider-grafana/pull/134
I had a bit of trouble making sure that the changes were working correctly so I decided to add a unit test for the provider configuration

Changes to PR #134:
- Add sub-elem string type to the `http_headers` attribute
- Remove `http_headers` DefaultFunc, it isn't being called
- Add provider configure tests to test that configuring headers works both from env and explicitely

Other changes:
- Add unit test pipeline to CI