### PR TITLE
Update CI Grafana versions: Add 9.3.2

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,4 +1,4 @@
-local grafanaVersions = ['9.3.1', '9.2.7', '9.1.8', '8.5.15', '7.5.17'];
+local grafanaVersions = ['9.3.2', '9.2.8', '9.1.8', '8.5.15', '7.5.17'];
 local images = {
   go: 'golang:1.18',
   python: 'python:3.9-alpine',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,4 +1,4 @@
-local grafanaVersions = ['9.2.4', '9.1.8', '8.5.15', '7.5.17'];
+local grafanaVersions = ['9.3.1', '9.2.7', '9.1.8', '8.5.15', '7.5.17'];
 local images = {
   go: 'golang:1.18',
   python: 'python:3.9-alpine',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -165,14 +165,14 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 9.2.4'
+name: 'oss tests: 9.3.1'
 platform:
   arch: amd64
   os: linux
 services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-  image: grafana/grafana:9.2.4
+  image: grafana/grafana:9.3.1
   name: grafana
 steps:
 - commands:
@@ -187,7 +187,44 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 9.2.4
+    GRAFANA_VERSION: 9.3.1
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
+  image: golang:1.18
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+workspace:
+  path: /drone/terraform-provider-grafana
+---
+kind: pipeline
+name: 'oss tests: 9.2.7'
+platform:
+  arch: amd64
+  os: linux
+services:
+- environment:
+    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
+  image: grafana/grafana:9.2.7
+  name: grafana
+steps:
+- commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
+  - sleep 5
+  - make testacc-oss
+  environment:
+    GRAFANA_AUTH: admin:admin
+    GRAFANA_ORG_ID: 1
+    GRAFANA_URL: http://grafana:3000
+    GRAFANA_VERSION: 9.2.7
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
@@ -349,6 +386,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: 0629906c776d28b768ddb481e5e5b5266b8f7d16475b2555044e087fae552adb
+hmac: 661aee3062276ad4087a00fd8c546172b529b978c9d49912858943e205c873f0
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -165,14 +165,14 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 9.3.1'
+name: 'oss tests: 9.3.2'
 platform:
   arch: amd64
   os: linux
 services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-  image: grafana/grafana:9.3.1
+  image: grafana/grafana:9.3.2
   name: grafana
 steps:
 - commands:
@@ -187,7 +187,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 9.3.1
+    GRAFANA_VERSION: 9.3.2
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
@@ -202,14 +202,14 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 9.2.7'
+name: 'oss tests: 9.2.8'
 platform:
   arch: amd64
   os: linux
 services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-  image: grafana/grafana:9.2.7
+  image: grafana/grafana:9.2.8
   name: grafana
 steps:
 - commands:
@@ -224,7 +224,7 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_ORG_ID: 1
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 9.2.7
+    GRAFANA_VERSION: 9.2.8
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.18
   name: tests
@@ -386,6 +386,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: 661aee3062276ad4087a00fd8c546172b529b978c9d49912858943e205c873f0
+hmac: 704130d97109eeb943529e12dd37ac883795b94803967dce71317e57526c5b05
 
 ...

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= 9.0.2
+GRAFANA_VERSION ?= 9.3.1
 
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= 9.3.1
+GRAFANA_VERSION ?= 9.3.2
 
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m

--- a/grafana/resource_playlist.go
+++ b/grafana/resource_playlist.go
@@ -174,7 +174,10 @@ func expandPlaylistItems(items []interface{}) []gapi.PlaylistItem {
 
 func flattenPlaylistItems(items []gapi.PlaylistItem) []interface{} {
 	playlistItems := make([]interface{}, 0)
-	for _, item := range items {
+	for i, item := range items {
+		if item.Order == 0 {
+			item.Order = i + 1
+		}
 		p := map[string]interface{}{
 			"type":  item.Type,
 			"value": item.Value,

--- a/grafana/resource_playlist.go
+++ b/grafana/resource_playlist.go
@@ -99,7 +99,7 @@ func ReadPlaylist(ctx context.Context, d *schema.ResourceData, meta interface{})
 	resp, err := client.Playlist(d.Id())
 
 	// In Grafana 9.0+, if the playlist doesn't exist, the API returns an empty playlist but not a 404
-	if (err != nil && strings.HasPrefix(err.Error(), "status: 404")) || resp.ID == 0 {
+	if (err != nil && strings.HasPrefix(err.Error(), "status: 404")) || (resp.ID == 0 && resp.UID == "") {
 		log.Printf("[WARN] removing playlist %s from state because it no longer exists in grafana", d.Id())
 		d.SetId("")
 		return nil

--- a/grafana/resource_playlist_test.go
+++ b/grafana/resource_playlist_test.go
@@ -187,14 +187,15 @@ resource "grafana_playlist" "test" {
 	interval = %[2]q
 
 	item {
+		order = 2
+		title = "Terraform Dashboard By ID"
+	}
+
+	item {
 		order = 1
 		title = "Terraform Dashboard By Tag"
 	}
 
-	item {
-		order = 2
-		title = "Terraform Dashboard By ID"
-	}
 }
 `, name, interval)
 }


### PR DESCRIPTION
To make it work, I had to fix two issues with the playlist resource:
1. The `id` field is no longer returned by the API, so I had to change the condition that indicates that a playlist no longer exists (id == 0)
2. The `order` field of items in a playlist is no longer returned by the API, it now relies on the order of the list returned by the API

Cloud instance tests are still failing but that's unrelated