### PR TITLE
Allow removing already deleted users from an organization

### DIFF
--- a/grafana/resource_organization.go
+++ b/grafana/resource_organization.go
@@ -289,6 +289,10 @@ func addIdsToChanges(d *schema.ResourceData, meta interface{}, changes []UserCha
 	create := d.Get("create_users").(bool)
 	for _, change := range changes {
 		id, ok := gUserMap[change.User.Email]
+		if !ok && change.Type == Remove {
+			log.Printf("[WARN] can't remove user %s from organization %s because it no longer exists in grafana", change.User.Email, d.Id())
+			continue
+		}
 		if !ok && !create {
 			return nil, fmt.Errorf("error adding user %s. User does not exist in Grafana", change.User.Email)
 		}

--- a/grafana/resource_user.go
+++ b/grafana/resource_user.go
@@ -2,7 +2,9 @@ package grafana
 
 import (
 	"context"
+	"log"
 	"strconv"
+	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -94,8 +96,15 @@ func ReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	}
 	user, err := client.User(id)
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+			log.Printf("[WARN] removing user %s from state because it no longer exists in grafana", d.Id())
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
+
 	d.Set("user_id", user.ID)
 	d.Set("email", user.Email)
 	d.Set("name", user.Name)


### PR DESCRIPTION
It is currently impossible to remove a user from a org if it has been deleted. This PR fixes that

Fixes https://github.com/grafana/terraform-provider-grafana/issues/427