### PR TITLE
Add readiness check for cloud stacks

### DIFF
--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -36,6 +36,7 @@ available at “https://<stack_slug>.grafana.net".
 - **region_slug** (String) Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region
 - **url** (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
+- **wait_for_readiness** (Boolean) Whether to wait for readiness of the stack after creating it. The check is a simple GET request to the stack URL (Grafana instance). Defaults to `true`.
 
 ### Read-Only
 

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -36,7 +36,7 @@ available at “https://<stack_slug>.grafana.net".
 - **region_slug** (String) Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region
 - **url** (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
-- **wait_for_readiness** (Boolean) Whether to wait for readiness of the stack after creating it. The check is a simple GET request to the stack URL (Grafana instance). Defaults to `true`.
+- **wait_for_readiness** (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
 
 ### Read-Only
 

--- a/grafana/data_source_cloud_stack_test.go
+++ b/grafana/data_source_cloud_stack_test.go
@@ -3,11 +3,9 @@ package grafana
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDatasourceCloudStack_Basic(t *testing.T) {
@@ -34,13 +32,6 @@ func TestAccDatasourceCloudStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "prometheus_url"),
 					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "prometheus_user_id"),
 					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "alertmanager_user_id"),
-
-					// TODO: Check how we can remove this sleep
-					// Sometimes the stack is not ready to be deleted at the end of the test
-					func(s *terraform.State) error {
-						time.Sleep(time.Second * 15)
-						return nil
-					},
 				),
 			},
 		},

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -299,6 +299,7 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
 			return resource.RetryableError(errors.New("stack is not ready yet"))
 		}

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"strconv"
 	"testing"
@@ -47,13 +46,6 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "name", resourceName+"new"),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
-
-					// TODO: Check how we can remove this sleep
-					// Sometimes the stack is not ready to be deleted at the end of the test
-					func(s *terraform.State) error {
-						time.Sleep(time.Second * 15)
-						return nil
-					},
 				),
 			},
 		},


### PR DESCRIPTION
The API doesn't expose any indication that a stack is actually ready
There is a `status` field on the API response (GETing the stack) but it shows "active" immediately after POST

So this PR adds a readiness check using the created Grafana instance URL. Whenever the Grafana instance returns a 200 (from the login screen), it's ready
This check can also be disabled by setting `wait_for_readiness` to false on the resource