### PR TITLE
NOOP: Various small code formatting and shell script cleanup tasks

### DIFF
--- a/.drone/wait-for-instance.sh
+++ b/.drone/wait-for-instance.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 getStatus() {
-  "$(curl -I -L -s -o /dev/null -w "%{http_code}" "${1}")"
+  curl -I -L -s -o /dev/null -w "%{http_code}" "${1}"
 }
 
 status=$(getStatus "${1}")

--- a/.drone/wait-for-instance.sh
+++ b/.drone/wait-for-instance.sh
@@ -3,17 +3,17 @@
 set -euxo pipefail
 
 getStatus() {
-  echo "$(curl -I -L -s -o /dev/null -w "%{http_code}" $1)"
+  echo "$(curl -I -L -s -o /dev/null -w "%{http_code}" "${1}")"
 }
 
-status=$(getStatus $1)
+status=$(getStatus "${1}")
 i=0
 while [ "${status}" != "200" ]; do
   if [ "${i}" -gt "30" ]; then
     echo "instance never became ready"
     exit 1
   fi
-  status=$(getStatus $1)
+  status=$(getStatus "${1}")
   i=$((i+1))
   sleep 2
 done

--- a/.drone/wait-for-instance.sh
+++ b/.drone/wait-for-instance.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 getStatus() {
-  echo "$(curl -I -L -s -o /dev/null -w "%{http_code}" "${1}")"
+  "$(curl -I -L -s -o /dev/null -w "%{http_code}" "${1}")"
 }
 
 status=$(getStatus "${1}")

--- a/.drone/wait-for-instance.sh
+++ b/.drone/wait-for-instance.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 getStatus() {
-    echo "$(curl -I -L -s -o /dev/null -w "%{http_code}" $1)"
+  echo "$(curl -I -L -s -o /dev/null -w "%{http_code}" $1)"
 }
 
 status=$(getStatus $1)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
 # Test OSS features
-testacc-oss: 
+testacc-oss:
 	TF_ACC_OSS=true make testacc
 
 # Test Enterprise features


### PR DESCRIPTION
Hello! Thanks for your work on on `terraform-provider-grafana`. This PR addresses a few small code cleanup opportunities I noticed in the source code, but should not impact functionality:

* removes trailing whitespace from `GNUMakefile`
* `.drone/wait-for-instance.sh` now uses consistent 2 space indentation
* `.drone/wait-for-instance.sh` now conforms to [shellcheck](https://github.com/koalaman/shellcheck) recommendations (specifically, it 1) uses double quotes surrounding variables to prevent globbing and wordsplitting if/when in put contains spaces, line feeds, or glob characters, and 2) no longer features an unnecessary `echo`

Thank you!