### PR TITLE
Add implementation in data source (#454)

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -123,6 +123,7 @@ Optional:
 - `github_url` (String) (Github) Github URL
 - `graphite_version` (String) (Graphite) Graphite version.
 - `http_method` (String) (Prometheus) HTTP method to use for making requests.
+- `implementation` (String) (Alertmanager) Implementation of Alertmanager. Either 'cortex' or 'prometheus'
 - `interval` (String) (Elasticsearch) Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly'.
 - `log_level_field` (String) (Elasticsearch) Which field should be used to indicate the priority of the log message.
 - `log_message_field` (String) (Elasticsearch) Which field should be used as the log message.

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -247,6 +247,11 @@ source selected (via the 'type' argument).
 							Optional:    true,
 							Description: "(Elasticsearch) Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly'.",
 						},
+						"implementation": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "(Alertmanager) Implementation of Alertmanager. Either 'cortex' or 'prometheus'",
+						},
 						"log_level_field": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -694,6 +699,7 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		GraphiteVersion:            d.Get("json_data.0.graphite_version").(string),
 		HTTPMethod:                 d.Get("json_data.0.http_method").(string),
 		Interval:                   d.Get("json_data.0.interval").(string),
+		Implementation:             d.Get("json_data.0.implementation").(string),
 		LogLevelField:              d.Get("json_data.0.log_level_field").(string),
 		LogMessageField:            d.Get("json_data.0.log_message_field").(string),
 		MaxConcurrentShardRequests: int64(d.Get("json_data.0.max_concurrent_shard_requests").(int)),


### PR DESCRIPTION
* Adds support for the "implementation" field of the json_data block of
  the grafana_data_source resource. This allows users to specify the
  Alertmanager implementation when installing an Alertmanager data source
  resource.

Closes: #454