### PR TITLE
Longer Cloud Stack readiness timeout

### DIFF
--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -37,6 +37,7 @@ available at “https://<stack_slug>.grafana.net".
 Changing region will destroy the existing stack and create a new one in the desired region
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
+- `wait_for_readiness_timeout` (String) How long to wait for readiness. The default is 5 minutes. Defaults to `5m`.
 
 ### Read-Only
 

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -37,7 +37,7 @@ available at “https://<stack_slug>.grafana.net".
 Changing region will destroy the existing stack and create a new one in the desired region
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
-- `wait_for_readiness_timeout` (String) How long to wait for readiness Defaults to `5m0s`.
+- `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.
 
 ### Read-Only
 

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -37,7 +37,7 @@ available at “https://<stack_slug>.grafana.net".
 Changing region will destroy the existing stack and create a new one in the desired region
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
-- `wait_for_readiness_timeout` (String) How long to wait for readiness. The default is 5 minutes. Defaults to `5m`.
+- `wait_for_readiness_timeout` (String) How long to wait for readiness Defaults to `5m0s`.
 
 ### Read-Only
 

--- a/grafana/data_source_cloud_stack.go
+++ b/grafana/data_source_cloud_stack.go
@@ -24,7 +24,8 @@ available at “https://<stack_slug>.grafana.net".`,
 				Computed:    true,
 				Description: "The region this stack is deployed to.",
 			},
-			"wait_for_readiness": nil,
+			"wait_for_readiness":         nil,
+			"wait_for_readiness_timeout": nil,
 		}),
 	}
 }

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -338,7 +338,7 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 		return nil
 	}
 
-	err := resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
 		req, err := http.NewRequestWithContext(ctx, http.MethodHead, d.Get("url").(string), nil)
 		if err != nil {
 			return resource.NonRetryableError(err)

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -89,6 +89,7 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "5m",
+				Computed: false,
 				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
 					v := i.(string)
 					_, err := time.ParseDuration(v)

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -1,8 +1,8 @@
 package grafana
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -349,7 +349,9 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
-			return resource.RetryableError(errors.New("stack is not ready yet"))
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(resp.Body)
+			return resource.RetryableError(fmt.Errorf("stack is not ready. Status code: %d, Response: %s", resp.StatusCode, buf))
 		}
 
 		return nil

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -83,7 +83,7 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
 				// Suppress the diff if the new value is "false" because this attribute is only used at creation-time
 				// If the diff is suppress for a "true" value, the attribute cannot be read at all
-				DiffSuppressFunc: func(_, _, newValue string, _ *schema.ResourceData) bool { return newValue == "false" },
+				DiffSuppressFunc: func(_, _, newValue string, _ *schema.ResourceData) bool { return newValue == strconv.FormatBool(false) },
 			},
 			"wait_for_readiness_timeout": {
 				Type:     schema.TypeString,
@@ -99,7 +99,7 @@ Changing region will destroy the existing stack and create a new one in the desi
 				},
 				// Only used when wait_for_readiness is true
 				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
-					return d.Get("wait_for_readiness") == "false"
+					return d.Get("wait_for_readiness") == strconv.FormatBool(false)
 				},
 				Description: "How long to wait for readiness. The default is 5 minutes.",
 			},

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -374,7 +374,7 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 			} else {
 				body = buf.String()
 			}
-			return resource.RetryableError(fmt.Errorf("stack is not ready. Status code: %d, Body: %s", resp.StatusCode, body))
+			return resource.RetryableError(fmt.Errorf("stack was not ready in %s. Status code: %d, Body: %s", waitTime, resp.StatusCode, body))
 		}
 
 		return nil

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -357,7 +357,7 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 		return nil
 	}
 
-	waitTime, _ := time.ParseDuration(d.GetOk("wait_for_readiness_timeout").(string))
+	waitTime, _ := time.ParseDuration(d.Get("wait_for_readiness_timeout").(string))
 	err := resource.RetryContext(ctx, waitTime, func() *resource.RetryError {
 		req, err := http.NewRequestWithContext(ctx, http.MethodHead, d.Get("url").(string), nil)
 		if err != nil {

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -89,7 +89,6 @@ Changing region will destroy the existing stack and create a new one in the desi
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "5m",
-				Computed: false,
 				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
 					v := i.(string)
 					_, err := time.ParseDuration(v)

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -97,7 +97,8 @@ Changing region will destroy the existing stack and create a new one in the desi
 					}
 					return nil
 				},
-				Description: "How long to wait for readiness. The default is 5 minutes.",
+				DiffSuppressFunc: func(_, _, _ string, _ *schema.ResourceData) bool { return true },
+				Description:      "How long to wait for readiness. The default is 5 minutes.",
 			},
 			"org_id": {
 				Type:        schema.TypeInt,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -97,7 +97,8 @@ Changing region will destroy the existing stack and create a new one in the desi
 					}
 					return nil
 				},
-				DiffSuppressFunc: func(_, _, _ string, _ *schema.ResourceData) bool { return true },
+				// Only used at creation-time
+				DiffSuppressFunc: func(_, oldValue, newValue string, _ *schema.ResourceData) bool { return oldValue != "" },
 				Description:      "How long to wait for readiness. The default is 5 minutes.",
 			},
 			"org_id": {

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -97,9 +97,11 @@ Changing region will destroy the existing stack and create a new one in the desi
 					}
 					return nil
 				},
-				// Only used at creation-time
-				DiffSuppressFunc: func(_, oldValue, newValue string, _ *schema.ResourceData) bool { return oldValue != "" },
-				Description:      "How long to wait for readiness. The default is 5 minutes.",
+				// Only used when wait_for_readiness is true
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					return d.Get("wait_for_readiness") == "false"
+				},
+				Description: "How long to wait for readiness. The default is 5 minutes.",
 			},
 			"org_id": {
 				Type:        schema.TypeInt,
@@ -355,7 +357,7 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 		return nil
 	}
 
-	waitTime, _ := time.ParseDuration(d.Get("wait_for_readiness_timeout").(string))
+	waitTime, _ := time.ParseDuration(d.GetOk("wait_for_readiness_timeout").(string))
 	err := resource.RetryContext(ctx, waitTime, func() *resource.RetryError {
 		req, err := http.NewRequestWithContext(ctx, http.MethodHead, d.Get("url").(string), nil)
 		if err != nil {

--- a/grafana/schema.go
+++ b/grafana/schema.go
@@ -31,6 +31,7 @@ func cloneResourceSchemaForDatasource(r *schema.Resource, updates map[string]*sc
 		clone[k].Default = nil
 		clone[k].StateFunc = nil
 		clone[k].DiffSuppressFunc = nil
+		clone[k].ValidateDiagFunc = nil
 		clone[k].ValidateFunc = nil
 	}
 	for k, v := range updates {


### PR DESCRIPTION
Lots of tests have been failing recently. Bumping the readiness timeout from 2 minutes to 5 minutes should make sure the tests always pass. Adding some more info to the error messages also