### PR TITLE
Make dashboard's folder reference a string

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -31,7 +31,7 @@ resource "grafana_dashboard" "metrics" {
 
 ### Optional
 
-- **folder** (Number) The id of the folder to save the dashboard in.
+- **folder** (String) The id of the folder to save the dashboard in. This attribute is a string to reflect the type of the folder's id.
 - **id** (String) The ID of this resource.
 - **message** (String) Set a commit message for the version history.
 - **overwrite** (Boolean) Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -204,7 +204,7 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 	d.SetId(dashboard.Model["uid"].(string))
 	d.Set("uid", dashboard.Model["uid"].(string))
 	d.Set("slug", dashboard.Meta.Slug)
-	d.Set("folder", dashboard.Folder)
+	d.Set("folder", strconv.FormatInt(dashboard.Folder, 10))
 	d.Set("dashboard_id", int64(dashboard.Model["id"].(float64)))
 	d.Set("version", int64(dashboard.Model["version"].(float64)))
 

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -63,6 +63,7 @@ Manages Grafana dashboards.
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Default:      "0",
 				Description:  "The id of the folder to save the dashboard in. This attribute is a string to reflect the type of the folder's id.",
 				ValidateFunc: validation.StringMatch(idRegexp, "must be a valid folder id"),
 			},

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -269,9 +269,13 @@ func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 }
 
 func makeDashboard(d *schema.ResourceData) (gapi.Dashboard, error) {
-	parsedFolder, err := strconv.ParseInt(d.Get("folder").(string), 10, 64)
-	if err != nil {
-		return gapi.Dashboard{}, fmt.Errorf("error parsing folder: %s", err)
+	var parsedFolder int64 = 0
+	var err error
+	if folderStr := d.Get("folder").(string); folderStr != "" {
+		parsedFolder, err = strconv.ParseInt(d.Get("folder").(string), 10, 64)
+		if err != nil {
+			return gapi.Dashboard{}, fmt.Errorf("error parsing folder: %s", err)
+		}
 	}
 
 	dashboard := gapi.Dashboard{


### PR DESCRIPTION
- This matches the type of the folder's `id` attribute
- The migration from a number to a string is done automatically, no need for a StateUpgrader
- The reason for this is to make crossplane references work. They require string IDs