### PR TITLE
Disable failing Cloud Instance test

### DIFF
--- a/grafana/resource_datasource_permission_test.go
+++ b/grafana/resource_datasource_permission_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccDatasourcePermission_basic(t *testing.T) {
+	t.Skip("This test is failing in Grafana Cloud 9.3+")
 	CheckCloudInstanceTestsEnabled(t)
 
 	datasourceID := int64(-1)


### PR DESCRIPTION
Couldn't figure out what's going on. Opened an issue here: https://github.com/grafana/terraform-provider-grafana/issues/755 to track it