### PR TITLE
Validate that clients exist in all resources

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -44,6 +44,102 @@ func init() {
 }
 
 func Provider(version string) func() *schema.Provider {
+	var (
+		// Resources that require the Grafana client to exist.
+		grafanaClientResources = addResourcesMetadataValidation(grafanaClientPresent, map[string]*schema.Resource{
+			// Grafana
+			"grafana_annotation":              ResourceAnnotation(),
+			"grafana_alert_notification":      ResourceAlertNotification(),
+			"grafana_builtin_role_assignment": ResourceBuiltInRoleAssignment(),
+			"grafana_contact_point":           ResourceContactPoint(),
+			"grafana_dashboard":               ResourceDashboard(),
+			"grafana_dashboard_permission":    ResourceDashboardPermission(),
+			"grafana_data_source":             ResourceDataSource(),
+			"grafana_data_source_permission":  ResourceDatasourcePermission(),
+			"grafana_folder":                  ResourceFolder(),
+			"grafana_folder_permission":       ResourceFolderPermission(),
+			"grafana_library_panel":           ResourceLibraryPanel(),
+			"grafana_message_template":        ResourceMessageTemplate(),
+			"grafana_mute_timing":             ResourceMuteTiming(),
+			"grafana_notification_policy":     ResourceNotificationPolicy(),
+			"grafana_organization":            ResourceOrganization(),
+			"grafana_playlist":                ResourcePlaylist(),
+			"grafana_report":                  ResourceReport(),
+			"grafana_role":                    ResourceRole(),
+			"grafana_rule_group":              ResourceRuleGroup(),
+			"grafana_team":                    ResourceTeam(),
+			"grafana_team_preferences":        ResourceTeamPreferences(),
+			"grafana_team_external_group":     ResourceTeamExternalGroup(),
+			"grafana_service_account_token":   ResourceServiceAccountToken(),
+			"grafana_service_account":         ResourceServiceAccount(),
+			"grafana_user":                    ResourceUser(),
+
+			// Machine Learning
+			"grafana_machine_learning_job": ResourceMachineLearningJob(),
+		})
+
+		// Resources that require the Synthetic Monitoring client to exist.
+		smClientResources = addResourcesMetadataValidation(smClientPresent, map[string]*schema.Resource{
+			"grafana_synthetic_monitoring_check":        ResourceSyntheticMonitoringCheck(),
+			"grafana_synthetic_monitoring_probe":        ResourceSyntheticMonitoringProbe(),
+			"grafana_synthetic_monitoring_installation": ResourceSyntheticMonitoringInstallation(),
+		})
+
+		// Resources that require the Cloud client to exist.
+		cloudClientResources = addResourcesMetadataValidation(cloudClientPresent, map[string]*schema.Resource{
+			"grafana_cloud_api_key":             ResourceCloudAPIKey(),
+			"grafana_cloud_plugin_installation": ResourceCloudPluginInstallation(),
+			"grafana_cloud_stack":               ResourceCloudStack(),
+		})
+
+		// Resources that require the OnCall client to exist.
+		onCallClientResources = addResourcesMetadataValidation(onCallClientPresent, map[string]*schema.Resource{
+			"grafana_oncall_integration":      ResourceOnCallIntegration(),
+			"grafana_oncall_route":            ResourceOnCallRoute(),
+			"grafana_oncall_escalation_chain": ResourceOnCallEscalationChain(),
+			"grafana_oncall_escalation":       ResourceOnCallEscalation(),
+			"grafana_oncall_on_call_shift":    ResourceOnCallOnCallShift(),
+			"grafana_oncall_schedule":         ResourceOnCallSchedule(),
+			"grafana_oncall_outgoing_webhook": ResourceOnCallOutgoingWebhook(),
+		})
+
+		// Datasources that require the Grafana client to exist.
+		grafanaClientDatasources = addResourcesMetadataValidation(grafanaClientPresent, map[string]*schema.Resource{
+			"grafana_dashboard":     DatasourceDashboard(),
+			"grafana_dashboards":    DatasourceDashboards(),
+			"grafana_folder":        DatasourceFolder(),
+			"grafana_folders":       DatasourceFolders(),
+			"grafana_library_panel": DatasourceLibraryPanel(),
+			"grafana_user":          DatasourceUser(),
+			"grafana_team":          DatasourceTeam(),
+			"grafana_organization":  DatasourceOrganization(),
+		})
+
+		// Datasources that require the Synthetic Monitoring client to exist.
+		smClientDatasources = addResourcesMetadataValidation(smClientPresent, map[string]*schema.Resource{
+			"grafana_synthetic_monitoring_probe":  DatasourceSyntheticMonitoringProbe(),
+			"grafana_synthetic_monitoring_probes": DatasourceSyntheticMonitoringProbes(),
+		})
+
+		// Datasources that require the Cloud client to exist.
+		cloudClientDatasources = addResourcesMetadataValidation(cloudClientPresent, map[string]*schema.Resource{
+			"grafana_cloud_ips":   DatasourceCloudIPs(),
+			"grafana_cloud_stack": DatasourceCloudStack(),
+		})
+
+		// Datasources that require the OnCall client to exist.
+		onCallClientDatasources = addResourcesMetadataValidation(onCallClientPresent, map[string]*schema.Resource{
+			"grafana_oncall_user":             DataSourceOnCallUser(),
+			"grafana_oncall_escalation_chain": DataSourceOnCallEscalationChain(),
+			"grafana_oncall_schedule":         DataSourceOnCallSchedule(),
+			"grafana_oncall_slack_channel":    DataSourceOnCallSlackChannel(),
+			"grafana_oncall_action":           DataSourceOnCallAction(), // deprecated
+			"grafana_oncall_outgoing_webhook": DataSourceOnCallOutgoingWebhook(),
+			"grafana_oncall_user_group":       DataSourceOnCallUserGroup(),
+			"grafana_oncall_team":             DataSourceOnCallTeam(),
+		})
+	)
+
 	return func() *schema.Provider {
 		p := &schema.Provider{
 			Schema: map[string]*schema.Schema{
@@ -159,87 +255,14 @@ func Provider(version string) func() *schema.Provider {
 				},
 			},
 
-			ResourcesMap: map[string]*schema.Resource{
-				// Grafana
-				"grafana_annotation":              ResourceAnnotation(),
-				"grafana_api_key":                 ResourceAPIKey(),
-				"grafana_alert_notification":      ResourceAlertNotification(),
-				"grafana_builtin_role_assignment": ResourceBuiltInRoleAssignment(),
-				"grafana_contact_point":           ResourceContactPoint(),
-				"grafana_dashboard":               ResourceDashboard(),
-				"grafana_dashboard_permission":    ResourceDashboardPermission(),
-				"grafana_data_source":             ResourceDataSource(),
-				"grafana_data_source_permission":  ResourceDatasourcePermission(),
-				"grafana_folder":                  ResourceFolder(),
-				"grafana_folder_permission":       ResourceFolderPermission(),
-				"grafana_library_panel":           ResourceLibraryPanel(),
-				"grafana_message_template":        ResourceMessageTemplate(),
-				"grafana_mute_timing":             ResourceMuteTiming(),
-				"grafana_notification_policy":     ResourceNotificationPolicy(),
-				"grafana_organization":            ResourceOrganization(),
-				"grafana_playlist":                ResourcePlaylist(),
-				"grafana_report":                  ResourceReport(),
-				"grafana_role":                    ResourceRole(),
-				"grafana_rule_group":              ResourceRuleGroup(),
-				"grafana_team":                    ResourceTeam(),
-				"grafana_team_preferences":        ResourceTeamPreferences(),
-				"grafana_team_external_group":     ResourceTeamExternalGroup(),
-				"grafana_service_account_token":   ResourceServiceAccountToken(),
-				"grafana_service_account":         ResourceServiceAccount(),
-				"grafana_user":                    ResourceUser(),
+			ResourcesMap: mergeResourceMaps(
+				// Special case, this resource supports both Grafana and Cloud (depending on context)
+				map[string]*schema.Resource{
+					"grafana_api_key": ResourceAPIKey(),
+				},
+				grafanaClientResources, smClientResources, onCallClientResources, cloudClientResources),
 
-				// Cloud
-				"grafana_cloud_api_key":             ResourceCloudAPIKey(),
-				"grafana_cloud_plugin_installation": ResourceCloudPluginInstallation(),
-				"grafana_cloud_stack":               ResourceCloudStack(),
-
-				// Synthetic Monitoring
-				"grafana_synthetic_monitoring_check":        ResourceSyntheticMonitoringCheck(),
-				"grafana_synthetic_monitoring_probe":        ResourceSyntheticMonitoringProbe(),
-				"grafana_synthetic_monitoring_installation": ResourceSyntheticMonitoringInstallation(),
-
-				// Machine Learning
-				"grafana_machine_learning_job": ResourceMachineLearningJob(),
-
-				// OnCall
-				"grafana_oncall_integration":      ResourceOnCallIntegration(),
-				"grafana_oncall_route":            ResourceOnCallRoute(),
-				"grafana_oncall_escalation_chain": ResourceOnCallEscalationChain(),
-				"grafana_oncall_escalation":       ResourceOnCallEscalation(),
-				"grafana_oncall_on_call_shift":    ResourceOnCallOnCallShift(),
-				"grafana_oncall_schedule":         ResourceOnCallSchedule(),
-				"grafana_oncall_outgoing_webhook": ResourceOnCallOutgoingWebhook(),
-			},
-
-			DataSourcesMap: map[string]*schema.Resource{
-				// Grafana
-				"grafana_dashboard":     DatasourceDashboard(),
-				"grafana_dashboards":    DatasourceDashboards(),
-				"grafana_folder":        DatasourceFolder(),
-				"grafana_folders":       DatasourceFolders(),
-				"grafana_library_panel": DatasourceLibraryPanel(),
-				"grafana_user":          DatasourceUser(),
-				"grafana_team":          DatasourceTeam(),
-				"grafana_organization":  DatasourceOrganization(),
-
-				// Cloud
-				"grafana_cloud_ips":   DatasourceCloudIPs(),
-				"grafana_cloud_stack": DatasourceCloudStack(),
-
-				// Synthetic Monitoring
-				"grafana_synthetic_monitoring_probe":  DatasourceSyntheticMonitoringProbe(),
-				"grafana_synthetic_monitoring_probes": DatasourceSyntheticMonitoringProbes(),
-
-				// OnCall
-				"grafana_oncall_user":             DataSourceOnCallUser(),
-				"grafana_oncall_escalation_chain": DataSourceOnCallEscalationChain(),
-				"grafana_oncall_schedule":         DataSourceOnCallSchedule(),
-				"grafana_oncall_slack_channel":    DataSourceOnCallSlackChannel(),
-				"grafana_oncall_action":           DataSourceOnCallAction(), // deprecated
-				"grafana_oncall_outgoing_webhook": DataSourceOnCallOutgoingWebhook(),
-				"grafana_oncall_user_group":       DataSourceOnCallUserGroup(),
-				"grafana_oncall_team":             DataSourceOnCallTeam(),
-			},
+			DataSourcesMap: mergeResourceMaps(grafanaClientDatasources, smClientDatasources, onCallClientDatasources, cloudClientDatasources),
 		}
 
 		p.ConfigureContextFunc = configure(version, p)
@@ -274,19 +297,25 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 
 		c := &client{}
 
-		c.gapiURL, c.gapiConfig, c.gapi, err = createGrafanaClient(d)
-		if err != nil {
-			return nil, diag.FromErr(err)
+		if d.Get("auth").(string) != "" && d.Get("url").(string) != "" {
+			c.gapiURL, c.gapiConfig, c.gapi, err = createGrafanaClient(d)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+			c.mlapi, err = createMLClient(c.gapiURL, c.gapiConfig)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
 		}
-		c.gcloudapi, err = createCloudClient(d)
-		if err != nil {
-			return nil, diag.FromErr(err)
+		if d.Get("cloud_api_key").(string) != "" {
+			c.gcloudapi, err = createCloudClient(d)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
 		}
-		c.mlapi, err = createMLClient(c.gapiURL, c.gapiConfig)
-		if err != nil {
-			return nil, diag.FromErr(err)
+		if d.Get("sm_access_token").(string) != "" {
+			c.smURL, c.smapi = createSMClient(d)
 		}
-		c.smURL, c.smapi = createSMClient(d)
 		if d.Get("oncall_access_token").(string) != "" {
 			c.onCallAPI, err = createOnCallClient(d)
 			if err != nil {
@@ -420,4 +449,14 @@ func getJSONMap(k string) (map[string]interface{}, error) {
 		return valObj, nil
 	}
 	return nil, nil
+}
+
+func mergeResourceMaps(maps ...map[string]*schema.Resource) map[string]*schema.Resource {
+	result := make(map[string]*schema.Resource)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
 }

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -260,9 +260,18 @@ func Provider(version string) func() *schema.Provider {
 				map[string]*schema.Resource{
 					"grafana_api_key": ResourceAPIKey(),
 				},
-				grafanaClientResources, smClientResources, onCallClientResources, cloudClientResources),
+				grafanaClientResources,
+				smClientResources,
+				onCallClientResources,
+				cloudClientResources,
+			),
 
-			DataSourcesMap: mergeResourceMaps(grafanaClientDatasources, smClientDatasources, onCallClientDatasources, cloudClientDatasources),
+			DataSourcesMap: mergeResourceMaps(
+				grafanaClientDatasources,
+				smClientDatasources,
+				onCallClientDatasources,
+				cloudClientDatasources,
+			),
 		}
 
 		p.ConfigureContextFunc = configure(version, p)

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -323,9 +323,9 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 				return nil, diag.FromErr(err)
 			}
 		}
-		if d.Get("sm_access_token").(string) != "" {
-			smToken := d.Get("sm_access_token").(string)
-			c.smURL = d.Get("sm_url").(string)
+		c.smURL = d.Get("sm_url").(string)
+		if smToken := d.Get("sm_access_token").(string); smToken != "" {
+
 			c.smapi = smapi.NewClient(c.smURL, smToken, nil)
 		}
 		if d.Get("oncall_access_token").(string) != "" {

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -80,16 +80,16 @@ func Provider(version string) func() *schema.Provider {
 
 		// Resources that require the Synthetic Monitoring client to exist.
 		smClientResources = addResourcesMetadataValidation(smClientPresent, map[string]*schema.Resource{
-			"grafana_synthetic_monitoring_check":        ResourceSyntheticMonitoringCheck(),
-			"grafana_synthetic_monitoring_probe":        ResourceSyntheticMonitoringProbe(),
-			"grafana_synthetic_monitoring_installation": ResourceSyntheticMonitoringInstallation(),
+			"grafana_synthetic_monitoring_check": ResourceSyntheticMonitoringCheck(),
+			"grafana_synthetic_monitoring_probe": ResourceSyntheticMonitoringProbe(),
 		})
 
 		// Resources that require the Cloud client to exist.
 		cloudClientResources = addResourcesMetadataValidation(cloudClientPresent, map[string]*schema.Resource{
-			"grafana_cloud_api_key":             ResourceCloudAPIKey(),
-			"grafana_cloud_plugin_installation": ResourceCloudPluginInstallation(),
-			"grafana_cloud_stack":               ResourceCloudStack(),
+			"grafana_cloud_api_key":                     ResourceCloudAPIKey(),
+			"grafana_cloud_plugin_installation":         ResourceCloudPluginInstallation(),
+			"grafana_cloud_stack":                       ResourceCloudStack(),
+			"grafana_synthetic_monitoring_installation": ResourceSyntheticMonitoringInstallation(), // This one installs SM on an instance, it really is a cloud resource.
 		})
 
 		// Resources that require the OnCall client to exist.

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -325,7 +325,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		}
 		c.smURL = d.Get("sm_url").(string)
 		if smToken := d.Get("sm_access_token").(string); smToken != "" {
-
 			c.smapi = smapi.NewClient(c.smURL, smToken, nil)
 		}
 		if d.Get("oncall_access_token").(string) != "" {

--- a/grafana/provider_validation.go
+++ b/grafana/provider_validation.go
@@ -1,0 +1,78 @@
+package grafana
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// This file contains validations functions that can be added to a map of resources.
+// These validations are added to the Create and Read functions of all resources,
+//   because they are entrypoints (code that will be run in all cases).
+
+type metadataValidation func(resourceName string, m interface{}) error
+
+func grafanaClientPresent(resourceName string, m interface{}) error {
+	if m.(*client).gapi == nil {
+		return fmt.Errorf("the Grafana client is required for `%s`. Set the auth and url provider attributes", resourceName)
+	}
+	return nil
+}
+
+func smClientPresent(resourceName string, m interface{}) error {
+	if m.(*client).smapi == nil {
+		return fmt.Errorf("the Synthetic Monitoring client is required for `%s`. Set the sm_access_token provider attribute", resourceName)
+	}
+	return nil
+}
+
+func cloudClientPresent(resourceName string, m interface{}) error {
+	if m.(*client).gcloudapi == nil {
+		return fmt.Errorf("the Cloud API client is required for `%s`. Set the cloud_api_key provider attribute", resourceName)
+	}
+	return nil
+}
+
+func onCallClientPresent(resourceName string, m interface{}) error {
+	if m.(*client).onCallAPI == nil {
+		return fmt.Errorf("the Oncall client is required for `%s`. Set the oncall_access_token provider attribute", resourceName)
+	}
+	return nil
+}
+
+func addResourcesMetadataValidation(validateFunc metadataValidation, resources map[string]*schema.Resource) map[string]*schema.Resource {
+	for name, r := range resources {
+		name := name
+		//nolint:staticcheck
+		if r.Read != nil {
+			log.Fatalf("%s: Read function is not supported", name)
+		}
+		if r.ReadContext != nil {
+			prev := r.ReadContext
+			r.ReadContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+				if err := validateFunc(name, m); err != nil {
+					return diag.FromErr(err)
+				}
+				return prev(ctx, d, m)
+			}
+		}
+		//nolint:staticcheck
+		if r.Create != nil {
+			log.Fatalf("%s: Create function is not supported", name)
+		}
+		if r.CreateContext != nil {
+			prev := r.CreateContext
+			r.CreateContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+				if err := validateFunc(name, m); err != nil {
+					return diag.FromErr(err)
+				}
+				return prev(ctx, d, m)
+			}
+		}
+		resources[name] = r
+	}
+	return resources
+}

--- a/grafana/provider_validation.go
+++ b/grafana/provider_validation.go
@@ -11,7 +11,7 @@ import (
 
 // This file contains validations functions that can be added to a map of resources.
 // These validations are added to the Create and Read functions of all resources,
-//   because they are entrypoints (code that will be run in all cases).
+// because they are entrypoints (code that will be run in all cases).
 
 type metadataValidation func(resourceName string, m interface{}) error
 

--- a/grafana/resource_oncall_escalation.go
+++ b/grafana/resource_oncall_escalation.go
@@ -200,9 +200,6 @@ func ResourceOnCallEscalation() *schema.Resource {
 
 func resourceEscalationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	escalationChainIDData := d.Get("escalation_chain_id").(string)
 
@@ -309,9 +306,6 @@ func resourceEscalationCreate(ctx context.Context, d *schema.ResourceData, m int
 
 func resourceEscalationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	escalation, r, err := client.Escalations.GetEscalation(d.Id(), &onCallAPI.GetEscalationOptions{})
 	if err != nil {
@@ -341,9 +335,6 @@ func resourceEscalationRead(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceEscalationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	updateOptions := &onCallAPI.UpdateEscalationOptions{
 		ManualOrder: true,
@@ -430,9 +421,6 @@ func resourceEscalationUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 func resourceEscalationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	_, err := client.Escalations.DeleteEscalation(d.Id(), &onCallAPI.DeleteEscalationOptions{})
 	if err != nil {

--- a/grafana/resource_oncall_escalation_chain.go
+++ b/grafana/resource_oncall_escalation_chain.go
@@ -40,9 +40,6 @@ func ResourceOnCallEscalationChain() *schema.Resource {
 
 func ResourceOnCallEscalationChainCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
@@ -64,9 +61,6 @@ func ResourceOnCallEscalationChainCreate(ctx context.Context, d *schema.Resource
 
 func ResourceOnCallEscalationChainRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	escalationChain, r, err := client.EscalationChains.GetEscalationChain(d.Id(), &onCallAPI.GetEscalationChainOptions{})
 	if err != nil {
@@ -86,9 +80,6 @@ func ResourceOnCallEscalationChainRead(ctx context.Context, d *schema.ResourceDa
 
 func ResourceOnCallEscalationChainUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	nameData := d.Get("name").(string)
 
@@ -107,9 +98,6 @@ func ResourceOnCallEscalationChainUpdate(ctx context.Context, d *schema.Resource
 
 func ResourceOnCallEscalationChainDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	_, err := client.EscalationChains.DeleteEscalationChain(d.Id(), &onCallAPI.DeleteEscalationChainOptions{})
 	if err != nil {

--- a/grafana/resource_oncall_integration.go
+++ b/grafana/resource_oncall_integration.go
@@ -167,9 +167,6 @@ func ResourceOnCallIntegration() *schema.Resource {
 
 func ResourceOnCallIntegrationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	teamIDData := d.Get("team_id").(string)
 	nameData := d.Get("name").(string)
@@ -197,9 +194,6 @@ func ResourceOnCallIntegrationCreate(ctx context.Context, d *schema.ResourceData
 
 func ResourceOnCallIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	nameData := d.Get("name").(string)
 	templateData := d.Get("templates").([]interface{})
@@ -223,9 +217,6 @@ func ResourceOnCallIntegrationUpdate(ctx context.Context, d *schema.ResourceData
 
 func ResourceOnCallIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 	options := &onCallAPI.GetIntegrationOptions{}
 	integration, r, err := client.Integrations.GetIntegration(d.Id(), options)
 	if err != nil {
@@ -249,9 +240,6 @@ func ResourceOnCallIntegrationRead(ctx context.Context, d *schema.ResourceData, 
 
 func ResourceOnCallIntegrationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 	options := &onCallAPI.DeleteIntegrationOptions{}
 	_, err := client.Integrations.DeleteIntegration(d.Id(), options)
 	if err != nil {

--- a/grafana/resource_oncall_on_call_shift.go
+++ b/grafana/resource_oncall_on_call_shift.go
@@ -177,9 +177,6 @@ func ResourceOnCallOnCallShift() *schema.Resource {
 
 func ResourceOnCallOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	teamIDData := d.Get("team_id").(string)
 	typeData := d.Get("type").(string)
@@ -303,9 +300,6 @@ func ResourceOnCallOnCallShiftCreate(ctx context.Context, d *schema.ResourceData
 
 func ResourceOnCallOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	typeData := d.Get("type").(string)
 	nameData := d.Get("name").(string)
@@ -427,9 +421,6 @@ func ResourceOnCallOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData
 
 func ResourceOnCallOnCallShiftRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 	options := &onCallAPI.GetOnCallShiftOptions{}
 	onCallShift, r, err := client.OnCallShifts.GetOnCallShift(d.Id(), options)
 	if err != nil {
@@ -463,9 +454,6 @@ func ResourceOnCallOnCallShiftRead(ctx context.Context, d *schema.ResourceData, 
 
 func ResourceOnCallOnCallShiftDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 	options := &onCallAPI.DeleteOnCallShiftOptions{}
 	_, err := client.OnCallShifts.DeleteOnCallShift(d.Id(), options)
 	if err != nil {

--- a/grafana/resource_oncall_outgoing_webhook.go
+++ b/grafana/resource_oncall_outgoing_webhook.go
@@ -70,9 +70,6 @@ func ResourceOnCallOutgoingWebhook() *schema.Resource {
 
 func ResourceOnCallOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	name := d.Get("name").(string)
 	teamID := d.Get("team_id").(string)
@@ -120,9 +117,6 @@ func ResourceOnCallOutgoingWebhookCreate(ctx context.Context, d *schema.Resource
 
 func ResourceOnCallOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	outgoingWebhook, r, err := client.CustomActions.GetCustomAction(d.Id(), &onCallAPI.GetCustomActionOptions{})
 	if err != nil {
@@ -148,9 +142,6 @@ func ResourceOnCallOutgoingWebhookRead(ctx context.Context, d *schema.ResourceDa
 
 func ResourceOnCallOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	name := d.Get("name").(string)
 	url := d.Get("url").(string)
@@ -195,9 +186,6 @@ func ResourceOnCallOutgoingWebhookUpdate(ctx context.Context, d *schema.Resource
 
 func ResourceOnCallOutgoingWebhookDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	_, err := client.CustomActions.DeleteCustomAction(d.Id(), &onCallAPI.DeleteCustomActionOptions{})
 	if err != nil {

--- a/grafana/resource_oncall_route.go
+++ b/grafana/resource_oncall_route.go
@@ -66,9 +66,6 @@ func ResourceOnCallRoute() *schema.Resource {
 
 func ResourceOnCallRouteCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	integrationIDData := d.Get("integration_id").(string)
 	escalationChainIDData := d.Get("escalation_chain_id").(string)
@@ -97,9 +94,6 @@ func ResourceOnCallRouteCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func ResourceOnCallRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	route, r, err := client.Routes.GetRoute(d.Id(), &onCallAPI.GetRouteOptions{})
 	if err != nil {
@@ -122,9 +116,6 @@ func ResourceOnCallRouteRead(ctx context.Context, d *schema.ResourceData, m inte
 
 func ResourceOnCallRouteUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	escalationChainIDData := d.Get("escalation_chain_id").(string)
 	routingRegexData := d.Get("routing_regex").(string)
@@ -150,9 +141,6 @@ func ResourceOnCallRouteUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 func ResourceOnCallRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	_, err := client.Routes.DeleteRoute(d.Id(), &onCallAPI.DeleteRouteOptions{})
 	if err != nil {

--- a/grafana/resource_oncall_schedule.go
+++ b/grafana/resource_oncall_schedule.go
@@ -97,9 +97,6 @@ func ResourceOnCallSchedule() *schema.Resource {
 
 func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
@@ -160,9 +157,6 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 
 	nameData := d.Get("name").(string)
 	slackData := d.Get("slack").([]interface{})
@@ -220,9 +214,6 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 	options := &onCallAPI.GetScheduleOptions{}
 	schedule, r, err := client.Schedules.GetSchedule(d.Id(), options)
 	if err != nil {
@@ -248,9 +239,6 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client).onCallAPI
-	if client == nil {
-		return diag.Errorf("grafana OnCall api client is not configured")
-	}
 	options := &onCallAPI.DeleteScheduleOptions{}
 	_, err := client.Schedules.DeleteSchedule(d.Id(), options)
 	if err != nil {

--- a/grafana/resource_synthetic_monitoring_installation.go
+++ b/grafana/resource_synthetic_monitoring_installation.go
@@ -61,7 +61,7 @@ This resource cannot be imported but it can be used on an existing Synthetic Mon
 }
 
 func ResourceSyntheticMonitoringInstallationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*client).smapi
+	c := smapi.NewClient(meta.(*client).smURL, "", nil)
 	stackID, metricsID, logsID := d.Get("stack_id").(int), d.Get("metrics_instance_id").(int), d.Get("logs_instance_id").(int)
 	resp, err := c.Install(ctx, int64(stackID), int64(metricsID), int64(logsID), d.Get("metrics_publisher_key").(string))
 	if err != nil {


### PR DESCRIPTION
This is a long standing issue, since we started using the provider for multiple things (SM, Grafana, Cloud, Oncall)
You can now configure your provider in a way that is valid but not for the resources you are using
Example, configuring a cloud provider but using a Grafana resource

The OnCall team added a validation on all of their resources, which works but is a bit tedious
This PR adds a validation on every resource, the corresponding client has to exist at read and create time

Here's what an error looks like:
```
│ Error: the Grafana client is required for `grafana_data_source`. Set the auth and url provider attributes
│
│   with grafana_data_source.elasticsearch-arbitrary,
│   on test-2022-08-24-datasources.tf line 14, in resource "grafana_data_source" "elasticsearch-arbitrary":
│   14: resource "grafana_data_source" "elasticsearch-arbitrary" {
```

Instead of `Error: Post "/api/v1/provisioning/contact-points": unsupported protocol scheme ""`

Fixes #610