### PR TITLE
return error if datasource organization is not found

### DIFF
--- a/grafana/data_source_organization.go
+++ b/grafana/data_source_organization.go
@@ -58,7 +58,7 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, met
 
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "status: 404") {
-			return nil
+			return diag.FromErr(fmt.Errorf("no organization with name %q", name))
 		}
 		return diag.FromErr(err)
 	}

--- a/grafana/data_source_organization.go
+++ b/grafana/data_source_organization.go
@@ -58,7 +58,7 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, met
 
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "status: 404") {
-			return diag.FromErr(fmt.Errorf("no organization with name %q", name))
+			return diag.Errorf("no organization with name %q", name)
 		}
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Hello, 

Currenlty the datasource organization doesn't return an error if organization doesn't exists. This could bring some strange behavior, like the following example

**Example:** 
If the `sre` organization doesn't exists, the folder will be created in **default org_id** without any error.

```
terraform {
  required_providers {
    grafana = {
      source  = "grafana/grafana"
      version = "1.31.1"
    }
  }
}

provider "grafana" {
  url  = "https://grafana.example.com"
  auth = "admin:password"
}

data "grafana_organization" "tenant" {
  name = "sre"
}

provider "grafana" {
  alias  = "tenant"
  url    = "https://grafana.example.com"
  auth   = "admin:password"
  org_id = data.grafana_organization.tenant.id
}

resource "grafana_folder" "test_folder" {
  provider = grafana.tenant
  title    = "Terraform Test Folder"
}
``` 