### PR TITLE
RBAC: use correct scope in tests

### DIFF
--- a/grafana/resource_role_test.go
+++ b/grafana/resource_role_test.go
@@ -84,7 +84,7 @@ func TestAccRole(t *testing.T) {
 						"grafana_role.test", "permissions.0.action", "users:create",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_role.test", "permissions.1.scope", "global:users:*",
+						"grafana_role.test", "permissions.1.scope", "global.users:*",
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_role.test", "permissions.1.action", "users:read",
@@ -154,7 +154,7 @@ resource "grafana_role" "test" {
   hidden = true
   permissions {
 	action = "users:read"
-    scope = "global:users:*"
+    scope = "global.users:*"
   }
   permissions {
 	action = "users:create"


### PR DESCRIPTION
Since we've introduced validation for actions and scopes when roles are being created (it was introduced in this PR: https://github.com/grafana/grafana-enterprise/pull/3756) role resource test started failing, as it's using incorrect scope.

This PR fixes the scope.