### PR TITLE
Cloud Stack: Fix read on existing slacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/grafana/grafana-api-golang-client v0.5.0
+	github.com/grafana/grafana-api-golang-client v0.5.1
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.8.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/grafana-api-golang-client v0.5.0 h1:wLb8izoz4rEtgwpD6ORDmpqWnKoLUzGspFjX1n1e00o=
-github.com/grafana/grafana-api-golang-client v0.5.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.5.1 h1:PsYNB9mZ2LBC348eciPnU2y5lMqsQg6nANbBEAgG+Po=
+github.com/grafana/grafana-api-golang-client v0.5.1/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
 github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.8.0 h1:X2fMX8J9SKLk9g4jvnNOmMsv0zFOjRP5Rv6f1TGMVzI=

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -80,6 +80,8 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Optional:    true,
 				Default:     true,
 				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
+				// // Always suppress diff, we don't care about this field, it is only used at creation time.
+				// DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool { return true },
 			},
 			"org_id": {
 				Type:        schema.TypeInt,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -82,7 +82,7 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
 				// Suppress the diff if the new value is "false" because this attribute is only used at creation-time
 				// If the diff is suppress for a "true" value, the attribute cannot be read at all
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool { return newValue == "false" },
+				DiffSuppressFunc: func(_, _, newValue string, _ *schema.ResourceData) bool { return newValue == "false" },
 			},
 			"org_id": {
 				Type:        schema.TypeInt,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -80,8 +80,9 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Optional:    true,
 				Default:     true,
 				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
-				// Always suppress diff, we don't care about this field, it is only used at creation time.
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool { return true },
+				// Suppress the diff if the new value is "false" because this attribute is only used at creation-time
+				// If the diff is suppress for a "true" value, the attribute cannot be read at all
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool { return newValue == "false" },
 			},
 			"org_id": {
 				Type:        schema.TypeInt,
@@ -266,6 +267,9 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	}
 
 	FlattenStack(d, stack)
+	// Always set the wait attribute to true after creation
+	// It no longer matters
+	d.Set("wait_for_readiness", true)
 
 	return nil
 }

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -80,8 +80,8 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Optional:    true,
 				Default:     true,
 				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
-				// // Always suppress diff, we don't care about this field, it is only used at creation time.
-				// DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool { return true },
+				// Always suppress diff, we don't care about this field, it is only used at creation time.
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool { return true },
 			},
 			"org_id": {
 				Type:        schema.TypeInt,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -268,7 +268,7 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 
 	FlattenStack(d, stack)
 	// Always set the wait attribute to true after creation
-	// It no longer matters
+	// It no longer matters and this will prevent drift if the stack was imported
 	d.Set("wait_for_readiness", true)
 
 	return nil

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -55,7 +55,6 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 				),
 			},
-
 			{
 				Config: testAccStackConfigUpdate(resourceName+"new", resourceName, stackDescription),
 				Check: resource.ComposeTestCheckFunc(

--- a/grafana/resource_cloud_stack_test.go
+++ b/grafana/resource_cloud_stack_test.go
@@ -55,6 +55,7 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 				),
 			},
+
 			{
 				Config: testAccStackConfigUpdate(resourceName+"new", resourceName, stackDescription),
 				Check: resource.ComposeTestCheckFunc(
@@ -65,6 +66,11 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 				),
+			},
+			{
+				ResourceName:      "grafana_cloud_stack.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/grafana/terraform-provider-grafana/issues/448
Bumping the client to https://github.com/grafana/grafana-api-golang-client/pull/76 does it

Also, I found an import issue on the cloud stacks while testing this. I added an import test