### PR TITLE
Remove the `testAccPreCheck` check

### DIFF
--- a/grafana/data_source_cloud_stack_test.go
+++ b/grafana/data_source_cloud_stack_test.go
@@ -19,7 +19,6 @@ func TestAccDatasourceCloudStack_Basic(t *testing.T) {
 	var stack gapi.Stack
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccDeleteExistingStacks(t, prefix)
 		},
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/data_source_dashboard_test.go
+++ b/grafana/data_source_dashboard_test.go
@@ -35,7 +35,6 @@ func TestAccDatasourceDashboardBasicID(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard),
 		Steps: []resource.TestStep{
@@ -51,7 +50,6 @@ func TestAccDatasourceDashboardBadExactlyOneOf(t *testing.T) {
 	CheckOSSTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/data_source_dashboards_test.go
+++ b/grafana/data_source_dashboards_test.go
@@ -30,7 +30,6 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/data_source_folder_test.go
+++ b/grafana/data_source_folder_test.go
@@ -25,7 +25,6 @@ func TestAccDatasourceFolder(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccFolderCheckDestroy(&folder),
 		Steps: []resource.TestStep{

--- a/grafana/data_source_library_panel_test.go
+++ b/grafana/data_source_library_panel_test.go
@@ -30,7 +30,6 @@ func TestAccDatasourceLibraryPanel(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{

--- a/grafana/data_source_synthetic_monitoring_probe_test.go
+++ b/grafana/data_source_synthetic_monitoring_probe_test.go
@@ -10,7 +10,6 @@ func TestAccDataSourceSyntheticMonitoringProbe(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/data_source_synthetic_monitoring_probes_test.go
+++ b/grafana/data_source_synthetic_monitoring_probes_test.go
@@ -10,7 +10,6 @@ func TestAccDataSourceSyntheticMonitoringProbes(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/data_source_user_test.go
+++ b/grafana/data_source_user_test.go
@@ -35,7 +35,6 @@ func TestAccDatasourceUser(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccUserCheckDestroy(&user),
 		Steps: []resource.TestStep{

--- a/grafana/resource_alert_notification_test.go
+++ b/grafana/resource_alert_notification_test.go
@@ -18,7 +18,6 @@ func TestAccAlertNotification_basic(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
@@ -57,7 +56,6 @@ func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
@@ -96,7 +94,6 @@ func TestAccAlertNotification_invalid_frequency(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
@@ -114,7 +111,6 @@ func TestAccAlertNotification_reminder_no_frequency(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{

--- a/grafana/resource_api_key_test.go
+++ b/grafana/resource_api_key_test.go
@@ -28,7 +28,6 @@ func TestAccGrafanaAuthKey(t *testing.T) {
 	CheckOSSTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrafanaAuthKeyCheckDestroy,
 		Steps: []resource.TestStep{

--- a/grafana/resource_builtin_role_assignment_test.go
+++ b/grafana/resource_builtin_role_assignment_test.go
@@ -27,7 +27,6 @@ func TestAccBuiltInRoleAssignment(t *testing.T) {
 	var assignments map[string][]*gapi.Role
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccBuiltInRoleAssignmentCheckDestroy(&assignments, []string{roleUID3, roleUID4}, nil),
 		Steps: []resource.TestStep{
@@ -65,7 +64,6 @@ func TestAccBuiltInRoleAssignmentUpdate(t *testing.T) {
 	var assignments map[string][]*gapi.Role
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccBuiltInRoleAssignmentCheckDestroy(&assignments, []string{roleUID5, roleUID6}, []string{roleUID1, roleUID2}),
 		Steps: []resource.TestStep{

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -25,7 +25,6 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
 			testAccDeleteExistingStacks(t, prefix)
 		},
 		ProviderFactories: testAccProviderFactories,

--- a/grafana/resource_dashboard_permission_test.go
+++ b/grafana/resource_dashboard_permission_test.go
@@ -15,7 +15,6 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 	dashboardID := int64(-1)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDashboardPermissionCheckDestroy(),
 		Steps: []resource.TestStep{

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -31,7 +31,6 @@ func TestAccDashboard_basic(t *testing.T) {
 			}
 
 			resource.Test(t, resource.TestCase{
-				PreCheck:          func() { testAccPreCheck(t) },
 				ProviderFactories: testAccProviderFactories,
 				CheckDestroy:      testAccDashboardCheckDestroy(&dashboard),
 				Steps: []resource.TestStep{
@@ -92,7 +91,6 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 	var dashboard gapi.Dashboard
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard),
 		Steps: []resource.TestStep{
@@ -137,7 +135,6 @@ func TestAccDashboard_computed_config(t *testing.T) {
 	var dashboard gapi.Dashboard
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard),
 		Steps: []resource.TestStep{
@@ -160,7 +157,6 @@ func TestAccDashboard_folder(t *testing.T) {
 	var folder gapi.Folder
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDashboardFolderCheckDestroy(&dashboard, &folder),
 		Steps: []resource.TestStep{

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -531,7 +531,6 @@ func TestAccDataSource_basic(t *testing.T) {
 		}
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
 			ProviderFactories: testAccProviderFactories,
 			CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
 			Steps: []resource.TestStep{

--- a/grafana/resource_datasource_permission_test.go
+++ b/grafana/resource_datasource_permission_test.go
@@ -15,7 +15,6 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 	datasourceID := int64(-1)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/resource_folder_permission_test.go
+++ b/grafana/resource_folder_permission_test.go
@@ -14,7 +14,6 @@ func TestAccFolderPermission_basic(t *testing.T) {
 	folderUID := "uninitialized"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccFolderPermissionCheckDestroy(),
 		Steps: []resource.TestStep{

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -17,7 +17,6 @@ func TestAccFolder_basic(t *testing.T) {
 	var folder gapi.Folder
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccFolderCheckDestroy(&folder),
 		Steps: []resource.TestStep{

--- a/grafana/resource_library_panel_test.go
+++ b/grafana/resource_library_panel_test.go
@@ -17,7 +17,6 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 	var panel gapi.LibraryPanel
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
@@ -56,7 +55,6 @@ func TestAccLibraryPanel_computed_config(t *testing.T) {
 	var panel gapi.LibraryPanel
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
@@ -80,7 +78,6 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 	var folder gapi.Folder
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccLibraryPanelFolderCheckDestroy(&panel, &folder),
 		Steps: []resource.TestStep{
@@ -108,7 +105,6 @@ func TestAccLibraryPanel_dashboard(t *testing.T) {
 	var dashboard gapi.Dashboard
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{

--- a/grafana/resource_machine_learning_job_test.go
+++ b/grafana/resource_machine_learning_job_test.go
@@ -16,7 +16,6 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 
 	var job mlapi.Job
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccMLJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
@@ -108,7 +107,6 @@ func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/resource_organization_test.go
+++ b/grafana/resource_organization_test.go
@@ -16,7 +16,6 @@ func TestAccOrganization_basic(t *testing.T) {
 	var org gapi.Org
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
@@ -70,7 +69,6 @@ func TestAccOrganization_users(t *testing.T) {
 	var org gapi.Org
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
@@ -138,7 +136,6 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 	var org gapi.Org
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{

--- a/grafana/resource_playlist_test.go
+++ b/grafana/resource_playlist_test.go
@@ -20,7 +20,6 @@ func TestAccPlaylist_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
@@ -57,7 +56,6 @@ func TestAccPlaylist_update(t *testing.T) {
 	updatedName := "updated name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
@@ -97,7 +95,6 @@ func TestAccPlaylist_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{

--- a/grafana/resource_report_test.go
+++ b/grafana/resource_report_test.go
@@ -16,7 +16,6 @@ func TestAccResourceReport(t *testing.T) {
 	var report gapi.Report
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccReportCheckDestroy(&report),
 		Steps: []resource.TestStep{

--- a/grafana/resource_role_test.go
+++ b/grafana/resource_role_test.go
@@ -16,7 +16,6 @@ func TestAccRole(t *testing.T) {
 	var role gapi.Role
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccRoleCheckDestroy(&role),
 		Steps: []resource.TestStep{

--- a/grafana/resource_synthetic_monitoring_check_test.go
+++ b/grafana/resource_synthetic_monitoring_check_test.go
@@ -11,7 +11,6 @@ func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -63,7 +62,6 @@ func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -120,7 +118,6 @@ func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -158,7 +155,6 @@ func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -204,7 +200,6 @@ func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -244,7 +239,6 @@ func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -260,7 +254,6 @@ func TestAccResourceSyntheticMonitoringCheck_multiple(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -10,7 +10,6 @@ func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/grafana/resource_team_external_group_test.go
+++ b/grafana/resource_team_external_group_test.go
@@ -15,7 +15,6 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 	teamID := int64(-1)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccTeamExternalGroupCheckDestroy(),
 		Steps: []resource.TestStep{

--- a/grafana/resource_team_preferences_test.go
+++ b/grafana/resource_team_preferences_test.go
@@ -11,7 +11,6 @@ func TestAccTeamPreferences_basic(t *testing.T) {
 	CheckOSSTestsEnabled(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccTeamPreferencesCheckDestroy(),
 		Steps: []resource.TestStep{

--- a/grafana/resource_team_test.go
+++ b/grafana/resource_team_test.go
@@ -16,7 +16,6 @@ func TestAccTeam_basic(t *testing.T) {
 	var team gapi.Team
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{
@@ -62,7 +61,6 @@ func TestAccTeam_Members(t *testing.T) {
 	var team gapi.Team
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{

--- a/grafana/resource_user_test.go
+++ b/grafana/resource_user_test.go
@@ -16,7 +16,6 @@ func TestAccUser_basic(t *testing.T) {
 
 	var user gapi.User
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccUserCheckDestroy(&user),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
One last annoyance before I get into actual useful things 😄 

This check func is still being called on every test. It used to serve the same function as the new `Check...Enabled` functions, which were added to exit tests as early as possible

The `testAccPreCheck` function is now only used to bootstrap the test provider.
This PR merges that function into the `Check...` functions, removing lots of boilerplate