### PR TITLE
Fix removal of old team members when new are added

### DIFF
--- a/grafana/resource_team.go
+++ b/grafana/resource_team.go
@@ -71,7 +71,7 @@ A set of email addresses corresponding to users who should be given membership
 to the team. Note: users specified here must already exist in Grafana.
 `,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if old == new || (new == "[]" && old == "") || (new == "" && old == "[]") {
+					if (new == "[]" && old == "") || (new == "" && old == "[]") {
 						return true
 					}
 					return false


### PR DESCRIPTION
The grafana_team resource removes existing users from teams when new ones are added. This change should fix it.

How to reproduce the issue:
- Add new members to existing team members using the grafana_team resource and apply
- Run terraform plan and observe that all users previously there were removed and want to be re-added
- Run again, the old ones are re-added, the new ones are removed (repeats on each rerun)

TF version: 1.3.7
Grafana version: 9.1.5