### PR TITLE
Alerting: Document version reqs for all alerting resources

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -5,6 +5,7 @@ subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting contact points.
   Official documentation https://grafana.com/docs/grafana/next/alerting/contact-pointsHTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
+  This resource requires Grafana 9.1.0 or later.
 ---
 
 # grafana_contact_point (Resource)
@@ -13,6 +14,8 @@ Manages Grafana Alerting contact points.
 
 * [Official documentation](https://grafana.com/docs/grafana/next/alerting/contact-points)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
+
+This resource requires Grafana 9.1.0 or later.
 
 ## Example Usage
 

--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -3,13 +3,19 @@
 page_title: "grafana_message_template Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
+  Manages Grafana Alerting message templates.
   Official documentation https://grafana.com/docs/grafana/next/alerting/contact-points/message-templating/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates
+  This resource requires Grafana 9.1.0 or later.
 ---
 
 # grafana_message_template (Resource)
 
+Manages Grafana Alerting message templates.
+
 * [Official documentation](https://grafana.com/docs/grafana/next/alerting/contact-points/message-templating/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates)
+
+This resource requires Grafana 9.1.0 or later.
 
 ## Example Usage
 

--- a/docs/resources/mute_timing.md
+++ b/docs/resources/mute_timing.md
@@ -3,13 +3,19 @@
 page_title: "grafana_mute_timing Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
+  Manages Grafana Alerting mute timings.
   Official documentation https://grafana.com/docs/grafana/next/alerting/notifications/mute-timings/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings
+  This resource requires Grafana 9.1.0 or later.
 ---
 
 # grafana_mute_timing (Resource)
 
+Manages Grafana Alerting mute timings.
+
 * [Official documentation](https://grafana.com/docs/grafana/next/alerting/notifications/mute-timings/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings)
+
+This resource requires Grafana 9.1.0 or later.
 
 ## Example Usage
 

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -4,15 +4,18 @@ page_title: "grafana_notification_policy Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
-  * Official documentation https://grafana.com/docs/grafana/latest/alerting/notifications/
-  * HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/notifications/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies
+  This resource requires Grafana 9.1.0 or later.
 ---
 
 # grafana_notification_policy (Resource)
 
 Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
+
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/notifications/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies)
+
+This resource requires Grafana 9.1.0 or later.
 
 ## Example Usage
 

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -5,6 +5,7 @@ subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting rule groups.
   Official documentation https://grafana.com/docs/grafana/latest/alerting/alerting-rulesHTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules
+  This resource requires Grafana 9.1.0 or later.
 ---
 
 # grafana_rule_group (Resource)
@@ -13,6 +14,8 @@ Manages Grafana Alerting rule groups.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
+
+This resource requires Grafana 9.1.0 or later.
 
 ## Example Usage
 

--- a/grafana/resource_alerting_contact_point.go
+++ b/grafana/resource_alerting_contact_point.go
@@ -38,6 +38,8 @@ Manages Grafana Alerting contact points.
 
 * [Official documentation](https://grafana.com/docs/grafana/next/alerting/contact-points)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
+
+This resource requires Grafana 9.1.0 or later.
 `,
 		CreateContext: createContactPoint,
 		ReadContext:   readContactPoint,

--- a/grafana/resource_alerting_message_template.go
+++ b/grafana/resource_alerting_message_template.go
@@ -12,8 +12,12 @@ import (
 func ResourceMessageTemplate() *schema.Resource {
 	return &schema.Resource{
 		Description: `
+Manages Grafana Alerting message templates.
+
 * [Official documentation](https://grafana.com/docs/grafana/next/alerting/contact-points/message-templating/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates)
+
+This resource requires Grafana 9.1.0 or later.
 `,
 		CreateContext: createMessageTemplate,
 		ReadContext:   readMessageTemplate,

--- a/grafana/resource_alerting_mute_timing.go
+++ b/grafana/resource_alerting_mute_timing.go
@@ -14,9 +14,13 @@ import (
 func ResourceMuteTiming() *schema.Resource {
 	return &schema.Resource{
 		Description: `
+Manages Grafana Alerting mute timings.
+
 * [Official documentation](https://grafana.com/docs/grafana/next/alerting/notifications/mute-timings/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings)
-		`,
+
+This resource requires Grafana 9.1.0 or later.
+`,
 
 		CreateContext: createMuteTiming,
 		ReadContext:   readMuteTiming,

--- a/grafana/resource_alerting_notification_policy.go
+++ b/grafana/resource_alerting_notification_policy.go
@@ -13,8 +13,11 @@ func ResourceNotificationPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
+
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/notifications/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies)
+
+This resource requires Grafana 9.1.0 or later.
 `,
 
 		CreateContext: createNotificationPolicy,

--- a/grafana/resource_alerting_rule_group.go
+++ b/grafana/resource_alerting_rule_group.go
@@ -21,6 +21,7 @@ Manages Grafana Alerting rule groups.
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
 
+This resource requires Grafana 9.1.0 or later.
 `,
 		CreateContext: createAlertRuleGroup,
 		ReadContext:   readAlertRuleGroup,


### PR DESCRIPTION
We now document the required version of Grafana for all Alerting resources. They have later requirements than many of the other resources.

Fixes https://github.com/grafana/terraform-provider-grafana/issues/659