### PR TITLE
Document how to run a single cloud test

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -11,3 +11,7 @@ jobs:
         with:
           message: |
             In order to lower resource usage and have a faster runtime, PRs will not run Cloud tests automatically. To do so, a Grafana Labs employee must promote the Drone build.
+            
+            _For maintainers_, it's better to run only the Cloud tests you need, rather than all of them. You can do so by setting the following parameter when promoting:
+            
+            `TESTARGS='-run=<testname>'`


### PR DESCRIPTION
Cloud tests are run on Drone promotions. 
We can pass env variables in those 
Using that, we can run targeted tests, which is nice because our test base creates lots of stacks which can cause issues