### PR TITLE
Alerting: Add support for `slack`, `teams`, `telegram`, and `threema` notifiers

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -49,6 +49,10 @@ resource "grafana_contact_point" "my_contact_point" {
 - `pagerduty` (Block List) A contact point that sends notifications to PagerDuty. (see [below for nested schema](#nestedblock--pagerduty))
 - `pushover` (Block List) A contact point that sends notifications to Pushover. (see [below for nested schema](#nestedblock--pushover))
 - `sensugo` (Block List) A contact point that sends notifications to SensuGo. (see [below for nested schema](#nestedblock--sensugo))
+- `slack` (Block List) A contact point that sends notifications to Slack. (see [below for nested schema](#nestedblock--slack))
+- `teams` (Block List) A contact point that sends notifications to Microsoft Teams. (see [below for nested schema](#nestedblock--teams))
+- `telegram` (Block List) A contact point that sends notifications to Telegram. (see [below for nested schema](#nestedblock--telegram))
+- `threema` (Block List) A contact point that sends notifications to Threema. (see [below for nested schema](#nestedblock--threema))
 
 ### Read-Only
 
@@ -255,6 +259,89 @@ Optional:
 - `handler` (String) A custom handler to execute in addition to the check.
 - `message` (String) Templated message content describing the alert.
 - `namespace` (String) The namespace in which the check resides.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--slack"></a>
+### Nested Schema for `slack`
+
+Optional:
+
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `endpoint_url` (String) Use this to override the Slack API endpoint URL to send requests to.
+- `icon_emoji` (String) The name of a Slack workspace emoji to use as the bot icon.
+- `icon_url` (String) A URL of an image to use as the bot icon.
+- `mention_channel` (String) Describes how to ping the slack channel that messages are being sent to. Options are `here` for an @here ping, `channel` for @channel, or empty for no ping.
+- `mention_groups` (String) Comma-separated list of groups to mention in the message.
+- `mention_users` (String) Comma-separated list of users to mention in the message.
+- `recipient` (String) Channel, private group, or IM channel (can be an encoded ID or a name) to send messages to.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+- `text` (String) Templated content of the message.
+- `title` (String) Templated title of the message.
+- `token` (String, Sensitive) A Slack API token,for sending messages directly without the webhook method.
+- `url` (String, Sensitive) A Slack webhook URL,for sending messages via the webhook method.
+- `username` (String) Username for the bot to use.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--teams"></a>
+### Nested Schema for `teams`
+
+Required:
+
+- `url` (String, Sensitive) A Teams webhook URL.
+
+Optional:
+
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `message` (String) The templated message content to send.
+- `section_title` (String) The templated subtitle for each message section.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+- `title` (String) The templated title of the message.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--telegram"></a>
+### Nested Schema for `telegram`
+
+Required:
+
+- `chat_id` (String) The chat ID to send messages to.
+- `token` (String, Sensitive) The Telegram bot token.
+
+Optional:
+
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `message` (String) The templated content of the message.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--threema"></a>
+### Nested Schema for `threema`
+
+Required:
+
+- `api_secret` (String, Sensitive) The Threema API key.
+- `gateway_id` (String) The Threema gateway ID.
+
+Optional:
+
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `recipient_id` (String) The ID of the recipient of the message.
 - `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
 
 Read-Only:

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -107,4 +107,10 @@ resource "grafana_contact_point" "receiver_types" {
         chat_id = "chat-id"
         message = "message"
     }
+
+    threema {
+        gateway_id = "*gateway"
+        recipient_id = "*target1"
+        api_secret = "secret"
+    }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -94,4 +94,11 @@ resource "grafana_contact_point" "receiver_types" {
         mention_users = "user"
         mention_groups = "group"
     }
+
+    teams {
+        url = "http://teams-webhook"
+        message = "message"
+        title = "title"
+        section_title = "section"
+    }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -80,4 +80,18 @@ resource "grafana_contact_point" "receiver_types" {
         handler = "handler"
         message = "message"
     }
+
+    slack {
+        endpoint_url = "http://custom-slack-url"
+        token = "xoxb-token"
+        recipient = "#channel"
+        text = "message"
+        title = "title"
+        username = "bot"
+        icon_emoji = ":icon:"
+        icon_url = "http://domain/icon.png"
+        mention_channel = "here"
+        mention_users = "user"
+        mention_groups = "group"
+    }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -101,4 +101,10 @@ resource "grafana_contact_point" "receiver_types" {
         title = "title"
         section_title = "section"
     }
+
+    telegram {
+        token = "token"
+        chat_id = "chat-id"
+        message = "message"
+    }
 }

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -23,6 +23,7 @@ var notifiers = []notifier{
 	pushoverNotifier{},
 	sensugoNotifier{},
 	slackNotifier{},
+	teamsNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -24,6 +24,7 @@ var notifiers = []notifier{
 	sensugoNotifier{},
 	slackNotifier{},
 	teamsNotifier{},
+	telegramNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {
@@ -284,4 +285,17 @@ type notifierMeta struct {
 	field   string
 	typeStr string
 	desc    string
+}
+
+func packNotifierStringField(gfSettings, tfSettings *map[string]interface{}, gfKey, tfKey string) {
+	if v, ok := (*gfSettings)[gfKey]; ok && v != nil {
+		(*tfSettings)[tfKey] = v.(string)
+		delete(*gfSettings, gfKey)
+	}
+}
+
+func unpackNotifierStringField(tfSettings, gfSettings *map[string]interface{}, tfKey, gfKey string) {
+	if v, ok := (*tfSettings)[tfKey]; ok && v != nil {
+		(*gfSettings)[gfKey] = v.(string)
+	}
 }

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -22,6 +22,7 @@ var notifiers = []notifier{
 	pagerDutyNotifier{},
 	pushoverNotifier{},
 	sensugoNotifier{},
+	slackNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -25,6 +25,7 @@ var notifiers = []notifier{
 	slackNotifier{},
 	teamsNotifier{},
 	telegramNotifier{},
+	threemaNotifier{},
 }
 
 func ResourceContactPoint() *schema.Resource {

--- a/grafana/resource_alerting_contact_point_notifiers.go
+++ b/grafana/resource_alerting_contact_point_notifiers.go
@@ -1084,42 +1084,18 @@ func (s slackNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
 	json := raw.(map[string]interface{})
 	uid, disableResolve, settings := unpackCommonNotifierFields(json)
 
-	if v, ok := json["endpoint_url"]; ok && v != nil {
-		settings["endpointUrl"] = v.(string)
-	}
-	if v, ok := json["url"]; ok && v != nil {
-		settings["url"] = v.(string)
-	}
-	if v, ok := json["token"]; ok && v != nil {
-		settings["token"] = v.(string)
-	}
-	if v, ok := json["recipient"]; ok && v != nil {
-		settings["recipient"] = v.(string)
-	}
-	if v, ok := json["text"]; ok && v != nil {
-		settings["text"] = v.(string)
-	}
-	if v, ok := json["title"]; ok && v != nil {
-		settings["title"] = v.(string)
-	}
-	if v, ok := json["username"]; ok && v != nil {
-		settings["username"] = v.(string)
-	}
-	if v, ok := json["icon_emoji"]; ok && v != nil {
-		settings["icon_emoji"] = v.(string)
-	}
-	if v, ok := json["icon_url"]; ok && v != nil {
-		settings["icon_url"] = v.(string)
-	}
-	if v, ok := json["mention_channel"]; ok && v != nil {
-		settings["mentionChannel"] = v.(string)
-	}
-	if v, ok := json["mention_users"]; ok && v != nil {
-		settings["mentionUsers"] = v.(string)
-	}
-	if v, ok := json["mention_groups"]; ok && v != nil {
-		settings["mentionGroups"] = v.(string)
-	}
+	unpackNotifierStringField(&json, &settings, "endpoint_url", "endpointUrl")
+	unpackNotifierStringField(&json, &settings, "url", "url")
+	unpackNotifierStringField(&json, &settings, "token", "token")
+	unpackNotifierStringField(&json, &settings, "recipient", "recipient")
+	unpackNotifierStringField(&json, &settings, "text", "text")
+	unpackNotifierStringField(&json, &settings, "title", "title")
+	unpackNotifierStringField(&json, &settings, "username", "username")
+	unpackNotifierStringField(&json, &settings, "icon_emoji", "icon_emoji")
+	unpackNotifierStringField(&json, &settings, "icon_url", "icon_url")
+	unpackNotifierStringField(&json, &settings, "mention_channel", "mentionChannel")
+	unpackNotifierStringField(&json, &settings, "mention_users", "mentionUsers")
+	unpackNotifierStringField(&json, &settings, "mention_groups", "mentionGroups")
 
 	return gapi.ContactPoint{
 		UID:                   uid,
@@ -1180,9 +1156,33 @@ func (t teamsNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	return notifier, nil
 }
 
+func (t teamsNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
+	json := raw.(map[string]interface{})
+	uid, disableResolve, settings := unpackCommonNotifierFields(json)
+
+	unpackNotifierStringField(&json, &settings, "url", "url")
+	unpackNotifierStringField(&json, &settings, "message", "message")
+	unpackNotifierStringField(&json, &settings, "title", "title")
+	unpackNotifierStringField(&json, &settings, "section_title", "sectiontitle")
+
+	return gapi.ContactPoint{
+		UID:                   uid,
+		Name:                  name,
+		Type:                  t.meta().typeStr,
+		DisableResolveMessage: disableResolve,
+		Settings:              settings,
+	}
+}
+
 func packNotifierStringField(gfSettings, tfSettings *map[string]interface{}, gfKey, tfKey string) {
 	if v, ok := (*gfSettings)[gfKey]; ok && v != nil {
 		(*tfSettings)[tfKey] = v.(string)
 		delete(*gfSettings, gfKey)
+	}
+}
+
+func unpackNotifierStringField(tfSettings, gfSettings *map[string]interface{}, tfKey, gfKey string) {
+	if v, ok := (*tfSettings)[tfKey]; ok && v != nil {
+		(*gfSettings)[gfKey] = v.(string)
 	}
 }

--- a/grafana/resource_alerting_contact_point_notifiers.go
+++ b/grafana/resource_alerting_contact_point_notifiers.go
@@ -978,3 +978,188 @@ func (s sensugoNotifier) unpack(raw interface{}, name string) gapi.ContactPoint 
 		Settings:              settings,
 	}
 }
+
+type slackNotifier struct{}
+
+var _ notifier = (*slackNotifier)(nil)
+
+func (s slackNotifier) meta() notifierMeta {
+	return notifierMeta{
+		field:   "slack",
+		typeStr: "slack",
+		desc:    "A contact point that sends notifications to Slack.",
+	}
+}
+
+func (s slackNotifier) schema() *schema.Resource {
+	r := commonNotifierResource()
+	r.Schema["endpoint_url"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Use this to override the Slack API endpoint URL to send requests to.",
+	}
+	r.Schema["url"] = &schema.Schema{
+		Type:             schema.TypeString,
+		Optional:         true,
+		Sensitive:        true,
+		DiffSuppressFunc: redactedContactPointDiffSuppress,
+		Description:      "A Slack webhook URL,for sending messages via the webhook method.",
+	}
+	r.Schema["token"] = &schema.Schema{
+		Type:             schema.TypeString,
+		Optional:         true,
+		Sensitive:        true,
+		DiffSuppressFunc: redactedContactPointDiffSuppress,
+		Description:      "A Slack API token,for sending messages directly without the webhook method.",
+	}
+	r.Schema["recipient"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Channel, private group, or IM channel (can be an encoded ID or a name) to send messages to.",
+	}
+	r.Schema["text"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Templated content of the message.",
+	}
+	r.Schema["title"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Templated title of the message.",
+	}
+	r.Schema["username"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Username for the bot to use.",
+	}
+	r.Schema["icon_emoji"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The name of a Slack workspace emoji to use as the bot icon.",
+	}
+	r.Schema["icon_url"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "A URL of an image to use as the bot icon.",
+	}
+	r.Schema["mention_channel"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Describes how to ping the slack channel that messages are being sent to. Options are `here` for an @here ping, `channel` for @channel, or empty for no ping.",
+	}
+	r.Schema["mention_users"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Comma-separated list of users to mention in the message.",
+	}
+	r.Schema["mention_groups"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Comma-separated list of groups to mention in the message.",
+	}
+	return r
+}
+
+func (s slackNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+	notifier := packCommonNotifierFields(&p)
+	if v, ok := p.Settings["endpointUrl"]; ok && v != nil {
+		notifier["endpoint_url"] = v.(string)
+		delete(p.Settings, "endpointUrl")
+	}
+	if v, ok := p.Settings["url"]; ok && v != nil {
+		notifier["url"] = v.(string)
+		delete(p.Settings, "url")
+	}
+	if v, ok := p.Settings["token"]; ok && v != nil {
+		notifier["token"] = v.(string)
+		delete(p.Settings, "token")
+	}
+	if v, ok := p.Settings["recipient"]; ok && v != nil {
+		notifier["recipient"] = v.(string)
+		delete(p.Settings, "recipient")
+	}
+	if v, ok := p.Settings["text"]; ok && v != nil {
+		notifier["text"] = v.(string)
+		delete(p.Settings, "text")
+	}
+	if v, ok := p.Settings["title"]; ok && v != nil {
+		notifier["title"] = v.(string)
+		delete(p.Settings, "title")
+	}
+	if v, ok := p.Settings["username"]; ok && v != nil {
+		notifier["username"] = v.(string)
+		delete(p.Settings, "username")
+	}
+	if v, ok := p.Settings["icon_emoji"]; ok && v != nil {
+		notifier["icon_emoji"] = v.(string)
+		delete(p.Settings, "icon_emoji")
+	}
+	if v, ok := p.Settings["icon_url"]; ok && v != nil {
+		notifier["icon_url"] = v.(string)
+		delete(p.Settings, "icon_url")
+	}
+	if v, ok := p.Settings["mentionChannel"]; ok && v != nil {
+		notifier["mention_channel"] = v.(string)
+		delete(p.Settings, "mentionChannel")
+	}
+	if v, ok := p.Settings["mentionUsers"]; ok && v != nil {
+		notifier["mention_users"] = v.(string)
+		delete(p.Settings, "mentionUsers")
+	}
+	if v, ok := p.Settings["mentionGroups"]; ok && v != nil {
+		notifier["mention_groups"] = v.(string)
+		delete(p.Settings, "mentionGroups")
+	}
+	notifier["settings"] = packSettings(&p)
+	return notifier, nil
+}
+
+func (s slackNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
+	json := raw.(map[string]interface{})
+	uid, disableResolve, settings := unpackCommonNotifierFields(json)
+
+	if v, ok := json["endpoint_url"]; ok && v != nil {
+		settings["endpointUrl"] = v.(string)
+	}
+	if v, ok := json["url"]; ok && v != nil {
+		settings["url"] = v.(string)
+	}
+	if v, ok := json["token"]; ok && v != nil {
+		settings["token"] = v.(string)
+	}
+	if v, ok := json["recipient"]; ok && v != nil {
+		settings["recipient"] = v.(string)
+	}
+	if v, ok := json["text"]; ok && v != nil {
+		settings["text"] = v.(string)
+	}
+	if v, ok := json["title"]; ok && v != nil {
+		settings["title"] = v.(string)
+	}
+	if v, ok := json["username"]; ok && v != nil {
+		settings["username"] = v.(string)
+	}
+	if v, ok := json["icon_emoji"]; ok && v != nil {
+		settings["icon_emoji"] = v.(string)
+	}
+	if v, ok := json["icon_url"]; ok && v != nil {
+		settings["icon_url"] = v.(string)
+	}
+	if v, ok := json["mention_channel"]; ok && v != nil {
+		settings["mentionChannel"] = v.(string)
+	}
+	if v, ok := json["mention_users"]; ok && v != nil {
+		settings["mentionUsers"] = v.(string)
+	}
+	if v, ok := json["mention_groups"]; ok && v != nil {
+		settings["mentionGroups"] = v.(string)
+	}
+
+	return gapi.ContactPoint{
+		UID:                   uid,
+		Name:                  name,
+		Type:                  s.meta().typeStr,
+		DisableResolveMessage: disableResolve,
+		Settings:              settings,
+	}
+}

--- a/grafana/resource_alerting_contact_point_notifiers.go
+++ b/grafana/resource_alerting_contact_point_notifiers.go
@@ -1062,54 +1062,20 @@ func (s slackNotifier) schema() *schema.Resource {
 
 func (s slackNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
-	if v, ok := p.Settings["endpointUrl"]; ok && v != nil {
-		notifier["endpoint_url"] = v.(string)
-		delete(p.Settings, "endpointUrl")
-	}
-	if v, ok := p.Settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(p.Settings, "url")
-	}
-	if v, ok := p.Settings["token"]; ok && v != nil {
-		notifier["token"] = v.(string)
-		delete(p.Settings, "token")
-	}
-	if v, ok := p.Settings["recipient"]; ok && v != nil {
-		notifier["recipient"] = v.(string)
-		delete(p.Settings, "recipient")
-	}
-	if v, ok := p.Settings["text"]; ok && v != nil {
-		notifier["text"] = v.(string)
-		delete(p.Settings, "text")
-	}
-	if v, ok := p.Settings["title"]; ok && v != nil {
-		notifier["title"] = v.(string)
-		delete(p.Settings, "title")
-	}
-	if v, ok := p.Settings["username"]; ok && v != nil {
-		notifier["username"] = v.(string)
-		delete(p.Settings, "username")
-	}
-	if v, ok := p.Settings["icon_emoji"]; ok && v != nil {
-		notifier["icon_emoji"] = v.(string)
-		delete(p.Settings, "icon_emoji")
-	}
-	if v, ok := p.Settings["icon_url"]; ok && v != nil {
-		notifier["icon_url"] = v.(string)
-		delete(p.Settings, "icon_url")
-	}
-	if v, ok := p.Settings["mentionChannel"]; ok && v != nil {
-		notifier["mention_channel"] = v.(string)
-		delete(p.Settings, "mentionChannel")
-	}
-	if v, ok := p.Settings["mentionUsers"]; ok && v != nil {
-		notifier["mention_users"] = v.(string)
-		delete(p.Settings, "mentionUsers")
-	}
-	if v, ok := p.Settings["mentionGroups"]; ok && v != nil {
-		notifier["mention_groups"] = v.(string)
-		delete(p.Settings, "mentionGroups")
-	}
+
+	packNotifierStringField(&p.Settings, &notifier, "endpointUrl", "endpoint_url")
+	packNotifierStringField(&p.Settings, &notifier, "url", "url")
+	packNotifierStringField(&p.Settings, &notifier, "token", "token")
+	packNotifierStringField(&p.Settings, &notifier, "recipient", "recipient")
+	packNotifierStringField(&p.Settings, &notifier, "text", "text")
+	packNotifierStringField(&p.Settings, &notifier, "title", "title")
+	packNotifierStringField(&p.Settings, &notifier, "username", "username")
+	packNotifierStringField(&p.Settings, &notifier, "icon_emoji", "icon_emoji")
+	packNotifierStringField(&p.Settings, &notifier, "icon_url", "icon_url")
+	packNotifierStringField(&p.Settings, &notifier, "mentionChannel", "mention_channel")
+	packNotifierStringField(&p.Settings, &notifier, "mentionUsers", "mention_users")
+	packNotifierStringField(&p.Settings, &notifier, "mentionGroups", "mention_groups")
+
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
 }
@@ -1161,5 +1127,62 @@ func (s slackNotifier) unpack(raw interface{}, name string) gapi.ContactPoint {
 		Type:                  s.meta().typeStr,
 		DisableResolveMessage: disableResolve,
 		Settings:              settings,
+	}
+}
+
+type teamsNotifier struct{}
+
+var _ notifier = (*teamsNotifier)(nil)
+
+func (t teamsNotifier) meta() notifierMeta {
+	return notifierMeta{
+		field:   "teams",
+		typeStr: "teams",
+		desc:    "A contact point that sends notifications to Microsoft Teams.",
+	}
+}
+
+func (t teamsNotifier) schema() *schema.Resource {
+	r := commonNotifierResource()
+	r.Schema["url"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "A Teams webhook URL.",
+	}
+	r.Schema["message"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The templated message content to send.",
+	}
+	r.Schema["title"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The templated title of the message.",
+	}
+	r.Schema["section_title"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The templated subtitle for each message section.",
+	}
+	return r
+}
+
+func (t teamsNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+	notifier := packCommonNotifierFields(&p)
+
+	packNotifierStringField(&p.Settings, &notifier, "url", "url")
+	packNotifierStringField(&p.Settings, &notifier, "message", "message")
+	packNotifierStringField(&p.Settings, &notifier, "title", "title")
+	packNotifierStringField(&p.Settings, &notifier, "sectiontitle", "section_title")
+
+	notifier["settings"] = packSettings(&p)
+	return notifier, nil
+}
+
+func packNotifierStringField(gfSettings, tfSettings *map[string]interface{}, gfKey, tfKey string) {
+	if v, ok := (*gfSettings)[gfKey]; ok && v != nil {
+		(*tfSettings)[tfKey] = v.(string)
+		delete(*gfSettings, gfKey)
 	}
 }

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 11),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 12),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -230,6 +230,12 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_channel", "here"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_users", "user"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_groups", "group"),
+					// teams
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.url", "http://teams-webhook"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.message", "message"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.title", "title"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.section_title", "section"),
 				),
 			},
 		},

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 12),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 13),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -236,6 +236,11 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.message", "message"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.title", "title"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.section_title", "section"),
+					// telegram
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.token", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.chat_id", "chat-id"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.message", "message"),
 				),
 			},
 		},

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 13),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 14),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -241,6 +241,11 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.token", "[REDACTED]"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.chat_id", "chat-id"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.message", "message"),
+					// threema
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.gateway_id", "*gateway"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.recipient_id", "*target1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.api_secret", "[REDACTED]"),
 				),
 			},
 		},

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -148,7 +148,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			{
 				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 10),
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 11),
 					// alertmanager
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
@@ -217,6 +217,19 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.namespace", "namespace"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.handler", "handler"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.message", "message"),
+					// slack
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.endpoint_url", "http://custom-slack-url"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.token", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.recipient", "#channel"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.text", "message"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.title", "title"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.username", "bot"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.icon_emoji", ":icon:"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.icon_url", "http://domain/icon.png"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_channel", "here"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_users", "user"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_groups", "group"),
 				),
 			},
 		},


### PR DESCRIPTION
Adds the next batch of notifiers, plus a helper that makes serialization code simpler for string fields.