### PR TITLE
Download Terraform CLI outside of tests

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -3,7 +3,18 @@ local images = {
   go: 'golang:1.18',
   python: 'python:3.9-alpine',
   lint: 'golangci/golangci-lint:v1.49',
+  terraform: 'hashicorp/terraform',
   grafana(version): 'grafana/grafana:' + version,
+};
+
+local terraformPath = '/drone/terraform-provider-grafana/terraform';
+local installTerraformStep = {
+  name: 'download-terraform',
+  image: images.terraform,
+  commands: [
+    'cp /bin/terraform ' + terraformPath,
+    'chmod a+x ' + terraformPath,
+  ],
 };
 
 local secret(name, vaultPath, vaultKey) = {
@@ -84,12 +95,16 @@ local pipeline(name, steps, services=[]) = {
   pipeline(
     'unit tests',
     steps=[
+      installTerraformStep,
       {
         name: 'tests',
         image: images.go,
         commands: [
           'go test ./...',
         ],
+        environment: {
+          TF_ACC_TERRAFORM_PATH: terraformPath,
+        },
       },
     ]
   ),
@@ -97,6 +112,7 @@ local pipeline(name, steps, services=[]) = {
   pipeline(
     'cloud api tests',
     steps=[
+      installTerraformStep,
       {
         name: 'tests',
         image: images.go,
@@ -106,6 +122,7 @@ local pipeline(name, steps, services=[]) = {
         environment: {
           GRAFANA_CLOUD_API_KEY: cloudApiKey.fromSecret,
           GRAFANA_CLOUD_ORG: 'terraformprovidergrafana',
+          TF_ACC_TERRAFORM_PATH: terraformPath,
         },
       },
     ]
@@ -117,6 +134,7 @@ local pipeline(name, steps, services=[]) = {
   pipeline(
     'cloud instance tests',
     steps=[
+      installTerraformStep,
       {
         name: 'wait for instance',
         image: images.go,
@@ -132,6 +150,7 @@ local pipeline(name, steps, services=[]) = {
           GRAFANA_SM_ACCESS_TOKEN: smToken.fromSecret,
           GRAFANA_ORG_ID: 1,
           GRAFANA_ONCALL_ACCESS_TOKEN: onCallToken.fromSecret,
+          TF_ACC_TERRAFORM_PATH: terraformPath,
         },
       },
     ]
@@ -148,6 +167,7 @@ local pipeline(name, steps, services=[]) = {
   pipeline(
     'oss tests: %s' % version,
     steps=[
+      installTerraformStep,
       {
         name: 'tests',
         image: images.go,
@@ -160,6 +180,7 @@ local pipeline(name, steps, services=[]) = {
           GRAFANA_AUTH: 'admin:admin',
           GRAFANA_VERSION: version,
           GRAFANA_ORG_ID: 1,
+          TF_ACC_TERRAFORM_PATH: terraformPath,
         },
       },
     ],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -62,7 +62,14 @@ platform:
 services: []
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - go test ./...
+  environment:
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -85,11 +92,17 @@ platform:
 services: []
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - make testacc-cloud-api
   environment:
     GRAFANA_CLOUD_API_KEY:
       from_secret: grafana-cloud-api-key
     GRAFANA_CLOUD_ORG: terraformprovidergrafana
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -112,6 +125,11 @@ platform:
 services: []
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - .drone/wait-for-instance.sh https://terraformprovidergrafana.grafana.net/
   image: golang:1.18
   name: wait for instance
@@ -126,6 +144,7 @@ steps:
     GRAFANA_SM_ACCESS_TOKEN:
       from_secret: grafana-sm-token
     GRAFANA_URL: https://terraformprovidergrafana.grafana.net/
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -174,6 +193,11 @@ services:
   name: grafana
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - sleep 5
   - make testacc-oss
   environment:
@@ -181,6 +205,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 9.1.0
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -205,6 +230,11 @@ services:
   name: grafana
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - sleep 5
   - make testacc-oss
   environment:
@@ -212,6 +242,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 9.0.7
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -236,6 +267,11 @@ services:
   name: grafana
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - sleep 5
   - make testacc-oss
   environment:
@@ -243,6 +279,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.5.5
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -267,6 +304,11 @@ services:
   name: grafana
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - sleep 5
   - make testacc-oss
   environment:
@@ -274,6 +316,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.4.7
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -298,6 +341,11 @@ services:
   name: grafana
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - sleep 5
   - make testacc-oss
   environment:
@@ -305,6 +353,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.3.7
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -329,6 +378,11 @@ services:
   name: grafana
 steps:
 - commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
   - sleep 5
   - make testacc-oss
   environment:
@@ -336,6 +390,7 @@ steps:
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 7.5.15
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
 trigger:
@@ -349,6 +404,6 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: signature
-hmac: 5305c32d78ea4fd8751e54de562674e698f9b4d415934d03568881933a7921f9
+hmac: 8c44f9980e078778581b1c708a316480b4d6636cb4389b091c057f94ed3afaa7
 
 ...


### PR DESCRIPTION
This should fix this kind of random failures: https://drone.grafana.net/grafana/terraform-provider-grafana/1608/5/3
`cannot run Terraform provider tests: failed to find or install Terraform CLI from [0xc002db6640 0xc001106480]: Unknown status: 502`

It also seems to make tests much faster