### PR TITLE
Add a deprecation message for grafana_builtin_role_assignment

### DIFF
--- a/docs/resources/builtin_role_assignment.md
+++ b/docs/resources/builtin_role_assignment.md
@@ -3,14 +3,14 @@
 page_title: "grafana_builtin_role_assignment Resource - terraform-provider-grafana"
 subcategory: ""
 description: |-
-  Note: This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead.
+  Note: This resource is going to be deprecated with Grafana 9.+, please use grafana_role https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role instead.
   Note: This resource is available only with Grafana Enterprise 8.+.
   Official documentation https://grafana.com/docs/grafana/latest/enterprise/access-control/HTTP API https://grafana.com/docs/grafana/latest/http_api/access_control/
 ---
 
 # grafana_builtin_role_assignment (Resource)
 
-**Note:** This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead.
+**Note:** This resource is going to be deprecated with Grafana 9.+, please use [grafana_role](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role) instead.
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/access-control/)

--- a/docs/resources/builtin_role_assignment.md
+++ b/docs/resources/builtin_role_assignment.md
@@ -3,12 +3,14 @@
 page_title: "grafana_builtin_role_assignment Resource - terraform-provider-grafana"
 subcategory: ""
 description: |-
+  Note: This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead.
   Note: This resource is available only with Grafana Enterprise 8.+.
   Official documentation https://grafana.com/docs/grafana/latest/enterprise/access-control/HTTP API https://grafana.com/docs/grafana/latest/http_api/access_control/
 ---
 
 # grafana_builtin_role_assignment (Resource)
 
+**Note:** This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead.
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/access-control/)

--- a/grafana/resource_builtin_role_assignment.go
+++ b/grafana/resource_builtin_role_assignment.go
@@ -15,7 +15,7 @@ import (
 func ResourceBuiltInRoleAssignment() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-**Note:** This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead.
+**Note:** This resource is going to be deprecated with Grafana 9.+, please use [grafana_role](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role) instead.
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/access-control/)
@@ -28,7 +28,7 @@ func ResourceBuiltInRoleAssignment() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		DeprecationMessage: "This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead",
+		DeprecationMessage: "This resource is going to be deprecated with Grafana 9.+, please use [grafana_role](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/role) instead",
 		Schema: map[string]*schema.Schema{
 			// Built-in roles are all organization roles and Grafana Admin
 			"builtin_role": {

--- a/grafana/resource_builtin_role_assignment.go
+++ b/grafana/resource_builtin_role_assignment.go
@@ -15,6 +15,7 @@ import (
 func ResourceBuiltInRoleAssignment() *schema.Resource {
 	return &schema.Resource{
 		Description: `
+**Note:** This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead.
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/access-control/)
@@ -27,6 +28,7 @@ func ResourceBuiltInRoleAssignment() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		DeprecationMessage: "This resource is going to be deprecated with Grafana 9.+, please use grafana_role instead",
 		Schema: map[string]*schema.Schema{
 			// Built-in roles are all organization roles and Grafana Admin
 			"builtin_role": {


### PR DESCRIPTION
We are going to remove the resource once the Grafana 9.0 is released. This PR adds a small deprecation message as an in advance warning.