### PR TITLE
Small provider authentication docs improvements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -202,7 +202,7 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 
 ### Optional
 
-- `auth` (String, Sensitive) API token or basic auth base64-encoded `username:password`. May alternatively be set via the `GRAFANA_AUTH` environment variable.
+- `auth` (String, Sensitive) API token or basic auth `username:password`. May alternatively be set via the `GRAFANA_AUTH` environment variable.
 - `ca_cert` (String) Certificate CA bundle to use to verify the Grafana server's certificate. May alternatively be set via the `GRAFANA_CA_CERT` environment variable.
 - `cloud_api_key` (String, Sensitive) API key for Grafana Cloud. May alternatively be set via the `GRAFANA_CLOUD_API_KEY` environment variable.
 - `cloud_api_url` (String) Grafana Cloud's API URL. May alternatively be set via the `GRAFANA_CLOUD_API_URL` environment variable.
@@ -225,7 +225,7 @@ One, or many, of the following authentication settings must be set. Each authent
 
 ### `auth`
 
-This can be a basic auth base64-encoded `username:password` string, or a
+This can be a Grafana API key, basic auth `username:password`, or a
 [Grafana API key](https://grafana.com/docs/grafana/latest/http_api/create-api-tokens-for-org/).
 
 ### `cloud_api_key`
@@ -261,20 +261,20 @@ the portal. First, you need to create a Stack by clicking "Add Stack". When it's
 created you will be taken to its landing page on the portal. Get your `stackId`
 from the URL in your browser:
 
-```http
+```
 https://grafana.com/orgs/<org-slug>/stacks/<stack-id>
 ```
 
 Next, go to "Details" for Prometheus. Again, get `metricsInstanceId` from your URL:
 
-```http
+```
 https://grafana.com/orgs/<org-slug>/hosted-metrics/<metrics-instance-id>
 ```
 
 Finally, go back to your stack page, and go to "Details" for Loki to get
 `logsInstanceId`.
 
-```http
+```
 https://grafana.com/orgs/<org-slug>/hosted-logs/<logs-instance-id>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,7 +257,7 @@ Based on the region of your Grafana Cloud stack, you need to use a different API
 Please [see API docs](https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md#api-url) to find `SM_API_URL` for your region.
 
 `stackId`, `metricsInstanceId`, and `logsInstanceId` may also be obtained on
-the portal. First you need to create a Stack by clicking "Add Stack". When it's
+the portal. First, you need to create a Stack by clicking "Add Stack". When it's
 created you will be taken to its landing page on the portal. Get your `stackId`
 from the URL in your browser:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -202,7 +202,7 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 
 ### Optional
 
-- `auth` (String, Sensitive) API token or basic auth username:password. May alternatively be set via the `GRAFANA_AUTH` environment variable.
+- `auth` (String, Sensitive) API token or basic auth base64-encoded `username:password`. May alternatively be set via the `GRAFANA_AUTH` environment variable.
 - `ca_cert` (String) Certificate CA bundle to use to verify the Grafana server's certificate. May alternatively be set via the `GRAFANA_CA_CERT` environment variable.
 - `cloud_api_key` (String, Sensitive) API key for Grafana Cloud. May alternatively be set via the `GRAFANA_CLOUD_API_KEY` environment variable.
 - `cloud_api_url` (String) Grafana Cloud's API URL. May alternatively be set via the `GRAFANA_CLOUD_API_URL` environment variable.
@@ -225,7 +225,7 @@ One, or many, of the following authentication settings must be set. Each authent
 
 ### `auth`
 
-This can be a Grafana API key, basic auth `username:password`, or a
+This can be a basic auth base64-encoded `username:password` string, or a
 [Grafana API key](https://grafana.com/docs/grafana/latest/http_api/create-api-tokens-for-org/).
 
 ### `cloud_api_key`

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -59,7 +59,7 @@ func Provider(version string) func() *schema.Provider {
 					Optional:     true,
 					Sensitive:    true,
 					DefaultFunc:  schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
-					Description:  "API token or basic auth username:password. May alternatively be set via the `GRAFANA_AUTH` environment variable.",
+					Description:  "API token or basic auth `username:password`. May alternatively be set via the `GRAFANA_AUTH` environment variable.",
 					AtLeastOneOf: []string{"auth", "cloud_api_key", "sm_access_token", "oncall_access_token"},
 				},
 				"http_headers": {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -72,24 +72,24 @@ Based on the region of your Grafana Cloud stack, you need to use a different API
 Please [see API docs](https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md#api-url) to find `SM_API_URL` for your region.
 
 `stackId`, `metricsInstanceId`, and `logsInstanceId` may also be obtained on
-the portal. First you need to create a Stack by clicking "Add Stack". When it's
+the portal. First, you need to create a Stack by clicking "Add Stack". When it's
 created you will be taken to its landing page on the portal. Get your `stackId`
 from the URL in your browser:
 
-```http
+```
 https://grafana.com/orgs/<org-slug>/stacks/<stack-id>
 ```
 
 Next, go to "Details" for Prometheus. Again, get `metricsInstanceId` from your URL:
 
-```http
+```
 https://grafana.com/orgs/<org-slug>/hosted-metrics/<metrics-instance-id>
 ```
 
 Finally, go back to your stack page, and go to "Details" for Loki to get
 `logsInstanceId`.
 
-```http
+```
 https://grafana.com/orgs/<org-slug>/hosted-logs/<logs-instance-id>
 ```
 


### PR DESCRIPTION
This introduces a few small provider authentication docs improvements:

* fix issue #547 and ensure the documentation features the correct URLs
* consistently format `username:password` as code
* ~clarify that a basic auth `username:password` string should be base64-encoded~ Update: it seems the underlying HTTP client packages ensure the string is base64-encoded
* add missing comma

Thank you! :) 