### PR TITLE
Update list of stack regions and avoid duplication

### DIFF
--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -51,7 +51,7 @@ resource "grafana_cloud_access_policy_token" "test" {
 
 - `name` (String) Name of the access policy.
 - `realm` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--realm))
-- `region` (String) Region where the API is deployed. Region where the API is deployed. Generally where the stack is deployed. Valid values are 'us', 'eu', and 'au'.
+- `region` (String) Region where the API is deployed. Generally where the stack is deployed. Available options: prod-sa-east-0 (GCP Brazil), us (GCP US Central), us-azure (Azure US Central), eu (GCP Belgium), au (GCP Australia), prod-ap-south-0 (GCP India), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-eu-west-3 (Azure Netherlands)
 - `scopes` (Set of String) Scopes of the access policy. See https://grafana.com/docs/grafana-cloud/authentication-and-permissions/access-policies/#scopes for possible values.
 
 ### Optional

--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -51,7 +51,7 @@ resource "grafana_cloud_access_policy_token" "test" {
 
 - `name` (String) Name of the access policy.
 - `realm` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--realm))
-- `region` (String) Region where the API is deployed. Generally where the stack is deployed. Available options: prod-sa-east-0 (GCP Brazil), us (GCP US Central), us-azure (Azure US Central), eu (GCP Belgium), au (GCP Australia), prod-ap-south-0 (GCP India), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-eu-west-3 (Azure Netherlands)
+- `region` (String) Region where the API is deployed. Generally where the stack is deployed. Available options: us (GCP US Central), us-azure (Azure US Central), eu (GCP Belgium), au (GCP Australia), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-eu-west-3 (Azure Netherlands), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
 - `scopes` (Set of String) Scopes of the access policy. See https://grafana.com/docs/grafana-cloud/authentication-and-permissions/access-policies/#scopes for possible values.
 
 ### Optional

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -35,7 +35,7 @@ available at “https://<stack_slug>.grafana.net".
 - `description` (String) Description of stack.
 - `region_slug` (String) Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region.
-Available options: prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-eu-west-3 (Azure Netherlands), us (GCP US Central), us-azure (Azure US Central), eu (GCP Belgium), au (GCP Australia), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
+Available options: us (GCP US Central), us-azure (Azure US Central), eu (GCP Belgium), au (GCP Australia), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-eu-west-3 (Azure Netherlands), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
 - `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -35,7 +35,7 @@ available at “https://<stack_slug>.grafana.net".
 - `description` (String) Description of stack.
 - `region_slug` (String) Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region.
-Available input au (GCP Australia), eu (GCP Belgium), us (GCP US Central), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
+Available options: prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-eu-west-3 (Azure Netherlands), us (GCP US Central), us-azure (Azure US Central), eu (GCP Belgium), au (GCP Australia), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
 - `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.

--- a/grafana/resource_cloud_access_policy.go
+++ b/grafana/resource_cloud_access_policy.go
@@ -36,8 +36,8 @@ func ResourceCloudAccessPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				Description:  "Region where the API is deployed. Region where the API is deployed. Generally where the stack is deployed. Valid values are 'us', 'eu', and 'au'.",
-				ValidateFunc: validation.StringInSlice([]string{"us", "eu", "au"}, false),
+				Description:  "Region where the API is deployed. Generally where the stack is deployed. Available options: " + stackRegions.DescriptionOptions(),
+				ValidateFunc: validation.StringInSlice(stackRegions.Slugs(), false),
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/grafana/resource_cloud_access_policy.go
+++ b/grafana/resource_cloud_access_policy.go
@@ -36,8 +36,8 @@ func ResourceCloudAccessPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				Description:  "Region where the API is deployed. Generally where the stack is deployed. Available options: " + stackRegions.DescriptionOptions(),
-				ValidateFunc: validation.StringInSlice(stackRegions.Slugs(), false),
+				Description:  "Region where the API is deployed. Generally where the stack is deployed. Available options: " + stackRegions.descriptionOptions(),
+				ValidateFunc: validation.StringInSlice(stackRegions.slugs(), false),
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -70,8 +70,8 @@ available at “https://<stack_slug>.grafana.net".`,
 				ForceNew: true,
 				Description: `Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region.
-Available options: ` + stackRegions.DescriptionOptions(),
-				ValidateFunc: validation.StringInSlice(stackRegions.Slugs(), false),
+Available options: ` + stackRegions.descriptionOptions(),
+				ValidateFunc: validation.StringInSlice(stackRegions.slugs(), false),
 			},
 			"url": {
 				Type:        schema.TypeString,

--- a/grafana/resource_cloud_stack.go
+++ b/grafana/resource_cloud_stack.go
@@ -70,8 +70,8 @@ available at “https://<stack_slug>.grafana.net".`,
 				ForceNew: true,
 				Description: `Region slug to assign to this stack.
 Changing region will destroy the existing stack and create a new one in the desired region.
-Available input au (GCP Australia), eu (GCP Belgium), us (GCP US Central), prod-ap-southeast-0 (GCP Singapore), prod-gb-south-0 (GCP UK), prod-ap-south-0 (GCP India), prod-sa-east-0 (GCP Brazil)`,
-				ValidateFunc: validation.StringInSlice([]string{"au", "eu", "us", "prod-ap-southeast-0", "prod-gb-south-0", "prod-ap-south-0", "prod-sa-east-0"}, false),
+Available options: ` + stackRegions.DescriptionOptions(),
+				ValidateFunc: validation.StringInSlice(stackRegions.Slugs(), false),
 			},
 			"url": {
 				Type:        schema.TypeString,

--- a/grafana/stack_regions.go
+++ b/grafana/stack_regions.go
@@ -1,0 +1,41 @@
+package grafana
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	stackRegions = StackRegions{
+		"us":                  "GCP US Central",
+		"us-azure":            "Azure US Central",
+		"eu":                  "GCP Belgium",
+		"au":                  "GCP Australia",
+		"prod-ap-southeast-0": "GCP Singapore",
+		"prod-gb-south-0":     "GCP UK",
+		"prod-eu-west-3":      "Azure Netherlands",
+		"prod-ap-south-0":     "GCP India",
+		"prod-sa-east-0":      "GCP Brazil",
+	}
+)
+
+type StackRegions map[string]string
+
+// Slugs returns the list of all available stack regions.
+func (sr StackRegions) Slugs() []string {
+	slugs := make([]string, 0)
+	for slug := range sr {
+		slugs = append(slugs, slug)
+	}
+	return slugs
+}
+
+// DescriptionOptions returns a human-friendly string containing the list of
+// the region slugs and names.
+func (sr StackRegions) DescriptionOptions() string {
+	options := make([]string, 0)
+	for slug, name := range sr {
+		options = append(options, fmt.Sprintf("%s (%s)", slug, name))
+	}
+	return strings.Join(options, ", ")
+}

--- a/grafana/stack_regions.go
+++ b/grafana/stack_regions.go
@@ -6,36 +6,40 @@ import (
 )
 
 var (
-	stackRegions = StackRegions{
-		"us":                  "GCP US Central",
-		"us-azure":            "Azure US Central",
-		"eu":                  "GCP Belgium",
-		"au":                  "GCP Australia",
-		"prod-ap-southeast-0": "GCP Singapore",
-		"prod-gb-south-0":     "GCP UK",
-		"prod-eu-west-3":      "Azure Netherlands",
-		"prod-ap-south-0":     "GCP India",
-		"prod-sa-east-0":      "GCP Brazil",
+	stackRegions = stackRegionList{
+		{slug: "us", name: "GCP US Central"},
+		{slug: "us-azure", name: "Azure US Central"},
+		{slug: "eu", name: "GCP Belgium"},
+		{slug: "au", name: "GCP Australia"},
+		{slug: "prod-ap-southeast-0", name: "GCP Singapore"},
+		{slug: "prod-gb-south-0", name: "GCP UK"},
+		{slug: "prod-eu-west-3", name: "Azure Netherlands"},
+		{slug: "prod-ap-south-0", name: "GCP India"},
+		{slug: "prod-sa-east-0", name: "GCP Brazil"},
 	}
 )
 
-type StackRegions map[string]string
+type stackRegion struct {
+	slug string
+	name string
+}
+type stackRegionList []stackRegion
 
-// Slugs returns the list of all available stack regions.
-func (sr StackRegions) Slugs() []string {
+// slugs returns the list of all available stack regions.
+func (l stackRegionList) slugs() []string {
 	slugs := make([]string, 0)
-	for slug := range sr {
-		slugs = append(slugs, slug)
+	for _, region := range l {
+		slugs = append(slugs, region.slug)
 	}
 	return slugs
 }
 
-// DescriptionOptions returns a human-friendly string containing the list of
+// descriptionOptions returns a human-friendly string containing the list of
 // the region slugs and names.
-func (sr StackRegions) DescriptionOptions() string {
+func (l stackRegionList) descriptionOptions() string {
 	options := make([]string, 0)
-	for slug, name := range sr {
-		options = append(options, fmt.Sprintf("%s (%s)", slug, name))
+	for _, region := range l {
+		options = append(options, fmt.Sprintf("%s (%s)", region.slug, region.name))
 	}
 	return strings.Join(options, ", ")
 }


### PR DESCRIPTION
This PR updates the list of stack regions available to the latest options. It also consolidates the two lists into a single one with helpers for generating the list of slugs and the friendly description.

Ideally, this would be fetched using the `GET /api/stack-regions` endpoint, but this seems like a reasonable compromise for the time being.