### PR TITLE
Remove deprecated attributes from datasource docs

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -36,56 +36,50 @@ resource "grafana_data_source" "arbitrary-data" {
 }
 
 resource "grafana_data_source" "influxdb" {
-  type          = "influxdb"
-  name          = "myapp-metrics"
-  url           = "http://influxdb.example.net:8086/"
-  username      = "myapp"
-  password      = "foobarbaz"
-  database_name = influxdb_database.metrics.name
+  type                = "influxdb"
+  name                = "myapp-metrics"
+  url                 = "http://influxdb.example.net:8086/"
+  basic_auth_enabled  = true
+  basic_auth_username = "username"
+  database_name       = influxdb_database.metrics.name
+
+  json_data_encoded = jsonencode({
+    authType          = "default"
+    basicAuthPassword = "mypassword"
+  })
 }
 
 resource "grafana_data_source" "cloudwatch" {
   type = "cloudwatch"
   name = "cw-example"
 
-  json_data {
-    default_region = "us-east-1"
-    auth_type      = "keys"
-  }
+  json_data_encoded = jsonencode({
+    defaultRegion = "us-east-1"
+    authType      = "keys"
+  })
 
-  secure_json_data {
-    access_key = "123"
-    secret_key = "456"
-  }
+  secure_json_data_encoded = jsonencode({
+    accessKey = "123"
+    secretKey = "456"
+  })
 }
 
 resource "grafana_data_source" "prometheus" {
-  type = "prometheus"
-  name = "amp"
-  url  = "https://aps-workspaces.eu-west-1.amazonaws.com/workspaces/ws-1234567890/"
+  type                = "prometheus"
+  name                = "mimir"
+  url                 = "https://my-instances.com"
+  basic_auth_enabled  = true
+  basic_auth_username = "username"
 
-  json_data {
-    http_method     = "POST"
-    sigv4_auth      = true
-    sigv4_auth_type = "default"
-    sigv4_region    = "eu-west-1"
-  }
-}
+  json_data_encoded = jsonencode({
+    httpMethod        = "POST"
+    prometheusType    = "Mimir"
+    prometheusVersion = "2.4.0"
+  })
 
-resource "grafana_data_source" "stackdriver" {
-  type = "stackdriver"
-  name = "sd-example"
-
-  json_data {
-    token_uri           = "https://oauth2.googleapis.com/token"
-    authentication_type = "jwt"
-    default_project     = "default-project"
-    client_email        = "client-email@default-project.iam.gserviceaccount.com"
-  }
-
-  secure_json_data {
-    private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
-  }
+  secure_json_data_encoded = jsonencode({
+    basicAuthPassword = "password"
+  })
 }
 ```
 

--- a/examples/resources/grafana_data_source/resource.tf
+++ b/examples/resources/grafana_data_source/resource.tf
@@ -15,54 +15,49 @@ resource "grafana_data_source" "arbitrary-data" {
 }
 
 resource "grafana_data_source" "influxdb" {
-  type          = "influxdb"
-  name          = "myapp-metrics"
-  url           = "http://influxdb.example.net:8086/"
-  username      = "myapp"
-  password      = "foobarbaz"
-  database_name = influxdb_database.metrics.name
+  type                = "influxdb"
+  name                = "myapp-metrics"
+  url                 = "http://influxdb.example.net:8086/"
+  basic_auth_enabled  = true
+  basic_auth_username = "username"
+  database_name       = influxdb_database.metrics.name
+
+  json_data_encoded = jsonencode({
+    authType          = "default"
+    basicAuthPassword = "mypassword"
+  })
 }
 
 resource "grafana_data_source" "cloudwatch" {
   type = "cloudwatch"
   name = "cw-example"
 
-  json_data {
-    default_region = "us-east-1"
-    auth_type      = "keys"
-  }
+  json_data_encoded = jsonencode({
+    defaultRegion = "us-east-1"
+    authType      = "keys"
+  })
 
-  secure_json_data {
-    access_key = "123"
-    secret_key = "456"
-  }
+  secure_json_data_encoded = jsonencode({
+    accessKey = "123"
+    secretKey = "456"
+  })
 }
 
 resource "grafana_data_source" "prometheus" {
-  type = "prometheus"
-  name = "amp"
-  url  = "https://aps-workspaces.eu-west-1.amazonaws.com/workspaces/ws-1234567890/"
+  type                = "prometheus"
+  name                = "mimir"
+  url                 = "https://my-instances.com"
+  basic_auth_enabled  = true
+  basic_auth_username = "username"
 
-  json_data {
-    http_method     = "POST"
-    sigv4_auth      = true
-    sigv4_auth_type = "default"
-    sigv4_region    = "eu-west-1"
-  }
+  json_data_encoded = jsonencode({
+    httpMethod        = "POST"
+    prometheusType    = "Mimir"
+    prometheusVersion = "2.4.0"
+  })
+
+  secure_json_data_encoded = jsonencode({
+    basicAuthPassword = "password"
+  })
 }
 
-resource "grafana_data_source" "stackdriver" {
-  type = "stackdriver"
-  name = "sd-example"
-
-  json_data {
-    token_uri           = "https://oauth2.googleapis.com/token"
-    authentication_type = "jwt"
-    default_project     = "default-project"
-    client_email        = "client-email@default-project.iam.gserviceaccount.com"
-  }
-
-  secure_json_data {
-    private_key = "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n"
-  }
-}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/714 and closes https://github.com/grafana/terraform-provider-grafana/issues/715

We are telling users to stop using `json_data` and `secure_json_data`. The docs should reflect that