### PR TITLE
Add retries on the gcloud client

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -379,7 +379,8 @@ func createMLClient(url string, grafanaCfg *gapi.Config) (*mlapi.Client, error) 
 
 func createCloudClient(d *schema.ResourceData) (*gapi.Client, error) {
 	cfg := gapi.Config{
-		APIKey: d.Get("cloud_api_key").(string),
+		APIKey:     d.Get("cloud_api_key").(string),
+		NumRetries: d.Get("retries").(int),
 	}
 	return gapi.New(d.Get("cloud_api_url").(string), cfg)
 }


### PR DESCRIPTION
We often get 500s on the tests (probably timing errors because we create and delete stacks pretty quick)
This should help