### PR TITLE
Fix grafana_dashboard import example

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -48,5 +48,5 @@ resource "grafana_dashboard" "metrics" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_dashboard.dashboard_name {{dashboard_slug}}
+terraform import grafana_dashboard.dashboard_name {{dashboard_uid}}
 ```

--- a/examples/resources/grafana_dashboard/import.sh
+++ b/examples/resources/grafana_dashboard/import.sh
@@ -1,1 +1,1 @@
-terraform import grafana_dashboard.dashboard_name {{dashboard_slug}}
+terraform import grafana_dashboard.dashboard_name {{dashboard_uid}}


### PR DESCRIPTION
Importing a `grafana_dashboard` by `slug` does not seem to be supported anymore. It results in:
```
$ terragrunt import 'grafana_dashboard.dashboards["test-dashboard"]' test-dashboard
...
Acquiring state lock. This may take a few moments...
grafana_dashboard.dashboards["test-dashboard"]: Importing from ID "test-dashboard"...
grafana_dashboard.dashboards["test-dashboard"]: Import prepared!
  Prepared grafana_dashboard for import
grafana_dashboard.dashboards["test-dashboard"]: Refreshing state... [id=test-dashboard]

Warning: Dashboard "test-dashboard" is in state, but no longer exists in grafana

"test-dashboard" will be recreated when you apply

Error: Cannot import non-existent remote object

While attempting to import an existing object to
grafana_dashboard.dashboards["test-dashboard"], the provider
detected that no object exists with the given id. Only pre-existing objects
can be imported; check that the id is correct and that it is associated with
the provider's configured region or endpoint, or use "terraform apply" to
create a new remote object for this resource.

Releasing state lock. This may take a few moments...
[terragrunt] 2022/03/02 09:16:38 Hit multiple errors:
exit status 1
```

On the other hand, import by `uid` worked:
```
$ terragrunt import 'grafana_dashboard.dashboards["test-dashboard"]' ABCD88E46
...
Acquiring state lock. This may take a few moments...
grafana_dashboard.dashboards["test-dashboard"]: Importing from ID "ABCD88E46"...
grafana_dashboard.dashboards["test-dashboard"]: Import prepared!
  Prepared grafana_dashboard for import
grafana_dashboard.dashboards["test-dashboard"]: Refreshing state... [id=ABCD88E46]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

Releasing state lock. This may take a few moments...
```