### PR TITLE
Add `url` attribute to dashboard and folder

### DIFF
--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -18,6 +18,7 @@ description: |-
 resource "grafana_dashboard" "test" {
   config_json = jsonencode({
     id            = 12345,
+    uid           = "test-ds-dashboard-uid"
     title         = "Production Overview",
     tags          = ["templated"],
     timezone      = "browser",
@@ -32,7 +33,10 @@ data "grafana_dashboard" "from_id" {
 }
 
 data "grafana_dashboard" "from_uid" {
-  uid = grafana_dashboard.test.id
+  depends_on = [
+    grafana_dashboard.test
+  ]
+  uid = "test-ds-dashboard-uid"
 }
 ```
 
@@ -52,6 +56,7 @@ data "grafana_dashboard" "from_uid" {
 - **is_starred** (Boolean) Whether or not the Grafana dashboard is starred. Starred Dashboards will show up on your own Home Dashboard by default, and are a convenient way to mark Dashboards that you’re interested in.
 - **slug** (String) URL slug of the dashboard (deprecated).
 - **title** (String) The title of the Grafana dashboard.
+- **url** (String) The full URL of the dashboard.
 - **version** (Number) The numerical version of the Grafana dashboard.
 
 

--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -16,6 +16,7 @@ description: |-
 ```terraform
 resource "grafana_folder" "test" {
   title = "test-folder"
+  uid   = "test-ds-folder-uid"
 }
 
 data "grafana_folder" "from_title" {
@@ -34,5 +35,6 @@ data "grafana_folder" "from_title" {
 
 - **id** (Number) The numerical ID of the Grafana folder.
 - **uid** (String) The uid of the Grafana folder.
+- **url** (String) The full URL of the folder.
 
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -40,7 +40,8 @@ resource "grafana_dashboard" "metrics" {
 
 - **dashboard_id** (Number) The numeric ID of the dashboard computed by Grafana.
 - **slug** (String, Deprecated) URL friendly version of the dashboard title. This field is deprecated, please use `uid` instead.
-- **uid** (String) The unique identifier of a dashboard. This is used to construct its URL. It’s automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs.
+- **uid** (String) The unique identifier of a dashboard. This is used to construct its URL. It's automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs.
+- **url** (String) The full URL of the dashboard.
 - **version** (Number) Whenever you save a version of your dashboard, a copy of that version is saved so that previous versions of your dashboard are not lost.
 
 ## Import

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -48,6 +48,7 @@ resource "grafana_folder" "test_folder_with_uid" {
 ### Read-Only
 
 - **id** (String) Unique internal identifier.
+- **url** (String) The full URL of the folder.
 
 ## Import
 

--- a/examples/data-sources/grafana_dashboard/data-source.tf
+++ b/examples/data-sources/grafana_dashboard/data-source.tf
@@ -1,6 +1,7 @@
 resource "grafana_dashboard" "test" {
   config_json = jsonencode({
     id            = 12345,
+    uid           = "test-ds-dashboard-uid"
     title         = "Production Overview",
     tags          = ["templated"],
     timezone      = "browser",
@@ -15,5 +16,8 @@ data "grafana_dashboard" "from_id" {
 }
 
 data "grafana_dashboard" "from_uid" {
-  uid = grafana_dashboard.test.id
+  depends_on = [
+    grafana_dashboard.test
+  ]
+  uid = "test-ds-dashboard-uid"
 }

--- a/examples/data-sources/grafana_folder/data-source.tf
+++ b/examples/data-sources/grafana_folder/data-source.tf
@@ -1,5 +1,6 @@
 resource "grafana_folder" "test" {
   title = "test-folder"
+  uid   = "test-ds-folder-uid"
 }
 
 data "grafana_folder" "from_title" {

--- a/grafana/data_source_dashboard.go
+++ b/grafana/data_source_dashboard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -65,6 +66,11 @@ func DatasourceDashboard() *schema.Resource {
 				Computed:    true,
 				Description: "URL slug of the dashboard (deprecated).",
 			},
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The full URL of the dashboard.",
+			},
 		},
 	}
 }
@@ -89,6 +95,7 @@ func findDashboardWithID(client *gapi.Client, id int64) (*gapi.FolderDashboardSe
 }
 
 func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	gapiURL := meta.(*client).gapiURL
 	var dashboard *gapi.Dashboard
 	client := meta.(*client).gapi
 
@@ -121,6 +128,7 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("folder", dashboard.Folder)
 	d.Set("is_starred", dashboard.Meta.IsStarred)
 	d.Set("slug", dashboard.Meta.Slug)
+	d.Set("url", strings.TrimRight(gapiURL, "/")+dashboard.Meta.URL)
 
 	return nil
 }

--- a/grafana/data_source_dashboard_test.go
+++ b/grafana/data_source_dashboard_test.go
@@ -1,7 +1,9 @@
 package grafana
 
 import (
+	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -29,8 +31,11 @@ func TestAccDatasourceDashboardBasicID(t *testing.T) {
 		resource.TestMatchResourceAttr(
 			"data.grafana_dashboard.from_uid", "dashboard_id", idRegexp,
 		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_dashboard.from_uid", "uid", uidRegexp,
+		resource.TestCheckResourceAttr(
+			"data.grafana_dashboard.from_uid", "uid", "test-ds-dashboard-uid",
+		),
+		resource.TestCheckResourceAttr(
+			"data.grafana_dashboard.from_uid", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/d/test-ds-dashboard-uid/production-overview",
 		),
 	}
 

--- a/grafana/data_source_folder_test.go
+++ b/grafana/data_source_folder_test.go
@@ -1,6 +1,8 @@
 package grafana
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -19,8 +21,11 @@ func TestAccDatasourceFolder(t *testing.T) {
 		resource.TestMatchResourceAttr(
 			"data.grafana_folder.from_title", "id", idRegexp,
 		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_folder.from_title", "uid", uidRegexp,
+		resource.TestCheckResourceAttr(
+			"data.grafana_folder.from_title", "uid", "test-ds-folder-uid",
+		),
+		resource.TestCheckResourceAttr(
+			"data.grafana_folder.from_title", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/dashboards/f/test-ds-folder-uid/test-folder",
 		),
 	}
 

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -39,7 +39,7 @@ Manages Grafana dashboards.
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "The unique identifier of a dashboard. This is used to construct its URL. " +
-					"It’s automatically generated if not provided when creating a dashboard. " +
+					"It's automatically generated if not provided when creating a dashboard. " +
 					"The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs. ",
 			},
 			"slug": {
@@ -52,6 +52,11 @@ Manages Grafana dashboards.
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The numeric ID of the dashboard computed by Grafana.",
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The full URL of the dashboard.",
 			},
 			"version": {
 				Type:     schema.TypeInt,
@@ -186,6 +191,7 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 }
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	gapiURL := meta.(*client).gapiURL
 	client := meta.(*client).gapi
 	uid := d.Id()
 	dashboard, err := client.DashboardByUID(uid)
@@ -209,6 +215,7 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 	d.Set("slug", dashboard.Meta.Slug)
 	d.Set("dashboard_id", int64(dashboard.Model["id"].(float64)))
 	d.Set("version", int64(dashboard.Model["version"].(float64)))
+	d.Set("url", strings.TrimRight(gapiURL, "/")+dashboard.Meta.URL)
 	if dashboard.Folder > 0 {
 		d.Set("folder", strconv.FormatInt(dashboard.Folder, 10))
 	} else {

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -41,6 +42,7 @@ func TestAccDashboard_basic(t *testing.T) {
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "basic"),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "basic"),
+							resource.TestCheckResourceAttr("grafana_dashboard.test", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/d/basic/terraform-acceptance-test"),
 							resource.TestCheckResourceAttr(
 								"grafana_dashboard.test", "config_json", expectedInitialConfig,
 							),
@@ -67,6 +69,7 @@ func TestAccDashboard_basic(t *testing.T) {
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "basic-update"),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "basic-update"),
+							resource.TestCheckResourceAttr("grafana_dashboard.test", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/d/basic-update/updated-title"),
 							resource.TestCheckResourceAttr(
 								"grafana_dashboard.test", "config_json", expectedUpdatedUIDConfig,
 							),

--- a/grafana/resource_folder.go
+++ b/grafana/resource_folder.go
@@ -46,6 +46,11 @@ func ResourceFolder() *schema.Resource {
 				ForceNew:    true,
 				Description: "The title of the folder.",
 			},
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The full URL of the folder.",
+			},
 		},
 	}
 }
@@ -75,6 +80,7 @@ func CreateFolder(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	gapiURL := meta.(*client).gapiURL
 	client := meta.(*client).gapi
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
@@ -96,6 +102,7 @@ func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	d.SetId(strconv.FormatInt(folder.ID, 10))
 	d.Set("title", folder.Title)
 	d.Set("uid", folder.UID)
+	d.Set("url", strings.TrimRight(gapiURL, "/")+folder.URL)
 
 	return nil
 }

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -2,7 +2,9 @@ package grafana
 
 import (
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -36,6 +38,7 @@ func TestAccFolder_basic(t *testing.T) {
 					resource.TestMatchResourceAttr("grafana_folder.test_folder_with_uid", "id", idRegexp),
 					resource.TestCheckResourceAttr("grafana_folder.test_folder_with_uid", "uid", "test-folder-uid"),
 					resource.TestCheckResourceAttr("grafana_folder.test_folder_with_uid", "title", "Terraform Test Folder With UID"),
+					resource.TestCheckResourceAttr("grafana_folder.test_folder_with_uid", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/dashboards/f/test-folder-uid/terraform-test-folder-with-uid"),
 				),
 			},
 			{


### PR DESCRIPTION
In both resources and datasources

There could probably be some refactoring in those DS and resources to merge some of that logic. However, we can leave that for another PR

Closes https://github.com/grafana/terraform-provider-grafana/issues/160