### PR TITLE
Allow dynamic auth configuration

### DIFF
--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -155,12 +155,11 @@ func Provider(version string) func() *schema.Provider {
 					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 				},
 				"auth": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Sensitive:    true,
-					DefaultFunc:  schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
-					Description:  "API token or basic auth `username:password`. May alternatively be set via the `GRAFANA_AUTH` environment variable.",
-					AtLeastOneOf: []string{"auth", "cloud_api_key", "sm_access_token", "oncall_access_token"},
+					Type:        schema.TypeString,
+					Optional:    true,
+					Sensitive:   true,
+					DefaultFunc: schema.EnvDefaultFunc("GRAFANA_AUTH", nil),
+					Description: "API token or basic auth `username:password`. May alternatively be set via the `GRAFANA_AUTH` environment variable.",
 				},
 				"http_headers": {
 					Type:        schema.TypeMap,

--- a/grafana/provider_test.go
+++ b/grafana/provider_test.go
@@ -83,11 +83,6 @@ func TestProviderConfigure(t *testing.T) {
 		check       func(t *testing.T, provider *schema.Provider)
 	}{
 		{
-			name:        "no config",
-			env:         map[string]string{},
-			expectedErr: "\"auth\": one of `auth,cloud_api_key,oncall_access_token,sm_access_token` must\nbe specified",
-		},
-		{
 			name: "grafana config from env",
 			env: map[string]string{
 				"GRAFANA_AUTH": "admin:admin",


### PR DESCRIPTION
A validation check on seems to disallows using dynamic sources for authentication attributes in the provider:

```
data "aws_ssm_parameter" "grafana_key" {
  name = "grafana-cloud-data-key"
}

provider "grafana" {
  alias         = "cloud"
  cloud_api_key = data.aws_ssm_parameter.grafana_key.value
}

data "grafana_cloud_stack" "grafana_stack" {
  provider = grafana.cloud
  slug     = "my_stack"
}

output "grafana_stack" {
  value = {
    alert_manager_url = data.grafana_cloud_stack.grafana_stack.alertmanager_url
    prometheus_url    = data.grafana_cloud_stack.grafana_stack.prometheus_url
    logs_url          = data.grafana_cloud_stack.grafana_stack.logs_url
  }
}
```

I couldn't find an alternative way to implement the validation - suggestions are welcome :)