### PR TITLE
Clean up Cloud API keys from tests

### DIFF
--- a/grafana/resource_synthetic_monitoring_installation_test.go
+++ b/grafana/resource_synthetic_monitoring_installation_test.go
@@ -14,13 +14,14 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 
 	var stack gapi.Stack
 	stackPrefix := "tfsminstalltest"
+	testAccDeleteExistingStacks(t, stackPrefix)
 	stackSlug := GetRandomStackName(stackPrefix)
-	apiKeyName := "zzztest-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	apiKeyPrefix := "testsminstall-"
+	testAccDeleteExistingCloudAPIKeys(t, apiKeyPrefix)
+	apiKeyName := apiKeyPrefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccDeleteExistingStacks(t, stackPrefix)
-		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
If a test fails, they aren't always deleted and they tend to add up This will clean them up before each test run. That way, we'll have at most one of each prefix