### PR TITLE
feat: support Azure Monitor datasource

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -108,6 +108,8 @@ Optional:
 - `authentication_type` (String) (Stackdriver) The authentication type: `jwt` or `gce`.
 - `catalog` (String) (Athena) Athena catalog.
 - `client_email` (String) (Stackdriver) Service account email address.
+- `client_id` (String) (Azure Monitor) The service account client id.
+- `cloud_name` (String) (Azure Monitor) The cloud name.
 - `conn_max_lifetime` (Number) (MySQL, PostgreSQL, and MSSQL) Maximum amount of time in seconds a connection may be reused (Grafana v5.4+).
 - `custom_metrics_namespaces` (String) (CloudWatch) A comma-separated list of custom namespaces to be queried by the CloudWatch data source.
 - `database` (String) (Athena) Name of the database within the catalog.
@@ -141,6 +143,8 @@ Optional:
 - `sigv4_profile` (String) (Elasticsearch and Prometheus) Credentials profile name, leave blank for default.
 - `sigv4_region` (String) (Elasticsearch and Prometheus) AWS region to use for Sigv4.
 - `ssl_mode` (String) (PostgreSQL) SSLmode. 'disable', 'require', 'verify-ca' or 'verify-full'.
+- `subscription_id` (String) (Azure Monitor) The subscription id
+- `tenant_id` (String) (Azure Monitor) Service account tenant ID.
 - `time_field` (String) (Elasticsearch) Which field that should be used as timestamp.
 - `time_interval` (String) (Prometheus, Elasticsearch, InfluxDB, MySQL, PostgreSQL, and MSSQL) Lowest interval/step value that should be used for this data source.
 - `timescaledb` (Boolean) (PostgreSQL) Enable usage of TimescaleDB extension.
@@ -175,6 +179,7 @@ Optional:
 - `access_token` (String, Sensitive) (Github) The access token used to access the data source.
 - `auth_token` (String, Sensitive) (Sentry) Authorization token.
 - `basic_auth_password` (String, Sensitive) (All) Password to use for basic authentication.
+- `client_secret` (String, Sensitive) (Azure Monitor) Client secret for authentication.
 - `password` (String, Sensitive) (All) Password to use for authentication.
 - `private_key` (String, Sensitive) (Stackdriver) The service account key `private_key` to use to access the data source.
 - `secret_key` (String, Sensitive) (CloudWatch, Athena) The secret key to use to access the data source.

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -135,6 +135,16 @@ source selected (via the 'type' argument).
 							Optional:    true,
 							Description: "(Stackdriver) Service account email address.",
 						},
+						"client_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "(Azure Monitor) The service account client id.",
+						},
+						"cloud_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "(Azure Monitor) The cloud name.",
+						},
 						"conn_max_lifetime": {
 							Type:        schema.TypeInt,
 							Optional:    true,
@@ -332,6 +342,16 @@ source selected (via the 'type' argument).
 							Optional:    true,
 							Description: "(PostgreSQL) SSLmode. 'disable', 'require', 'verify-ca' or 'verify-full'.",
 						},
+						"subscription_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "(Azure Monitor) The subscription id",
+						},
+						"tenant_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "(Azure Monitor) Service account tenant ID.",
+						},
 						"timescaledb": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -438,6 +458,12 @@ source selected (via the 'type' argument).
 							Optional:    true,
 							Sensitive:   true,
 							Description: "(All) Password to use for basic authentication.",
+						},
+						"client_secret": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: "(Azure Monitor) Client secret for authentication.",
 						},
 						"password": {
 							Type:        schema.TypeString,
@@ -652,6 +678,8 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		AuthenticationType:         d.Get("json_data.0.authentication_type").(string),
 		Catalog:                    d.Get("json_data.0.catalog").(string),
 		ClientEmail:                d.Get("json_data.0.client_email").(string),
+		ClientID:                   d.Get("json_data.0.client_id").(string),
+		CloudName:                  d.Get("json_data.0.cloud_name").(string),
 		ConnMaxLifetime:            int64(d.Get("json_data.0.conn_max_lifetime").(int)),
 		CustomMetricsNamespaces:    d.Get("json_data.0.custom_metrics_namespaces").(string),
 		Database:                   d.Get("json_data.0.database").(string),
@@ -685,6 +713,8 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		SigV4Profile:               d.Get("json_data.0.sigv4_profile").(string),
 		SigV4Region:                d.Get("json_data.0.sigv4_region").(string),
 		Sslmode:                    d.Get("json_data.0.ssl_mode").(string),
+		SubscriptionID:             d.Get("json_data.0.subscription_id").(string),
+		TenantID:                   d.Get("json_data.0.tenant_id").(string),
 		Timescaledb:                d.Get("json_data.0.timescaledb").(bool),
 		TimeField:                  d.Get("json_data.0.time_field").(string),
 		TimeInterval:               d.Get("json_data.0.time_interval").(string),
@@ -706,6 +736,7 @@ func makeSecureJSONData(d *schema.ResourceData) gapi.SecureJSONData {
 		AccessToken:       d.Get("secure_json_data.0.access_token").(string),
 		AuthToken:         d.Get("secure_json_data.0.auth_token").(string),
 		BasicAuthPassword: d.Get("secure_json_data.0.basic_auth_password").(string),
+		ClientSecret:      d.Get("secure_json_data.0.client_secret").(string),
 		Password:          d.Get("secure_json_data.0.password").(string),
 		PrivateKey:        d.Get("secure_json_data.0.private_key").(string),
 		SecretKey:         d.Get("secure_json_data.0.secret_key").(string),

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -510,6 +510,32 @@ func TestAccDataSource_basic(t *testing.T) {
 				"secure_json_data.0.secret_key": "456",
 			},
 		},
+		{
+			resource: "grafana_data_source.azure",
+			config: `
+			resource "grafana_data_source" "azure" {
+				type = "grafana-azure-monitor-datasource"
+				name = "azure"
+				json_data {
+					client_id = "lorem-ipsum"
+					cloud_name = "azuremonitor"
+					subscription_id = "lorem-ipsum"
+					tenant_id = "lorem-ipsum"
+				}
+				secure_json_data {
+					client_secret = "lorem-ipsum"
+				}
+			}
+			`,
+			attrChecks: map[string]string{
+				"type":                        "grafana-azure-monitor-datasource",
+				"name":                        "azure",
+				"json_data.0.client_id":       "lorem-ipsum",
+				"json_data.0.cloud_name":      "azuremonitor",
+				"json_data.0.subscription_id": "lorem-ipsum",
+				"json_data.0.tenant_id":       "lorem-ipsum",
+			},
+		},
 	}
 
 	// Iterate over the provided configurations for datasources


### PR DESCRIPTION
# What

Add Azure Monithor datasource.


# Why

In the recent versions of Grafana, the Azure Monitor has been added. The purpose of this PR is to support this new datasource.

Fixes and closes #345 