### PR TITLE
Cloud Plugins tests: Delete existing as pre-check

### DIFF
--- a/grafana/resource_cloud_plugin_test.go
+++ b/grafana/resource_cloud_plugin_test.go
@@ -16,6 +16,8 @@ func TestAccResourceCloudPluginInstallation(t *testing.T) {
 	pluginVersion := "1.7.0"
 
 	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccCloudPluginDeleteExisting(t, slug, pluginSlug) },
+
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -68,6 +70,20 @@ func testAccCloudPluginInstallationDestroy(stackSlug string, pluginSlug string) 
 		}
 
 		return nil
+	}
+}
+
+func testAccCloudPluginDeleteExisting(t *testing.T, instanceSlug, pluginSlug string) {
+	client := testAccProvider.Meta().(*client).gcloudapi
+	installed, err := client.IsCloudPluginInstalled(instanceSlug, pluginSlug)
+	if err != nil {
+		t.Fatalf("error checking if plugin is installed: %s", err)
+	}
+	if installed {
+		err = client.UninstallCloudPlugin(instanceSlug, pluginSlug)
+		if err != nil {
+			t.Fatalf("error uninstalling plugin: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
We've been getting some `Plugin is already installed on this instance` in the tests. This should fix it forever