### PR TITLE
Cloud Stack: Use same schema for data and resource

### DIFF
--- a/docs/data-sources/library_panel.md
+++ b/docs/data-sources/library_panel.md
@@ -90,7 +90,7 @@ data "grafana_dashboard" "from_library_panel_connection" {
 
 - **id** (String) The ID of this resource.
 - **name** (String) Name of the library panel.
-- **uid** (String) The unique identifier (UID) of a library panel uniquely identifies library panels between multiple Grafana installs. It’s automatically generated unless you specify it during library panel creation.The UID provides consistent URLs for accessing library panels and when syncing library panels between multiple Grafana installs.
+- **uid** (String) The unique identifier (UID) of the library panel.
 
 ### Read-Only
 

--- a/grafana/data_source_cloud_stack.go
+++ b/grafana/data_source_cloud_stack.go
@@ -11,12 +11,7 @@ func DatasourceCloudStack() *schema.Resource {
 	return &schema.Resource{
 		Description: "Data source for Grafana Stack",
 		ReadContext: datasourceCloudStackRead,
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The stack id assigned to this stack by Grafana.",
-			},
+		Schema: cloneResourceSchemaForDatasource(ResourceCloudStack(), map[string]*schema.Schema{
 			"slug": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -24,113 +19,13 @@ func DatasourceCloudStack() *schema.Resource {
 Subdomain that the Grafana instance will be available at (i.e. setting slug to “<stack_slug>” will make the instance
 available at “https://<stack_slug>.grafana.net".`,
 			},
-			"name": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Name of stack. Conventionally matches the url of the instance (e.g. “<stack_slug>.grafana.net”).",
-			},
-			"description": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Description of stack.",
-			},
 			"region_slug": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The region this stack is deployed to.",
 			},
-			"url": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack",
-			},
-			"org_id": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Organization id to assign to this stack.",
-			},
-			"org_slug": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Organization slug to assign to this stack.",
-			},
-			"org_name": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Organization name to assign to this stack.",
-			},
-			"status": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Status of the stack.",
-			},
-			"prometheus_user_id": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Promehteus user ID. Used for e.g. remote_write.",
-			},
-			"prometheus_url": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Prometheus url for this instance.",
-			},
-			"prometheus_name": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Prometheus name for this instance.",
-			},
-			"prometheus_remote_endpoint": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Use this URL to query hosted metrics data e.g. Prometheus data source in Grafana",
-			},
-			"prometheus_remote_write_endpoint": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Use this URL to send prometheus metrics to Grafana cloud",
-			},
-			"prometheus_status": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Prometheus status for this instance.",
-			},
-			"alertmanager_user_id": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "User ID of the Alertmanager instance configured for this stack.",
-			},
-			"alertmanager_name": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Name of the Alertmanager instance configured for this stack.",
-			},
-			"alertmanager_url": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Base URL of the Alertmanager instance configured for this stack.",
-			},
-			"alertmanager_status": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Status of the Alertmanager instance configured for this stack.",
-			},
-			"logs_user_id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"logs_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"logs_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"logs_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
+			"wait_for_readiness": nil,
+		}),
 	}
 }
 

--- a/grafana/data_source_library_panel.go
+++ b/grafana/data_source_library_panel.go
@@ -8,16 +8,21 @@ import (
 )
 
 func DatasourceLibraryPanel() *schema.Resource {
-	panelSchema := datasourceSchemaFromResourceSchema(libraryPanel.Schema)
-	panelSchema["uid"].Optional = true
-	panelSchema["name"].Optional = true
-	panelSchema["uid"].ExactlyOneOf = []string{"uid", "name"}
-	panelSchema["name"].ExactlyOneOf = []string{"uid", "name"}
-
 	return &schema.Resource{
 		Description: "Data source for retrieving a single library panel by name or uid.",
 		ReadContext: dataSourceLibraryPanelRead,
-		Schema:      panelSchema,
+		Schema: cloneResourceSchemaForDatasource(ResourceLibraryPanel(), map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of the library panel.",
+			},
+			"uid": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The unique identifier (UID) of the library panel.",
+			},
+		}),
 	}
 }
 

--- a/grafana/data_source_synthetic_monitoring_probe.go
+++ b/grafana/data_source_synthetic_monitoring_probe.go
@@ -10,15 +10,18 @@ import (
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
-func dataSourceSyntheticMonitoringProbe() *schema.Resource {
-	probeSchema := datasourceSchemaFromResourceSchema(syntheticMonitoringProbe.Schema)
-	addRequiredFieldsToSchema(probeSchema, "name")
-	delete(probeSchema, "auth_token")
-
+func DatasourceSyntheticMonitoringProbe() *schema.Resource {
 	return &schema.Resource{
 		Description: "Data source for retrieving a single probe by name.",
 		ReadContext: dataSourceSyntheticMonitoringProbeRead,
-		Schema:      probeSchema,
+		Schema: cloneResourceSchemaForDatasource(ResourceSyntheticMonitoringProbe(), map[string]*schema.Schema{
+			"name": {
+				Description: "Name of the probe.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"auth_token": nil,
+		}),
 	}
 }
 

--- a/grafana/data_source_synthetic_monitoring_probes.go
+++ b/grafana/data_source_synthetic_monitoring_probes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceSyntheticMonitoringProbes() *schema.Resource {
+func DatasourceSyntheticMonitoringProbes() *schema.Resource {
 	return &schema.Resource{
 		Description: "Data source for retrieving all probes.",
 		ReadContext: dataSourceSyntheticMonitoringProbesRead,

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -168,12 +168,12 @@ func Provider(version string) func() *schema.Provider {
 				"grafana_cloud_stack":   ResourceCloudStack(),
 
 				// Synthetic Monitoring
-				"grafana_synthetic_monitoring_check":        resourceSyntheticMonitoringCheck(),
-				"grafana_synthetic_monitoring_probe":        resourceSyntheticMonitoringProbe(),
+				"grafana_synthetic_monitoring_check":        ResourceSyntheticMonitoringCheck(),
+				"grafana_synthetic_monitoring_probe":        ResourceSyntheticMonitoringProbe(),
 				"grafana_synthetic_monitoring_installation": ResourceSyntheticMonitoringInstallation(),
 
 				// Machine Learning
-				"grafana_machine_learning_job": resourceMachineLearningJob(),
+				"grafana_machine_learning_job": ResourceMachineLearningJob(),
 			},
 
 			DataSourcesMap: map[string]*schema.Resource{
@@ -188,8 +188,8 @@ func Provider(version string) func() *schema.Provider {
 				"grafana_cloud_stack": DatasourceCloudStack(),
 
 				// Synthetic Monitoring
-				"grafana_synthetic_monitoring_probe":  dataSourceSyntheticMonitoringProbe(),
-				"grafana_synthetic_monitoring_probes": dataSourceSyntheticMonitoringProbes(),
+				"grafana_synthetic_monitoring_probe":  DatasourceSyntheticMonitoringProbe(),
+				"grafana_synthetic_monitoring_probes": DatasourceSyntheticMonitoringProbes(),
 			},
 		}
 

--- a/grafana/resource_library_panel.go
+++ b/grafana/resource_library_panel.go
@@ -12,8 +12,8 @@ import (
 	gapi "github.com/grafana/grafana-api-golang-client"
 )
 
-var (
-	libraryPanel = &schema.Resource{
+func ResourceLibraryPanel() *schema.Resource {
+	return &schema.Resource{
 
 		Description: `
 Manages Grafana library panels.
@@ -109,10 +109,6 @@ Manages Grafana library panels.
 			},
 		},
 	}
-)
-
-func ResourceLibraryPanel() *schema.Resource {
-	return libraryPanel
 }
 
 func CreateLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/grafana/resource_machine_learning_job.go
+++ b/grafana/resource_machine_learning_job.go
@@ -10,8 +10,8 @@ import (
 	"github.com/grafana/machine-learning-go-client/mlapi"
 )
 
-var (
-	machineLearningJob = &schema.Resource{
+func ResourceMachineLearningJob() *schema.Resource {
+	return &schema.Resource{
 
 		Description: `
 A job defines the queries and model parameters for a machine learning task.
@@ -81,10 +81,6 @@ A job defines the queries and model parameters for a machine learning task.
 			},
 		},
 	}
-)
-
-func resourceMachineLearningJob() *schema.Resource {
-	return machineLearningJob
 }
 
 func resourceMachineLearningJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/grafana/resource_synthetic_monitoring_check.go
+++ b/grafana/resource_synthetic_monitoring_check.go
@@ -428,7 +428,7 @@ var (
 	}
 )
 
-func resourceSyntheticMonitoringCheck() *schema.Resource {
+func ResourceSyntheticMonitoringCheck() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `

--- a/grafana/resource_synthetic_monitoring_probe.go
+++ b/grafana/resource_synthetic_monitoring_probe.go
@@ -13,8 +13,8 @@ import (
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
-var (
-	syntheticMonitoringProbe = &schema.Resource{
+func ResourceSyntheticMonitoringProbe() *schema.Resource {
+	return &schema.Resource{
 
 		Description: `
 Besides the public probes run by Grafana Labs, you can also install your
@@ -88,10 +88,6 @@ Grafana Synthetic Monitoring Agent.
 			},
 		},
 	}
-)
-
-func resourceSyntheticMonitoringProbe() *schema.Resource {
-	return syntheticMonitoringProbe
 }
 
 func resourceSyntheticMonitoringProbeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/grafana/resource_synthetic_monitoring_probe_helper_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_helper_test.go
@@ -40,7 +40,7 @@ func TestImportProbeStateWithToken(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			d := schema.TestResourceDataRaw(t, syntheticMonitoringProbe.Schema, nil)
+			d := schema.TestResourceDataRaw(t, ResourceSyntheticMonitoringProbe().Schema, nil)
 			d.SetId(tc.input)
 
 			res, err := importProbeStateWithToken(context.Background(), d, nil)

--- a/grafana/schema.go
+++ b/grafana/schema.go
@@ -38,7 +38,7 @@ func cloneResourceSchemaForDatasource(r *schema.Resource, updates map[string]*sc
 			delete(clone, k)
 		} else {
 			clone[k] = v
-		}		
+		}
 	}
 	return clone
 }

--- a/grafana/schema.go
+++ b/grafana/schema.go
@@ -20,62 +20,21 @@ func schemaDiffFloat32(k, old string, nw string, d *schema.ResourceData) bool {
 	return old32 == nw32
 }
 
-// datasourceSchemaFromResourceSchema is a recursive func that
-// converts an existing Resource schema to a Datasource schema.
-// All schema elements are copied, but certain attributes are ignored or changed:
-// - all attributes have Computed = true
-// - all attributes have ForceNew, Required = false
-// - Validation funcs and attributes (e.g. MaxItems) are not copied
-func datasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
-	ds := make(map[string]*schema.Schema, len(rs))
-	for k, v := range rs {
-		dv := &schema.Schema{
-			Computed:    true,
-			ForceNew:    false,
-			Required:    false,
-			Description: v.Description,
-			Type:        v.Type,
-		}
-		switch v.Type {
-		case schema.TypeSet:
-			dv.Set = v.Set
-			fallthrough
-		case schema.TypeList:
-			// List & Set types are generally used for 2 cases:
-			// - a list/set of simple primitive values (e.g. list of strings)
-			// - a sub resource
-			if elem, ok := v.Elem.(*schema.Resource); ok {
-				// handle the case where the Element is a sub-resource
-				dv.Elem = &schema.Resource{
-					Schema: datasourceSchemaFromResourceSchema(elem.Schema),
-				}
-			} else {
-				// handle simple primitive case
-				dv.Elem = v.Elem
-			}
-		default:
-			// Elem of all other types are copied as-is
-			dv.Elem = v.Elem
-		}
-		ds[k] = dv
+func cloneResourceSchemaForDatasource(r *schema.Resource, updates map[string]*schema.Schema) map[string]*schema.Schema {
+	resourceSchema := r.Schema
+	clone := make(map[string]*schema.Schema)
+	for k, v := range resourceSchema {
+		clone[k] = v
+		clone[k].Computed = true
+		clone[k].Optional = false
+		clone[k].Required = false
+		clone[k].Default = nil
 	}
-	return ds
-}
-
-// fixDatasourceSchemaFlags is a convenience func that toggles the Computed,
-// Optional + Required flags on a schema element. This is useful when the schema
-// has been generated (using `datasourceSchemaFromResourceSchema` above for
-// example) and therefore the attribute flags were not set appropriately when
-// first added to the schema definition. Currently only supports top-level
-// schema elements.
-func fixDatasourceSchemaFlags(schema map[string]*schema.Schema, required bool, keys ...string) {
-	for _, v := range keys {
-		schema[v].Computed = false
-		schema[v].Optional = !required
-		schema[v].Required = required
+	for k, v := range updates {
+		clone[k] = v
+		if v == nil {
+			delete(clone, k)
+		}
 	}
-}
-
-func addRequiredFieldsToSchema(schema map[string]*schema.Schema, keys ...string) {
-	fixDatasourceSchemaFlags(schema, true, keys...)
+	return clone
 }

--- a/grafana/schema.go
+++ b/grafana/schema.go
@@ -29,6 +29,9 @@ func cloneResourceSchemaForDatasource(r *schema.Resource, updates map[string]*sc
 		clone[k].Optional = false
 		clone[k].Required = false
 		clone[k].Default = nil
+		clone[k].StateFunc = nil
+		clone[k].DiffSuppressFunc = nil
+		clone[k].ValidateFunc = nil
 	}
 	for k, v := range updates {
 		clone[k] = v

--- a/grafana/schema.go
+++ b/grafana/schema.go
@@ -34,10 +34,11 @@ func cloneResourceSchemaForDatasource(r *schema.Resource, updates map[string]*sc
 		clone[k].ValidateFunc = nil
 	}
 	for k, v := range updates {
-		clone[k] = v
 		if v == nil {
 			delete(clone, k)
-		}
+		} else {
+			clone[k] = v
+		}		
 	}
 	return clone
 }


### PR DESCRIPTION
Also:
- Some refactoring to the functions to do this (use the same functions for SM probe)
- Rename resource functions to be public (to be standard across all datasources and resources)