### PR TITLE
Synthetic Monitoring: Restrict invalid labels

### DIFF
--- a/grafana/resource_synthetic_monitoring_probe.go
+++ b/grafana/resource_synthetic_monitoring_probe.go
@@ -15,8 +15,6 @@ import (
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
-const smProbeLabelBannedChars = ","
-
 func ResourceSyntheticMonitoringProbe() *schema.Resource {
 	return &schema.Resource{
 

--- a/grafana/resource_synthetic_monitoring_probe.go
+++ b/grafana/resource_synthetic_monitoring_probe.go
@@ -87,13 +87,7 @@ Grafana Synthetic Monitoring Agent.
 					for k, vInt := range i.(map[string]interface{}) {
 						v := vInt.(string)
 						lbl := sm.Label{Name: k, Value: v}
-
-						err := lbl.Validate()
-						if err == nil && strings.ContainsAny(v, smProbeLabelBannedChars) {
-							err = fmt.Errorf("invalid character in value (one of %q)", smProbeLabelBannedChars)
-						}
-
-						if err != nil {
+						if err := lbl.Validate(); err != nil {
 							return diag.Errorf(`invalid label "%s=%s": %s`, k, v, err)
 						}
 					}

--- a/grafana/resource_synthetic_monitoring_probe.go
+++ b/grafana/resource_synthetic_monitoring_probe.go
@@ -16,6 +16,10 @@ import (
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
+var smProbeLabelNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+const smProbeLabelBannedChars = ","
+
 func ResourceSyntheticMonitoringProbe() *schema.Resource {
 	return &schema.Resource{
 
@@ -83,19 +87,17 @@ Grafana Synthetic Monitoring Agent.
 					Type: schema.TypeString,
 				},
 				ValidateDiagFunc: func(i interface{}, p cty.Path) diag.Diagnostics {
-					labelNameRegex := regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 					for k, vInt := range i.(map[string]interface{}) {
-						if !labelNameRegex.MatchString(k) {
-							return diag.Errorf("invalid label name %q. Must match %s", k, labelNameRegex)
+						if !smProbeLabelNameRegex.MatchString(k) {
+							return diag.Errorf("invalid label name %q. Must match %s", k, smProbeLabelNameRegex)
 						}
 
 						v := vInt.(string)
 						if v == "" {
 							return diag.Errorf("label %q has an empty value", k)
 						}
-						bannedChars := ","
-						if strings.ContainsAny(v, bannedChars) {
-							return diag.Errorf("label %q has an invalid character it its value (one of %q)", k, bannedChars)
+						if strings.ContainsAny(v, smProbeLabelBannedChars) {
+							return diag.Errorf("label %q has an invalid character it its value (one of %q)", k, smProbeLabelBannedChars)
 						}
 					}
 					return nil

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -100,10 +100,6 @@ func TestAccResourceSyntheticMonitoringProbe_InvalidLabels(t *testing.T) {
 			cfg: testSyntheticMonitoringProbeLabel("thisisempty", ""),
 			err: `invalid label "thisisempty=": invalid label value`,
 		},
-		{
-			cfg: testSyntheticMonitoringProbeLabel("name", ","),
-			err: `invalid label "name=,": invalid character in value \(one of ","\)`,
-		},
 	} {
 		steps = append(steps, resource.TestStep{
 			Config:      tc.cfg,

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -2,6 +2,8 @@ package grafana
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -76,4 +78,59 @@ func TestAccResourceSyntheticMonitoringProbe_recreate(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceSyntheticMonitoringProbe_InvalidLabels(t *testing.T) {
+	CheckCloudInstanceTestsEnabled(t)
+
+	var steps []resource.TestStep
+	for _, tc := range []struct {
+		cfg string
+		err string
+	}{
+		{
+			cfg: testSyntheticMonitoringProbeLabel("", "any"),
+			err: `invalid label name ""`,
+		},
+		{
+			cfg: testSyntheticMonitoringProbeLabel("42", "any"),
+			err: `invalid label name "42"`,
+		},
+		{
+			cfg: testSyntheticMonitoringProbeLabel("bad-label", "any"),
+			err: `invalid label name "bad-label"`,
+		},
+		{
+			cfg: testSyntheticMonitoringProbeLabel("thisisempty", ""),
+			err: `label "thisisempty" has an empty value`,
+		},
+		{
+			cfg: testSyntheticMonitoringProbeLabel("name", ","),
+			err: `label "name" has an invalid character it its value`,
+		},
+	} {
+		steps = append(steps, resource.TestStep{
+			Config:      tc.cfg,
+			ExpectError: regexp.MustCompile(tc.err),
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		Steps:             steps,
+	})
+}
+
+func testSyntheticMonitoringProbeLabel(name, value string) string {
+	return fmt.Sprintf(`
+resource "grafana_synthetic_monitoring_probe" "main" {
+	name      = "Everest"
+	latitude  = 27.98606
+	longitude = 86.92262
+	region    = "APAC"
+	labels = {
+		"%s" = "%s"
+	}
+}
+`, name, value)
 }

--- a/grafana/resource_synthetic_monitoring_probe_test.go
+++ b/grafana/resource_synthetic_monitoring_probe_test.go
@@ -90,23 +90,19 @@ func TestAccResourceSyntheticMonitoringProbe_InvalidLabels(t *testing.T) {
 	}{
 		{
 			cfg: testSyntheticMonitoringProbeLabel("", "any"),
-			err: `invalid label name ""`,
-		},
-		{
-			cfg: testSyntheticMonitoringProbeLabel("42", "any"),
-			err: `invalid label name "42"`,
+			err: `invalid label "=any": invalid label name`,
 		},
 		{
 			cfg: testSyntheticMonitoringProbeLabel("bad-label", "any"),
-			err: `invalid label name "bad-label"`,
+			err: `invalid label "bad-label=any": invalid label name`,
 		},
 		{
 			cfg: testSyntheticMonitoringProbeLabel("thisisempty", ""),
-			err: `label "thisisempty" has an empty value`,
+			err: `invalid label "thisisempty=": invalid label value`,
 		},
 		{
 			cfg: testSyntheticMonitoringProbeLabel("name", ","),
-			err: `label "name" has an invalid character it its value`,
+			err: `invalid label "name=,": invalid character in value \(one of ","\)`,
 		},
 	} {
 		steps = append(steps, resource.TestStep{


### PR DESCRIPTION
Restricting label names according to the prometheus data model: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
For the value, I found that commas and empty values are disallowed by the SM API (it returns a 500). @mem @grafana/synthetic-monitoring, any other characters that should be checked. I tried a bunch of weird stuff and all of it worked except commas
Fixes https://github.com/grafana/terraform-provider-grafana/issues/541