### PR TITLE
Add `Edit` permission to resource_datasource_permission

### DIFF
--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -62,7 +62,7 @@ resource "grafana_data_source_permission" "fooPermissions" {
 
 Required:
 
-- `permission` (String) Permission to associate with item. Must be `Query`.
+- `permission` (String) Permission to associate with item. Must be `Query` or `Edit`.
 
 Optional:
 

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -62,7 +62,7 @@ resource "grafana_data_source_permission" "fooPermissions" {
 
 Required:
 
-- `permission` (String) Permission to associate with item. Must be `Query` or `Edit`.
+- `permission` (String) Permission to associate with item. Must be one of `Query` or `Edit`.
 
 Optional:
 

--- a/grafana/resource_datasource_permission.go
+++ b/grafana/resource_datasource_permission.go
@@ -54,7 +54,7 @@ func ResourceDatasourcePermission() *schema.Resource {
 						"permission": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Query","Edit"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"Query", "Edit"}, false),
 							Description:  "Permission to associate with item. Must be `Query` or `Edit`.",
 						},
 					},

--- a/grafana/resource_datasource_permission.go
+++ b/grafana/resource_datasource_permission.go
@@ -54,8 +54,8 @@ func ResourceDatasourcePermission() *schema.Resource {
 						"permission": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Query"}, false),
-							Description:  "Permission to associate with item. Must be `Query`.",
+							ValidateFunc: validation.StringInSlice([]string{"Query","Edit"}, false),
+							Description:  "Permission to associate with item. Must be `Query` or `Edit`.",
 						},
 					},
 				},

--- a/grafana/resource_datasource_permission.go
+++ b/grafana/resource_datasource_permission.go
@@ -55,7 +55,7 @@ func ResourceDatasourcePermission() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"Query", "Edit"}, false),
-							Description:  "Permission to associate with item. Must be `Query` or `Edit`.",
+							Description:  "Permission to associate with item. Must be one of `Query` or `Edit`.",
 						},
 					},
 				},


### PR DESCRIPTION
From the Grafana Instance, when adding permissions for a data source, it can be either `Query` or `Edit`. But when adding permissions to data source, due to the check, It can be only `Query`. 
Therefore adding `Edit` as an option. 