### PR TITLE
fix(cloud-stack): region_slug add new regions

### DIFF
--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -35,7 +35,7 @@ available at “https://<stack_slug>.grafana.net".
 - `description` (String) Description of stack.
 - `region_slug` (String) Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region.
-Available input au(GCP Australia), eu(GCP Belgium), us(GCP US Central), prod-ap-southeast-0(GCP Singapore), prod-gb-south-0(GCP UK), prod-ap-south-0(GCP India), prod-sa-east-0(GCP Brazil)
+Available input au (GCP Australia), eu (GCP Belgium), us (GCP US Central), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
 - `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -34,7 +34,8 @@ available at “https://<stack_slug>.grafana.net".
 
 - `description` (String) Description of stack.
 - `region_slug` (String) Region slug to assign to this stack.
-Changing region will destroy the existing stack and create a new one in the desired region
+Changing region will destroy the existing stack and create a new one in the desired region.
+Available input au(GCP Australia), eu(GCP Belgium), us(GCP US Central), prod-ap-southeast-0(GCP Singapore), prod-gb-south-0(GCP UK), prod-ap-south-0(GCP India), prod-sa-east-0(GCP Brazil)
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
 - `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -69,8 +69,10 @@ available at “https://<stack_slug>.grafana.net".`,
 				Optional: true,
 				ForceNew: true,
 				Description: `Region slug to assign to this stack.
-Changing region will destroy the existing stack and create a new one in the desired region`,
-				ValidateFunc: validation.StringInSlice([]string{"au", "eu", "us"}, false),
+Changing region will destroy the existing stack and create a new one in the desired region.
+Available input au(GCP Australia), eu(GCP Belgium), us(GCP US Central), prod-ap-southeast-0(GCP Singapore), prod-gb-south-0(GCP UK), prod-ap-south-0(GCP India), prod-sa-east-0(GCP Brazil)
+`,
+				ValidateFunc: validation.StringInSlice([]string{"au", "eu", "us", "prod-ap-southeast-0", "prod-gb-south-0", "prod-ap-south-0", "prod-sa-east-0"}, false),
 			},
 			"url": {
 				Type:        schema.TypeString,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -70,8 +70,7 @@ available at “https://<stack_slug>.grafana.net".`,
 				ForceNew: true,
 				Description: `Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region.
-Available input au(GCP Australia), eu(GCP Belgium), us(GCP US Central), prod-ap-southeast-0(GCP Singapore), prod-gb-south-0(GCP UK), prod-ap-south-0(GCP India), prod-sa-east-0(GCP Brazil)
-`,
+Available input au (GCP Australia), eu (GCP Belgium), us (GCP US Central), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)`,
 				ValidateFunc: validation.StringInSlice([]string{"au", "eu", "us", "prod-ap-southeast-0", "prod-gb-south-0", "prod-ap-south-0", "prod-sa-east-0"}, false),
 			},
 			"url": {


### PR DESCRIPTION
add region prod-ap-southeast-0(GCP Singapore), prod-gb-south-0(GCP UK), prod-ap-south-0(GCP India), prod-sa-east-0(GCP Brazil)

Fix #705 