### PR TITLE
Trim whitespace on `alerting_message_template.template`

### DIFF
--- a/grafana/resource_alerting_message_template.go
+++ b/grafana/resource_alerting_message_template.go
@@ -35,6 +35,9 @@ func ResourceMessageTemplate() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The content of the message template.",
+				StateFunc: func(v interface{}) string {
+					return strings.TrimSpace(v.(string))
+				},
 			},
 		},
 	}

--- a/grafana/resource_alerting_message_template_test.go
+++ b/grafana/resource_alerting_message_template_test.go
@@ -35,6 +35,21 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test update with heredoc template doesn't change
+			{
+				Config: testAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
+					`template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"`: `template = <<-EOT
+{{define "My Reusable Template" }}
+ template content
+{{ end }}
+EOT`,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testMessageTemplateCheckExists("grafana_message_template.my_template", &tmpl),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Reusable Template"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"),
+				),
+			},
 			// Test update content.
 			{
 				Config: testAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{

--- a/grafana/resource_alerting_message_template_test.go
+++ b/grafana/resource_alerting_message_template_test.go
@@ -77,6 +77,7 @@ EOT`,
 	})
 }
 
+//nolint:unparam // `rname` always receives `"grafana_message_template.my_template"`
 func testMessageTemplateCheckExists(rname string, mt *gapi.AlertingMessageTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources[rname]


### PR DESCRIPTION
Fixes #608.

Turns out that using heredoc is introduces leading and/or trailing whitespace which makes it always fail the difference.