### PR TITLE
Datasource: Set datasource UID to force recreation

### DIFF
--- a/grafana/resource_data_source.go
+++ b/grafana/resource_data_source.go
@@ -108,6 +108,7 @@ source selected (via the 'type' argument).
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: "Unique identifier. If unset, this will be automatically generated.",
 			},
 

--- a/grafana/resource_data_source_test.go
+++ b/grafana/resource_data_source_test.go
@@ -855,6 +855,45 @@ func TestDatasourceMigrationV0(t *testing.T) {
 	}
 }
 
+func TestAccDataSource_changeUID(t *testing.T) {
+	CheckOSSTestsEnabled(t)
+
+	var dataSource gapi.DataSource
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+	resource "grafana_data_source" "test" {
+		name = "test-change-uid"
+		type = "prometheus"
+		url  = "http://localhost:9090"
+		uid  = "initial-uid"
+	}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceCheckExists("grafana_data_source.test", &dataSource),
+					resource.TestCheckResourceAttr("grafana_data_source.test", "uid", "initial-uid"),
+				),
+			},
+			{
+				Config: `
+	resource "grafana_data_source" "test" {
+		name = "test-change-uid"
+		type = "prometheus"
+		url  = "http://localhost:9090"
+		uid  = "changed-uid"
+	}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceCheckExists("grafana_data_source.test", &dataSource),
+					resource.TestCheckResourceAttr("grafana_data_source.test", "uid", "changed-uid"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceCheckExists(rn string, dataSource *gapi.DataSource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]


### PR DESCRIPTION
As reported here: https://github.com/grafana/terraform-provider-grafana/pull/315#issuecomment-1360047242 
I think the safest thing to do is to force recreation. 
Changing the UID of a datasource is not something that should be done often in any case