### PR TITLE
Datasource: Remove `secure_json_data_encoded` read

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -577,7 +577,6 @@ source selected (via the 'type' argument).
 			"secure_json_data_encoded": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Sensitive:     true,
 				ConflictsWith: []string{"json_data", "secure_json_data"},
 				Description:   "Serialized JSON string containing the secure json data. Replaces the secure_json_data attribute, this attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI.",
 				ValidateFunc:  validation.StringIsJSON,
@@ -657,32 +656,13 @@ func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 	d.Set("uid", dataSource.UID)
 
 	// If `json_data` is not set, then we'll use the new attribute: `json_data_encoded`. This allows support of imports.
-	gottenJSONData, gottenSecureJSONData, gottenHeaders := gapi.ExtractHeadersFromJSONData(dataSource.JSONData, dataSource.SecureJSONData)
+	gottenJSONData, _, gottenHeaders := gapi.ExtractHeadersFromJSONData(dataSource.JSONData, dataSource.SecureJSONData)
 	if _, ok := d.GetOk("json_data_encoded"); ok {
 		encodedJSONData, err := json.Marshal(gottenJSONData)
 		if err != nil {
 			return diag.Errorf("Failed to marshal JSON data: %s", err)
 		}
 		d.Set("json_data_encoded", string(encodedJSONData))
-	}
-
-	// For headers and secure data, we do not know the value (the API does not return secret data)
-	// so we only remove keys from the state that are no longer present in the API.
-	if currentSecureJSONDataEncoded := d.Get("secure_json_data_encoded").(string); currentSecureJSONDataEncoded != "" {
-		var currentSecureJSONData map[string]interface{}
-		if err := json.Unmarshal([]byte(currentSecureJSONDataEncoded), &currentSecureJSONData); err != nil {
-			return diag.Errorf("Failed to unmarshal current secure JSON data: %s", err)
-		}
-		for key := range currentSecureJSONData {
-			if _, ok := gottenSecureJSONData[key]; !ok {
-				delete(currentSecureJSONData, key)
-			}
-		}
-		encodedSecureJSONData, err := json.Marshal(currentSecureJSONData)
-		if err != nil {
-			return diag.Errorf("Failed to marshal secure_json_data_encoded: %s", err)
-		}
-		d.Set("secure_json_data_encoded", string(encodedSecureJSONData))
 	}
 
 	currentHeaders := d.Get("http_headers").(map[string]interface{})

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -666,6 +666,8 @@ func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 		d.Set("json_data_encoded", string(encodedJSONData))
 	}
 
+	// For headers, we do not know the value (the API does not return secret data)
+	// so we only remove keys from the state that are no longer present in the API.
 	currentHeaders := d.Get("http_headers").(map[string]interface{})
 	for key := range currentHeaders {
 		if _, ok := gottenHeaders[key]; !ok {

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -577,6 +577,7 @@ source selected (via the 'type' argument).
 			"secure_json_data_encoded": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Sensitive:     true,
 				ConflictsWith: []string{"json_data", "secure_json_data"},
 				Description:   "Serialized JSON string containing the secure json data. Replaces the secure_json_data attribute, this attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI.",
 				ValidateFunc:  validation.StringIsJSON,


### PR DESCRIPTION
The API doesn't return the keys of the secure map for all datasources it seems
By removing this, we rely entirely on what the user provides