### PR TITLE
Add `org_id` to dashboards

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -33,6 +33,7 @@ resource "grafana_dashboard" "metrics" {
 
 - `folder` (String) The id of the folder to save the dashboard in. This attribute is a string to reflect the type of the folder's id.
 - `message` (String) Set a commit message for the version history.
+- `org_id` (Number) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `overwrite` (Boolean) Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.
 
 ### Read-Only
@@ -49,5 +50,6 @@ resource "grafana_dashboard" "metrics" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_dashboard.dashboard_name {{dashboard_uid}}
+terraform import grafana_dashboard.dashboard_name {{dashboard_uid}} # To use the default provider org
+terraform import grafana_dashboard.dashboard_name {{org_id}}:{{dashboard_uid}} # When "org_id" is set on the resource
 ```

--- a/examples/resources/grafana_dashboard/import.sh
+++ b/examples/resources/grafana_dashboard/import.sh
@@ -1,1 +1,2 @@
-terraform import grafana_dashboard.dashboard_name {{dashboard_uid}}
+terraform import grafana_dashboard.dashboard_name {{dashboard_uid}} # To use the default provider org
+terraform import grafana_dashboard.dashboard_name {{org_id}}:{{dashboard_uid}} # When "org_id" is set on the resource

--- a/grafana/data_source_dashboard_test.go
+++ b/grafana/data_source_dashboard_test.go
@@ -41,7 +41,7 @@ func TestAccDatasourceDashboardBasicID(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard),
+		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, 0),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccExample(t, "data-sources/grafana_dashboard/data-source.tf"),

--- a/grafana/oss_org_id.go
+++ b/grafana/oss_org_id.go
@@ -1,0 +1,43 @@
+package grafana
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func makeOSSOrgID(orgID int64, resourceID interface{}) string {
+	return fmt.Sprintf("%d:%s", orgID, fmt.Sprint(resourceID))
+}
+
+func splitOSSOrgID(id string) (int64, string) {
+	if strings.ContainsRune(id, ':') {
+		parts := strings.SplitN(id, ":", 2)
+		orgID, _ := strconv.ParseInt(parts[0], 10, 64)
+		return orgID, parts[1]
+	}
+
+	return 0, id
+}
+
+// nolint: unparam
+func clientFromOSSOrgID(meta interface{}, id string) (*gapi.Client, int64, string) {
+	orgID, restOfID := splitOSSOrgID(id)
+	client := meta.(*client).gapi
+	if orgID > 0 {
+		client = client.WithOrgID(orgID)
+	}
+	return client, orgID, restOfID
+}
+
+func clientFromOrgIDAttr(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
+	orgID := int64(d.Get("org_id").(int))
+	client := meta.(*client).gapi
+	if orgID > 0 {
+		client = client.WithOrgID(orgID)
+	}
+	return client, orgID
+}

--- a/grafana/resource_organization_preferences.go
+++ b/grafana/resource_organization_preferences.go
@@ -31,6 +31,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				ForceNew:    true,
 			},
 			"theme": {
 				Type:         schema.TypeString,
@@ -65,11 +66,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 }
 
 func CreateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*client).gapi
-	id := d.Get("org_id").(int)
-	if id > 0 {
-		client = client.WithOrgID(int64(id))
-	}
+	client, orgID := clientFromOrgIDAttr(meta, d)
 
 	_, err := client.UpdateAllOrgPreferences(gapi.Preferences{
 		Theme:            d.Get("theme").(string),
@@ -82,7 +79,7 @@ func CreateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	d.SetId(strconv.Itoa(id))
+	d.SetId(strconv.FormatInt(orgID, 10))
 
 	return ReadOrganizationPreferences(ctx, d, meta)
 }


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/747 Follow-up to https://github.com/grafana/terraform-provider-grafana/pull/776

This will allow such a config:

```terraform
resource "grafana_organization" "test" {
	name = "test"
}

resource "grafana_dashboard" "test" {
	org_id      = grafana_organization.test.id
	config_json = jsonencode({
	  title = "dashboard-test"
	})
}
```

The main change here is that the ID of resources becomes: `<org id>:<resource id>`. This can be changed transparently because if the first block isn't there, it means the currently configured org

Also added some helpers for org IDs, as these will be used in every resource soon