### PR TITLE
Fix rule group import docs

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -167,5 +167,5 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_alert_rule.alert_rule_name {{alert_rule_name}}
+terraform import grafana_rule_group.rule_group_name {{folder_uid}};{{rule_group_name}}
 ```

--- a/examples/resources/grafana_rule_group/import.sh
+++ b/examples/resources/grafana_rule_group/import.sh
@@ -1,1 +1,1 @@
-terraform import grafana_alert_rule.alert_rule_name {{alert_rule_name}}
+terraform import grafana_rule_group.rule_group_name {{folder_uid}};{{rule_group_name}}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/641
Seems to be `{{folder_uid}};{{rule_group_name}}`