### PR TITLE
Cloud: Stop validating region slugs

### DIFF
--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -51,7 +51,7 @@ resource "grafana_cloud_access_policy_token" "test" {
 
 - `name` (String) Name of the access policy.
 - `realm` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--realm))
-- `region` (String) Region where the API is deployed. Region where the API is deployed. Generally where the stack is deployed. Valid values are 'us', 'eu', and 'au'.
+- `region` (String) Region where the API is deployed. Generally where the stack is deployed. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/reference/cloud-api/#list-regions.
 - `scopes` (Set of String) Scopes of the access policy. See https://grafana.com/docs/grafana-cloud/authentication-and-permissions/access-policies/#scopes for possible values.
 
 ### Optional

--- a/docs/resources/cloud_access_policy_token.md
+++ b/docs/resources/cloud_access_policy_token.md
@@ -51,7 +51,7 @@ resource "grafana_cloud_access_policy_token" "test" {
 
 - `access_policy_id` (String) ID of the access policy for which to create a token.
 - `name` (String) Name of the access policy token.
-- `region` (String) Region of the access policy. Should be set to the same region as the access policy.
+- `region` (String) Region of the access policy. Should be set to the same region as the access policy. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/reference/cloud-api/#list-regions.
 
 ### Optional
 

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -33,9 +33,7 @@ available at “https://<stack_slug>.grafana.net".
 ### Optional
 
 - `description` (String) Description of stack.
-- `region_slug` (String) Region slug to assign to this stack.
-Changing region will destroy the existing stack and create a new one in the desired region.
-Available input au (GCP Australia), eu (GCP Belgium), us (GCP US Central), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
+- `region_slug` (String) Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/reference/cloud-api/#list-regions.
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
 - `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.

--- a/grafana/resource_cloud_access_policy.go
+++ b/grafana/resource_cloud_access_policy.go
@@ -33,11 +33,10 @@ func ResourceCloudAccessPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Description:  "Region where the API is deployed. Region where the API is deployed. Generally where the stack is deployed. Valid values are 'us', 'eu', and 'au'.",
-				ValidateFunc: validation.StringInSlice([]string{"us", "eu", "au"}, false),
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Region where the API is deployed. Generally where the stack is deployed. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/reference/cloud-api/#list-regions.",
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/grafana/resource_cloud_access_policy_token.go
+++ b/grafana/resource_cloud_access_policy_token.go
@@ -41,7 +41,7 @@ func ResourceCloudAccessPolicyToken() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Region of the access policy. Should be set to the same region as the access policy.",
+				Description: "Region of the access policy. Should be set to the same region as the access policy. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/reference/cloud-api/#list-regions.",
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -65,13 +65,10 @@ available at “https://<stack_slug>.grafana.net".`,
 				ValidateFunc: validation.StringMatch(stackSlugRegex, "must be a lowercase alphanumeric string and must start with a letter."),
 			},
 			"region_slug": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Description: `Region slug to assign to this stack.
-Changing region will destroy the existing stack and create a new one in the desired region.
-Available input au (GCP Australia), eu (GCP Belgium), us (GCP US Central), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)`,
-				ValidateFunc: validation.StringInSlice([]string{"au", "eu", "us", "prod-ap-southeast-0", "prod-gb-south-0", "prod-ap-south-0", "prod-sa-east-0"}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/reference/cloud-api/#list-regions.`,
 			},
 			"url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
We're getting more and more regions in Cloud and it's hard to keep track of them 
This removes the Terraform-side validation on those region slugs