### PR TITLE
add golangci-lint Make command

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,5 +46,14 @@ drone:
 	drone lint .drone/drone.yml
 	drone sign --save grafana/terraform-provider-grafana .drone/drone.yml
 
+golangci-lint:
+	docker run \
+		--rm \
+		--interactive \
+		--tty \
+		--volume "$(shell pwd):/src" \
+		--workdir "/src" \
+		golangci/golangci-lint:v1.45 golangci-lint run ./...
+
 linkcheck:
 	docker run -it --entrypoint sh -v "$$PWD:$$PWD" -w "$$PWD" python:3.9-alpine -c "pip3 install linkchecker && linkchecker --config .linkcheckerrc docs"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -49,8 +49,6 @@ drone:
 golangci-lint:
 	docker run \
 		--rm \
-		--interactive \
-		--tty \
 		--volume "$(shell pwd):/src" \
 		--workdir "/src" \
 		golangci/golangci-lint:v1.45 golangci-lint run ./...


### PR DESCRIPTION
Previously, `terraform-provider-grafana`'s `GNUmakefile`
offered no easy way to locally reproduce the `lint` step
that occurs in CI (https://github.com/grafana/terraform-provider-grafana/blob/master/.drone/drone.yml#L10-L13).

This seeks to fix that by addressing issue #563.