### PR TITLE
Fix setting either a home dashboard ID or UID for org prefs

### DIFF
--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -23,7 +23,7 @@ data "grafana_organization_preferences" "test" {}
 ### Read-Only
 
 - `home_dashboard_id` (Number) The Organization home dashboard ID.
-- `home_dashboard_uid` (String) The Organization home dashboard UID.
+- `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `id` (String) The ID of this resource.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `theme` (String) The Organization theme. Available values are `light`, `dark`, or an empty string for the default.

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -27,7 +27,7 @@ resource "grafana_organization_preferences" "test" {
 ### Optional
 
 - `home_dashboard_id` (Number) The Organization home dashboard ID.
-- `home_dashboard_uid` (String) The Organization home dashboard UID.
+- `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `theme` (String) The Organization theme. Available values are `light`, `dark`, or an empty string for the default.
 - `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.

--- a/grafana/resource_organization_preferences.go
+++ b/grafana/resource_organization_preferences.go
@@ -40,14 +40,24 @@ func ResourceOrganizationPreferences() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"light", "dark", ""}, false),
 			},
 			"home_dashboard_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The Organization home dashboard ID.",
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Description:   "The Organization home dashboard ID.",
+				ConflictsWith: []string{"home_dashboard_uid"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, uidSet := d.GetOk("home_dashboard_uid")
+					return uidSet
+				},
 			},
 			"home_dashboard_uid": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The Organization home dashboard UID.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "The Organization home dashboard UID.",
+				ConflictsWith: []string{"home_dashboard_id"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, idSet := d.GetOk("home_dashboard_id")
+					return idSet
+				},
 			},
 			"timezone": {
 				Type:         schema.TypeString,

--- a/grafana/resource_organization_preferences.go
+++ b/grafana/resource_organization_preferences.go
@@ -52,7 +52,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 			"home_dashboard_uid": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Description:   "The Organization home dashboard UID.",
+				Description:   "The Organization home dashboard UID. This is only available in Grafana 9.0+.",
 				ConflictsWith: []string{"home_dashboard_id"},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					_, idSet := d.GetOk("home_dashboard_id")

--- a/grafana/resource_organization_preferences_test.go
+++ b/grafana/resource_organization_preferences_test.go
@@ -21,7 +21,7 @@ func TestAccResourceOrganizationPreferences_WithDashboardID(t *testing.T) {
 
 func TestAccResourceOrganizationPreferences_WithDashboardUID(t *testing.T) {
 	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	CheckOSSTestsSemver(t, ">=9.0.0") // UID support was added in 9.0.0
 	testAccResourceOrganizationPreferences(t, true)
 }
 
@@ -46,6 +46,12 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 
 	testRandName := acctest.RandString(10)
 
+	// In versions < 9.0.0, the home dashboard UID is not returned by the API
+	dashboardCheck := resource.TestMatchResourceAttr("grafana_organization_preferences.test", "home_dashboard_id", idRegexp)
+	if withUID {
+		dashboardCheck = resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName)
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccOrganizationPreferencesCheckDestroy(),
@@ -56,10 +62,9 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 					testAccOrganizationPreferencesCheckExists("grafana_organization_preferences.test", prefs),
 					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "id", idRegexp),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", prefs.Theme),
-					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "home_dashboard_id", idRegexp),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", prefs.Timezone),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", prefs.WeekStart),
+					dashboardCheck,
 				),
 			},
 			{
@@ -68,10 +73,9 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 					testAccOrganizationPreferencesCheckExists("grafana_organization_preferences.test", updatedPrefs),
 					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "id", idRegexp),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", updatedPrefs.Theme),
-					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "home_dashboard_id", idRegexp),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", updatedPrefs.Timezone),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", updatedPrefs.WeekStart),
+					dashboardCheck,
 				),
 			},
 			{
@@ -80,10 +84,9 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 					testAccOrganizationPreferencesCheckExists("grafana_organization_preferences.test", finalPrefs),
 					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "id", idRegexp),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", finalPrefs.Theme),
-					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "home_dashboard_id", idRegexp),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", finalPrefs.Timezone),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", finalPrefs.WeekStart),
+					dashboardCheck,
 				),
 			},
 		},


### PR DESCRIPTION
The tests didn't check that either the ID or UID attributes worked, so I added two tests for those. Moreover, the UID attribute only works with Grafana 9+, so I added a note

* Closes https://github.com/grafana/terraform-provider-grafana/issues/768 