### PR TITLE
Provision Grafana API key from Grafana Cloud

### DIFF
--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -48,6 +48,7 @@ output "api_key_bar" {
 
 ### Optional
 
+- **cloud_stack_slug** (String) If set, the API key will be created for the given Cloud stack. This can be used to bootstrap a management API key for a new stack. **Note**: This requires a cloud token to be configured.
 - **seconds_to_live** (Number)
 
 ### Read-Only

--- a/examples/provider/provider-cloud.tf
+++ b/examples/provider/provider-cloud.tf
@@ -1,0 +1,4 @@
+provider "grafana" {
+  url  = "http://grafana.example.com/"
+  auth = var.grafana_auth
+}

--- a/examples/provider/provider-cloud.tf
+++ b/examples/provider/provider-cloud.tf
@@ -1,4 +1,35 @@
+// Step 1: Create a stack
 provider "grafana" {
-  url  = "http://grafana.example.com/"
-  auth = var.grafana_auth
+  alias         = "cloud"
+  cloud_api_key = "my-token"
+}
+
+resource "grafana_cloud_stack" "my_stack" {
+  provider = grafana.cloud
+
+  name        = "myteststack"
+  slug        = "myteststack"
+  region_slug = "us"
+}
+
+resource "grafana_api_key" "management" {
+  provider = grafana.cloud
+
+  cloud_stack_slug = grafana_cloud_stack.my_stack.slug
+  name             = "management-key"
+  role             = "Admin"
+}
+
+// Step 2: Create resources within the stack
+provider "grafana" {
+  alias = "my_stack"
+
+  url  = grafana_cloud_stack.my_stack.url
+  auth = grafana_api_key.management.key
+}
+
+resource "grafana_folder" "my_folder" {
+  provider = grafana.my_stack
+
+  title = "Test Folder"
 }

--- a/examples/provider/provider-organization.tf
+++ b/examples/provider/provider-organization.tf
@@ -1,0 +1,25 @@
+// Step 1: Create an organization
+provider "grafana" {
+  alias = "base"
+  url   = "http://grafana.example.com/"
+  auth  = var.grafana_auth
+}
+
+resource "grafana_organization" "my_org" {
+  provider = grafana.base
+  name     = "my_org"
+}
+
+// Step 2: Create resources within the organization
+provider "grafana" {
+  alias  = "my_org"
+  url    = "http://grafana.example.com/"
+  auth   = var.grafana_auth
+  org_id = grafana_organization.my_org.org_id
+}
+
+resource "grafana_folder" "my_folder" {
+  provider = grafana.my_org
+
+  title = "Test Folder"
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/grafana/grafana-api-golang-client v0.4.4
+	github.com/grafana/grafana-api-golang-client v0.4.5-0.20220309185301-22ca64ba0f8e
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.7.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/grafana/grafana-api-golang-client v0.4.5-0.20220309185301-22ca64ba0f8e
+	github.com/grafana/grafana-api-golang-client v0.4.5
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.7.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,12 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/grafana/grafana-api-golang-client v0.4.3-0.20220307132504-154291db2e32 h1:vqkd9HP1STajON+D/BJR8bOmjlIZxD879xSaBc0vn/I=
+github.com/grafana/grafana-api-golang-client v0.4.3-0.20220307132504-154291db2e32/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/grafana-api-golang-client v0.4.4 h1:tYx11Pdwx4MVtHqWuC+qV8Llqj05jMWpoaNftVoC7Ok=
 github.com/grafana/grafana-api-golang-client v0.4.4/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.4.5-0.20220309185301-22ca64ba0f8e h1:htD0Jo3KvFFS8AYnQdTnDXbYSbJtcJMsVT3+tRsMbYc=
+github.com/grafana/grafana-api-golang-client v0.4.5-0.20220309185301-22ca64ba0f8e/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
 github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.7.0 h1:/lakJGrpCm8aby8Nu7rGLHUllIgPIsJ6UCbqUtGDjIM=

--- a/go.sum
+++ b/go.sum
@@ -457,12 +457,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.4.3-0.20220307132504-154291db2e32 h1:vqkd9HP1STajON+D/BJR8bOmjlIZxD879xSaBc0vn/I=
-github.com/grafana/grafana-api-golang-client v0.4.3-0.20220307132504-154291db2e32/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
-github.com/grafana/grafana-api-golang-client v0.4.4 h1:tYx11Pdwx4MVtHqWuC+qV8Llqj05jMWpoaNftVoC7Ok=
-github.com/grafana/grafana-api-golang-client v0.4.4/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
-github.com/grafana/grafana-api-golang-client v0.4.5-0.20220309185301-22ca64ba0f8e h1:htD0Jo3KvFFS8AYnQdTnDXbYSbJtcJMsVT3+tRsMbYc=
-github.com/grafana/grafana-api-golang-client v0.4.5-0.20220309185301-22ca64ba0f8e/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.4.5 h1:2g7alXWcxjfAAS30uiNU3bTdPGWoBh4WjmSCLyWXLrk=
+github.com/grafana/grafana-api-golang-client v0.4.5/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
 github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.7.0 h1:/lakJGrpCm8aby8Nu7rGLHUllIgPIsJ6UCbqUtGDjIM=

--- a/grafana/resource_api_key_test.go
+++ b/grafana/resource_api_key_test.go
@@ -1,28 +1,17 @@
 package grafana
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 
+	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-
-const testAccGrafanaAuthKeyBasicConfig = `
-resource "grafana_api_key" "foo" {
-	name = "foo-name"
-	role = "Admin"
-}
-`
-
-const testAccGrafanaAuthKeyExpandedConfig = `
-resource "grafana_api_key" "bar" {
-	name 			= "bar-name"
-	role 			= "Viewer"
-	seconds_to_live = 300
-}
-`
 
 func TestAccGrafanaAuthKey(t *testing.T) {
 	CheckOSSTestsEnabled(t)
@@ -42,6 +31,42 @@ func TestAccGrafanaAuthKey(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccGrafanaAuthKeyCheckFields("grafana_api_key.bar", "bar-name", "Viewer", true),
 				),
+			},
+		},
+	})
+}
+
+func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
+	CheckCloudAPITestsEnabled(t)
+
+	var stack gapi.Stack
+	prefix := "tfapikeytest"
+	slug := GetRandomStackName(prefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccDeleteExistingStacks(t, prefix)
+		},
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccStackCheckDestroy(&stack),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGrafanaAuthKeyFromCloud(slug, slug),
+				Check: resource.ComposeTestCheckFunc(
+					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
+					testAccGrafanaAuthKeyCheckFields("grafana_api_key.management", "management-key", "Admin", false),
+
+					// TODO: Check how we can remove this sleep
+					// Sometimes the stack is not ready to be deleted at the end of the test
+					func(s *terraform.State) error {
+						time.Sleep(time.Second * 15)
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccStackConfigBasic(slug, slug),
+				Check:  testAccGrafanaAuthKeyCheckDestroyCloud,
 			},
 		},
 	})
@@ -110,4 +135,59 @@ func testAccGrafanaAuthKeyCheckFields(n string, name string, role string, expire
 
 		return nil
 	}
+}
+
+// Checks that all API keys are deleted, to be called before the stack is completely destroyed
+func testAccGrafanaAuthKeyCheckDestroyCloud(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "grafana_cloud_stack" {
+			continue
+		}
+
+		cloudClient := testAccProvider.Meta().(*client).gcloudapi
+		c, cleanup, err := cloudClient.CreateTemporaryStackGrafanaClient(rs.Primary.Attributes["slug"], "test-api-key-", 60*time.Second)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		response, err := c.GetAPIKeys(true)
+		if err != nil {
+			return err
+		}
+
+		for _, key := range response {
+			if !strings.HasPrefix(key.Name, "test-api-key-") {
+				return fmt.Errorf("Found unexpected API key: %s", key.Name)
+			}
+		}
+		return nil
+	}
+
+	return errors.New("no cloud stack created")
+}
+
+const testAccGrafanaAuthKeyBasicConfig = `
+resource "grafana_api_key" "foo" {
+	name = "foo-name"
+	role = "Admin"
+}
+`
+
+const testAccGrafanaAuthKeyExpandedConfig = `
+resource "grafana_api_key" "bar" {
+	name 			= "bar-name"
+	role 			= "Viewer"
+	seconds_to_live = 300
+}
+`
+
+func testAccGrafanaAuthKeyFromCloud(name, slug string) string {
+	return testAccStackConfigBasic(name, slug) + `
+	resource "grafana_api_key" "management" {
+		cloud_stack_slug = grafana_cloud_stack.test.slug
+		name             = "management-key"
+		role             = "Admin"
+	}
+	`
 }

--- a/grafana/resource_api_key_test.go
+++ b/grafana/resource_api_key_test.go
@@ -55,13 +55,6 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
 					testAccGrafanaAuthKeyCheckFields("grafana_api_key.management", "management-key", "Admin", false),
-
-					// TODO: Check how we can remove this sleep
-					// Sometimes the stack is not ready to be deleted at the end of the test
-					func(s *terraform.State) error {
-						time.Sleep(time.Second * 15)
-						return nil
-					},
 				),
 			},
 			{

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -69,6 +69,7 @@ func testAccDeleteExistingStacks(t *testing.T, prefix string) {
 	}
 }
 
+// nolint: unparam
 func testAccStackCheckExists(rn string, a *gapi.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -12,7 +12,11 @@ The Grafana provider provides configuration management resources for
 
 ## Example Usage
 
+### Simple use-case on an already existing Grafana instance
+
 {{ tffile "examples/provider/provider.tf" }}
+
+### Full Grafana Cloud example
 
 {{ .SchemaMarkdown | trimspace }}
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -12,11 +12,17 @@ The Grafana provider provides configuration management resources for
 
 ## Example Usage
 
-### Simple use-case on an already existing Grafana instance
+### Creating a Grafana provider
 
 {{ tffile "examples/provider/provider.tf" }}
 
-### Full Grafana Cloud example
+### Creating a Grafana organization provider (on-premise)
+
+{{ tffile "examples/provider/provider-organization.tf" }}
+
+### Creating a Grafana Cloud stack provider
+
+{{ tffile "examples/provider/provider-cloud.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
Adds a `cloud_stack_slug` attribute to the `grafana_api_key` resource
This is meant to bridge the gap between Cloud and Grafana and it allows full management of stacks from only a Cloud API key
See the README for an example on how to do that, I added some pretty complete examples