### PR TITLE
Fix grafana_oncall_route docs.

### DIFF
--- a/docs/resources/oncall_route.md
+++ b/docs/resources/oncall_route.md
@@ -27,7 +27,7 @@ resource "grafana_oncall_integration" "example_integration" {
   type = "grafana"
 }
 
-resource "oncall_route" "example_route" {
+resource "grafana_oncall_route" "example_route" {
   integration_id      = grafana_oncall_integration.example_integration.id
   escalation_chain_id = data.grafana_oncall_escalation_chain.default.id
   routing_regex       = "us-(east|west)"

--- a/examples/resources/grafana_oncall_route/resource.tf
+++ b/examples/resources/grafana_oncall_route/resource.tf
@@ -11,7 +11,7 @@ resource "grafana_oncall_integration" "example_integration" {
   type = "grafana"
 }
 
-resource "oncall_route" "example_route" {
+resource "grafana_oncall_route" "example_route" {
   integration_id      = grafana_oncall_integration.example_integration.id
   escalation_chain_id = data.grafana_oncall_escalation_chain.default.id
   routing_regex       = "us-(east|west)"


### PR DESCRIPTION
Noticed that this specific example for the `grafana_oncall_route` resource was incorrect.

Signed-off-by: Callum Styan <callumstyan@gmail.com>