### PR TITLE
Add `org_id` to folders

### DIFF
--- a/docs/data-sources/dashboards.md
+++ b/docs/data-sources/dashboards.md
@@ -85,8 +85,9 @@ data "grafana_dashboards" "limit_one" {
 
 ### Optional
 
-- `folder_ids` (List of Number) Numerical IDs of Grafana folders containing dashboards. Specify to filter for dashboards by folder (eg. `[0]` for General folder), or leave blank to get all dashboards in all folders.
+- `folder_ids` (List of String) Folders containing dashboards. Specify to filter for dashboards by folder (eg. `[0]` for General folder), or leave blank to get all dashboards in all folders.
 - `limit` (Number) Maximum number of dashboard search results to return. Defaults to `5000`.
+- `org_id` (Number) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `tags` (List of String) List of string Grafana dashboard tags to search for, eg. `["prod"]`. Used only as search input, i.e., attribute value will remain unchanged.
 
 ### Read-Only

--- a/docs/data-sources/library_panel.md
+++ b/docs/data-sources/library_panel.md
@@ -96,7 +96,7 @@ data "grafana_dashboard" "from_library_panel_connection" {
 - `created` (String) Timestamp when the library panel was created.
 - `dashboard_ids` (List of Number) Numerical IDs of Grafana dashboards containing the library panel.
 - `description` (String) Description of the library panel.
-- `folder_id` (Number) ID of the folder where the library panel is stored.
+- `folder_id` (String) ID of the folder where the library panel is stored.
 - `folder_name` (String) Name of the folder containing the library panel.
 - `folder_uid` (String) Unique ID (UID) of the folder containing the library panel.
 - `id` (String) The ID of this resource.

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -43,11 +43,12 @@ resource "grafana_folder" "test_folder_with_uid" {
 
 ### Optional
 
+- `org_id` (Number) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `uid` (String) Unique identifier.
 
 ### Read-Only
 
-- `id` (String) Unique internal identifier.
+- `id` (String) The ID of this resource.
 - `url` (String) The full URL of the folder.
 
 ## Import
@@ -55,6 +56,6 @@ resource "grafana_folder" "test_folder_with_uid" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_folder.by_integer_id {{folder_id}}
-terraform import grafana_folder.by_uid {{folder_uid}}
+terraform import grafana_folder.by_integer_id {{org_id}}:{{folder_id}}
+terraform import grafana_folder.by_uid {{org_id}}:{{folder_uid}}
 ```

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -37,7 +37,7 @@ resource "grafana_library_panel" "test" {
 
 ### Optional
 
-- `folder_id` (Number) ID of the folder where the library panel is stored.
+- `folder_id` (String) ID of the folder where the library panel is stored.
 - `uid` (String) The unique identifier (UID) of a library panel uniquely identifies library panels between multiple Grafana installs. It’s automatically generated unless you specify it during library panel creation.The UID provides consistent URLs for accessing library panels and when syncing library panels between multiple Grafana installs.
 
 ### Read-Only

--- a/examples/resources/grafana_folder/import.sh
+++ b/examples/resources/grafana_folder/import.sh
@@ -1,2 +1,2 @@
-terraform import grafana_folder.by_integer_id {{folder_id}}
-terraform import grafana_folder.by_uid {{folder_uid}}
+terraform import grafana_folder.by_integer_id {{org_id}}:{{folder_id}}
+terraform import grafana_folder.by_uid {{org_id}}:{{folder_uid}}

--- a/grafana/provider.go
+++ b/grafana/provider.go
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	ossOrgIDRegexp       = regexp.MustCompile(`^(\d:)?[a-zA-Z0-9-_]+$`)
 	idRegexp             = regexp.MustCompile(`^\d+$`)
 	uidRegexp            = regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
 	emailRegexp          = regexp.MustCompile(`.+\@.+\..+`)


### PR DESCRIPTION
** DO NOT REVIEW YET **

Issue: https://github.com/grafana/terraform-provider-grafana/issues/747

This will allow such a config:

```terraform
resource "grafana_organization" "test" {
	name = "test"
}

resource "grafana_folder" "test" {
	org_id = grafana_organization.test.id
	title  = "folder-test"
}

resource "grafana_dashboard" "test" {
	org_id      = grafana_organization.test.id
	folder      = grafana_folder.test.id
	config_json = jsonencode({
	  title = "dashboard-test"
	})
}
```

Due to the change in the ID format, I also had to modify library panels and dashboards