### PR TITLE
Alerting: Import contact points by name instead of by UID list

### DIFF
--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -79,7 +79,7 @@ func importContactPoint(ctx context.Context, data *schema.ResourceData, meta int
 		return nil, err
 	}
 
-	if ps == nil || len(ps) == 0 {
+	if len(ps) == 0 {
 		return nil, fmt.Errorf("no contact points with the given name were found to import")
 	}
 

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -45,7 +45,7 @@ Manages Grafana Alerting contact points.
 		DeleteContext: deleteContactPoint,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: importContactPoint,
 		},
 
 		SchemaVersion: 0,
@@ -68,6 +68,28 @@ Manages Grafana Alerting contact points.
 	}
 
 	return resource
+}
+
+func importContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	name := data.Id()
+	client := meta.(*client).gapi
+
+	ps, err := client.ContactPointsByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if ps == nil || len(ps) == 0 {
+		return nil, fmt.Errorf("no contact points with the given name were found to import")
+	}
+
+	uids := make([]string, 0, len(ps))
+	for _, p := range ps {
+		uids = append(uids, p.UID)
+	}
+
+	data.SetId(packUIDs(uids))
+	return []*schema.ResourceData{data}, nil
 }
 
 func readContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/grafana/resource_alerting_contact_point_test.go
+++ b/grafana/resource_alerting_contact_point_test.go
@@ -36,6 +36,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 			{
 				ResourceName:      "grafana_contact_point.my_contact_point",
 				ImportState:       true,
+				ImportStateId:     "My Contact Point",
 				ImportStateVerify: true,
 			},
 			// Test update content.


### PR DESCRIPTION
Allow importing of contact points by name, which is much more familiar to users, rather than by semicolon-separated UIDs.

No need to touch docs as part of this PR. They already (incorrectly!) state that contact points can be imported by name.