### PR TITLE
Convert `org_id` references to TypeString

### DIFF
--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -25,7 +25,7 @@ data "grafana_organization_preferences" "test" {}
 - `home_dashboard_id` (Number) The Organization home dashboard ID.
 - `home_dashboard_uid` (String) The Organization home dashboard UID.
 - `id` (String) The ID of this resource.
-- `org_id` (Number) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `theme` (String) The Organization theme. Available values are `light`, `dark`, or an empty string for the default.
 - `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.
 - `week_start` (String) The Organization week start.

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -33,7 +33,7 @@ resource "grafana_dashboard" "metrics" {
 
 - `folder` (String) The id of the folder to save the dashboard in. This attribute is a string to reflect the type of the folder's id.
 - `message` (String) Set a commit message for the version history.
-- `org_id` (Number) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `overwrite` (Boolean) Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.
 
 ### Read-Only

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -28,7 +28,7 @@ resource "grafana_organization_preferences" "test" {
 
 - `home_dashboard_id` (Number) The Organization home dashboard ID.
 - `home_dashboard_uid` (String) The Organization home dashboard UID.
-- `org_id` (Number) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `theme` (String) The Organization theme. Available values are `light`, `dark`, or an empty string for the default.
 - `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.
 - `week_start` (String) The Organization week start.

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -115,7 +115,7 @@ EOT
 - `folder_uid` (String) The UID of the folder that the group belongs to.
 - `interval_seconds` (Number) The interval, in seconds, at which all rules in the group are evaluated. If a group contains many rules, the rules are evaluated sequentially.
 - `name` (String) The name of the rule group.
-- `org_id` (Number) The ID of the org to which the group belongs.
+- `org_id` (String) The ID of the org to which the group belongs.
 - `rule` (Block List, Min: 1) The rules within the group. (see [below for nested schema](#nestedblock--rule))
 
 ### Read-Only

--- a/grafana/oss_org_id.go
+++ b/grafana/oss_org_id.go
@@ -34,7 +34,7 @@ func clientFromOSSOrgID(meta interface{}, id string) (*gapi.Client, int64, strin
 }
 
 func clientFromOrgIDAttr(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
-	orgID := int64(d.Get("org_id").(int))
+	orgID, _ := strconv.ParseInt(d.Get("org_id").(string), 10, 64)
 	client := meta.(*client).gapi
 	if orgID > 0 {
 		client = client.WithOrgID(orgID)

--- a/grafana/resource_dashboard.go
+++ b/grafana/resource_dashboard.go
@@ -36,7 +36,7 @@ Manages Grafana dashboards.
 
 		Schema: map[string]*schema.Schema{
 			"org_id": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 				ForceNew:    true,

--- a/grafana/resource_organization_preferences.go
+++ b/grafana/resource_organization_preferences.go
@@ -28,7 +28,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"org_id": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
 				ForceNew:    true,


### PR DESCRIPTION
This is strictly for the crossplane provider. It doesn't affect the Terraform provider :

- The Crossplane provider only works with string references, because IDs are always strings in Terraform 
- Terraform, however, doesn't care and will happily convert between int and string, which is why there is no migration needed from this PR. You can even go back to the int version and it will convert it right back to int.