### PR TITLE
Access Control: Allow assigning `Edit` permissions for data source

### DIFF
--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -40,7 +40,7 @@ resource "grafana_data_source_permission" "fooPermissions" {
   }
   permissions {
     user_id    = 3 // 3 is the admin user in cloud. It can't be queried
-    permission = "Query"
+    permission = "Edit"
   }
 }
 ```

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -62,7 +62,7 @@ resource "grafana_data_source_permission" "fooPermissions" {
 
 Required:
 
-- `permission` (String) Permission to associate with item. Must be `Query`.
+- `permission` (String) Permission to associate with item. Options: `Query` or `Edit` (`Edit` can only be used with Grafana v9.2.3+).
 
 Optional:
 

--- a/examples/resources/grafana_data_source_permission/resource.tf
+++ b/examples/resources/grafana_data_source_permission/resource.tf
@@ -25,6 +25,6 @@ resource "grafana_data_source_permission" "fooPermissions" {
   }
   permissions {
     user_id    = 3 // 3 is the admin user in cloud. It can't be queried
-    permission = "Query"
+    permission = "Edit"
   }
 }

--- a/grafana/resource_datasource_permission.go
+++ b/grafana/resource_datasource_permission.go
@@ -55,7 +55,7 @@ func ResourceDatasourcePermission() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"Query", "Edit"}, false),
-							Description:  "Permission to associate with item. Options: `Query` or `Edit`.",
+							Description:  "Permission to associate with item. Options: `Query` or `Edit` (`Edit` can only be used with Grafana v9.2.3+).",
 						},
 					},
 				},

--- a/grafana/resource_datasource_permission.go
+++ b/grafana/resource_datasource_permission.go
@@ -54,8 +54,8 @@ func ResourceDatasourcePermission() *schema.Resource {
 						"permission": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Query"}, false),
-							Description:  "Permission to associate with item. Must be `Query`.",
+							ValidateFunc: validation.StringInSlice([]string{"Query", "Edit"}, false),
+							Description:  "Permission to associate with item. Options: `Query` or `Edit`.",
 						},
 					},
 				},
@@ -206,15 +206,21 @@ addLoop:
 }
 
 func mapDatasourcePermissionStringToType(permission string) (gapi.DatasourcePermissionType, error) {
-	if permission == "Query" {
+	switch permission {
+	case "Query":
 		return gapi.DatasourcePermissionQuery, nil
+	case "Edit":
+		return gapi.DatasourcePermissionEdit, nil
 	}
 	return 0, fmt.Errorf("unknown datasource permission: %s", permission)
 }
 
 func mapDatasourcePermissionTypeToString(permission gapi.DatasourcePermissionType) (string, error) {
-	if permission == gapi.DatasourcePermissionQuery {
+	switch permission {
+	case gapi.DatasourcePermissionQuery:
 		return "Query", nil
+	case gapi.DatasourcePermissionEdit:
+		return "Edit", nil
 	}
 	return "", fmt.Errorf("unknown permission type: %d", permission)
 }


### PR DESCRIPTION
**What:**
* allow assigning `Edit` permission on a data source

**Notes:**
* `Edit` permission is only supported when RBAC is enabled. If RBAC is disabled `Edit` assignments will default back to `Query` assignments;
* this change requires https://github.com/grafana/grafana-enterprise/pull/4049 to be merged and released (it should be included in Grafana v9.2.3) and https://github.com/grafana/grafana-api-golang-client/pull/116 to be released (also need to update dependencies to the new `grafana-api-golang-client` version once that is done).