### PR TITLE
Add nil checks to list converters + add empty string validations

### DIFF
--- a/grafana/adapters.go
+++ b/grafana/adapters.go
@@ -7,7 +7,11 @@ import (
 func listToStringSlice(src []interface{}) []string {
 	dst := make([]string, 0, len(src))
 	for _, s := range src {
-		dst = append(dst, s.(string))
+		val, ok := s.(string)
+		if !ok {
+			val = ""
+		}
+		dst = append(dst, val)
 	}
 	return dst
 }
@@ -19,7 +23,11 @@ func setToStringSlice(src *schema.Set) []string {
 func listToIntSlice(src []interface{}) []int {
 	dst := make([]int, 0, len(src))
 	for _, s := range src {
-		dst = append(dst, s.(int))
+		val, ok := s.(int)
+		if !ok {
+			val = 0
+		}
+		dst = append(dst, val)
 	}
 	return dst
 }

--- a/grafana/resource_alerting_contact_point_notifiers.go
+++ b/grafana/resource_alerting_contact_point_notifiers.go
@@ -7,6 +7,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 type alertmanagerNotifier struct{}
@@ -258,7 +259,8 @@ func (e emailNotifier) schema() *schema.Resource {
 		Required:    true,
 		Description: "The addresses to send emails to.",
 		Elem: &schema.Schema{
-			Type: schema.TypeString,
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 	r.Schema["single_email"] = &schema.Schema{
@@ -336,10 +338,7 @@ func packAddrs(addrs string) []string {
 }
 
 func unpackAddrs(addrs []interface{}) string {
-	strs := make([]string, 0, len(addrs))
-	for _, addr := range addrs {
-		strs = append(strs, addr.(string))
-	}
+	strs := listToStringSlice(addrs)
 	return strings.Join(strs, addrSeparator)
 }
 

--- a/grafana/resource_alerting_notification_policy.go
+++ b/grafana/resource_alerting_notification_policy.go
@@ -7,6 +7,7 @@ import (
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceNotificationPolicy() *schema.Resource {
@@ -40,7 +41,8 @@ This resource requires Grafana 9.1.0 or later.
 				Required:    true,
 				Description: "A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping.",
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"group_wait": {


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/674

Whenever an empty string is passed to `group_by` or email addresses, the API returns a nil which crashes the conversion functions

This fixes the bug in two locations, it should no longer panic and also refuse empty values