### PR TITLE
Grafana role resource: Use correct description when updating a role

### DIFF
--- a/grafana/resource_role.go
+++ b/grafana/resource_role.go
@@ -174,16 +174,11 @@ func UpdateRole(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	client := meta.(*client).gapi
 
 	if d.HasChange("version") || d.HasChange("name") || d.HasChange("description") || d.HasChange("permissions") {
-		desc := ""
-		// If description is defined, use the value from the config
-		if v, ok := d.GetOk("description"); !ok {
-			desc = v.(string)
-		}
 		r := gapi.Role{
 			UID:         d.Id(),
 			Name:        d.Get("name").(string),
 			Global:      d.Get("global").(bool),
-			Description: desc,
+			Description: d.Get("description").(string),
 			Version:     int64(d.Get("version").(int)),
 			Permissions: permissions(d),
 		}


### PR DESCRIPTION
### Context

The description field in the grafana role is optional - it can be empty or null. In the past, Grafana backend was not handling this gracefully, so we needed to make sure that description is only set when it is defined in the config. That said, the following code was actually completely wrong, as it was not setting the description when it was defined, and had the opposite check
```
if v, ok := d.GetOk("description"); !ok {
			desc = v.(string)
		}
```

### The fix

We don't need to check for field being set at all now, as Grafana backend handles the optional fields correctly and will set description to empty by default for null values, [here is the code](https://github.com/grafana/grafana-enterprise/blob/main/src/pkg/extensions/accesscontrol/database/database.go#L266). So the PR just removes entire if block.