### PR TITLE
Clearer `json_data` docs

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -95,14 +95,14 @@ resource "grafana_data_source" "prometheus" {
 
 - `access_mode` (String) The method by which Grafana will access the data source: `proxy` or `direct`. Defaults to `proxy`.
 - `basic_auth_enabled` (Boolean) Whether to enable basic auth for the data source. Defaults to `false`.
-- `basic_auth_password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.basicAuthPassword instead Defaults to ``.
+- `basic_auth_password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.basicAuthPassword instead. Defaults to ``.
 - `basic_auth_username` (String) Basic auth username. Defaults to ``.
 - `database_name` (String) (Required by some data source types) The name of the database to use on the selected data source server. Defaults to ``.
 - `http_headers` (Map of String, Sensitive) Custom HTTP headers
 - `is_default` (Boolean) Whether to set the data source as default. This should only be `true` to a single data source. Defaults to `false`.
 - `json_data` (Block List, Deprecated) Use json_data_encoded instead (see [below for nested schema](#nestedblock--json_data))
 - `json_data_encoded` (String) Serialized JSON string containing the json data. This attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
-- `password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.password instead Defaults to ``.
+- `password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.password instead. Defaults to ``.
 - `secure_json_data` (Block List, Deprecated) Use secure_json_data_encoded instead (see [below for nested schema](#nestedblock--secure_json_data))
 - `secure_json_data_encoded` (String, Sensitive) Serialized JSON string containing the secure json data. This attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
 - `uid` (String) Unique identifier. If unset, this will be automatically generated.

--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -95,16 +95,16 @@ resource "grafana_data_source" "prometheus" {
 
 - `access_mode` (String) The method by which Grafana will access the data source: `proxy` or `direct`. Defaults to `proxy`.
 - `basic_auth_enabled` (Boolean) Whether to enable basic auth for the data source. Defaults to `false`.
-- `basic_auth_password` (String, Sensitive, Deprecated) Basic auth password. Deprecated:Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. This attribute is removed in Grafana 9.0+. Defaults to ``.
+- `basic_auth_password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.basicAuthPassword instead Defaults to ``.
 - `basic_auth_username` (String) Basic auth username. Defaults to ``.
 - `database_name` (String) (Required by some data source types) The name of the database to use on the selected data source server. Defaults to ``.
 - `http_headers` (Map of String, Sensitive) Custom HTTP headers
 - `is_default` (Boolean) Whether to set the data source as default. This should only be `true` to a single data source. Defaults to `false`.
-- `json_data` (Block List, Deprecated) (Required by some data source types). Deprecated: Use json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. (see [below for nested schema](#nestedblock--json_data))
-- `json_data_encoded` (String) Serialized JSON string containing the json data. Replaces the json_data attribute, this attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI.
-- `password` (String, Sensitive, Deprecated) (Required by some data source types) The password to use to authenticate to the data source. Deprecated: Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. This attribute is removed in Grafana 9.0+. Defaults to ``.
-- `secure_json_data` (Block List, Deprecated) Deprecated: Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. (see [below for nested schema](#nestedblock--secure_json_data))
-- `secure_json_data_encoded` (String, Sensitive) Serialized JSON string containing the secure json data. Replaces the secure_json_data attribute, this attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI.
+- `json_data` (Block List, Deprecated) Use json_data_encoded instead (see [below for nested schema](#nestedblock--json_data))
+- `json_data_encoded` (String) Serialized JSON string containing the json data. This attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
+- `password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.password instead Defaults to ``.
+- `secure_json_data` (Block List, Deprecated) Use secure_json_data_encoded instead (see [below for nested schema](#nestedblock--secure_json_data))
+- `secure_json_data_encoded` (String, Sensitive) Serialized JSON string containing the secure json data. This attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
 - `uid` (String) Unique identifier. If unset, this will be automatically generated.
 - `url` (String) The URL for the data source. The type of URL required varies depending on the chosen data source type.
 - `username` (String) (Required by some data source types) The username to use to authenticate to the data source. Defaults to ``.

--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -100,10 +100,10 @@ resource "grafana_data_source" "prometheus" {
 - `database_name` (String) (Required by some data source types) The name of the database to use on the selected data source server. Defaults to ``.
 - `http_headers` (Map of String, Sensitive) Custom HTTP headers
 - `is_default` (Boolean) Whether to set the data source as default. This should only be `true` to a single data source. Defaults to `false`.
-- `json_data` (Block List, Deprecated) Use json_data_encoded instead (see [below for nested schema](#nestedblock--json_data))
+- `json_data` (Block List, Deprecated) Use json_data_encoded instead. (see [below for nested schema](#nestedblock--json_data))
 - `json_data_encoded` (String) Serialized JSON string containing the json data. This attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
 - `password` (String, Sensitive, Deprecated) Use secure_json_data_encoded.password instead. Defaults to ``.
-- `secure_json_data` (Block List, Deprecated) Use secure_json_data_encoded instead (see [below for nested schema](#nestedblock--secure_json_data))
+- `secure_json_data` (Block List, Deprecated) Use secure_json_data_encoded instead. (see [below for nested schema](#nestedblock--secure_json_data))
 - `secure_json_data_encoded` (String, Sensitive) Serialized JSON string containing the secure json data. This attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
 - `uid` (String) Unique identifier. If unset, this will be automatically generated.
 - `url` (String) The URL for the data source. The type of URL required varies depending on the chosen data source type.

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -74,8 +74,8 @@ source selected (via the 'type' argument).
 				Optional:    true,
 				Default:     "",
 				Sensitive:   true,
-				Description: "Basic auth password. Deprecated:Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. This attribute is removed in Grafana 9.0+.",
-				Deprecated:  "Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. This attribute is removed in Grafana 9.0+.",
+				Description: "Use secure_json_data_encoded.basicAuthPassword instead",
+				Deprecated:  "Use secure_json_data_encoded.basicAuthPassword instead",
 			},
 			"basic_auth_username": {
 				Type:        schema.TypeString,
@@ -114,8 +114,8 @@ source selected (via the 'type' argument).
 			"json_data": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "(Required by some data source types). Deprecated: Use json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes.",
-				Deprecated:  "Use json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes.",
+				Description: "Use json_data_encoded instead",
+				Deprecated:  "Use json_data_encoded instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"alertmanager_uid": {
@@ -459,15 +459,15 @@ source selected (via the 'type' argument).
 				Optional:    true,
 				Default:     "",
 				Sensitive:   true,
-				Description: "(Required by some data source types) The password to use to authenticate to the data source. Deprecated: Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. This attribute is removed in Grafana 9.0+.",
-				Deprecated:  "Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes. This attribute is removed in Grafana 9.0+.",
+				Description: "Use secure_json_data_encoded.password instead",
+				Deprecated:  "Use secure_json_data_encoded.password instead",
 			},
 			"secure_json_data": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Deprecated: Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes.",
-				Deprecated:  "Use secure_json_data_encoded instead. It supports arbitrary JSON data, and therefore all attributes.",
+				Description: "Use secure_json_data_encoded instead",
+				Deprecated:  "Use secure_json_data_encoded instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"access_key": {
@@ -571,7 +571,7 @@ source selected (via the 'type' argument).
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"json_data", "secure_json_data"},
-				Description:   "Serialized JSON string containing the json data. Replaces the json_data attribute, this attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI.",
+				Description:   "Serialized JSON string containing the json data. This attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.",
 				ValidateFunc:  validation.StringIsJSON,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
@@ -584,7 +584,7 @@ source selected (via the 'type' argument).
 				Optional:      true,
 				Sensitive:     true,
 				ConflictsWith: []string{"json_data", "secure_json_data"},
-				Description:   "Serialized JSON string containing the secure json data. Replaces the secure_json_data attribute, this attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI.",
+				Description:   "Serialized JSON string containing the secure json data. This attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.",
 				ValidateFunc:  validation.StringIsJSON,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
@@ -681,9 +681,8 @@ func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 	d.Set("http_headers", currentHeaders)
 
-	// TODO: these fields should be migrated to SecureJSONData.
 	d.Set("basic_auth_enabled", dataSource.BasicAuth)
-	d.Set("basic_auth_username", dataSource.BasicAuthUser) //nolint:staticcheck // deprecated
+	d.Set("basic_auth_username", dataSource.BasicAuthUser)
 
 	return nil
 }

--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -74,8 +74,8 @@ source selected (via the 'type' argument).
 				Optional:    true,
 				Default:     "",
 				Sensitive:   true,
-				Description: "Use secure_json_data_encoded.basicAuthPassword instead",
-				Deprecated:  "Use secure_json_data_encoded.basicAuthPassword instead",
+				Description: "Use secure_json_data_encoded.basicAuthPassword instead.",
+				Deprecated:  "Use secure_json_data_encoded.basicAuthPassword instead.",
 			},
 			"basic_auth_username": {
 				Type:        schema.TypeString,
@@ -114,8 +114,8 @@ source selected (via the 'type' argument).
 			"json_data": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Use json_data_encoded instead",
-				Deprecated:  "Use json_data_encoded instead",
+				Description: "Use json_data_encoded instead.",
+				Deprecated:  "Use json_data_encoded instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"alertmanager_uid": {
@@ -459,15 +459,15 @@ source selected (via the 'type' argument).
 				Optional:    true,
 				Default:     "",
 				Sensitive:   true,
-				Description: "Use secure_json_data_encoded.password instead",
-				Deprecated:  "Use secure_json_data_encoded.password instead",
+				Description: "Use secure_json_data_encoded.password instead.",
+				Deprecated:  "Use secure_json_data_encoded.password instead.",
 			},
 			"secure_json_data": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Use secure_json_data_encoded instead",
-				Deprecated:  "Use secure_json_data_encoded instead",
+				Description: "Use secure_json_data_encoded instead.",
+				Deprecated:  "Use secure_json_data_encoded instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"access_key": {


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/742 
Strips `json_data` and `secure_json_data` of their description, except the deprecation notice 
Add a note that `json_data_encoded` attributes are usually camelCase