### PR TITLE
CI: Do not run Cloud tests automatically

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -146,6 +146,9 @@ local pipeline(name, steps, services=[]) = {
       },
     ]
   ) + {
+    trigger: {
+      event: ['promote'],
+    },
     concurrency: { limit: 1 },
   },
 

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -112,11 +112,8 @@ steps:
   image: golang:1.18
   name: tests
 trigger:
-  branch:
-  - master
   event:
-  - pull_request
-  - push
+  - promote
 type: docker
 workspace:
   path: /drone/terraform-provider-grafana
@@ -426,6 +423,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: 859b4ecec6d95fed515f77177060967caf27b048bb6d8539a0b8a5f85317fd78
+hmac: e06354c28923331f229731c554363c1d778fb01464cde4ec885bb4f15a4e92fc
 
 ...

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            In order to preserve resources and have a faster runtime, PRs will not run Cloud tests automatically. To do so, a Grafana Labs employee must promote the Drone build.

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-    types:
-      - opened
 
 jobs:
   info-comment:

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,8 +1,10 @@
 on:
   pull_request:
+    types:
+      - opened
 
 jobs:
-  test:
+  info-comment:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: mshick/add-pr-comment@v2
         with:
           message: |
-            In order to preserve resources and have a faster runtime, PRs will not run Cloud tests automatically. To do so, a Grafana Labs employee must promote the Drone build.
+            In order to lower resource usage and have a faster runtime, PRs will not run Cloud tests automatically. To do so, a Grafana Labs employee must promote the Drone build.


### PR DESCRIPTION
This will lead to faster runtimes and less flakiness. We rarely have to run those tests, we have very few cloud resources