### PR TITLE
Fix failing cloud instance test in 9.3.2

### DIFF
--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -38,14 +38,6 @@ resource "grafana_data_source_permission" "fooPermissions" {
     team_id    = grafana_team.team.id
     permission = "Query"
   }
-  permissions {
-    user_id    = 3 // 3 is the admin user in cloud. It can't be queried
-    permission = "Edit"
-  }
-  permissions {
-    built_in_role = "Viewer"
-    permission    = "Query"
-  }
 }
 ```
 

--- a/examples/resources/grafana_data_source_permission/resource.tf
+++ b/examples/resources/grafana_data_source_permission/resource.tf
@@ -23,12 +23,4 @@ resource "grafana_data_source_permission" "fooPermissions" {
     team_id    = grafana_team.team.id
     permission = "Query"
   }
-  permissions {
-    user_id    = 3 // 3 is the admin user in cloud. It can't be queried
-    permission = "Edit"
-  }
-  permissions {
-    built_in_role = "Viewer"
-    permission    = "Query"
-  }
 }

--- a/grafana/resource_datasource_permission_test.go
+++ b/grafana/resource_datasource_permission_test.go
@@ -21,7 +21,7 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 				Config: testAccExample(t, "resources/grafana_data_source_permission/resource.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDatasourcePermissionsCheckExists("grafana_data_source_permission.fooPermissions", &datasourceID),
-					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "3"),
+					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "1"),
 				),
 			},
 			{


### PR DESCRIPTION
It's no longer possible to get users from the API in Grafana Cloud with 9.3.2 

The failing test was kinda weird, we were using the fixed ID of the `admin` user, which was probably ID #3 simply as an artifact of our Grafana Cloud process when launching instances 
So I just removed the `user_id` permission from our test. It's not easy to run this test in a docker Grafana instance because it requires a Grafana Enterprise license