### PR TITLE
Make the Github comment workflow work on forks

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   info-comment:


### PR DESCRIPTION
It currently fails on forks because we can't give `pull-requests` permissions