### PR TITLE
Fix "create folder from editor key" test

### DIFF
--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -118,6 +118,7 @@ func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 			var folder gapi.Folder
 			var name = acctest.RandomWithPrefix(tc.role + "-key")
 
+			// Create an API key with the correct role and inject it in envvars. This auth will be used when the test runs
 			client := testAccProvider.Meta().(*client).gapi
 			key, err := client.CreateAPIKey(gapi.CreateAPIKeyRequest{
 				Name: name,

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -158,7 +158,6 @@ func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 			})
 		})
 	}
-
 }
 
 func testAccFolderIDDidntChange(rn string, folder *gapi.Folder) resource.TestCheckFunc {

--- a/grafana/resource_folder_test.go
+++ b/grafana/resource_folder_test.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -95,33 +96,68 @@ func TestAccFolder_basic(t *testing.T) {
 	})
 }
 
-// This is a bug in Grafana, not the provider. It was fixed in 9.3.0, this test will check for regressions
-func TestAccFolder_createFromEditor(t *testing.T) {
-	t.Skip("This test is flaky, skipping for now. See https://github.com/grafana/terraform-provider-grafana/issues/773")
-
+// This is a bug in Grafana, not the provider. It was fixed in 9.2.7+ and 9.3.0+, this test will check for regressions
+func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.3.0")
+	CheckOSSTestsSemver(t, ">=9.2.7")
 
-	var folder gapi.Folder
-	var name = acctest.RandomWithPrefix("editor-key")
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccFolderCheckDestroy(&folder),
-		),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFolderFromEditorKey(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccFolderCheckExists("grafana_folder.bar", &folder),
-					resource.TestMatchResourceAttr("grafana_folder.bar", "id", idRegexp),
-					resource.TestMatchResourceAttr("grafana_folder.bar", "uid", uidRegexp),
-					resource.TestCheckResourceAttr("grafana_folder.bar", "title", name),
-				),
-			},
+	for _, tc := range []struct {
+		role        string
+		expectError *regexp.Regexp
+	}{
+		{
+			role:        "Viewer",
+			expectError: regexp.MustCompile(".*Access denied.*"),
 		},
-	})
+		{
+			role:        "Editor",
+			expectError: nil,
+		},
+	} {
+		t.Run(tc.role, func(t *testing.T) {
+			var folder gapi.Folder
+			var name = acctest.RandomWithPrefix(tc.role + "-key")
+
+			client := testAccProvider.Meta().(*client).gapi
+			key, err := client.CreateAPIKey(gapi.CreateAPIKeyRequest{
+				Name: name,
+				Role: tc.role,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.DeleteAPIKey(key.ID)
+			oldValue := os.Getenv("GRAFANA_AUTH")
+			defer os.Setenv("GRAFANA_AUTH", oldValue)
+			os.Setenv("GRAFANA_AUTH", key.Key)
+
+			config := fmt.Sprintf(`
+		resource "grafana_folder" "bar" {
+			title    = "%[1]s"
+		}`, name)
+
+			// Do not make parallel, fiddling with auth will break other tests that run in parallel
+			resource.Test(t, resource.TestCase{
+				ProviderFactories: testAccProviderFactories,
+				CheckDestroy: resource.ComposeTestCheckFunc(
+					testAccFolderCheckDestroy(&folder),
+				),
+				Steps: []resource.TestStep{
+					{
+						Config:      config,
+						ExpectError: tc.expectError,
+						Check: resource.ComposeTestCheckFunc(
+							testAccFolderCheckExists("grafana_folder.bar", &folder),
+							resource.TestMatchResourceAttr("grafana_folder.bar", "id", idRegexp),
+							resource.TestMatchResourceAttr("grafana_folder.bar", "uid", uidRegexp),
+							resource.TestCheckResourceAttr("grafana_folder.bar", "title", name),
+						),
+					},
+				},
+			})
+		})
+	}
+
 }
 
 func testAccFolderIDDidntChange(rn string, folder *gapi.Folder) resource.TestCheckFunc {
@@ -178,24 +214,4 @@ func testAccFolderCheckDestroy(folder *gapi.Folder) resource.TestCheckFunc {
 		}
 		return nil
 	}
-}
-
-// nolint: unused
-func testAccFolderFromEditorKey(name string) string {
-	return fmt.Sprintf(` 
-resource "grafana_api_key" "foo" {
-	name = "%[1]s"
-	role = "Editor"
-}
-  
-provider "grafana" {
-	alias = "api_key"
-	auth  = grafana_api_key.foo.key
-}
-
-resource "grafana_folder" "bar" {
-	provider = grafana.api_key
-	title    = "%[1]s"
-}
-`, name)
 }


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/773
The issue was that you can't create a new `provider` instance from tests. You need to use the factories functions in the test framework
The tests were failing in a random fashion because it seems like the test framework was sometimes using one provider to delete the api key, sometimes using the other

To fix the test, I instead create an API key and inject it in envvars at the test level (not in the Terraform config)
I also added a test for Viewers, it's a sanity check to make sure the auth is inject correctly. Using a Viewer api key causes an error