### PR TITLE
Alerting: Workaround for bad handling of empty strings in contact points API

### DIFF
--- a/examples/resources/grafana_contact_point/_acc_default_settings.tf
+++ b/examples/resources/grafana_contact_point/_acc_default_settings.tf
@@ -1,0 +1,8 @@
+resource "grafana_contact_point" "default_settings" {
+    name = "Default Settings"
+
+    slack {
+        token = "xoxb-token"
+        recipient = "#channel"
+    }
+}

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -208,12 +208,23 @@ func unpackContactPoints(data *schema.ResourceData) []gapi.ContactPoint {
 	for _, n := range notifiers {
 		if points, ok := data.GetOk(n.meta().field); ok {
 			for _, p := range points.([]interface{}) {
-				result = append(result, n.unpack(p, name))
+				result = append(result, unpackPointConfig(n, p, name))
 			}
 		}
 	}
 
 	return result
+}
+
+func unpackPointConfig(n notifier, data interface{}, name string) gapi.ContactPoint {
+	pt := n.unpack(data, name)
+	// Treat settings like `omitempty`. Workaround for versions affected by https://github.com/grafana/grafana/issues/55139
+	for k, v := range pt.Settings {
+		if v == "" {
+			delete(pt.Settings, k)
+		}
+	}
+	return pt
 }
 
 func packContactPoints(ps []gapi.ContactPoint, data *schema.ResourceData) error {


### PR DESCRIPTION
The Terraform default is to use empty-strings for blank or missing fields. This is consistent with a lot of Go-based clients, but Terraform is very aggressive with this. In fact, in many cases the provider API has no way of telling whether a field was missing from HCL entirely, or present with an empty string: https://github.com/hashicorp/terraform-plugin-sdk/issues/741

This is normally fine, assuming that the underlying API is well behaved. Most of Grafana's API handle this well, but the `settings` field in contact points do not handle this consistently. Empty strings circumvent the API validation entirely. See this issue in Grafana: https://github.com/grafana/grafana/issues/55139

This issue in Grafana will take quite some time to fix. This PR implements a much faster workaround in the provider. This allows us to get a workaround released to users faster, while we fix the main bug in the Grafana API. This also means the provider will continue to work with Grafana versions affected by the above issue, which is nice for compatibility.

We will now treat this settings blob as if it's a struct with all fields being `omitempty`. Empty settings values will simply not be sent to the server at all.