### PR TITLE
Add tls_configuration_method in data source

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -146,6 +146,7 @@ Optional:
 - **timescaledb** (Boolean) (PostgreSQL) Enable usage of TimescaleDB extension.
 - **tls_auth** (Boolean) (All) Enable TLS authentication using client cert configured in secure json data.
 - **tls_auth_with_ca_cert** (Boolean) (All) Enable TLS authentication using CA cert.
+- **tls_configuration_method** (String) (All) SSL Certificate configuration, either by ‘file-path’ or ‘file-content’.
 - **tls_skip_verify** (Boolean) (All) Controls whether a client verifies the server’s certificate chain and host name.
 - **token_uri** (String) (Stackdriver) The token URI used, provided in the service account key.
 - **tsdb_resolution** (Number) (OpenTSDB) Resolution.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/grafana/grafana-api-golang-client v0.4.0
+	github.com/grafana/grafana-api-golang-client v0.4.2
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.6.2
 	github.com/grafana/synthetic-monitoring-api-go-client v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.4.0 h1:lUaTh8G4vHtG3mKg4bkZrZsYvraWq8nTeKXWLAY+CoA=
-github.com/grafana/grafana-api-golang-client v0.4.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.4.2 h1:5w4x1/Xpdf/mkrBuTS/xVx15anjMsxPPkvfLXG/RVSM=
+github.com/grafana/grafana-api-golang-client v0.4.2/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
 github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.6.2 h1:JGTdlcu8y/ujwGQwTs1q9b1RLAQUr5oV1v4r7Cz5O9g=

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 )
@@ -356,6 +357,12 @@ source selected (via the 'type' argument).
 							Optional:    true,
 							Description: "(All) Enable TLS authentication using CA cert.",
 						},
+						"tls_configuration_method": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "(All) SSL Certificate configuration, either by ‘file-path’ or ‘file-content’.",
+							ValidateFunc: validation.StringInSlice([]string{"file-path", "file-content"}, false),
+						},
 						"tls_skip_verify": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -682,6 +689,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		TimeInterval:               d.Get("json_data.0.time_interval").(string),
 		TLSAuth:                    d.Get("json_data.0.tls_auth").(bool),
 		TLSAuthWithCACert:          d.Get("json_data.0.tls_auth_with_ca_cert").(bool),
+		TLSConfigurationMethod:     d.Get("json_data.0.tls_configuration_method").(string),
 		TLSSkipVerify:              d.Get("json_data.0.tls_skip_verify").(bool),
 		TokenURI:                   d.Get("json_data.0.token_uri").(string),
 		TsdbResolution:             int64(d.Get("json_data.0.tsdb_resolution").(int)),


### PR DESCRIPTION
* Adds support for the tls_configuration_method field of
  the json_data block of the grafana_data_source resource.

Closes: #404