### PR TITLE
Upgrade to go 1.17

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,6 +1,6 @@
 local grafanaVersions = ['8.4.3', '8.3.5', '8.2.7', '8.1.8', '7.5.15'];
 local images = {
-  go: 'golang:1.16',
+  go: 'golang:1.17',
   lint: 'golangci/golangci-lint',
   grafana(version): 'grafana/grafana:' + version,
 };

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -36,7 +36,7 @@ steps:
   - '  echo "docs are out of sync, run \"go generate\""'
   - '  exit 1'
   - fi
-  image: golang:1.16
+  image: golang:1.17
   name: check for drift
 trigger:
   branch:
@@ -57,7 +57,7 @@ services: []
 steps:
 - commands:
   - go test ./...
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -89,7 +89,7 @@ steps:
     GRAFANA_SM_ACCESS_TOKEN:
       from_secret: grafana-sm-token
     GRAFANA_URL: https://terraformprovidergrafana.grafana.net/
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -138,7 +138,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.4.3
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -169,7 +169,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.3.5
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -200,7 +200,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.2.7
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -231,7 +231,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.1.8
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -262,7 +262,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 7.5.15
-  image: golang:1.16
+  image: golang:1.17
   name: tests
 trigger:
   branch:
@@ -275,6 +275,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: c38c84f5d0d69205afba5a641ff418a50bf9991cace102a7e607735db92fd0b1
+hmac: af159720377f6a89c2f30c9ac98a010fea321064b6b250aa34fc9c761cf115e1
 
 ...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
     - name: Import GPG key
       id: import_gpg
       uses: paultyng/ghaction-import-gpg@v2.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
 
   grafana-provider:
-    image: golang:1.16
+    image: golang:1.17
     environment:
       - GRAFANA_URL=http://grafana:3000
       - GRAFANA_AUTH=admin:admin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/terraform-provider-grafana
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
@@ -12,4 +12,82 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
+)
+
+require (
+	cloud.google.com/go v0.65.0 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-cidr v1.0.1 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.40.45 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-getter v1.5.3 // indirect
+	github.com/hashicorp/go-hclog v0.16.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.1 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/hc-install v0.3.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-exec v0.15.0 // indirect
+	github.com/hashicorp/terraform-json v0.13.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.5.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.2.0 // indirect
+	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/mattn/go-colorable v0.1.11 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/cli v1.1.2 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.1.0 // indirect
+	github.com/posener/complete v1.2.3 // indirect
+	github.com/russross/blackfriday v1.6.0 // indirect
+	github.com/ulikunitz/xz v0.5.8 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/zclconf/go-cty v1.10.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/tools v0.1.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.30.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4 // indirect
+	google.golang.org/grpc v1.44.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -249,7 +248,7 @@ func createGrafanaClient(d *schema.ResourceData) (string, *gapi.Config, *gapi.Cl
 	caCert := d.Get("ca_cert").(string)
 	insecure := d.Get("insecure_skip_verify").(bool)
 	if caCert != "" {
-		ca, err := ioutil.ReadFile(caCert)
+		ca, err := os.ReadFile(caCert)
 		if err != nil {
 			return "", nil, nil, err
 		}

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -229,7 +228,7 @@ func testAccPreCheckCloudStack(t *testing.T) {
 // testAccExample returns an example config from the examples directory.
 // Examples are used for both documentation and acceptance tests.
 func testAccExample(t *testing.T, path string) string {
-	example, err := ioutil.ReadFile("../examples/" + path)
+	example, err := os.ReadFile("../examples/" + path)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Also, removed `ioutil` references which is deprecated as of 1.16
https://pkg.go.dev/io/ioutil
> As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.