### PR TITLE
grafana_cloud_stack with proper prometheus urls

### DIFF
--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -267,9 +267,8 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return nil
 	}
 
-	err = FlattenStack(d, stack)
-	if err != nil {
-		tflog.Error(ctx, "An error occurred")
+	if err := FlattenStack(d, stack); err != nil {
+		return diag.FromError(err)
 	}
 	// Always set the wait attribute to true after creation
 	// It no longer matters and this will prevent drift if the stack was imported

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -295,16 +295,16 @@ func FlattenStack(d *schema.ResourceData, stack gapi.Stack) error {
 	d.Set("prometheus_user_id", stack.HmInstancePromID)
 	d.Set("prometheus_url", stack.HmInstancePromURL)
 	d.Set("prometheus_name", stack.HmInstancePromName)
-	re_url, err := appendPath(stack.HmInstancePromURL, "/api/prom")
-	d.Set("prometheus_remote_endpoint", re_url)
+	reURL, err := appendPath(stack.HmInstancePromURL, "/api/prom")
+	d.Set("prometheus_remote_endpoint", reURL)
 	if err != nil {
 		return err
 	}
-	rwe_url, err := appendPath(stack.HmInstancePromURL, "/api/prom/push")
+	rweURL, err := appendPath(stack.HmInstancePromURL, "/api/prom/push")
 	if err != nil {
 		return err
 	}
-	d.Set("prometheus_remote_write_endpoint", rwe_url)
+	d.Set("prometheus_remote_write_endpoint", rweURL)
 	d.Set("prometheus_status", stack.HmInstancePromStatus)
 
 	d.Set("logs_user_id", stack.HlInstanceID)

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -268,7 +267,7 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	}
 
 	if err := FlattenStack(d, stack); err != nil {
-		return diag.FromError(err)
+		return diag.FromErr(err)
 	}
 	// Always set the wait attribute to true after creation
 	// It no longer matters and this will prevent drift if the stack was imported

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"path"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -292,8 +292,8 @@ func FlattenStack(d *schema.ResourceData, stack gapi.Stack) {
 	d.Set("prometheus_user_id", stack.HmInstancePromID)
 	d.Set("prometheus_url", stack.HmInstancePromURL)
 	d.Set("prometheus_name", stack.HmInstancePromName)
-	d.Set("prometheus_remote_endpoint", path.Join(stack.HmInstancePromURL, "api/prom"))
-	d.Set("prometheus_remote_write_endpoint", path.Join(stack.HmInstancePromURL, "api/prom/push"))
+	d.Set("prometheus_remote_endpoint", appendPath(stack.HmInstancePromURL, "/api/prom"))
+	d.Set("prometheus_remote_write_endpoint", appendPath(stack.HmInstancePromURL, "/api/prom/push"))
 	d.Set("prometheus_status", stack.HmInstancePromStatus)
 
 	d.Set("logs_user_id", stack.HlInstanceID)
@@ -305,6 +305,19 @@ func FlattenStack(d *schema.ResourceData, stack gapi.Stack) {
 	d.Set("alertmanager_name", stack.AmInstanceName)
 	d.Set("alertmanager_url", stack.AmInstanceURL)
 	d.Set("alertmanager_status", stack.AmInstanceStatus)
+}
+
+// Append path to baseurl
+func appendPath(baseUrl, path string) string {
+	bu, err := url.Parse(baseUrl)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	u, err := bu.Parse(path)
+	if err != nil {
+		diag.FromErr(err)
+	}
+	return u.String()
 }
 
 // waitForStackReadiness retries until the stack is ready, verified by querying the Grafana URL


### PR DESCRIPTION
Create prometheus_remote_endpoint and prometheus_remote_write_endpoint
using url.Parse instead of path.Join as the latter render an
invalid url, for example http:/test.com

`terraform plan` output with grafana/grafana version 1.22
```
Changes to Outputs:
  + grafana_cloud_stack_prometheus_remote_endpoint = {
      + prod = "https:/prometheus-prod-01-eu-west-0.grafana.net/api/prom"
      + test = "https:/prometheus-prod-01-eu-west-0.grafana.net/api/prom"
    }
```

Tested on a MacBook Air M1
```
file terraform-provider-grafana 
terraform-provider-grafana: Mach-O 64-bit executable arm64

Changes to Outputs:
  + grafana_cloud_stack_prometheus_remote_endpoint = {
      + prod = "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"
      + test = "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"
    }

```
