### PR TITLE
Allow Machine Learning jobs to be specified using datasource UID

### DIFF
--- a/docs/resources/machine_learning_job.md
+++ b/docs/resources/machine_learning_job.md
@@ -17,7 +17,6 @@ A job defines the queries and model parameters for a machine learning task.
 
 ### Required
 
-- `datasource_id` (Number) The id of the datasource to query.
 - `datasource_type` (String) The type of datasource being queried. Currently allowed values are prometheus, graphite, loki, postgres, and datadog.
 - `metric` (String) The metric used to query the job results.
 - `name` (String) The name of the job.
@@ -25,6 +24,8 @@ A job defines the queries and model parameters for a machine learning task.
 
 ### Optional
 
+- `datasource_id` (Number) The id of the datasource to query.
+- `datasource_uid` (String) The uid of the datasource to query.
 - `description` (String) A description of the job.
 - `hyper_params` (Map of String) The hyperparameters used to fine tune the algorithm. See https://grafana.com/docs/grafana-cloud/machine-learning/models/ for the full list of available hyperparameters. Defaults to `map[]`.
 - `interval` (Number) The data interval in seconds to train the data on. Defaults to `300`.

--- a/examples/resources/grafana_machine_learning_job/datasource_uid_job.tf
+++ b/examples/resources/grafana_machine_learning_job/datasource_uid_job.tf
@@ -6,8 +6,4 @@ resource "grafana_machine_learning_job" "test_job" {
   query_params = {
     expr = "grafanacloud_grafana_instance_active_user_count"
   }
-  hyper_params = {
-    daily_seasonality  = 15
-    weekly_seasonality = 10
-  }
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/grafana/amixr-api-go-client v0.0.5
 	github.com/grafana/grafana-api-golang-client v0.13.0
-	github.com/grafana/machine-learning-go-client v0.1.1
+	github.com/grafana/machine-learning-go-client v0.2.0
 	github.com/grafana/synthetic-monitoring-agent v0.9.4
 	github.com/grafana/synthetic-monitoring-api-go-client v0.6.3
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/grafana/amixr-api-go-client v0.0.5 h1:jqmljnd5FozuOsCNuyhZVpooxmj0BW9
 github.com/grafana/amixr-api-go-client v0.0.5/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.13.0 h1:o/gL3F7EjBSBKgrpjH9/+sYFJ0HBUofvAYlKhrT2opE=
 github.com/grafana/grafana-api-golang-client v0.13.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
-github.com/grafana/machine-learning-go-client v0.1.1 h1:Gw6cX8xAd6IVF2LApkXOIdBK8Gzz07B3jQPukecw7fc=
-github.com/grafana/machine-learning-go-client v0.1.1/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
+github.com/grafana/machine-learning-go-client v0.2.0 h1:5JgfJn5Q72D0jZlXnM0gZ9lV4Q4zzq9X0GVfPu8Vxis=
+github.com/grafana/machine-learning-go-client v0.2.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.9.4 h1:Enx5s6gFbc/RAzL5KDX/00catAlbcY7/1IFPBe5lo/c=
 github.com/grafana/synthetic-monitoring-agent v0.9.4/go.mod h1:PGcL9plaDkqkWenFE53vCfLamfws3yFba4jgWEt9kGw=
 github.com/grafana/synthetic-monitoring-api-go-client v0.6.3 h1:3jb4v5W8cEEr5zp5kVAzyV0UGF7mm06iY3nBpN4ZCDU=

--- a/grafana/resource_machine_learning_job_test.go
+++ b/grafana/resource_machine_learning_job_test.go
@@ -34,13 +34,26 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccExample(t, "resources/grafana_machine_learning_job/datasource_uid_job.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "metric", "tf_test_job"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_type", "prometheus"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_uid", "grafanacloud-usage"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "query_params.expr", "grafanacloud_grafana_instance_active_user_count"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "interval", "300"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "training_window", "7776000"),
+				),
+			},
+			{
 				Config: testAccExample(t, "resources/grafana_machine_learning_job/tuned_job.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "metric", "tf_test_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_type", "prometheus"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_id", "10"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_uid", "grafanacloud-usage"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "query_params.expr", "grafanacloud_grafana_instance_active_user_count"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "interval", "300"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "training_window", "7776000"),
@@ -103,6 +116,17 @@ resource "grafana_machine_learning_job" "invalid" {
 }
 `
 
+const machineLearningJobMissingDatasourceIDOrUID = `
+resource "grafana_machine_learning_job" "invalid" {
+  name            = "Test Job"
+  metric          = "tf_test_job"
+  datasource_type = "prometheus"
+  query_params = {
+    expr = "grafanacloud_grafana_instance_active_user_count"
+  }
+}
+`
+
 func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
 	CheckCloudInstanceTestsEnabled(t)
 
@@ -112,6 +136,10 @@ func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
 			{
 				Config:      machineLearningJobInvalid,
 				ExpectError: regexp.MustCompile(".*datasourceType.*"),
+			},
+			{
+				Config:      machineLearningJobMissingDatasourceIDOrUID,
+				ExpectError: regexp.MustCompile(".*datasource_id or datasource_uid.*"),
 			},
 		},
 	})


### PR DESCRIPTION
The Grafana Machine Learning API now supports jobs to specify their datasource
using UID; this PR updates the Terraform provider to also allow this.