### PR TITLE
Access Control: Update example with permissions that are available for cloud users

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -25,11 +25,16 @@ resource "grafana_role" "super_user" {
   global      = true
 
   permissions {
-    action = "users:create"
+    action = "org.users:add"
+    scope = "users:*"
   }
   permissions {
-    action = "users:read"
-    scope  = "global:users:*"
+    action = "org.users:write"
+    scope = "users:*"
+  }
+  permissions {
+    action = "org.users:read"
+    scope = "users:*"
   }
 }
 ```

--- a/examples/resources/grafana_role/resource.tf
+++ b/examples/resources/grafana_role/resource.tf
@@ -6,10 +6,15 @@ resource "grafana_role" "super_user" {
   global      = true
 
   permissions {
-    action = "users:create"
+    action = "org.users:add"
+    scope = "users:*"
   }
   permissions {
-    action = "users:read"
-    scope  = "global:users:*"
+    action = "org.users:write"
+    scope = "users:*"
+  }
+  permissions {
+    action = "org.users:read"
+    scope = "users:*"
   }
 }


### PR DESCRIPTION
**What?**

Updating role resource example with permissions that are accessible by Cloud as well as Enterprise users. 

**Why?**

Permissions that were used in role resource example are not accessible by cloud users, which was causing confusion (related issue: https://github.com/grafana/support-escalations/issues/4275)