### PR TITLE
Alerting: Add support for `opsgenie`, `pagerduty`, `pushover`, and `sensugo` notifiers

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -45,6 +45,10 @@ resource "grafana_contact_point" "my_contact_point" {
 - `email` (Block List) A contact point that sends notifications to an email address. (see [below for nested schema](#nestedblock--email))
 - `googlechat` (Block List) A contact point that sends notifications to Google Chat. (see [below for nested schema](#nestedblock--googlechat))
 - `kafka` (Block List) A contact point that publishes notifications to Apache Kafka topics. (see [below for nested schema](#nestedblock--kafka))
+- `opsgenie` (Block List) A contact point that sends notifications to OpsGenie. (see [below for nested schema](#nestedblock--opsgenie))
+- `pagerduty` (Block List) A contact point that sends notifications to PagerDuty. (see [below for nested schema](#nestedblock--pagerduty))
+- `pushover` (Block List) A contact point that sends notifications to Pushover. (see [below for nested schema](#nestedblock--pushover))
+- `sensugo` (Block List) A contact point that sends notifications to SensuGo. (see [below for nested schema](#nestedblock--sensugo))
 
 ### Read-Only
 
@@ -157,6 +161,100 @@ Required:
 Optional:
 
 - `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--opsgenie"></a>
+### Nested Schema for `opsgenie`
+
+Required:
+
+- `api_key` (String, Sensitive) The OpsGenie API key to use.
+
+Optional:
+
+- `auto_close` (Boolean) Whether to auto-close alerts in OpsGenie when they resolve in the Alertmanager.
+- `description` (String) A templated high-level description to use for the alert.
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `message` (String) The templated content of the message.
+- `override_priority` (Boolean) Whether to allow the alert priority to be configured via the value of the `og_priority` annotation on the alert.
+- `send_tags_as` (String) Whether to send annotations to OpsGenie as Tags, Details, or both. Supported values are `tags`, `details`, `both`, or empty to use the default behavior of Tags.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+- `url` (String) Allows customization of the OpsGenie API URL.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--pagerduty"></a>
+### Nested Schema for `pagerduty`
+
+Required:
+
+- `integration_key` (String, Sensitive) The PagerDuty API key.
+
+Optional:
+
+- `class` (String) The class or type of event, for example `ping failure`.
+- `component` (String) The component being affected by the event.
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `group` (String) The group to which the provided component belongs to.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+- `severity` (String) The PagerDuty event severity level. Default is `critical`.
+- `summary` (String) The templated summary message of the event.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--pushover"></a>
+### Nested Schema for `pushover`
+
+Required:
+
+- `api_token` (String, Sensitive) The Pushover API token.
+- `user_key` (String, Sensitive) The Pushover user key.
+
+Optional:
+
+- `device` (String) Comma-separated list of devices to which the event is associated.
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `expire` (Number) How many seconds for which the notification will continue to be retried by Pushover.
+- `message` (String) The templated notification message content.
+- `ok_priority` (Number) The priority level of the resolved event.
+- `ok_sound` (String) The sound associated with the resolved notification.
+- `priority` (Number) The priority level of the event.
+- `retry` (Number) How often, in seconds, the Pushover servers will send the same notification to the user.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+- `sound` (String) The sound associated with the notification.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--sensugo"></a>
+### Nested Schema for `sensugo`
+
+Required:
+
+- `api_key` (String, Sensitive) The SensuGo API key.
+- `url` (String) The SensuGo URL to send requests to.
+
+Optional:
+
+- `check` (String) The SensuGo check to which the event should be routed.
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `entity` (String) The entity being monitored.
+- `handler` (String) A custom handler to execute in addition to the check.
+- `message` (String) Templated message content describing the alert.
+- `namespace` (String) The namespace in which the check resides.
 - `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
 
 Read-Only:

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -57,4 +57,17 @@ resource "grafana_contact_point" "receiver_types" {
         group = "my service"
         summary = "message"
     }
+
+    pushover {
+        user_key = "userkey"
+        api_token = "token"
+        priority = 0
+        ok_priority = 0
+        retry = 45
+        expire = 80000
+        device = "device"
+        sound = "bugle"
+        ok_sound = "cashregister"
+        message = "message"
+    }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -38,4 +38,14 @@ resource "grafana_contact_point" "receiver_types" {
         rest_proxy_url = "http://kafka-rest-proxy-url"
         topic = "mytopic"
     }
+
+    opsgenie {
+        url = "http://opsgenie-api"
+        api_key = "token"
+        message = "message"
+        description = "description"
+        auto_close = true
+        override_priority = true
+        send_tags_as = "both"
+    }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -48,4 +48,13 @@ resource "grafana_contact_point" "receiver_types" {
         override_priority = true
         send_tags_as = "both"
     }
+
+    pagerduty {
+        integration_key = "token"
+        severity = "critical"
+        class = "ping failure"
+        component = "mysql"
+        group = "my service"
+        summary = "message"
+    }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -70,4 +70,14 @@ resource "grafana_contact_point" "receiver_types" {
         ok_sound = "cashregister"
         message = "message"
     }
+
+    sensugo {
+        url = "http://sensugo-url"
+        api_key = "key"
+        entity = "entity"
+        check = "check"
+        namespace = "namespace"
+        handler = "handler"
+        message = "message"
+    }
 }

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -21,6 +21,7 @@ var notifiers = []notifier{
 	opsGenieNotifier{},
 	pagerDutyNotifier{},
 	pushoverNotifier{},
+	sensugoNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -19,6 +19,7 @@ var notifiers = []notifier{
 	googleChatNotifier{},
 	kafkaNotifier{},
 	opsGenieNotifier{},
+	pagerDutyNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -18,6 +18,7 @@ var notifiers = []notifier{
 	emailNotifier{},
 	googleChatNotifier{},
 	kafkaNotifier{},
+	opsGenieNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {

--- a/grafana/resource_alerting_contact_point_notifiers.go
+++ b/grafana/resource_alerting_contact_point_notifiers.go
@@ -1,6 +1,7 @@
 package grafana
 
 import (
+	"strconv"
 	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -41,7 +42,7 @@ func (a alertmanagerNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (a alertmanagerNotifier) pack(p gapi.ContactPoint) interface{} {
+func (a alertmanagerNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -56,7 +57,7 @@ func (a alertmanagerNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "basicAuthPassword")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (a alertmanagerNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -111,7 +112,7 @@ func (d dingDingNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (d dingDingNotifier) pack(p gapi.ContactPoint) interface{} {
+func (d dingDingNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -126,7 +127,7 @@ func (d dingDingNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "message")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (d dingDingNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -190,7 +191,7 @@ func (d discordNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (d discordNotifier) pack(p gapi.ContactPoint) interface{} {
+func (d discordNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -210,7 +211,7 @@ func (d discordNotifier) pack(p gapi.ContactPoint) interface{} {
 	}
 
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (d discordNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -280,7 +281,7 @@ func (e emailNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (e emailNotifier) pack(p gapi.ContactPoint) interface{} {
+func (e emailNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["addresses"]; ok && v != nil {
 		notifier["addresses"] = packAddrs(v.(string))
@@ -299,7 +300,7 @@ func (e emailNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "subject")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (e emailNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -343,7 +344,7 @@ func unpackAddrs(addrs []interface{}) string {
 
 type googleChatNotifier struct{}
 
-var _ notifier = (*dingDingNotifier)(nil)
+var _ notifier = (*googleChatNotifier)(nil)
 
 func (g googleChatNotifier) meta() notifierMeta {
 	return notifierMeta{
@@ -369,7 +370,7 @@ func (g googleChatNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (g googleChatNotifier) pack(p gapi.ContactPoint) interface{} {
+func (g googleChatNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -380,7 +381,7 @@ func (g googleChatNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "message")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (g googleChatNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -428,7 +429,7 @@ func (k kafkaNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (k kafkaNotifier) pack(p gapi.ContactPoint) interface{} {
+func (k kafkaNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["kafkaRestProxy"]; ok && v != nil {
 		notifier["rest_proxy_url"] = v.(string)
@@ -439,7 +440,7 @@ func (k kafkaNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "kafkaTopic")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (k kafkaNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -511,7 +512,7 @@ func (o opsGenieNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (o opsGenieNotifier) pack(p gapi.ContactPoint) interface{} {
+func (o opsGenieNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["apiUrl"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -542,7 +543,7 @@ func (o opsGenieNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "sendTagsAs")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (o opsGenieNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -581,7 +582,7 @@ func (o opsGenieNotifier) unpack(raw interface{}, name string) gapi.ContactPoint
 
 type pagerDutyNotifier struct{}
 
-var _ notifier = (*opsGenieNotifier)(nil)
+var _ notifier = (*pagerDutyNotifier)(nil)
 
 func (p pagerDutyNotifier) meta() notifierMeta {
 	return notifierMeta{
@@ -628,7 +629,7 @@ func (p pagerDutyNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (n pagerDutyNotifier) pack(p gapi.ContactPoint) interface{} {
+func (n pagerDutyNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["integrationKey"]; ok && v != nil {
 		notifier["integration_key"] = v.(string)
@@ -655,7 +656,7 @@ func (n pagerDutyNotifier) pack(p gapi.ContactPoint) interface{} {
 		delete(p.Settings, "summary")
 	}
 	notifier["settings"] = packSettings(&p)
-	return notifier
+	return notifier, nil
 }
 
 func (n pagerDutyNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
@@ -678,6 +679,179 @@ func (n pagerDutyNotifier) unpack(raw interface{}, name string) gapi.ContactPoin
 	if v, ok := json["summary"]; ok && v != nil {
 		settings["summary"] = v.(string)
 	}
+	return gapi.ContactPoint{
+		UID:                   uid,
+		Name:                  name,
+		Type:                  n.meta().typeStr,
+		DisableResolveMessage: disableResolve,
+		Settings:              settings,
+	}
+}
+
+type pushoverNotifier struct{}
+
+var _ notifier = (*pushoverNotifier)(nil)
+
+func (p pushoverNotifier) meta() notifierMeta {
+	return notifierMeta{
+		field:   "pushover",
+		typeStr: "pushover",
+		desc:    "A contact point that sends notifications to Pushover.",
+	}
+}
+
+func (p pushoverNotifier) schema() *schema.Resource {
+	r := commonNotifierResource()
+	r.Schema["user_key"] = &schema.Schema{
+		Type:             schema.TypeString,
+		Required:         true,
+		Sensitive:        true,
+		DiffSuppressFunc: redactedContactPointDiffSuppress,
+		Description:      "The Pushover user key.",
+	}
+	r.Schema["api_token"] = &schema.Schema{
+		Type:             schema.TypeString,
+		Required:         true,
+		Sensitive:        true,
+		DiffSuppressFunc: redactedContactPointDiffSuppress,
+		Description:      "The Pushover API token.",
+	}
+	r.Schema["priority"] = &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "The priority level of the event.",
+	}
+	r.Schema["ok_priority"] = &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "The priority level of the resolved event.",
+	}
+	r.Schema["retry"] = &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "How often, in seconds, the Pushover servers will send the same notification to the user.",
+	}
+	r.Schema["expire"] = &schema.Schema{
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "How many seconds for which the notification will continue to be retried by Pushover.",
+	}
+	r.Schema["device"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Comma-separated list of devices to which the event is associated.",
+	}
+	r.Schema["sound"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The sound associated with the notification.",
+	}
+	r.Schema["ok_sound"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The sound associated with the resolved notification.",
+	}
+	r.Schema["message"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The templated notification message content.",
+	}
+	return r
+}
+
+func (n pushoverNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+	notifier := packCommonNotifierFields(&p)
+	if v, ok := p.Settings["userKey"]; ok && v != nil {
+		notifier["user_key"] = v.(string)
+		delete(p.Settings, "userKey")
+	}
+	if v, ok := p.Settings["apiToken"]; ok && v != nil {
+		notifier["api_token"] = v.(string)
+		delete(p.Settings, "apiToken")
+	}
+	if v, ok := p.Settings["priority"]; ok && v != nil {
+		priority, err := strconv.Atoi(v.(string))
+		if err != nil {
+			return nil, err
+		}
+		notifier["priority"] = priority
+		delete(p.Settings, "priority")
+	}
+	if v, ok := p.Settings["okPriority"]; ok && v != nil {
+		priority, err := strconv.Atoi(v.(string))
+		if err != nil {
+			return nil, err
+		}
+		notifier["ok_priority"] = priority
+		delete(p.Settings, "okPriority")
+	}
+	if v, ok := p.Settings["retry"]; ok && v != nil {
+		priority, err := strconv.Atoi(v.(string))
+		if err != nil {
+			return nil, err
+		}
+		notifier["retry"] = priority
+		delete(p.Settings, "retry")
+	}
+	if v, ok := p.Settings["expire"]; ok && v != nil {
+		priority, err := strconv.Atoi(v.(string))
+		if err != nil {
+			return nil, err
+		}
+		notifier["expire"] = priority
+		delete(p.Settings, "expire")
+	}
+	if v, ok := p.Settings["device"]; ok && v != nil {
+		notifier["device"] = v.(string)
+		delete(p.Settings, "device")
+	}
+	if v, ok := p.Settings["sound"]; ok && v != nil {
+		notifier["sound"] = v.(string)
+		delete(p.Settings, "sound")
+	}
+	if v, ok := p.Settings["okSound"]; ok && v != nil {
+		notifier["ok_sound"] = v.(string)
+		delete(p.Settings, "okSound")
+	}
+	if v, ok := p.Settings["message"]; ok && v != nil {
+		notifier["message"] = v.(string)
+		delete(p.Settings, "message")
+	}
+	notifier["settings"] = packSettings(&p)
+	return notifier, nil
+}
+
+func (n pushoverNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
+	json := raw.(map[string]interface{})
+	uid, disableResolve, settings := unpackCommonNotifierFields(json)
+
+	settings["userKey"] = json["user_key"].(string)
+	settings["apiToken"] = json["api_token"].(string)
+	if v, ok := json["priority"]; ok && v != nil {
+		settings["priority"] = strconv.Itoa(v.(int))
+	}
+	if v, ok := json["ok_priority"]; ok && v != nil {
+		settings["okPriority"] = strconv.Itoa(v.(int))
+	}
+	if v, ok := json["retry"]; ok && v != nil {
+		settings["retry"] = strconv.Itoa(v.(int))
+	}
+	if v, ok := json["expire"]; ok && v != nil {
+		settings["expire"] = strconv.Itoa(v.(int))
+	}
+	if v, ok := json["device"]; ok && v != nil {
+		settings["device"] = v.(string)
+	}
+	if v, ok := json["sound"]; ok && v != nil {
+		settings["sound"] = v.(string)
+	}
+	if v, ok := json["ok_sound"]; ok && v != nil {
+		settings["okSound"] = v.(string)
+	}
+	if v, ok := json["message"]; ok && v != nil {
+		settings["message"] = v.(string)
+	}
+
 	return gapi.ContactPoint{
 		UID:                   uid,
 		Name:                  name,

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 9),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 10),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -208,6 +208,15 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.sound", "bugle"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.ok_sound", "cashregister"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.message", "message"),
+					// sensugo
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.url", "http://sensugo-url"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.api_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.entity", "entity"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.check", "check"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.namespace", "namespace"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.handler", "handler"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.message", "message"),
 				),
 			},
 		},

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 7),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 8),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -188,6 +188,14 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.auto_close", "true"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.override_priority", "true"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.send_tags_as", "both"),
+					// pagerduty
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.integration_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.severity", "critical"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.class", "ping failure"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.component", "mysql"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.group", "my service"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.summary", "message"),
 				),
 			},
 		},

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 8),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 9),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -196,6 +196,18 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.component", "mysql"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.group", "my service"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.summary", "message"),
+					// pushover
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.user_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.api_token", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.priority", "0"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.ok_priority", "0"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.retry", "45"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.expire", "80000"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.device", "device"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.sound", "bugle"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.ok_sound", "cashregister"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.message", "message"),
 				),
 			},
 		},

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 6),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 7),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -179,6 +179,15 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "kafka.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "kafka.0.rest_proxy_url", "http://kafka-rest-proxy-url"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "kafka.0.topic", "mytopic"),
+					// opsgenie
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.url", "http://opsgenie-api"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.api_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.message", "message"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.description", "description"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.auto_close", "true"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.override_priority", "true"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.send_tags_as", "both"),
 				),
 			},
 		},


### PR DESCRIPTION
Adds the next batch of strongly-typed notifiers to the provider.

Extended the notifier interface a little - the marshalling code can now propagate arbitrary errors, which appear nicely in the Terraform output.