### PR TITLE
Handle 404s in Synthetic Monitoring

### DIFF
--- a/grafana/resource_synthetic_monitoring_check.go
+++ b/grafana/resource_synthetic_monitoring_check.go
@@ -3,7 +3,9 @@ package grafana
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -555,6 +557,11 @@ func resourceSyntheticMonitoringCheckRead(ctx context.Context, d *schema.Resourc
 	}
 	chk, err := c.GetCheck(ctx, id)
 	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			log.Printf("[WARN] removing check %s from state because it no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_synthetic_monitoring_probe.go
+++ b/grafana/resource_synthetic_monitoring_probe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -111,6 +112,11 @@ func resourceSyntheticMonitoringProbeRead(ctx context.Context, d *schema.Resourc
 	}
 	prb, err := c.GetProbe(ctx, id)
 	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			log.Printf("[WARN] removing probe %s from state because it no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -1,9 +1,12 @@
 package grafana
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
@@ -36,6 +39,39 @@ func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "region", "AMER"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "public", "false"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "labels.type", "volcano"),
+				),
+			},
+		},
+	})
+}
+
+// Test that a probe is recreated if deleted outside the Terraform process
+func TestAccResourceSyntheticMonitoringProbe_recreate(t *testing.T) {
+	CheckCloudInstanceTestsEnabled(t)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Check: func(s *terraform.State) error {
+					rs := s.RootModule().Resources["grafana_synthetic_monitoring_probe.main"]
+					id, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
+					return testAccProvider.Meta().(*client).smapi.DeleteProbe(context.Background(), id)
+				},
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
+					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", "Mount Everest"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "latitude", "27.986059188842773"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "longitude", "86.92262268066406"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "region", "APAC"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "public", "false"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "labels.type", "mountain"),
 				),
 			},
 		},


### PR DESCRIPTION
Getting a 404 on a resource means it should be cleared from state and recreated
Closes https://github.com/grafana/terraform-provider-grafana/issues/172 because I went over all Grafana resources a while ago. Only SM was remaining