### PR TITLE
Bump grafana-api-golang-client from 0.2.6 to 0.6.0 and fix incompatibilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/grafana/grafana-api-golang-client v0.2.6
+	github.com/grafana/grafana-api-golang-client v0.6.0
 	github.com/grafana/machine-learning-go-client v0.1.1
 	github.com/grafana/synthetic-monitoring-agent v0.6.2
 	github.com/grafana/synthetic-monitoring-api-go-client v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-api-golang-client v0.2.6 h1:/S9vz8gwwxURnQwU/SDgFl4JaX0PTGNrszBKKeOunF4=
-github.com/grafana/grafana-api-golang-client v0.2.6/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.6.0 h1:vIHRlBFuhv8RblcinH31ez1+JYYFhuJGx4kIRKlT6l8=
+github.com/grafana/grafana-api-golang-client v0.6.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
 github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.5.0/go.mod h1:oC2+OFrK7WHqrDmilaa8eNNjyB2fMRk7DCj3Z/b/TrA=

--- a/grafana/data_source_dashboard.go
+++ b/grafana/data_source_dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -70,10 +71,9 @@ func DatasourceDashboard() *schema.Resource {
 
 // search dashboards by ID
 func findDashboardWithID(client *gapi.Client, id int64) (*gapi.FolderDashboardSearchResponse, error) {
-	params := map[string]string{
-		"type":         "dash-db",
-		"dashboardIds": strconv.FormatInt(id, 10),
-	}
+	params := url.Values{}
+	params.Add("type", "dash-db")
+	params.Add("dashboardIds", strconv.FormatInt(id, 10))
 	resp, err := client.FolderDashboardSearch(params)
 	if err != nil {
 		return nil, err

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -133,10 +134,9 @@ func resourceDashboardV0() *schema.Resource {
 func resourceDashboardStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	client := meta.(*client).gapi
 	dashboardID := int64(rawState["dashboard_id"].(float64))
-	params := map[string]string{
-		"type":         "dash-db",
-		"dashboardIds": strconv.FormatInt(dashboardID, 10),
-	}
+	params := url.Values{}
+	params.Add("type", "dash-db")
+	params.Add("dashboardIds", strconv.FormatInt(dashboardID, 10))
 	resp, err := client.FolderDashboardSearch(params)
 	if err != nil {
 		return nil, fmt.Errorf("error attempting to migrate state. Grafana returned an error while searching for dashboard with ID %s: %s", params["dashboardIds"], err)

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -593,8 +593,8 @@ func makeJSONData(d *schema.ResourceData) gapi.JSONData {
 		TLSAuthWithCACert:          d.Get("json_data.0.tls_auth_with_ca_cert").(bool),
 		TLSSkipVerify:              d.Get("json_data.0.tls_skip_verify").(bool),
 		TokenURI:                   d.Get("json_data.0.token_uri").(string),
-		TsdbResolution:             d.Get("json_data.0.tsdb_resolution").(string),
-		TsdbVersion:                d.Get("json_data.0.tsdb_version").(string),
+		TsdbResolution:             d.Get("json_data.0.tsdb_resolution").(int64),
+		TsdbVersion:                d.Get("json_data.0.tsdb_version").(int64),
 		Workgroup:                  d.Get("json_data.0.workgroup").(string),
 	}
 }


### PR DESCRIPTION
Hello! We're wanting to extend the terraform provider with some new types for unified alerting.

We have an open PR to add the first of these types to the golang client: https://github.com/grafana/grafana-api-golang-client/pull/86

But, the terraform provider still depends on 0.2.6 of the client, which is incompatible with the latest version that the PR is open against. This PR bumps the provider to the latest version of the golang client.