### PR TITLE
Allow to ignore missing users when creating team/organization

### DIFF
--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -60,6 +60,12 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
+- `ignore_missing_users` (Boolean) Whether or not to ignore Grafana users specified in the organization's
+membership if they don't already exist in Grafana. If unspecified, this
+parameter defaults to false, causing an error to be thrown. Setting this
+option to true will cause an warning to be thrown for any users that do not
+already exist in Grafana.
+ Defaults to `false`.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -36,6 +36,12 @@ resource "grafana_team" "test-team" {
 - `ignore_externally_synced_members` (Boolean) Ignores team members that have been added to team by [Team Sync](https://grafana.com/docs/grafana/latest/enterprise/team-sync/).
 Team Sync can be provisioned using [grafana_team_external_group resource](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/team_external_group).
  Defaults to `true`.
+- `ignore_missing_users` (Boolean) Whether or not to ignore Grafana users specified in the team's
+membership if they don't already exist in the organizagion. If unspecified, this
+parameter defaults to false, causing an error to be thrown. Setting this
+option to true will cause an warning to be thrown for any users that do not
+already exist in the organization Grafana.
+ Defaults to `false`.
 - `members` (Set of String) A set of email addresses corresponding to users who should be given membership
 to the team. Note: users specified here must already exist in Grafana.
 


### PR DESCRIPTION
In the context where Grafana relies on an external entity to create users automatically, this could be corporate SSO. Example:

```yaml
  auth:
    disable_login_form: true
    disable_signout_menu: true
  auth.anonymous:
    enabled: false
  auth.proxy:
    enabled: true
    header_name: "X-REMOTE-USER"
  users:
    allow_org_create: true
    allow_sign_up: false
    auto_assign_org: true
    auto_assign_org_role: "Viewer"
    viewers_can_edit: true
```

Users might exist in Grafana at the apply which could be acceptable for the administrator in charge of the instance. Without this setting the apply will fail and this is undetected during the plan. The setting allow to skip the missing users and allow the apply to complete with a warning message.

As an alternative to detect the missing users one can use the following snippet:

```tf
data "grafana_user" "existency_check" {
  count = length(var.members)
  email = var.members[count.index]
}
resource "grafana_team" "example" {
  name    = var.team_name
  email   = var.email
  members = concat(data.grafana_user.existency_check[*].email, [var.admin_email])
}
```

As data are fetch during plan this causes terraform to return an error for missing users. This is not optimal as this crowd the state and the output of terraform. Moreover if users are added in several teams/orgs their data are fetched multiple time.

Finally, depending on the size of the instance being managed with terraform this setting give more flexibility to admin.
Relates to: #698
Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>