### PR TITLE
Tests: Wait for cloud instance to become ready

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -127,12 +127,12 @@ local pipeline(name, steps, services=[]) = {
           '    echo "instance never became ready"',
           '    exit 1',
           '  fi',
-          '  status="$(curl -I -L -s -o /dev/null -w "%{http_code}" %s)"' % cloud_instance_url,
+          '  status="$(curl -I -L -s -o /dev/null -w "%{http_code}" ' + cloud_instance_url + ')"',
           '  sleep 2',
           '  i=$((i+1))',
           'done',
         ],
-      }
+      },
       {
         name: 'tests',
         image: images.go,

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -119,26 +119,12 @@ local pipeline(name, steps, services=[]) = {
       {
         name: 'wait for instance',
         image: images.go,
-        commands: [
-          'status=0',
-          'i=0',
-          'while [ "${status}" != "200" ]; do',
-          '  if [ "${i}" -gt "30" ]; then',
-          '    echo "instance never became ready"',
-          '    exit 1',
-          '  fi',
-          '  status="$(curl -I -L -s -o /dev/null -w "%{http_code}" ' + cloud_instance_url + ')"',
-          '  sleep 2',
-          '  i=$((i+1))',
-          'done',
-        ],
+        commands: ['.drone/wait-for-instance.sh ' + cloud_instance_url],
       },
       {
         name: 'tests',
         image: images.go,
-        commands: [
-          'make testacc-cloud-instance',
-        ],
+        commands: ['make testacc-cloud-instance'],
         environment: {
           GRAFANA_URL: cloud_instance_url,
           GRAFANA_AUTH: apiToken.fromSecret,

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -111,6 +111,20 @@ platform:
 services: []
 steps:
 - commands:
+  - status=0
+  - i=0
+  - while [ "${status}" != "200" ]; do
+  - '  if [ "${i}" -gt "30" ]; then'
+  - '    echo "instance never became ready"'
+  - '    exit 1'
+  - '  fi'
+  - '  status="$(curl -I -L -s -o /dev/null -w "%{http_code}" https://terraformprovidergrafana.grafana.net/)"'
+  - '  sleep 2'
+  - '  i=$((i+1))'
+  - done
+  image: golang:1.18
+  name: wait for instance
+- commands:
   - make testacc-cloud-instance
   environment:
     GRAFANA_AUTH:
@@ -313,6 +327,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: 171eec7dc5357f381a1f11749be493256f117fe12977dfbb9d353966e0f8c1cf
+hmac: f172ac5d926deef332d87d33dbdb02301839595d89e61cbaf25222a1142c1770
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -111,17 +111,7 @@ platform:
 services: []
 steps:
 - commands:
-  - status=0
-  - i=0
-  - while [ "${status}" != "200" ]; do
-  - '  if [ "${i}" -gt "30" ]; then'
-  - '    echo "instance never became ready"'
-  - '    exit 1'
-  - '  fi'
-  - '  status="$(curl -I -L -s -o /dev/null -w "%{http_code}" https://terraformprovidergrafana.grafana.net/)"'
-  - '  sleep 2'
-  - '  i=$((i+1))'
-  - done
+  - .drone/wait-for-instance.sh https://terraformprovidergrafana.grafana.net/
   image: golang:1.18
   name: wait for instance
 - commands:
@@ -327,6 +317,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: f172ac5d926deef332d87d33dbdb02301839595d89e61cbaf25222a1142c1770
+hmac: 53e6bc46bd4d36a535b6430dfa7b4390ce336cda3b6a1985f528d970eaf3e022
 
 ...

--- a/.drone/wait-for-instance.sh
+++ b/.drone/wait-for-instance.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+getStatus() {
+    echo "$(curl -I -L -s -o /dev/null -w "%{http_code}" $1)"
+}
+
+status=$(getStatus $1)
+i=0
+while [ "${status}" != "200" ]; do
+  if [ "${i}" -gt "30" ]; then
+    echo "instance never became ready"
+    exit 1
+  fi
+  status=$(getStatus $1)
+  i=$((i+1))
+  sleep 2
+done


### PR DESCRIPTION
Sometimes, tests fail because the instance isn't ready. This curls it for a minute until it becomes ready