### PR TITLE
Playlist: Fix update

### DIFF
--- a/grafana/resource_playlist.go
+++ b/grafana/resource_playlist.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"log"
+	"strconv"
 	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -122,6 +123,13 @@ func UpdatePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{
 		Name:     d.Get("name").(string),
 		Interval: d.Get("interval").(string),
 		Items:    expandPlaylistItems(d.Get("item").(*schema.Set).List()),
+	}
+
+	// Support both Grafana 9.0+ and older versions (UID is used in 9.0+)
+	if idInt, err := strconv.Atoi(d.Id()); err == nil {
+		playlist.ID = idInt
+	} else {
+		playlist.UID = d.Id()
 	}
 
 	err := client.UpdatePlaylist(playlist)

--- a/grafana/resource_playlist_test.go
+++ b/grafana/resource_playlist_test.go
@@ -22,7 +22,7 @@ func TestAccPlaylist_basic(t *testing.T) {
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlaylistConfigBasic(rName),
+				Config: testAccPlaylistConfigBasic(rName, "5m"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPlaylistCheckExists(),
 					resource.TestMatchResourceAttr(paylistResource, "id", uidRegexp),
@@ -58,9 +58,17 @@ func TestAccPlaylist_update(t *testing.T) {
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlaylistConfigBasic(rName),
+				Config: testAccPlaylistConfigBasic(rName, "5m"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPlaylistCheckExists(),
+					resource.TestCheckResourceAttr(paylistResource, "interval", "5m"),
+				),
+			},
+			{
+				Config: testAccPlaylistConfigBasic(rName, "10m"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccPlaylistCheckExists(),
+					resource.TestCheckResourceAttr(paylistResource, "interval", "10m"),
 				),
 			},
 			{
@@ -97,7 +105,7 @@ func TestAccPlaylist_disappears(t *testing.T) {
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPlaylistConfigBasic(rName),
+				Config: testAccPlaylistConfigBasic(rName, "5m"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccPlaylistCheckExists(),
 					testAccPlaylistDisappears(),
@@ -172,11 +180,11 @@ func testAccPlaylistDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccPlaylistConfigBasic(name string) string {
+func testAccPlaylistConfigBasic(name, interval string) string {
 	return fmt.Sprintf(`
 resource "grafana_playlist" "test" {
 	name     = %[1]q
-	interval = "5m"
+	interval = %[2]q
 
 	item {
 		order = 1
@@ -188,7 +196,7 @@ resource "grafana_playlist" "test" {
 		title = "Terraform Dashboard By ID"
 	}
 }
-`, name)
+`, name, interval)
 }
 
 func testAccPlaylistConfigUpdate(name string) string {


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/710
The ID or UID of the playlist wasn't being set in the playlist when updating, and our update test was doing a full replacement of the playlist (destroy + create), so it wasn't a good test