### PR TITLE
Alerting: Resource-level write locking for resources backed by UA config file

### DIFF
--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -29,10 +29,13 @@ resource "grafana_mute_timing" "a_mute_timing" {
     intervals {
         weekdays = ["monday"]
     }
+<<<<<<< HEAD
 
     depends_on = [
         grafana_contact_point.a_contact_point
     ]
+=======
+>>>>>>> 319ed2e (Regenerate docs)
 }
 
 

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -29,13 +29,6 @@ resource "grafana_mute_timing" "a_mute_timing" {
     intervals {
         weekdays = ["monday"]
     }
-<<<<<<< HEAD
-
-    depends_on = [
-        grafana_contact_point.a_contact_point
-    ]
-=======
->>>>>>> 319ed2e (Regenerate docs)
 }
 
 

--- a/examples/resources/grafana_notification_policy/resource.tf
+++ b/examples/resources/grafana_notification_policy/resource.tf
@@ -13,10 +13,6 @@ resource "grafana_mute_timing" "a_mute_timing" {
     intervals {
         weekdays = ["monday"]
     }
-
-    depends_on = [
-        grafana_contact_point.a_contact_point
-    ]
 }
 
 

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -258,6 +259,8 @@ type client struct {
 	mlapi *mlapi.Client
 
 	onCallAPI *onCallAPI.Client
+
+	alertingMutex sync.Mutex
 }
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/grafana/resource_alerting_message_template.go
+++ b/grafana/resource_alerting_message_template.go
@@ -62,10 +62,13 @@ func readMessageTemplate(ctx context.Context, data *schema.ResourceData, meta in
 }
 
 func createMessageTemplate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 	name := data.Get("name").(string)
 	content := data.Get("template").(string)
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.SetMessageTemplate(name, content); err != nil {
 		return diag.FromErr(err)
 	}
@@ -75,10 +78,13 @@ func createMessageTemplate(ctx context.Context, data *schema.ResourceData, meta 
 }
 
 func updateMessageTemplate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 	name := data.Get("name").(string)
 	content := data.Get("template").(string)
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.SetMessageTemplate(name, content); err != nil {
 		return diag.FromErr(err)
 	}
@@ -87,11 +93,15 @@ func updateMessageTemplate(ctx context.Context, data *schema.ResourceData, meta 
 }
 
 func deleteMessageTemplate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 	name := data.Id()
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.DeleteMessageTemplate(name); err != nil {
 		return diag.FromErr(err)
 	}
+
 	return diag.Diagnostics{}
 }

--- a/grafana/resource_alerting_mute_timing.go
+++ b/grafana/resource_alerting_mute_timing.go
@@ -127,9 +127,13 @@ func readMuteTiming(ctx context.Context, data *schema.ResourceData, meta interfa
 }
 
 func createMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 
 	mt := unpackMuteTiming(data)
+
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.NewMuteTiming(&mt); err != nil {
 		return diag.FromErr(err)
 	}
@@ -139,10 +143,13 @@ func createMuteTiming(ctx context.Context, data *schema.ResourceData, meta inter
 }
 
 func updateMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 
 	mt := unpackMuteTiming(data)
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.UpdateMuteTiming(&mt); err != nil {
 		return diag.FromErr(err)
 	}
@@ -150,9 +157,12 @@ func updateMuteTiming(ctx context.Context, data *schema.ResourceData, meta inter
 }
 
 func deleteMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 	name := data.Id()
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.DeleteMuteTiming(name); err != nil {
 		return diag.FromErr(err)
 	}

--- a/grafana/resource_alerting_notification_policy.go
+++ b/grafana/resource_alerting_notification_policy.go
@@ -174,6 +174,7 @@ func readNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta
 }
 
 func createNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 
 	npt, err := unpackNotifPolicy(data)
@@ -181,6 +182,8 @@ func createNotificationPolicy(ctx context.Context, data *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.SetNotificationPolicyTree(&npt); err != nil {
 		return diag.FromErr(err)
 	}
@@ -190,6 +193,7 @@ func createNotificationPolicy(ctx context.Context, data *schema.ResourceData, me
 }
 
 func updateNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 
 	npt, err := unpackNotifPolicy(data)
@@ -197,6 +201,8 @@ func updateNotificationPolicy(ctx context.Context, data *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.SetNotificationPolicyTree(&npt); err != nil {
 		return diag.FromErr(err)
 	}
@@ -205,11 +211,15 @@ func updateNotificationPolicy(ctx context.Context, data *schema.ResourceData, me
 }
 
 func deleteNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	lock := &meta.(*client).alertingMutex
 	client := meta.(*client).gapi
 
+	lock.Lock()
+	defer lock.Unlock()
 	if err := client.ResetNotificationPolicyTree(); err != nil {
 		return diag.FromErr(err)
 	}
+
 	return diag.Diagnostics{}
 }
 


### PR DESCRIPTION
### Background
Some (not all) alerting resources are stored in json/yaml config file on the backend of the alerting system. The APIs for these resources use optimistic locking to perform write protection - the result is that all changes to alerting configs must be linearizable. Writing to these resources is safe from data loss, but as a tradeoff, requests may be rejected with a `409 Conflict`.

This may cause the `terraform apply` to intermittently fail on large plans, since TF naturally runs with a parallelism of 10, and these resources do not always have explicit dependencies between one another.

### Solution
This PR adds a mutex around write operations for affected resources.

### Alternatives Considered
- **Require the TF user to specify implicit dependencies** using `depends_on`. This is a really bad user experience.
- **Require applies with --parallelism=1** has the same behavior of this PR, but is much too far-reaching. We only need parallelism=1 for these four specific resources, not every single type of resource. This approach is too limiting.
- **Retries** are a good solution, but a mutex is more robust. Even with a high retry counter, there is always a chance an object may fail. With a mutex, there are fewer requests and fewer failures overall, the desired end result is usually achieved faster.
- **Rate-limiting** helps reduce the frequency of the problem (less contention) but is not sufficient to outright eliminate it. 
- **A semaphore** is already applied by TF with a value of 10. Even with parallelism of 2, we can intermittently see issues for very big plans.

### Reasoning
Read operations are atomic and not affected. This only applies to four specific alerting resources, namely **not rules.**

In practice, the vast majority of alerting resources are rules. Since rules are unaffected, the perf penalty here is kept relatively minimal.

We intend to improve this locking requirement at the alerting API layer in the future. When this is done, the mutex can be relaxed to a simple rate-limiter (or removed entirely) which will eliminate this penalty.