### PR TITLE
Recreate Cloud stack if it is deleted outside of Grafana

### DIFF
--- a/grafana/data_source_cloud_stack_test.go
+++ b/grafana/data_source_cloud_stack_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccDatasourceCloudStack_Basic(t *testing.T) {
+	t.Parallel()
 	CheckCloudAPITestsEnabled(t)
 
 	prefix := "tfdatatest"

--- a/grafana/resource_api_key_test.go
+++ b/grafana/resource_api_key_test.go
@@ -37,6 +37,7 @@ func TestAccGrafanaAuthKey(t *testing.T) {
 }
 
 func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
+	t.Parallel()
 	CheckCloudAPITestsEnabled(t)
 
 	var stack gapi.Stack

--- a/grafana/resource_cloud_api_key_test.go
+++ b/grafana/resource_cloud_api_key_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccCloudApiKey_Basic(t *testing.T) {
+	t.Parallel()
 	CheckCloudAPITestsEnabled(t)
 
 	var tests = []struct {

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -258,6 +258,12 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return diag.FromErr(err)
 	}
 
+	if stack.Status == "deleted" {
+		log.Printf("[WARN] removing stack %s from state because it was deleted outside of Terraform", stack.Name)
+		d.SetId("")
+		return nil
+	}
+
 	FlattenStack(d, stack)
 
 	return nil

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestResourceCloudStack_Basic(t *testing.T) {
+	t.Parallel()
 	CheckCloudAPITestsEnabled(t)
 
 	prefix := "tfresourcetest"
@@ -34,18 +35,35 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
 					resource.TestMatchResourceAttr("grafana_cloud_stack.test", "id", idRegexp),
-					resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "id"),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "name", resourceName),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
+				),
+			},
+			{
+				// Delete the stack outside of the test and make sure it is recreated
+				// Terraform should detect that it's gone and recreate it (status should be active at all times)
+				PreConfig: func() {
+					testAccDeleteExistingStacks(t, prefix)
+				},
+				Config: testAccStackConfigBasic(resourceName, resourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
+					resource.TestMatchResourceAttr("grafana_cloud_stack.test", "id", idRegexp),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "name", resourceName),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 				),
 			},
 			{
 				Config: testAccStackConfigUpdate(resourceName+"new", resourceName, stackDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
+					resource.TestMatchResourceAttr("grafana_cloud_stack.test", "id", idRegexp),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "name", resourceName+"new"),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 				),
 			},
 		},

--- a/grafana/resource_synthetic_monitoring_installation_test.go
+++ b/grafana/resource_synthetic_monitoring_installation_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccSyntheticMonitoringInstallation(t *testing.T) {
+	t.Parallel()
 	CheckCloudAPITestsEnabled(t)
 
 	var stack gapi.Stack


### PR DESCRIPTION
In that case, the API returns a status of `deleted` instead of `active`
Like all resources, if it is deleted outside of Grafana, we want to remove it from state so that it is recreated

Also, I set all the cloud tests parallel because they could be