### PR TITLE
Separate Cloud and Cloud instance tests

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -84,18 +84,35 @@ local pipeline(name, steps, services=[]) = {
   ),
 
   pipeline(
-    'cloud tests',
+    'cloud api tests',
     steps=[
       {
         name: 'tests',
         image: images.go,
         commands: [
-          'make testacc-cloud',
+          'make testacc-cloud-api',
+        ],
+        environment: {
+          GRAFANA_CLOUD_API_KEY: cloudApiKey.fromSecret,
+        },
+      },
+    ]
+  ) + {
+    concurrency: { limit: 1 },
+  },
+
+  pipeline(
+    'cloud instance tests',
+    steps=[
+      {
+        name: 'tests',
+        image: images.go,
+        commands: [
+          'make testacc-cloud-instance',
         ],
         environment: {
           GRAFANA_URL: 'https://terraformprovidergrafana.grafana.net/',
           GRAFANA_AUTH: apiToken.fromSecret,
-          GRAFANA_CLOUD_API_KEY: cloudApiKey.fromSecret,
           GRAFANA_SM_ACCESS_TOKEN: smToken.fromSecret,
           GRAFANA_ORG_ID: 1,
         },

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -72,19 +72,43 @@ workspace:
 concurrency:
   limit: 1
 kind: pipeline
-name: cloud tests
+name: cloud api tests
 platform:
   arch: amd64
   os: linux
 services: []
 steps:
 - commands:
-  - make testacc-cloud
+  - make testacc-cloud-api
+  environment:
+    GRAFANA_CLOUD_API_KEY:
+      from_secret: grafana-cloud-api-key
+  image: golang:1.17
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+workspace:
+  path: /drone/terraform-provider-grafana
+---
+concurrency:
+  limit: 1
+kind: pipeline
+name: cloud instance tests
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - make testacc-cloud-instance
   environment:
     GRAFANA_AUTH:
       from_secret: grafana-api-token
-    GRAFANA_CLOUD_API_KEY:
-      from_secret: grafana-cloud-api-key
     GRAFANA_ORG_ID: 1
     GRAFANA_SM_ACCESS_TOKEN:
       from_secret: grafana-sm-token
@@ -275,6 +299,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: af159720377f6a89c2f30c9ac98a010fea321064b6b250aa34fc9c761cf115e1
+hmac: 087ea63b283558d4c10e0dd0f3bf2a0dc9ff352d090c4b1f5852659f9c29aeef
 
 ...

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,14 +3,21 @@ GRAFANA_VERSION ?= 8.4.3
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
+# Test OSS features
 testacc-oss: 
 	TF_ACC_OSS=true make testacc
 
+# Test Enterprise features
 testacc-enterprise:
 	TF_ACC_ENTERPRISE=true make testacc
 
-testacc-cloud:
-	TF_ACC_CLOUD=true make testacc
+# Test Cloud API features
+testacc-cloud-api:
+	TF_ACC_CLOUD_API=true make testacc
+
+# Test Cloud instance features (ex: Machine Learning and Synthetic Monitoring)
+testacc-cloud-instance:
+	TF_ACC_CLOUD_INSTANCE=true make testacc
 
 testacc-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \

--- a/grafana/data_source_cloud_stack_test.go
+++ b/grafana/data_source_cloud_stack_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccDatasourceCloudStack_Basic(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudAPITestsEnabled(t)
 
 	prefix := "tfdatatest"
 
@@ -19,7 +19,7 @@ func TestAccDatasourceCloudStack_Basic(t *testing.T) {
 	var stack gapi.Stack
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudStack(t)
+			testAccPreCheck(t)
 			testAccDeleteExistingStacks(t, prefix)
 		},
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/data_source_dashboards_test.go
+++ b/grafana/data_source_dashboards_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 		resource.TestCheckResourceAttrSet("data.grafana_dashboard.from_data_source", "config_json"),
 	}
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/grafana/data_source_synthetic_monitoring_probe_test.go
+++ b/grafana/data_source_synthetic_monitoring_probe_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestAccDataSourceSyntheticMonitoringProbe(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
-	resource.UnitTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/data_source_synthetic_monitoring_probes_test.go
+++ b/grafana/data_source_synthetic_monitoring_probes_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestAccDataSourceSyntheticMonitoringProbes(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
-	resource.UnitTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -244,15 +244,15 @@ func IsUnitTest(t *testing.T) {
 func CheckOSSTestsEnabled(t *testing.T) {
 	t.Helper()
 
+	if !accTestsEnabled(t, "TF_ACC_OSS") {
+		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
+	}
+
 	checkEnvVarsSet(t, []string{
 		"GRAFANA_URL",
 		"GRAFANA_AUTH",
 		"GRAFANA_ORG_ID",
 	})
-
-	if !accTestsEnabled(t, "TF_ACC_OSS") {
-		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
-	}
 }
 
 // CheckOSSTestsSemver allows to skip tests that are not supported by the Grafana OSS version
@@ -276,18 +276,22 @@ func CheckOSSTestsSemver(t *testing.T, semverConstraint string) {
 func CheckCloudAPITestsEnabled(t *testing.T) {
 	t.Helper()
 
-	checkEnvVarsSet(t, []string{
-		"GRAFANA_CLOUD_API_KEY",
-	})
-
 	if !accTestsEnabled(t, "TF_ACC_CLOUD_API") {
 		t.Skip("TF_ACC_CLOUD_API must be set to a truthy value for Cloud API acceptance tests")
 	}
+
+	checkEnvVarsSet(t, []string{
+		"GRAFANA_CLOUD_API_KEY",
+	})
 }
 
 // CheckCloudInstanceTestsEnabled checks if tests that run on cloud instances are enabled. This should be the first line of any test that tests Grafana Cloud Pro features
 func CheckCloudInstanceTestsEnabled(t *testing.T) {
 	t.Helper()
+
+	if !accTestsEnabled(t, "TF_ACC_CLOUD_INSTANCE") {
+		t.Skip("TF_ACC_CLOUD_INSTANCE must be set to a truthy value for Cloud instance acceptance tests")
+	}
 
 	checkEnvVarsSet(t, []string{
 		"GRAFANA_URL",
@@ -295,23 +299,19 @@ func CheckCloudInstanceTestsEnabled(t *testing.T) {
 		"GRAFANA_ORG_ID",
 		"GRAFANA_SM_ACCESS_TOKEN",
 	})
-
-	if !accTestsEnabled(t, "TF_ACC_CLOUD_INSTANCE") {
-		t.Skip("TF_ACC_CLOUD_INSTANCE must be set to a truthy value for Cloud instance acceptance tests")
-	}
 }
 
 // CheckEnterpriseTestsEnabled checks if the enterprise tests are enabled. This should be the first line of any test that tests Grafana Enterprise features
 func CheckEnterpriseTestsEnabled(t *testing.T) {
 	t.Helper()
 
+	if !accTestsEnabled(t, "TF_ACC_ENTERPRISE") {
+		t.Skip("TF_ACC_ENTERPRISE must be set to a truthy value for Enterprise acceptance tests")
+	}
+
 	checkEnvVarsSet(t, []string{
 		"GRAFANA_URL",
 		"GRAFANA_AUTH",
 		"GRAFANA_ORG_ID",
 	})
-
-	if !accTestsEnabled(t, "TF_ACC_ENTERPRISE") {
-		t.Skip("TF_ACC_ENTERPRISE must be set to a truthy value for Enterprise acceptance tests")
-	}
 }

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -222,7 +222,7 @@ func accTestsEnabled(t *testing.T, envVarName string) bool {
 	return enabled
 }
 
-func checkEnvVarsSet(t *testing.T, envVars []string) {
+func checkEnvVarsSet(t *testing.T, envVars ...string) {
 	t.Helper()
 
 	for _, envVar := range envVars {
@@ -248,11 +248,11 @@ func CheckOSSTestsEnabled(t *testing.T) {
 		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
 	}
 
-	checkEnvVarsSet(t, []string{
+	checkEnvVarsSet(t,
 		"GRAFANA_URL",
 		"GRAFANA_AUTH",
 		"GRAFANA_ORG_ID",
-	})
+	)
 }
 
 // CheckOSSTestsSemver allows to skip tests that are not supported by the Grafana OSS version
@@ -280,9 +280,7 @@ func CheckCloudAPITestsEnabled(t *testing.T) {
 		t.Skip("TF_ACC_CLOUD_API must be set to a truthy value for Cloud API acceptance tests")
 	}
 
-	checkEnvVarsSet(t, []string{
-		"GRAFANA_CLOUD_API_KEY",
-	})
+	checkEnvVarsSet(t, "GRAFANA_CLOUD_API_KEY")
 }
 
 // CheckCloudInstanceTestsEnabled checks if tests that run on cloud instances are enabled. This should be the first line of any test that tests Grafana Cloud Pro features
@@ -293,12 +291,12 @@ func CheckCloudInstanceTestsEnabled(t *testing.T) {
 		t.Skip("TF_ACC_CLOUD_INSTANCE must be set to a truthy value for Cloud instance acceptance tests")
 	}
 
-	checkEnvVarsSet(t, []string{
+	checkEnvVarsSet(t,
 		"GRAFANA_URL",
 		"GRAFANA_AUTH",
 		"GRAFANA_ORG_ID",
 		"GRAFANA_SM_ACCESS_TOKEN",
-	})
+	)
 }
 
 // CheckEnterpriseTestsEnabled checks if the enterprise tests are enabled. This should be the first line of any test that tests Grafana Enterprise features
@@ -309,9 +307,9 @@ func CheckEnterpriseTestsEnabled(t *testing.T) {
 		t.Skip("TF_ACC_ENTERPRISE must be set to a truthy value for Enterprise acceptance tests")
 	}
 
-	checkEnvVarsSet(t, []string{
+	checkEnvVarsSet(t,
 		"GRAFANA_URL",
 		"GRAFANA_AUTH",
 		"GRAFANA_ORG_ID",
-	})
+	)
 }

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -184,25 +184,12 @@ func TestProviderConfigure(t *testing.T) {
 	}
 }
 
-// testAccPreCheckEnv contains all environment variables that must be present
-// for acceptance tests to run. These are checked in testAccPreCheck.
-var testAccPreCheckEnv = []string{
-	"GRAFANA_URL",
-	"GRAFANA_AUTH",
-	"GRAFANA_ORG_ID",
-}
-
 // testAccPreCheck verifies required provider testing configuration. It should
 // be present in every acceptance test.
 //
 // These verifications and configuration are preferred at this level to prevent
 // provider developers from experiencing less clear errors for every test.
 func testAccPreCheck(t *testing.T) {
-	for _, e := range testAccPreCheckEnv {
-		if v := os.Getenv(e); v == "" {
-			t.Fatal(e + " must be set for acceptance tests")
-		}
-	}
 	testAccProviderConfigure.Do(func() {
 		// Since we are outside the scope of the Terraform configuration we must
 		// call Configure() to properly initialize the provider configuration.
@@ -211,18 +198,6 @@ func testAccPreCheck(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-}
-
-// testAccPreCheckCloud should be called by cloud acceptance tests
-func testAccPreCheckCloud(t *testing.T) {
-	testAccPreCheckEnv = append(testAccPreCheckEnv, "GRAFANA_SM_ACCESS_TOKEN")
-	testAccPreCheck(t)
-}
-
-// testAccPreCheckCloudStack should be called by cloud stack acceptance tests
-func testAccPreCheckCloudStack(t *testing.T) {
-	testAccPreCheckEnv = append(testAccPreCheckEnv, "GRAFANA_CLOUD_API_KEY")
-	testAccPreCheck(t)
 }
 
 // testAccExample returns an example config from the examples directory.
@@ -247,6 +222,16 @@ func accTestsEnabled(t *testing.T, envVarName string) bool {
 	return enabled
 }
 
+func checkEnvVarsSet(t *testing.T, envVars []string) {
+	t.Helper()
+
+	for _, envVar := range envVars {
+		if os.Getenv(envVar) == "" {
+			t.Fatalf("%s must be set", envVar)
+		}
+	}
+}
+
 func IsUnitTest(t *testing.T) {
 	t.Helper()
 
@@ -255,13 +240,22 @@ func IsUnitTest(t *testing.T) {
 	}
 }
 
+// CheckOSSTestsEnabled checks if the OSS acceptance tests are enabled. This should be the first line of any test that uses Grafana OSS features only
 func CheckOSSTestsEnabled(t *testing.T) {
 	t.Helper()
+
+	checkEnvVarsSet(t, []string{
+		"GRAFANA_URL",
+		"GRAFANA_AUTH",
+		"GRAFANA_ORG_ID",
+	})
+
 	if !accTestsEnabled(t, "TF_ACC_OSS") {
 		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
 	}
 }
 
+// CheckOSSTestsSemver allows to skip tests that are not supported by the Grafana OSS version
 func CheckOSSTestsSemver(t *testing.T, semverConstraint string) {
 	t.Helper()
 
@@ -278,15 +272,45 @@ func CheckOSSTestsSemver(t *testing.T, semverConstraint string) {
 	}
 }
 
-func CheckCloudTestsEnabled(t *testing.T) {
+// CheckCloudTestsEnabled checks if the cloud tests are enabled. This should be the first line of any test that tests Cloud API features
+func CheckCloudAPITestsEnabled(t *testing.T) {
 	t.Helper()
-	if !accTestsEnabled(t, "TF_ACC_CLOUD") {
-		t.Skip("TF_ACC_CLOUD must be set to a truthy value for Cloud acceptance tests")
+
+	checkEnvVarsSet(t, []string{
+		"GRAFANA_CLOUD_API_KEY",
+	})
+
+	if !accTestsEnabled(t, "TF_ACC_CLOUD_API") {
+		t.Skip("TF_ACC_CLOUD_API must be set to a truthy value for Cloud API acceptance tests")
 	}
 }
 
+// CheckCloudInstanceTestsEnabled checks if tests that run on cloud instances are enabled. This should be the first line of any test that tests Grafana Cloud Pro features
+func CheckCloudInstanceTestsEnabled(t *testing.T) {
+	t.Helper()
+
+	checkEnvVarsSet(t, []string{
+		"GRAFANA_URL",
+		"GRAFANA_AUTH",
+		"GRAFANA_ORG_ID",
+		"GRAFANA_SM_ACCESS_TOKEN",
+	})
+
+	if !accTestsEnabled(t, "TF_ACC_CLOUD_INSTANCE") {
+		t.Skip("TF_ACC_CLOUD_INSTANCE must be set to a truthy value for Cloud instance acceptance tests")
+	}
+}
+
+// CheckEnterpriseTestsEnabled checks if the enterprise tests are enabled. This should be the first line of any test that tests Grafana Enterprise features
 func CheckEnterpriseTestsEnabled(t *testing.T) {
 	t.Helper()
+
+	checkEnvVarsSet(t, []string{
+		"GRAFANA_URL",
+		"GRAFANA_AUTH",
+		"GRAFANA_ORG_ID",
+	})
+
 	if !accTestsEnabled(t, "TF_ACC_ENTERPRISE") {
 		t.Skip("TF_ACC_ENTERPRISE must be set to a truthy value for Enterprise acceptance tests")
 	}

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestResourceCloudStack_Basic(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudAPITestsEnabled(t)
 
 	prefix := "tfresourcetest"
 
@@ -25,7 +25,7 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckCloudStack(t)
+			testAccPreCheck(t)
 			testAccDeleteExistingStacks(t, prefix)
 		},
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/resource_datasource_permission_test.go
+++ b/grafana/resource_datasource_permission_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDatasourcePermission_basic(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	datasourceID := int64(-1)
 

--- a/grafana/resource_machine_learning_job_test.go
+++ b/grafana/resource_machine_learning_job_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestAccResourceMachineLearningJob(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	var job mlapi.Job
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccMLJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
@@ -105,10 +105,10 @@ resource "grafana_machine_learning_job" "invalid" {
 `
 
 func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/resource_report_test.go
+++ b/grafana/resource_report_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func TestAccResourceReport(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	var report gapi.Report
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccReportCheckDestroy(&report),
 		Steps: []resource.TestStep{

--- a/grafana/resource_synthetic_monitoring_check_test.go
+++ b/grafana/resource_synthetic_monitoring_check_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -60,10 +60,10 @@ func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -117,10 +117,10 @@ func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -155,10 +155,10 @@ func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -201,10 +201,10 @@ func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -241,10 +241,10 @@ func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -257,10 +257,10 @@ func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_multiple(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/resource_synthetic_monitoring_probe_helper_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_helper_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestImportProbeStateWithToken(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	testcases := map[string]struct {
 		input             string

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
-	CheckCloudTestsEnabled(t)
+	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckCloud(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
As I am adding more resources and options for Cloud, I'm running into this annoying thing
I want to make sure that the tests do NOT use a grafana auth token because I'm generating one from the Cloud API
However, the `cloud` tests that we currently have include both API and "Pro features" tests and therefore, they need a Cloud token for some tests and a Grafana auth for others

This PR separates the API and instance tests into two different make targets and pipelines