### PR TITLE
Fix folder resource read for Grafana 8.5

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,4 +1,4 @@
-local grafanaVersions = ['8.4.4', '8.3.7', '8.2.7', '8.1.8', '7.5.15'];
+local grafanaVersions = ['8.5.0', '8.4.7', '8.3.7', '8.2.7', '7.5.15'];
 local images = {
   go: 'golang:1.18',
   lint: 'golangci/golangci-lint',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -145,14 +145,14 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: pipeline
-name: 'oss tests: 8.4.4'
+name: 'oss tests: 8.5.0'
 platform:
   arch: amd64
   os: linux
 services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-  image: grafana/grafana:8.4.4
+  image: grafana/grafana:8.5.0
   name: grafana
 steps:
 - commands:
@@ -162,7 +162,38 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 8.4.4
+    GRAFANA_VERSION: 8.5.0
+  image: golang:1.18
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+workspace:
+  path: /drone/terraform-provider-grafana
+---
+kind: pipeline
+name: 'oss tests: 8.4.7'
+platform:
+  arch: amd64
+  os: linux
+services:
+- environment:
+    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
+  image: grafana/grafana:8.4.7
+  name: grafana
+steps:
+- commands:
+  - sleep 5
+  - make testacc-oss
+  environment:
+    GRAFANA_AUTH: admin:admin
+    GRAFANA_ORG_ID: 1
+    GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 8.4.7
   image: golang:1.18
   name: tests
 trigger:
@@ -238,37 +269,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 8.1.8'
-platform:
-  arch: amd64
-  os: linux
-services:
-- environment:
-    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-  image: grafana/grafana:8.1.8
-  name: grafana
-steps:
-- commands:
-  - sleep 5
-  - make testacc-oss
-  environment:
-    GRAFANA_AUTH: admin:admin
-    GRAFANA_ORG_ID: 1
-    GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 8.1.8
-  image: golang:1.18
-  name: tests
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
-  - push
-type: docker
-workspace:
-  path: /drone/terraform-provider-grafana
----
-kind: pipeline
 name: 'oss tests: 7.5.15'
 platform:
   arch: amd64
@@ -300,6 +300,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: fb944ed34626806208f6ad39935f7d01bf1de4e6ee696f779c2b8b8f4233189b
+hmac: 6ff6d080f8016b9d41ac6f560d82c5bb0ea1a267e30adbf66fd2e99b1be6b5b0
 
 ...

--- a/grafana/data_source_folder.go
+++ b/grafana/data_source_folder.go
@@ -51,8 +51,8 @@ func findFolderWithTitle(client *gapi.Client, title string) (*gapi.Folder, error
 
 	for _, f := range folders {
 		if f.Title == title {
-			// Query the folder by ID, that API has additional information
-			return client.Folder(f.ID)
+			// Query the folder by UID, that API has additional information
+			return client.FolderByUID(f.UID)
 		}
 	}
 

--- a/grafana/resource_dashboard_test.go
+++ b/grafana/resource_dashboard_test.go
@@ -226,7 +226,7 @@ func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.
 		if err == nil {
 			return fmt.Errorf("dashboard still exists")
 		}
-		folder, err = client.Folder(folder.ID)
+		folder, err = getFolderById(client, folder.ID)
 		if err == nil {
 			return fmt.Errorf("the following folder still exists: %s", folder.Title)
 		}

--- a/grafana/resource_folder.go
+++ b/grafana/resource_folder.go
@@ -99,15 +99,14 @@ func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
-	folder, err := client.Folder(id)
+	folder, err := getFolderById(client, id)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "status: 404") {
-			log.Printf("[WARN] removing folder %d from state because it no longer exists in grafana", id)
-			d.SetId("")
-			return nil
-		}
-
 		return diag.FromErr(err)
+	}
+	if folder == nil {
+		log.Printf("[WARN] removing folder %d from state because it no longer exists in grafana", id)
+		d.SetId("")
+		return nil
 	}
 
 	d.SetId(strconv.FormatInt(folder.ID, 10))
@@ -160,4 +159,23 @@ func NormalizeFolderConfigJSON(configI interface{}) string {
 	}
 
 	return string(ret)
+}
+
+// Hackish way to get the folder by ID.
+// TODO: Revert to using the specific folder ID GET endpoint once it's fixed
+// Broken in 8.5.0
+func getFolderById(client *gapi.Client, id int64) (*gapi.Folder, error) {
+	folders, err := client.Folders()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, folder := range folders {
+		if folder.ID == id {
+			// Need to use another API call, because the "list" call doesn't have all the info
+			return client.FolderByUID(folder.UID)
+		}
+	}
+
+	return nil, nil
 }

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -108,7 +108,7 @@ func testAccFolderCheckExists(rn string, folder *gapi.Folder) resource.TestCheck
 			return fmt.Errorf("got a folder id of 0")
 		}
 		gotFolder, err := getFolderById(client, id)
-		if err != nil || gotFolder == nil {
+		if err != nil {
 			return fmt.Errorf("error getting folder: %s", err)
 		}
 
@@ -121,7 +121,7 @@ func testAccFolderCheckExists(rn string, folder *gapi.Folder) resource.TestCheck
 func testAccFolderCheckDestroy(folder *gapi.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*client).gapi
-		_, err := client.Folder(folder.ID)
+		_, err := getFolderById(client, folder.ID)
 		if err == nil {
 			return fmt.Errorf("folder still exists")
 		}

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -107,8 +107,8 @@ func testAccFolderCheckExists(rn string, folder *gapi.Folder) resource.TestCheck
 		if id == 0 {
 			return fmt.Errorf("got a folder id of 0")
 		}
-		gotFolder, err := client.Folder(id)
-		if err != nil {
+		gotFolder, err := getFolderById(client, id)
+		if err != nil || gotFolder == nil {
 			return fmt.Errorf("error getting folder: %s", err)
 		}
 

--- a/grafana/resource_library_panel_test.go
+++ b/grafana/resource_library_panel_test.go
@@ -167,7 +167,7 @@ func testAccLibraryPanelFolderCheckDestroy(panel *gapi.LibraryPanel, folder *gap
 		if err == nil {
 			return fmt.Errorf("panel still exists")
 		}
-		folder, err = client.Folder(folder.ID)
+		folder, err = getFolderById(client, folder.ID)
 		if err == nil {
 			return fmt.Errorf("the following folder still exists: %s", folder.Title)
 		}


### PR DESCRIPTION
Temporarily replace the read logic with a more hackish logic that works for every version (uses the "list" and "get by uid" endpoints which are more commonly used, and therefore not broken)

Fixes https://github.com/grafana/terraform-provider-grafana/issues/463