### PR TITLE
Adding grafana_alerting as a type to grafana_oncall_integration resource

### DIFF
--- a/docs/resources/oncall_integration.md
+++ b/docs/resources/oncall_integration.md
@@ -30,7 +30,7 @@ resource "grafana_oncall_integration" "test-acc-integration" {
 
 - `default_route` (Block List, Min: 1, Max: 1) The Default route for all alerts from the given integration (see [below for nested schema](#nestedblock--default_route))
 - `name` (String) The name of the service integration.
-- `type` (String) The type of integration. Can be grafana, webhook, alertmanager, kapacitor, fabric, newrelic, datadog, pagerduty, pingdom, elastalert, amazon_sns, curler, sentry, formatted_webhook, heartbeat, demo, manual, stackdriver, uptimerobot, sentry_platform, zabbix, prtg, slack_channel, inbound_email.
+- `type` (String) The type of integration. Can be grafana, grafana_alerting, webhook, alertmanager, kapacitor, fabric, newrelic, datadog, pagerduty, pingdom, elastalert, amazon_sns, curler, sentry, formatted_webhook, heartbeat, demo, manual, stackdriver, uptimerobot, sentry_platform, zabbix, prtg, slack_channel, inbound_email.
 
 ### Optional
 

--- a/grafana/resource_oncall_integration.go
+++ b/grafana/resource_oncall_integration.go
@@ -15,6 +15,7 @@ import (
 
 var integrationTypes = []string{
 	"grafana",
+	"grafana_alerting",
 	"webhook",
 	"alertmanager",
 	"kapacitor",


### PR DESCRIPTION
I was playing around with the [grafana_oncall_integration](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/oncall_integration) resource on Grafana Cloud, I was trying to pass the type as grafana_alerting but seems to be restricted since there is a check with [this](https://github.com/grafana/terraform-provider-grafana/blob/41145dd4640c1df629b26eb52bf05c24a7c87dff/grafana/resource_oncall_integration.go#L16). But passing type as grafana_alerting seems to work when directly using the API. Hence adding `grafana_alerting` to the list.