### PR TITLE
Move common test utils to `testutils` package

### DIFF
--- a/provider/data_source_cloud_ips_test.go
+++ b/provider/data_source_cloud_ips_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceCloudIPsRead(t *testing.T) {
 	testutils.CheckCloudAPITestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_cloud_ips/data-source.tf"),

--- a/provider/data_source_cloud_ips_test.go
+++ b/provider/data_source_cloud_ips_test.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceCloudIPsRead(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_cloud_ips/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_cloud_ips/data-source.tf"),
 				Check: func(s *terraform.State) error {
 					rs := s.RootModule().Resources["data.grafana_cloud_ips.test"]
 

--- a/provider/data_source_cloud_organization_test.go
+++ b/provider/data_source_cloud_organization_test.go
@@ -5,11 +5,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceCloudOrganization_Basic(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	config := fmt.Sprintf(`
 	data "grafana_cloud_organization" "test" {

--- a/provider/data_source_cloud_organization_test.go
+++ b/provider/data_source_cloud_organization_test.go
@@ -19,7 +19,7 @@ func TestAccDatasourceCloudOrganization_Basic(t *testing.T) {
 	`, os.Getenv("GRAFANA_CLOUD_ORG"))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/provider/data_source_cloud_stack_test.go
+++ b/provider/data_source_cloud_stack_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceCloudStack_Basic(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	prefix := "tfdatatest"
 

--- a/provider/data_source_cloud_stack_test.go
+++ b/provider/data_source_cloud_stack_test.go
@@ -20,7 +20,7 @@ func TestAccDatasourceCloudStack_Basic(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_dashboard_test.go
+++ b/provider/data_source_dashboard_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceDashboardBasicID(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
 	checks := []resource.TestCheckFunc{
@@ -44,7 +45,7 @@ func TestAccDatasourceDashboardBasicID(t *testing.T) {
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, 0),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_dashboard/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_dashboard/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -52,14 +53,14 @@ func TestAccDatasourceDashboardBasicID(t *testing.T) {
 }
 
 func TestAccDatasourceDashboardBadExactlyOneOf(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccExample(t, "data-sources/grafana_dashboard/bad-ExactlyOneOf.tf"),
+				Config:      testutils.TestAccExample(t, "data-sources/grafana_dashboard/bad-ExactlyOneOf.tf"),
 				ExpectError: regexp.MustCompile(".*only one of.*can be specified.*"),
 			},
 		},

--- a/provider/data_source_dashboard_test.go
+++ b/provider/data_source_dashboard_test.go
@@ -41,7 +41,7 @@ func TestAccDatasourceDashboardBasicID(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, 0),
 		Steps: []resource.TestStep{
 			{
@@ -57,7 +57,7 @@ func TestAccDatasourceDashboardBadExactlyOneOf(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testutils.TestAccExample(t, "data-sources/grafana_dashboard/bad-ExactlyOneOf.tf"),

--- a/provider/data_source_dashboards_test.go
+++ b/provider/data_source_dashboards_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_dashboards/data-source.tf"),

--- a/provider/data_source_dashboards_test.go
+++ b/provider/data_source_dashboards_test.go
@@ -4,11 +4,12 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	params := url.Values{
 		"limit": {"5000"},
@@ -33,7 +34,7 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_dashboards/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_dashboards/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_data_source_test.go
+++ b/provider/data_source_data_source_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceDatasource(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dataSource gapi.DataSource
 	checks := []resource.TestCheckFunc{
@@ -35,7 +36,7 @@ func TestAccDatasourceDatasource(t *testing.T) {
 		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_data_source/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_data_source/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_data_source_test.go
+++ b/provider/data_source_data_source_test.go
@@ -32,7 +32,7 @@ func TestAccDatasourceDatasource(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_folder_test.go
+++ b/provider/data_source_folder_test.go
@@ -31,7 +31,7 @@ func TestAccDatasourceFolder(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccFolderCheckDestroy(&folder),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_folder_test.go
+++ b/provider/data_source_folder_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceFolder(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var folder gapi.Folder
 	checks := []resource.TestCheckFunc{
@@ -34,7 +35,7 @@ func TestAccDatasourceFolder(t *testing.T) {
 		CheckDestroy:      testAccFolderCheckDestroy(&folder),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_folder/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_folder/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_folders_test.go
+++ b/provider/data_source_folders_test.go
@@ -33,7 +33,7 @@ func TestAccDatasourceFolders(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccFolderCheckDestroy(&folderA),
 			testAccFolderCheckDestroy(&folderB),

--- a/provider/data_source_folders_test.go
+++ b/provider/data_source_folders_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceFolders(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var folderA gapi.Folder
 	var folderB gapi.Folder
@@ -39,7 +40,7 @@ func TestAccDatasourceFolders(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_folders/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_folders/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_library_panel_test.go
+++ b/provider/data_source_library_panel_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceLibraryPanel(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	// var dashboard gapi.Dashboard
@@ -35,7 +36,7 @@ func TestAccDatasourceLibraryPanel(t *testing.T) {
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_library_panel_test.go
+++ b/provider/data_source_library_panel_test.go
@@ -32,7 +32,7 @@ func TestAccDatasourceLibraryPanel(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_oncall_action_test.go
+++ b/provider/data_source_oncall_action_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallAction_Basic(t *testing.T) {
 	actionName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallActionConfig(actionName),

--- a/provider/data_source_oncall_action_test.go
+++ b/provider/data_source_oncall_action_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallAction_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	actionName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_oncall_outgoing_webhook_test.go
+++ b/provider/data_source_oncall_outgoing_webhook_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallOutgoingWebhook_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	outgoingWebhookName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_oncall_outgoing_webhook_test.go
+++ b/provider/data_source_oncall_outgoing_webhook_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallOutgoingWebhook_Basic(t *testing.T) {
 	outgoingWebhookName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallOutgoingWebhookConfig(outgoingWebhookName),

--- a/provider/data_source_oncall_schedule_test.go
+++ b/provider/data_source_oncall_schedule_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallSchedule_Basic(t *testing.T) {
 	scheduleName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallScheduleConfig(scheduleName),

--- a/provider/data_source_oncall_schedule_test.go
+++ b/provider/data_source_oncall_schedule_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallSchedule_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	scheduleName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_oncall_slack_channel_test.go
+++ b/provider/data_source_oncall_slack_channel_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallSlackChannel_Basic(t *testing.T) {
 	slackChannelName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallSlackChannelConfig(slackChannelName),

--- a/provider/data_source_oncall_slack_channel_test.go
+++ b/provider/data_source_oncall_slack_channel_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallSlackChannel_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	slackChannelName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_oncall_team_test.go
+++ b/provider/data_source_oncall_team_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallTeam_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	teamName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_oncall_team_test.go
+++ b/provider/data_source_oncall_team_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallTeam_Basic(t *testing.T) {
 	teamName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallTeamConfig(teamName),

--- a/provider/data_source_oncall_user_group_test.go
+++ b/provider/data_source_oncall_user_group_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallUserGroup_Basic(t *testing.T) {
 	slackHandle := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallUserGroupConfig(slackHandle),

--- a/provider/data_source_oncall_user_group_test.go
+++ b/provider/data_source_oncall_user_group_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallUserGroup_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	slackHandle := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_oncall_user_test.go
+++ b/provider/data_source_oncall_user_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOnCallUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOnCallUserConfig(username),

--- a/provider/data_source_oncall_user_test.go
+++ b/provider/data_source_oncall_user_test.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceOnCallUser_Basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	username := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 

--- a/provider/data_source_organization_preferences_test.go
+++ b/provider/data_source_organization_preferences_test.go
@@ -23,7 +23,7 @@ func TestAccDatasourceOrganizationPreferences(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_organization_preferences/data-source.tf"),

--- a/provider/data_source_organization_preferences_test.go
+++ b/provider/data_source_organization_preferences_test.go
@@ -3,11 +3,12 @@ package provider
 import (
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceOrganizationPreferences(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(
@@ -25,7 +26,7 @@ func TestAccDatasourceOrganizationPreferences(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_organization_preferences/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_organization_preferences/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_organization_test.go
+++ b/provider/data_source_organization_test.go
@@ -39,7 +39,7 @@ func TestAccDatasourceOrganization(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&organization),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_organization_test.go
+++ b/provider/data_source_organization_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceOrganization(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var organization gapi.Org
 	checks := []resource.TestCheckFunc{
@@ -42,7 +43,7 @@ func TestAccDatasourceOrganization(t *testing.T) {
 		CheckDestroy:      testAccOrganizationCheckDestroy(&organization),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_organization/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_organization/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_synthetic_monitoring_probe_test.go
+++ b/provider/data_source_synthetic_monitoring_probe_test.go
@@ -3,18 +3,19 @@ package provider
 import (
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceSyntheticMonitoringProbe(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_synthetic_monitoring_probe/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probe/data-source.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probe.atlanta", "name", "Atlanta"),
 				),

--- a/provider/data_source_synthetic_monitoring_probe_test.go
+++ b/provider/data_source_synthetic_monitoring_probe_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceSyntheticMonitoringProbe(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probe/data-source.tf"),

--- a/provider/data_source_synthetic_monitoring_probes_test.go
+++ b/provider/data_source_synthetic_monitoring_probes_test.go
@@ -3,22 +3,23 @@ package provider
 import (
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceSyntheticMonitoringProbes(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/data-source.tf"),
 				Check:  resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta", "1"),
 			},
 			{
-				Config: testAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/with-deprecated.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/with-deprecated.tf"),
 				// We're not checking for deprecated probes here because there may not be any, causing tests to fail.
 				Check: resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta", "1"),
 			},

--- a/provider/data_source_synthetic_monitoring_probes_test.go
+++ b/provider/data_source_synthetic_monitoring_probes_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceSyntheticMonitoringProbes(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/data-source.tf"),

--- a/provider/data_source_team_test.go
+++ b/provider/data_source_team_test.go
@@ -23,7 +23,7 @@ func TestAccDatasourceTeam(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_team_test.go
+++ b/provider/data_source_team_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceTeam(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var team gapi.Team
 	checks := []resource.TestCheckFunc{
@@ -26,7 +27,7 @@ func TestAccDatasourceTeam(t *testing.T) {
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_team/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_team/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_user_test.go
+++ b/provider/data_source_user_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceUser(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var user gapi.User
 	checks := []resource.TestCheckFunc{
@@ -39,7 +40,7 @@ func TestAccDatasourceUser(t *testing.T) {
 		CheckDestroy:      testAccUserCheckDestroy(&user),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_user/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_user/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_user_test.go
+++ b/provider/data_source_user_test.go
@@ -36,7 +36,7 @@ func TestAccDatasourceUser(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccUserCheckDestroy(&user),
 		Steps: []resource.TestStep{
 			{

--- a/provider/data_source_users_test.go
+++ b/provider/data_source_users_test.go
@@ -3,11 +3,12 @@ package provider
 import (
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDatasourceUsers(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	checks := []resource.TestCheckFunc{
 		// Let's not test the number of users found as due to the test concurrency we might not find the expected value
@@ -27,7 +28,7 @@ func TestAccDatasourceUsers(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "data-sources/grafana_users/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_users/data-source.tf"),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},

--- a/provider/data_source_users_test.go
+++ b/provider/data_source_users_test.go
@@ -25,7 +25,7 @@ func TestAccDatasourceUsers(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_users/data-source.tf"),

--- a/provider/resource_alert_notification_test.go
+++ b/provider/resource_alert_notification_test.go
@@ -21,7 +21,7 @@ func TestAccAlertNotification_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
 			{
@@ -59,7 +59,7 @@ func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
 			{
@@ -97,7 +97,7 @@ func TestAccAlertNotification_invalid_frequency(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
 			{
@@ -114,7 +114,7 @@ func TestAccAlertNotification_reminder_no_frequency(t *testing.T) {
 	var alertNotification gapi.AlertNotification
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccAlertNotificationCheckDestroy(&alertNotification),
 		Steps: []resource.TestStep{
 			{
@@ -141,7 +141,7 @@ func testAccAlertNotificationCheckExists(rn string, a *gapi.AlertNotification) r
 			return fmt.Errorf("resource id is malformed")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		gotAlertNotification, err := client.AlertNotification(id)
 		if err != nil {
 			return fmt.Errorf("error getting data source: %s", err)
@@ -165,7 +165,7 @@ func testAccAlertNotificationDefinition(a *gapi.AlertNotification) resource.Test
 
 func testAccAlertNotificationCheckDestroy(a *gapi.AlertNotification) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		alert, err := client.AlertNotification(a.ID)
 		if err == nil && alert != nil {
 			return fmt.Errorf("alert-notification still exists")

--- a/provider/resource_alert_notification_test.go
+++ b/provider/resource_alert_notification_test.go
@@ -8,13 +8,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAlertNotification_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var alertNotification gapi.AlertNotification
 
@@ -53,7 +54,7 @@ func TestAccAlertNotification_basic(t *testing.T) {
 }
 
 func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var alertNotification gapi.AlertNotification
 
@@ -91,7 +92,7 @@ func TestAccAlertNotification_disableResolveMessage(t *testing.T) {
 }
 
 func TestAccAlertNotification_invalid_frequency(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var alertNotification gapi.AlertNotification
 
@@ -108,7 +109,7 @@ func TestAccAlertNotification_invalid_frequency(t *testing.T) {
 }
 
 func TestAccAlertNotification_reminder_no_frequency(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var alertNotification gapi.AlertNotification
 

--- a/provider/resource_alerting_contact_point_test.go
+++ b/provider/resource_alerting_contact_point_test.go
@@ -18,7 +18,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 	var points []gapi.ContactPoint
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testContactPointCheckDestroy(points),
 		Steps: []resource.TestStep{
@@ -78,7 +78,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 	// TODO: Make parallelizable
 	// Error: wrong number of contact points on the server, expected 2 but got []{..., ..., ...} (len=3)
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testContactPointCheckDestroy(points),
 		Steps: []resource.TestStep{
@@ -145,7 +145,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 	var points []gapi.ContactPoint
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testContactPointCheckDestroy(points),
 		Steps: []resource.TestStep{
@@ -284,7 +284,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 						}
 						uid := rs.Primary.ID
 
-						client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+						client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 						pt, err := client.ContactPoint(uid)
 						if err != nil {
 							return fmt.Errorf("error getting resource: %w", err)
@@ -314,7 +314,7 @@ func testContactPointCheckExists(rname string, pts *[]gapi.ContactPoint, expCoun
 			return fmt.Errorf("resource name not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		points, err := client.ContactPointsByName(name)
 		if err != nil {
 			return fmt.Errorf("error getting resource: %w", err)
@@ -339,7 +339,7 @@ func testContactPointCheckExists(rname string, pts *[]gapi.ContactPoint, expCoun
 
 func testContactPointCheckDestroy(points []gapi.ContactPoint) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		for _, p := range points {
 			_, err := client.ContactPoint(p.UID)
 			if err == nil {
@@ -353,7 +353,7 @@ func testContactPointCheckDestroy(points []gapi.ContactPoint) resource.TestCheck
 
 func testContactPointCheckAllDestroy(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		points, err := client.ContactPointsByName(name)
 		if err != nil {
 			return fmt.Errorf("error getting resource: %w", err)

--- a/provider/resource_alerting_contact_point_test.go
+++ b/provider/resource_alerting_contact_point_test.go
@@ -6,13 +6,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccContactPoint_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
 
 	var points []gapi.ContactPoint
 
@@ -23,7 +24,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_contact_point/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testContactPointCheckExists("grafana_contact_point.my_contact_point", &points, 1),
 					resource.TestCheckResourceAttr("grafana_contact_point.my_contact_point", "name", "My Contact Point"),
@@ -42,7 +43,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 			},
 			// Test update content.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_contact_point/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/resource.tf", map[string]string{
 					"company.org": "user.net",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -54,7 +55,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 			},
 			// Test rename.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_contact_point/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/resource.tf", map[string]string{
 					"My Contact Point": "A Different Contact Point",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -69,8 +70,8 @@ func TestAccContactPoint_basic(t *testing.T) {
 }
 
 func TestAccContactPoint_compound(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
 
 	var points []gapi.ContactPoint
 
@@ -83,7 +84,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_contact_point/_acc_compound_receiver.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_compound_receiver.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testContactPointCheckExists("grafana_contact_point.compound_contact_point", &points, 2),
 					resource.TestCheckResourceAttr("grafana_contact_point.compound_contact_point", "name", "Compound Contact Point"),
@@ -92,7 +93,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 			},
 			// Test update.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_contact_point/_acc_compound_receiver.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/_acc_compound_receiver.tf", map[string]string{
 					"one": "asdf",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -103,7 +104,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 			},
 			// Test addition of a contact point to an existing compound one.
 			{
-				Config: testAccExample(t, "resources/grafana_contact_point/_acc_compound_receiver_added.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_compound_receiver_added.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testContactPointCheckExists("grafana_contact_point.compound_contact_point", &points, 3),
 					resource.TestCheckResourceAttr("grafana_contact_point.compound_contact_point", "email.#", "3"),
@@ -114,7 +115,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 			},
 			// Test removal of a point from a compound one does not leak.
 			{
-				Config: testAccExample(t, "resources/grafana_contact_point/_acc_compound_receiver_subtracted.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_compound_receiver_subtracted.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testContactPointCheckExists("grafana_contact_point.compound_contact_point", &points, 1),
 					resource.TestCheckResourceAttr("grafana_contact_point.compound_contact_point", "email.#", "1"),
@@ -123,7 +124,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 			},
 			// Test rename.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_contact_point/_acc_compound_receiver.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/_acc_compound_receiver.tf", map[string]string{
 					"Compound Contact Point": "A Different Contact Point",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -138,8 +139,8 @@ func TestAccContactPoint_compound(t *testing.T) {
 }
 
 func TestAccContactPoint_notifiers(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	var points []gapi.ContactPoint
 
@@ -150,7 +151,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_receiver_types.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 17),
 					// alertmanager
@@ -270,7 +271,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 			},
 			// Test blank fields in settings should be omitted.
 			{
-				Config: testAccExample(t, "resources/grafana_contact_point/_acc_default_settings.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_default_settings.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testContactPointCheckExists("grafana_contact_point.default_settings", &points, 1),
 					resource.TestCheckResourceAttr("grafana_contact_point.default_settings", "slack.#", "1"),

--- a/provider/resource_alerting_message_template_test.go
+++ b/provider/resource_alerting_message_template_test.go
@@ -18,7 +18,7 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 	var tmpl gapi.AlertingMessageTemplate
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testMessageTemplateCheckDestroy(&tmpl),
 		Steps: []resource.TestStep{
@@ -90,7 +90,7 @@ func testMessageTemplateCheckExists(rname string, mt *gapi.AlertingMessageTempla
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		tmpl, err := client.MessageTemplate(resource.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting resource: %s", err)
@@ -103,7 +103,7 @@ func testMessageTemplateCheckExists(rname string, mt *gapi.AlertingMessageTempla
 
 func testMessageTemplateCheckDestroy(mt *gapi.AlertingMessageTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		tmpl, err := client.MessageTemplate(mt.Name)
 		if err == nil && tmpl != nil {
 			return fmt.Errorf("message template still exists on the server")

--- a/provider/resource_alerting_message_template_test.go
+++ b/provider/resource_alerting_message_template_test.go
@@ -6,13 +6,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccMessageTemplate_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
 
 	var tmpl gapi.AlertingMessageTemplate
 
@@ -23,7 +24,7 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_message_template/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_message_template/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testMessageTemplateCheckExists("grafana_message_template.my_template", &tmpl),
 					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Reusable Template"),
@@ -38,7 +39,7 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 			},
 			// Test update with heredoc template doesn't change
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
 					`template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"`: `template = <<-EOT
 {{define "My Reusable Template" }}
  template content
@@ -53,7 +54,7 @@ EOT`,
 			},
 			// Test update content.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
 					"template content": "different content",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -64,7 +65,7 @@ EOT`,
 			},
 			// Test rename.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
 					"My Reusable Template": "A Different Template",
 				}),
 				Check: resource.ComposeTestCheckFunc(

--- a/provider/resource_alerting_mute_timing_test.go
+++ b/provider/resource_alerting_mute_timing_test.go
@@ -18,7 +18,7 @@ func TestAccMuteTiming_basic(t *testing.T) {
 	var mt gapi.MuteTiming
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testMuteTimingCheckDestroy(&mt),
 		Steps: []resource.TestStep{
@@ -80,7 +80,7 @@ func testMuteTimingCheckExists(rname string, timing *gapi.MuteTiming) resource.T
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		mt, err := client.MuteTiming(resource.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting resource: %w", err)
@@ -92,7 +92,7 @@ func testMuteTimingCheckExists(rname string, timing *gapi.MuteTiming) resource.T
 
 func testMuteTimingCheckDestroy(timing *gapi.MuteTiming) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		mt, err := client.MuteTiming(timing.Name)
 		if err == nil && mt.Name != "" {
 			return fmt.Errorf("mute timing still exists on the server")

--- a/provider/resource_alerting_mute_timing_test.go
+++ b/provider/resource_alerting_mute_timing_test.go
@@ -6,13 +6,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccMuteTiming_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">9.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">9.0.0")
 
 	var mt gapi.MuteTiming
 
@@ -23,7 +24,7 @@ func TestAccMuteTiming_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_mute_timing/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_mute_timing/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testMuteTimingCheckExists("grafana_mute_timing.my_mute_timing", &mt),
 					resource.TestCheckResourceAttr("grafana_mute_timing.my_mute_timing", "intervals.0.weekdays.0", "monday"),
@@ -44,7 +45,7 @@ func TestAccMuteTiming_basic(t *testing.T) {
 			},
 			// Test update content.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_mute_timing/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_mute_timing/resource.tf", map[string]string{
 					"monday": "friday",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -55,7 +56,7 @@ func TestAccMuteTiming_basic(t *testing.T) {
 			},
 			// Test rename.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_mute_timing/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_mute_timing/resource.tf", map[string]string{
 					"My Mute Timing": "A Different Mute Timing",
 				}),
 				Check: resource.ComposeTestCheckFunc(

--- a/provider/resource_alerting_notification_policy_test.go
+++ b/provider/resource_alerting_notification_policy_test.go
@@ -6,13 +6,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccNotificationPolicy_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	// TODO: Make parallizable
 	resource.Test(t, resource.TestCase{
@@ -22,7 +23,7 @@ func TestAccNotificationPolicy_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_notification_policy/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_notification_policy/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testNotifPolicyCheckExists("grafana_notification_policy.my_notification_policy"),
 					resource.TestCheckResourceAttr("grafana_notification_policy.my_notification_policy", "contact_point", "A Contact Point"),
@@ -66,7 +67,7 @@ func TestAccNotificationPolicy_basic(t *testing.T) {
 			},
 			// Test update.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_notification_policy/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_notification_policy/resource.tf", map[string]string{
 					"...": "alertname",
 				}),
 				Check: resource.ComposeTestCheckFunc(

--- a/provider/resource_alerting_notification_policy_test.go
+++ b/provider/resource_alerting_notification_policy_test.go
@@ -17,7 +17,7 @@ func TestAccNotificationPolicy_basic(t *testing.T) {
 
 	// TODO: Make parallizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testNotifPolicyCheckDestroy(),
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccNotificationPolicy_basic(t *testing.T) {
 
 func testNotifPolicyCheckDestroy() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		npt, err := client.NotificationPolicyTree()
 		if err != nil {
 			return fmt.Errorf("failed to get notification policies")
@@ -107,7 +107,7 @@ func testNotifPolicyCheckExists(rname string) resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		npt, err := client.NotificationPolicyTree()
 		if err != nil {
 			return fmt.Errorf("failed to get notification policies")

--- a/provider/resource_alerting_rule_group_test.go
+++ b/provider/resource_alerting_rule_group_test.go
@@ -7,13 +7,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccAlertRule_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	var group gapi.RuleGroup
 
@@ -24,7 +25,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_rule_group/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_rule_group/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.my_alert_rule", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
@@ -41,7 +42,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 			},
 			// Test update content.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
 					"My Alert Rule 1": "A Different Rule",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -55,7 +56,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 			},
 			// Test rename group.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
 					"My Rule Group": "A Different Rule Group",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -69,7 +70,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 			},
 			// Test change interval.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
 					"240": "360",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -81,7 +82,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 			},
 			// Test re-parent folder.
 			{
-				Config: testAccExample(t, "resources/grafana_rule_group/_acc_reparent_folder.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_rule_group/_acc_reparent_folder.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.my_alert_rule", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
@@ -97,8 +98,8 @@ func TestAccAlertRule_basic(t *testing.T) {
 }
 
 func TestAccAlertRule_compound(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	var group gapi.RuleGroup
 
@@ -109,7 +110,7 @@ func TestAccAlertRule_compound(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
-				Config: testAccExample(t, "resources/grafana_rule_group/_acc_multi_rule_group.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_rule_group/_acc_multi_rule_group.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.my_multi_alert_group", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_multi_alert_group", "name", "My Multi-Alert Rule Group"),
@@ -126,7 +127,7 @@ func TestAccAlertRule_compound(t *testing.T) {
 			},
 			// Test update.
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_rule_group/_acc_multi_rule_group.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/_acc_multi_rule_group.tf", map[string]string{
 					"Rule 1": "asdf",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -139,7 +140,7 @@ func TestAccAlertRule_compound(t *testing.T) {
 			},
 			// Test addition of a rule to an existing group.
 			{
-				Config: testAccExample(t, "resources/grafana_rule_group/_acc_multi_rule_group_added.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_rule_group/_acc_multi_rule_group_added.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.my_multi_alert_group", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_multi_alert_group", "name", "My Multi-Alert Rule Group"),
@@ -151,7 +152,7 @@ func TestAccAlertRule_compound(t *testing.T) {
 			},
 			// Test removal of rules from an existing group.
 			{
-				Config: testAccExample(t, "resources/grafana_rule_group/_acc_multi_rule_group_subtracted.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_rule_group/_acc_multi_rule_group_subtracted.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.my_multi_alert_group", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_multi_alert_group", "name", "My Multi-Alert Rule Group"),

--- a/provider/resource_alerting_rule_group_test.go
+++ b/provider/resource_alerting_rule_group_test.go
@@ -19,7 +19,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 	var group gapi.RuleGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testAlertRuleCheckDestroy(&group),
 		Steps: []resource.TestStep{
@@ -104,7 +104,7 @@ func TestAccAlertRule_compound(t *testing.T) {
 	var group gapi.RuleGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: testAlertRuleCheckDestroy(&group),
 		Steps: []resource.TestStep{
@@ -176,7 +176,7 @@ func testRuleGroupCheckExists(rname string, g *gapi.RuleGroup) resource.TestChec
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		key := unpackGroupID(resource.Primary.ID)
 		grp, err := client.AlertRuleGroup(key.folderUID, key.name)
 		if err != nil {
@@ -190,7 +190,7 @@ func testRuleGroupCheckExists(rname string, g *gapi.RuleGroup) resource.TestChec
 
 func testAlertRuleCheckDestroy(group *gapi.RuleGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.AlertRuleGroup(group.FolderUID, group.Title)
 		if err == nil && strings.HasPrefix(err.Error(), "status: 404") {
 			return fmt.Errorf("rule group still exists on the server")

--- a/provider/resource_annotation_test.go
+++ b/provider/resource_annotation_test.go
@@ -24,7 +24,7 @@ func TestAccAnnotation_basic(t *testing.T) {
 	var annotation gapi.Annotation
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccAnnotationCheckDestroy(&annotation),
 		Steps: []resource.TestStep{
 			{
@@ -108,7 +108,7 @@ func testAccAnnotationCheckExists(rn string, annotation *gapi.Annotation) resour
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		annotations, err := client.Annotations(url.Values{})
 		if err != nil {
 			return fmt.Errorf("error getting annotation: %s", err)
@@ -126,7 +126,7 @@ func testAccAnnotationCheckExists(rn string, annotation *gapi.Annotation) resour
 
 func testAccAnnotationCheckDestroy(annotation *gapi.Annotation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		annotations, err := client.Annotations(url.Values{})
 		if err != nil {
 			return err

--- a/provider/resource_annotation_test.go
+++ b/provider/resource_annotation_test.go
@@ -8,6 +8,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,7 +20,7 @@ var (
 )
 
 func TestAccAnnotation_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 	var annotation gapi.Annotation
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/provider/resource_api_key_test.go
+++ b/provider/resource_api_key_test.go
@@ -20,7 +20,7 @@ func TestAccGrafanaAuthKey(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccGrafanaAuthKeyCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -50,7 +50,7 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{
@@ -69,7 +69,7 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 }
 
 func testAccGrafanaAuthKeyCheckDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*common.Client).GrafanaAPI
+	c := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "grafana_api_key" {
@@ -140,7 +140,7 @@ func testAccGrafanaAuthKeyCheckDestroyCloud(s *terraform.State) error {
 			continue
 		}
 
-		cloudClient := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		cloudClient := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		c, cleanup, err := cloudClient.CreateTemporaryStackGrafanaClient(rs.Primary.Attributes["slug"], "test-api-key-", 60*time.Second)
 		if err != nil {
 			return err

--- a/provider/resource_api_key_test.go
+++ b/provider/resource_api_key_test.go
@@ -10,12 +10,13 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccGrafanaAuthKey(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
@@ -39,7 +40,7 @@ func TestAccGrafanaAuthKey(t *testing.T) {
 }
 
 func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	var stack gapi.Stack
 	prefix := "tfapikeytest"

--- a/provider/resource_builtin_role_assignment_test.go
+++ b/provider/resource_builtin_role_assignment_test.go
@@ -29,7 +29,7 @@ func TestAccBuiltInRoleAssignment(t *testing.T) {
 	var assignments map[string][]*gapi.Role
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccBuiltInRoleAssignmentCheckDestroy(&assignments, []string{roleUID3, roleUID4}, nil),
 		Steps: []resource.TestStep{
 			{
@@ -66,7 +66,7 @@ func TestAccBuiltInRoleAssignmentUpdate(t *testing.T) {
 	var assignments map[string][]*gapi.Role
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccBuiltInRoleAssignmentCheckDestroy(&assignments, []string{roleUID5, roleUID6}, []string{roleUID1, roleUID2}),
 		Steps: []resource.TestStep{
 			{
@@ -123,7 +123,7 @@ func TestAccBuiltInRoleAssignmentUpdate(t *testing.T) {
 }
 
 func prepareDefaultAssignments() error {
-	client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 	r1 := gapi.Role{
 		UID:     roleUID1,
 		Version: 1,
@@ -179,7 +179,7 @@ func prepareDefaultAssignments() error {
 
 func testAccBuiltInRoleAssignmentWereNotDestroyed(brName string, roleUIDs ...string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		assignments, err := client.GetBuiltInRoleAssignments()
 		if err != nil || assignments[brName] == nil {
 			return fmt.Errorf("built-in assignments were destroyed, but expected to exist: %v", err)
@@ -199,7 +199,7 @@ func testAccBuiltInRoleAssignmentCheckExists(rn string, brAssignments *map[strin
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		assignments, err := client.GetBuiltInRoleAssignments()
 		if err != nil || assignments[rs.Primary.ID] == nil {
 			return fmt.Errorf("error getting built-in role assignments: %s", err)
@@ -214,7 +214,7 @@ func testAccBuiltInRoleAssignmentCheckExists(rn string, brAssignments *map[strin
 
 func testAccBuiltInRoleAssignmentCheckDestroy(brAssignments *map[string][]*gapi.Role, destroyedUIDs []string, preservedRoleUIDs []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		bra, err := client.GetBuiltInRoleAssignments()
 		if err != nil {
 			return fmt.Errorf("error getting built-in role assignments: %s", err)

--- a/provider/resource_builtin_role_assignment_test.go
+++ b/provider/resource_builtin_role_assignment_test.go
@@ -9,6 +9,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 )
 
 func TestAccBuiltInRoleAssignment(t *testing.T) {
-	CheckEnterpriseTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var assignments map[string][]*gapi.Role
 
@@ -60,7 +61,7 @@ func TestAccBuiltInRoleAssignment(t *testing.T) {
 }
 
 func TestAccBuiltInRoleAssignmentUpdate(t *testing.T) {
-	CheckEnterpriseTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var assignments map[string][]*gapi.Role
 

--- a/provider/resource_cloud_access_policy_token_test.go
+++ b/provider/resource_cloud_access_policy_token_test.go
@@ -10,6 +10,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -17,7 +18,7 @@ import (
 // This test covers both the cloud_access_policy and cloud_access_policy_token resources.
 func TestResourceCloudAccessPolicyToken_Basic(t *testing.T) {
 	t.Parallel()
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	var policy gapi.CloudAccessPolicy
 	var policyToken gapi.CloudAccessPolicyToken
@@ -113,7 +114,7 @@ func TestResourceCloudAccessPolicyToken_Basic(t *testing.T) {
 
 func TestResourceCloudAccessPolicyToken_NoExpiration(t *testing.T) {
 	t.Parallel()
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	var policy gapi.CloudAccessPolicy
 	var policyToken gapi.CloudAccessPolicyToken

--- a/provider/resource_cloud_access_policy_token_test.go
+++ b/provider/resource_cloud_access_policy_token_test.go
@@ -36,7 +36,7 @@ func TestResourceCloudAccessPolicyToken_Basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCloudAccessPolicyCheckDestroy("us", &policy),
 			testAccCloudAccessPolicyTokenCheckDestroy("us", &policyToken),
@@ -120,7 +120,7 @@ func TestResourceCloudAccessPolicyToken_NoExpiration(t *testing.T) {
 	var policyToken gapi.CloudAccessPolicyToken
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudAccessPolicyTokenConfigBasic("initial-no-expiration", "", []string{"metrics:read"}, ""),
@@ -153,7 +153,7 @@ func testAccCloudAccessPolicyCheckExists(rn string, a *gapi.CloudAccessPolicy) r
 
 		region, id, _ := strings.Cut(rs.Primary.ID, "/")
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		policy, err := client.CloudAccessPolicyByID(region, id)
 		if err != nil {
 			return fmt.Errorf("error getting cloud access policy: %s", err)
@@ -178,7 +178,7 @@ func testAccCloudAccessPolicyTokenCheckExists(rn string, a *gapi.CloudAccessPoli
 
 		region, id, _ := strings.Cut(rs.Primary.ID, "/")
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		token, err := client.CloudAccessPolicyTokenByID(region, id)
 		if err != nil {
 			return fmt.Errorf("error getting cloud access policy token: %s", err)
@@ -192,7 +192,7 @@ func testAccCloudAccessPolicyTokenCheckExists(rn string, a *gapi.CloudAccessPoli
 
 func testAccCloudAccessPolicyCheckDestroy(region string, a *gapi.CloudAccessPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		policy, err := client.CloudAccessPolicyByID(region, a.ID)
 		if err == nil && policy.Name != "" {
 			return fmt.Errorf("cloud access policy `%s` with ID `%s` still exists after destroy", policy.Name, policy.ID)
@@ -204,7 +204,7 @@ func testAccCloudAccessPolicyCheckDestroy(region string, a *gapi.CloudAccessPoli
 
 func testAccCloudAccessPolicyTokenCheckDestroy(region string, a *gapi.CloudAccessPolicyToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		token, err := client.CloudAccessPolicyTokenByID(region, a.ID)
 		if err == nil && token.Name != "" {
 			return fmt.Errorf("cloud access policy token `%s` with ID `%s` still exists after destroy", token.Name, token.ID)

--- a/provider/resource_cloud_api_key_test.go
+++ b/provider/resource_cloud_api_key_test.go
@@ -34,7 +34,7 @@ func TestAccCloudApiKey_Basic(t *testing.T) {
 			resourceName := prefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 			resource.ParallelTest(t, resource.TestCase{
-				ProviderFactories: testAccProviderFactories,
+				ProviderFactories: testutils.ProviderFactories,
 				CheckDestroy:      testAccCheckCloudAPIKeyDestroy,
 				Steps: []resource.TestStep{
 					{
@@ -70,7 +70,7 @@ func testAccCheckCloudAPIKeyExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource `%s` has no ID set", resourceName)
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		res, err := client.ListCloudAPIKeys(rs.Primary.Attributes["cloud_org_slug"])
 		if err != nil {
 			return err
@@ -87,7 +87,7 @@ func testAccCheckCloudAPIKeyExists(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccCheckCloudAPIKeyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 
 	for name, rs := range s.RootModule().Resources {
 		if rs.Type != "grafana_cloud_api_key" {
@@ -111,7 +111,7 @@ func testAccCheckCloudAPIKeyDestroy(s *terraform.State) error {
 
 func testAccDeleteExistingCloudAPIKeys(t *testing.T, prefix string) {
 	org := os.Getenv("GRAFANA_CLOUD_ORG")
-	client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 	resp, err := client.ListCloudAPIKeys(org)
 	if err != nil {
 		t.Error(err)

--- a/provider/resource_cloud_api_key_test.go
+++ b/provider/resource_cloud_api_key_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccCloudApiKey_Basic(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	prefix := "testcloudkey-"
 	testAccDeleteExistingCloudAPIKeys(t, prefix)
@@ -127,7 +128,7 @@ func testAccDeleteExistingCloudAPIKeys(t *testing.T, prefix string) {
 }
 
 func testAccCloudAPIKeyConfig(resourceName, role string) string {
-	// GRAFANA_CLOUD_ORG is required from the `CheckCloudAPITestsEnabled` function
+	// GRAFANA_CLOUD_ORG is required from the `testutils.CheckCloudAPITestsEnabled` function
 	return fmt.Sprintf(`
 resource "grafana_cloud_api_key" "test" {
   cloud_org_slug = "%s"

--- a/provider/resource_cloud_plugin_test.go
+++ b/provider/resource_cloud_plugin_test.go
@@ -21,7 +21,7 @@ func TestAccResourceCloudPluginInstallation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccCloudPluginDeleteExisting(t, slug, pluginSlug) },
 
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGrafanaCloudPluginInstallation(slug, pluginSlug, pluginVersion),
@@ -53,7 +53,7 @@ func testAccCloudPluginInstallationCheckExists(rn string, stackSlug string, plug
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		_, err := client.GetCloudPluginInstallation(stackSlug, pluginSlug)
 		if err != nil {
 			return fmt.Errorf("error getting installation: %s", err)
@@ -65,7 +65,7 @@ func testAccCloudPluginInstallationCheckExists(rn string, stackSlug string, plug
 
 func testAccCloudPluginInstallationDestroy(stackSlug string, pluginSlug string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 
 		installation, err := client.GetCloudPluginInstallation(stackSlug, pluginSlug)
 		if err == nil {
@@ -77,7 +77,7 @@ func testAccCloudPluginInstallationDestroy(stackSlug string, pluginSlug string) 
 }
 
 func testAccCloudPluginDeleteExisting(t *testing.T, instanceSlug, pluginSlug string) {
-	client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 	installed, err := client.IsCloudPluginInstalled(instanceSlug, pluginSlug)
 	if err != nil {
 		t.Fatalf("error checking if plugin is installed: %s", err)

--- a/provider/resource_cloud_plugin_test.go
+++ b/provider/resource_cloud_plugin_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceCloudPluginInstallation(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	slug := os.Getenv("GRAFANA_CLOUD_ORG")
 	pluginSlug := "aws-datasource-provisioner-app"

--- a/provider/resource_cloud_stack_test.go
+++ b/provider/resource_cloud_stack_test.go
@@ -28,7 +28,7 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{
@@ -84,7 +84,7 @@ func TestResourceCloudStack_Basic(t *testing.T) {
 }
 
 func testAccDeleteExistingStacks(t *testing.T, prefix string) {
-	client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 	resp, err := client.Stacks()
 	if err != nil {
 		t.Error(err)
@@ -115,7 +115,7 @@ func testAccStackCheckExists(rn string, a *gapi.Stack) resource.TestCheckFunc {
 			return fmt.Errorf("resource id is malformed")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		stack, err := client.StackByID(id)
 		if err != nil {
 			return fmt.Errorf("error getting data source: %s", err)
@@ -129,7 +129,7 @@ func testAccStackCheckExists(rn string, a *gapi.Stack) resource.TestCheckFunc {
 
 func testAccStackCheckDestroy(a *gapi.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaCloudAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		stack, err := client.StackBySlug(a.Slug)
 		if err == nil && stack.Name != "" {
 			return fmt.Errorf("stack `%s` with ID `%d` still exists after destroy", stack.Name, stack.ID)

--- a/provider/resource_cloud_stack_test.go
+++ b/provider/resource_cloud_stack_test.go
@@ -9,13 +9,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestResourceCloudStack_Basic(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	prefix := "tfresourcetest"
 

--- a/provider/resource_dashboard_permission_test.go
+++ b/provider/resource_dashboard_permission_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDashboardPermission_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.0.0") // Dashboard UIDs are only available as references in Grafana 9+
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0") // Dashboard UIDs are only available as references in Grafana 9+
 
 	dashboardUID := ""
 
@@ -45,7 +46,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 // Testing the deprecated case of using a dashboard ID instead of a dashboard UID
 // TODO: Remove in next major version
 func TestAccDashboardPermission_fromDashboardID(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	dashboardID := int64(-1)
 

--- a/provider/resource_dashboard_permission_test.go
+++ b/provider/resource_dashboard_permission_test.go
@@ -19,7 +19,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDashboardPermissionConfig_Basic,
@@ -52,7 +52,7 @@ func TestAccDashboardPermission_fromDashboardID(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDashboardPermissionConfig_FromID,
@@ -76,7 +76,7 @@ func testAccDashboardPermissionsCheckExistsUID(rn string, dashboardUID *string) 
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		gotDashboardUID := rs.Primary.ID
 
@@ -102,7 +102,7 @@ func testAccDashboardPermissionsCheckExists(rn string, dashboardID *int64) resou
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		gotDashboardID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
@@ -122,7 +122,7 @@ func testAccDashboardPermissionsCheckExists(rn string, dashboardID *int64) resou
 
 func testAccDashboardPermissionsCheckEmptyUID(dashboardUID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		permissions, err := client.DashboardPermissionsByUID(*dashboardUID)
 		if err != nil {
 			return fmt.Errorf("Error getting dashboard permissions %s: %s", *dashboardUID, err)

--- a/provider/resource_dashboard_test.go
+++ b/provider/resource_dashboard_test.go
@@ -8,6 +8,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestAccDashboard_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
 
@@ -40,7 +41,7 @@ func TestAccDashboard_basic(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						// Test resource creation.
-						Config: testAccExample(t, "resources/grafana_dashboard/_acc_basic.tf"),
+						Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_basic.tf"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "0:basic"), // <org id>:<uid>
@@ -53,7 +54,7 @@ func TestAccDashboard_basic(t *testing.T) {
 					},
 					{
 						// Updates title.
-						Config: testAccExample(t, "resources/grafana_dashboard/_acc_basic_update.tf"),
+						Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_basic_update.tf"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "0:basic"), // <org id>:<uid>
@@ -67,7 +68,7 @@ func TestAccDashboard_basic(t *testing.T) {
 						// Updates uid.
 						// uid is removed from `config_json` before writing it to state so it's
 						// important to ensure changing it triggers an update of `config_json`.
-						Config: testAccExample(t, "resources/grafana_dashboard/_acc_basic_update_uid.tf"),
+						Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_basic_update_uid.tf"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "0:basic-update"), // <org id>:<uid>
@@ -92,7 +93,7 @@ func TestAccDashboard_basic(t *testing.T) {
 }
 
 func TestAccDashboard_uid_unset(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
 
@@ -102,7 +103,7 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create dashboard with no uid set.
-				Config: testAccExample(t, "resources/grafana_dashboard/_acc_uid_unset.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_uid_unset.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 					resource.TestCheckResourceAttr(
@@ -113,7 +114,7 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 			{
 				// Update it to add a uid. We want to ensure that this causes a diff
 				// and subsequent update.
-				Config: testAccExample(t, "resources/grafana_dashboard/_acc_uid_unset_set.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_uid_unset_set.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 					resource.TestCheckResourceAttr(
@@ -123,7 +124,7 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 			},
 			{
 				// Remove the uid once again to ensure this is also supported.
-				Config: testAccExample(t, "resources/grafana_dashboard/_acc_uid_unset.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_uid_unset.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 					resource.TestCheckResourceAttr(
@@ -136,7 +137,7 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 }
 
 func TestAccDashboard_computed_config(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
 
@@ -146,7 +147,7 @@ func TestAccDashboard_computed_config(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test resource creation.
-				Config: testAccExample(t, "resources/grafana_dashboard/_acc_computed.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_computed.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
 					testAccDashboardCheckExists("grafana_dashboard.test-computed", &dashboard),
@@ -157,7 +158,7 @@ func TestAccDashboard_computed_config(t *testing.T) {
 }
 
 func TestAccDashboard_folder(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
 	var folder gapi.Folder
@@ -167,7 +168,7 @@ func TestAccDashboard_folder(t *testing.T) {
 		CheckDestroy:      testAccDashboardFolderCheckDestroy(&dashboard, &folder),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_dashboard/_acc_folder.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_folder.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
 					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
@@ -184,7 +185,7 @@ func TestAccDashboard_folder(t *testing.T) {
 }
 
 func TestAccDashboard_inOrg(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
 	var org gapi.Org
@@ -295,7 +296,7 @@ func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.
 }
 
 func Test_normalizeDashboardConfigJSON(t *testing.T) {
-	IsUnitTest(t)
+	testutils.IsUnitTest(t)
 
 	type args struct {
 		config interface{}

--- a/provider/resource_dashboard_test.go
+++ b/provider/resource_dashboard_test.go
@@ -36,7 +36,7 @@ func TestAccDashboard_basic(t *testing.T) {
 
 			// TODO: Make parallelizable
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: testAccProviderFactories,
+				ProviderFactories: testutils.ProviderFactories,
 				CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, 0),
 				Steps: []resource.TestStep{
 					{
@@ -98,7 +98,7 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 	var dashboard gapi.Dashboard
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, 0),
 		Steps: []resource.TestStep{
 			{
@@ -142,7 +142,7 @@ func TestAccDashboard_computed_config(t *testing.T) {
 	var dashboard gapi.Dashboard
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, 0),
 		Steps: []resource.TestStep{
 			{
@@ -164,7 +164,7 @@ func TestAccDashboard_folder(t *testing.T) {
 	var folder gapi.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDashboardFolderCheckDestroy(&dashboard, &folder),
 		Steps: []resource.TestStep{
 			{
@@ -193,7 +193,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 	orgName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDashboardCheckDestroy(&dashboard, org.ID),
 		Steps: []resource.TestStep{
 			{
@@ -229,7 +229,7 @@ func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.
 		}
 		orgID, dashboardUID := splitOSSOrgID(rs.Primary.ID)
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		// If the org ID is set, check that the dashboard doesn't exist in the default org
 		if orgID > 0 {
 			dashboard, err := client.DashboardByUID(dashboardUID)
@@ -261,7 +261,7 @@ func testAccDashboardCheckExistsInFolder(dashboard *gapi.Dashboard, folder *gapi
 func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard, orgID int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Check that the dashboard was deleted from the default organization
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		dashboard, err := client.DashboardByUID(dashboard.Model["uid"].(string))
 		if dashboard != nil || err == nil {
 			return fmt.Errorf("dashboard still exists")
@@ -282,7 +282,7 @@ func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard, orgID int64) resour
 
 func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *gapi.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.DashboardByUID(dashboard.Model["uid"].(string))
 		if err == nil {
 			return fmt.Errorf("dashboard still exists")

--- a/provider/resource_data_source_test.go
+++ b/provider/resource_data_source_test.go
@@ -687,7 +687,7 @@ func TestAccDataSource_basic(t *testing.T) {
 
 			// TODO: Make parallelizable
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: testAccProviderFactories,
+				ProviderFactories: testutils.ProviderFactories,
 				CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
 				Steps: []resource.TestStep{
 					{
@@ -864,7 +864,7 @@ func TestAccDataSource_changeUID(t *testing.T) {
 	var dataSource gapi.DataSource
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
 		Steps: []resource.TestStep{
 			{
@@ -913,7 +913,7 @@ func testAccDataSourceCheckExists(rn string, dataSource *gapi.DataSource) resour
 			return fmt.Errorf("resource id is malformed")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		gotDataSource, err := client.DataSource(id)
 		if err != nil {
 			return fmt.Errorf("error getting data source: %s", err)
@@ -927,7 +927,7 @@ func testAccDataSourceCheckExists(rn string, dataSource *gapi.DataSource) resour
 
 func testAccDataSourceCheckDestroy(dataSource *gapi.DataSource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.DataSource(dataSource.ID)
 		if err == nil {
 			return fmt.Errorf("data source still exists")

--- a/provider/resource_data_source_test.go
+++ b/provider/resource_data_source_test.go
@@ -9,13 +9,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSource_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dataSource gapi.DataSource
 
@@ -729,7 +730,7 @@ func TestAccDataSource_basic(t *testing.T) {
 }
 
 func TestDatasourceMigrationV0(t *testing.T) {
-	IsUnitTest(t)
+	testutils.IsUnitTest(t)
 
 	cases := []struct {
 		name     string
@@ -858,7 +859,7 @@ func TestDatasourceMigrationV0(t *testing.T) {
 }
 
 func TestAccDataSource_changeUID(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var dataSource gapi.DataSource
 

--- a/provider/resource_datasource_permission_test.go
+++ b/provider/resource_datasource_permission_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDatasourcePermission_basic(t *testing.T) {
 	t.Skip("This test is failing in Grafana Cloud 9.3+")
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	datasourceID := int64(-1)
 
@@ -20,14 +21,14 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_data_source_permission/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_data_source_permission/resource.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDatasourcePermissionsCheckExists("grafana_data_source_permission.fooPermissions", &datasourceID),
 					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "3"),
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_data_source_permission/_acc_resource_remove.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_data_source_permission/_acc_resource_remove.tf"),
 				Check:  testAccDatasourcePermissionCheckDestroy(&datasourceID),
 			},
 		},

--- a/provider/resource_datasource_permission_test.go
+++ b/provider/resource_datasource_permission_test.go
@@ -18,7 +18,7 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 	datasourceID := int64(-1)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_data_source_permission/resource.tf"),
@@ -47,7 +47,7 @@ func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) res
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		gotDatasourceID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
@@ -68,7 +68,7 @@ func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) res
 //nolint:unused
 func testAccDatasourcePermissionCheckDestroy(datasourceID *int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		response, err := client.DatasourcePermissions(*datasourceID)
 		if err != nil {
 			return fmt.Errorf("error getting datasource permissions %d: %s", *datasourceID, err)

--- a/provider/resource_folder_permission_test.go
+++ b/provider/resource_folder_permission_test.go
@@ -16,7 +16,7 @@ func TestAccFolderPermission_basic(t *testing.T) {
 	folderUID := "uninitialized"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccFolderPermissionCheckDestroy(),
 		Steps: []resource.TestStep{
 			{
@@ -47,7 +47,7 @@ func testAccFolderPermissionsCheckExists(rn string, folderUID *string) resource.
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		gotFolderUID := rs.Primary.ID
 		_, err := client.FolderPermissions(gotFolderUID)
@@ -63,7 +63,7 @@ func testAccFolderPermissionsCheckExists(rn string, folderUID *string) resource.
 
 func testAccFolderPermissionsCheckEmpty(folderUID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		permissions, err := client.FolderPermissions(*folderUID)
 		if err != nil {
 			return fmt.Errorf("Error getting folder permissions %s: %s", *folderUID, err)

--- a/provider/resource_folder_permission_test.go
+++ b/provider/resource_folder_permission_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccFolderPermission_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	folderUID := "uninitialized"
 

--- a/provider/resource_folder_test.go
+++ b/provider/resource_folder_test.go
@@ -10,6 +10,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestAccFolder_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var folder gapi.Folder
 	var folderWithUID gapi.Folder
@@ -30,7 +31,7 @@ func TestAccFolder_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_folder/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_folder/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
 					resource.TestMatchResourceAttr("grafana_folder.test_folder", "id", idRegexp),
@@ -56,7 +57,7 @@ func TestAccFolder_basic(t *testing.T) {
 			},
 			// Change the title of one folder, change the UID of the other. They shouldn't change IDs (the folder doesn't have to be recreated)
 			{
-				Config: testAccExampleWithReplace(t, "resources/grafana_folder/resource.tf", map[string]string{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_folder/resource.tf", map[string]string{
 					"Terraform Test Folder": "Terraform Test Folder Updated",
 					"test-folder-uid":       "test-folder-uid-other",
 				}),
@@ -99,8 +100,8 @@ func TestAccFolder_basic(t *testing.T) {
 
 // This is a bug in Grafana, not the provider. It was fixed in 9.2.7+ and 9.3.0+, this test will check for regressions
 func TestAccFolder_createFromDifferentRoles(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.2.7")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.2.7")
 
 	for _, tc := range []struct {
 		role        string

--- a/provider/resource_folder_test.go
+++ b/provider/resource_folder_test.go
@@ -24,7 +24,7 @@ func TestAccFolder_basic(t *testing.T) {
 	var folderWithUID gapi.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccFolderCheckDestroy(&folder),
 			testAccFolderCheckDestroy(&folderWithUID),
@@ -121,7 +121,7 @@ func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 			var name = acctest.RandomWithPrefix(tc.role + "-key")
 
 			// Create an API key with the correct role and inject it in envvars. This auth will be used when the test runs
-			client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+			client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 			key, err := client.CreateAPIKey(gapi.CreateAPIKeyRequest{
 				Name: name,
 				Role: tc.role,
@@ -141,7 +141,7 @@ func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 
 			// Do not make parallel, fiddling with auth will break other tests that run in parallel
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: testAccProviderFactories,
+				ProviderFactories: testutils.ProviderFactories,
 				CheckDestroy: resource.ComposeTestCheckFunc(
 					testAccFolderCheckDestroy(&folder),
 				),
@@ -187,7 +187,7 @@ func testAccFolderCheckExists(rn string, folder *gapi.Folder) resource.TestCheck
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
 			return err
@@ -209,7 +209,7 @@ func testAccFolderCheckExists(rn string, folder *gapi.Folder) resource.TestCheck
 
 func testAccFolderCheckDestroy(folder *gapi.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := getFolderByID(client, folder.ID)
 		if err == nil {
 			return fmt.Errorf("folder still exists")

--- a/provider/resource_library_panel_test.go
+++ b/provider/resource_library_panel_test.go
@@ -6,14 +6,15 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccLibraryPanel_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 
@@ -24,7 +25,7 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test resource creation.
-				Config: testAccExample(t, "resources/grafana_library_panel/_acc_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_library_panel/_acc_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccLibraryPanelCheckExists("grafana_library_panel.test", &panel),
 					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "basic"),
@@ -33,7 +34,7 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 			},
 			{
 				// Updates title.
-				Config: testAccExample(t, "resources/grafana_library_panel/_acc_basic_update.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_library_panel/_acc_basic_update.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccLibraryPanelCheckExists("grafana_library_panel.test", &panel),
 					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "updated name"),
@@ -51,8 +52,8 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 }
 
 func TestAccLibraryPanel_computed_config(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 
@@ -63,7 +64,7 @@ func TestAccLibraryPanel_computed_config(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test resource creation.
-				Config: testAccExample(t, "resources/grafana_library_panel/_acc_computed.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_library_panel/_acc_computed.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccLibraryPanelCheckExists("grafana_library_panel.test", &panel),
 					testAccLibraryPanelCheckExists("grafana_library_panel.test-computed", &panel),
@@ -74,8 +75,8 @@ func TestAccLibraryPanel_computed_config(t *testing.T) {
 }
 
 func TestAccLibraryPanel_folder(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	var folder gapi.Folder
@@ -86,7 +87,7 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 		CheckDestroy:      testAccLibraryPanelFolderCheckDestroy(&panel, &folder),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_library_panel/_acc_folder.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_library_panel/_acc_folder.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccLibraryPanelCheckExists("grafana_library_panel.test_folder", &panel),
 					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
@@ -102,8 +103,8 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 }
 
 func TestAccLibraryPanel_dashboard(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	var dashboard gapi.Dashboard
@@ -115,7 +116,7 @@ func TestAccLibraryPanel_dashboard(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test library panel is connected to dashboard
-				Config: testAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
+				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccLibraryPanelCheckExists("grafana_library_panel.dashboard", &panel),
 					testAccDashboardCheckExists("grafana_dashboard.with_library_panel", &dashboard),

--- a/provider/resource_library_panel_test.go
+++ b/provider/resource_library_panel_test.go
@@ -20,7 +20,7 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
 			{
@@ -59,7 +59,7 @@ func TestAccLibraryPanel_computed_config(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
 			{
@@ -83,7 +83,7 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccLibraryPanelFolderCheckDestroy(&panel, &folder),
 		Steps: []resource.TestStep{
 			{
@@ -111,7 +111,7 @@ func TestAccLibraryPanel_dashboard(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccLibraryPanelCheckDestroy(&panel),
 		Steps: []resource.TestStep{
 			{
@@ -136,7 +136,7 @@ func testAccLibraryPanelCheckExists(rn string, panel *gapi.LibraryPanel) resourc
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		gotLibraryPanel, err := client.LibraryPanelByUID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting panel: %s", err)
@@ -157,7 +157,7 @@ func testAccLibraryPanelCheckExistsInFolder(panel *gapi.LibraryPanel, folder *ga
 
 func testAccLibraryPanelCheckDestroy(panel *gapi.LibraryPanel) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.LibraryPanelByUID(panel.UID)
 		if err == nil {
 			return fmt.Errorf("panel still exists")
@@ -168,7 +168,7 @@ func testAccLibraryPanelCheckDestroy(panel *gapi.LibraryPanel) resource.TestChec
 
 func testAccLibraryPanelFolderCheckDestroy(panel *gapi.LibraryPanel, folder *gapi.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.LibraryPanelByUID(panel.UID)
 		if err == nil {
 			return fmt.Errorf("panel still exists")

--- a/provider/resource_machine_learning_holiday_test.go
+++ b/provider/resource_machine_learning_holiday_test.go
@@ -18,7 +18,7 @@ func TestAccResourceMachineLearningHoliday(t *testing.T) {
 
 	var holiday mlapi.Holiday
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccMLHolidayCheckDestroy(&holiday),
 		Steps: []resource.TestStep{
 			{
@@ -52,7 +52,7 @@ func testAccMLHolidayCheckExists(rn string, holiday *mlapi.Holiday) resource.Tes
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).MLAPI
+		client := testutils.Provider.Meta().(*common.Client).MLAPI
 		gotHoliday, err := client.Holiday(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting holiday: %s", err)
@@ -71,7 +71,7 @@ func testAccMLHolidayCheckDestroy(holiday *mlapi.Holiday) resource.TestCheckFunc
 		if holiday.ID == "" {
 			return fmt.Errorf("checking deletion of empty id")
 		}
-		client := testAccProvider.Meta().(*common.Client).MLAPI
+		client := testutils.Provider.Meta().(*common.Client).MLAPI
 		_, err := client.Holiday(context.Background(), holiday.ID)
 		if err == nil {
 			return fmt.Errorf("holiday still exists on server")
@@ -108,7 +108,7 @@ func TestAccResourceInvalidMachineLearningHoliday(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      machineLearningHolidayInvalid,

--- a/provider/resource_machine_learning_holiday_test.go
+++ b/provider/resource_machine_learning_holiday_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceMachineLearningHoliday(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	var holiday mlapi.Holiday
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,7 +22,7 @@ func TestAccResourceMachineLearningHoliday(t *testing.T) {
 		CheckDestroy:      testAccMLHolidayCheckDestroy(&holiday),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_holiday/ical_holiday.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_holiday/ical_holiday.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLHolidayCheckExists("grafana_machine_learning_holiday.ical", &holiday),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_holiday.ical", "id"),
@@ -29,7 +30,7 @@ func TestAccResourceMachineLearningHoliday(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_holiday/custom_periods_holiday.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_holiday/custom_periods_holiday.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLHolidayCheckExists("grafana_machine_learning_holiday.custom_periods", &holiday),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_holiday.custom_periods", "id"),
@@ -104,7 +105,7 @@ resource "grafana_machine_learning_holiday" "invalid" {
 `
 
 func TestAccResourceInvalidMachineLearningHoliday(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_machine_learning_job_test.go
+++ b/provider/resource_machine_learning_job_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceMachineLearningJob(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	var job mlapi.Job
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,7 +22,7 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 		CheckDestroy:      testAccMLJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_job/job.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/job.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLJobCheckExists("grafana_machine_learning_job.test_job", &job),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
@@ -35,7 +36,7 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_job/datasource_uid_job.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/datasource_uid_job.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
@@ -48,7 +49,7 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_job/tuned_job.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/tuned_job.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
@@ -63,7 +64,7 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_job/holidays_job.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/holidays_job.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
@@ -143,7 +144,7 @@ resource "grafana_machine_learning_job" "invalid" {
 `
 
 func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_machine_learning_job_test.go
+++ b/provider/resource_machine_learning_job_test.go
@@ -18,7 +18,7 @@ func TestAccResourceMachineLearningJob(t *testing.T) {
 
 	var job mlapi.Job
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccMLJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
 			{
@@ -92,7 +92,7 @@ func testAccMLJobCheckExists(rn string, job *mlapi.Job) resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).MLAPI
+		client := testutils.Provider.Meta().(*common.Client).MLAPI
 		gotJob, err := client.Job(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting job: %s", err)
@@ -111,7 +111,7 @@ func testAccMLJobCheckDestroy(job *mlapi.Job) resource.TestCheckFunc {
 		if job.ID == "" {
 			return fmt.Errorf("checking deletion of empty id")
 		}
-		client := testAccProvider.Meta().(*common.Client).MLAPI
+		client := testutils.Provider.Meta().(*common.Client).MLAPI
 		_, err := client.Job(context.Background(), job.ID)
 		if err == nil {
 			return fmt.Errorf("job still exists on server")
@@ -147,7 +147,7 @@ func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      machineLearningJobInvalid,

--- a/provider/resource_machine_learning_outlier_detector_test.go
+++ b/provider/resource_machine_learning_outlier_detector_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceMachineLearningOutlierDetector(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	var outlier mlapi.OutlierDetector
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,7 +22,7 @@ func TestAccResourceMachineLearningOutlierDetector(t *testing.T) {
 		CheckDestroy:      testAccMLOutlierCheckDestroy(&outlier),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_outlier_detector/mad.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_outlier_detector/mad.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLOutlierCheckExists("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", &outlier),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "id"),
@@ -36,7 +37,7 @@ func TestAccResourceMachineLearningOutlierDetector(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_machine_learning_outlier_detector/dbscan.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_outlier_detector/dbscan.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "id"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "name", "My DBSCAN outlier detector"),
@@ -174,7 +175,7 @@ resource "grafana_machine_learning_outlier_detector" "invalid" {
 `
 
 func TestAccResourceInvalidMachineLearningOutlierDetector(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_machine_learning_outlier_detector_test.go
+++ b/provider/resource_machine_learning_outlier_detector_test.go
@@ -18,7 +18,7 @@ func TestAccResourceMachineLearningOutlierDetector(t *testing.T) {
 
 	var outlier mlapi.OutlierDetector
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccMLOutlierCheckDestroy(&outlier),
 		Steps: []resource.TestStep{
 			{
@@ -66,7 +66,7 @@ func testAccMLOutlierCheckExists(rn string, outlier *mlapi.OutlierDetector) reso
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).MLAPI
+		client := testutils.Provider.Meta().(*common.Client).MLAPI
 		gotOutlier, err := client.OutlierDetector(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting outlier: %s", err)
@@ -85,7 +85,7 @@ func testAccMLOutlierCheckDestroy(outlier *mlapi.OutlierDetector) resource.TestC
 		if outlier.ID == "" {
 			return fmt.Errorf("checking deletion of empty id")
 		}
-		client := testAccProvider.Meta().(*common.Client).MLAPI
+		client := testutils.Provider.Meta().(*common.Client).MLAPI
 		_, err := client.OutlierDetector(context.Background(), outlier.ID)
 		if err == nil {
 			return fmt.Errorf("outlier still exists on server")
@@ -178,7 +178,7 @@ func TestAccResourceInvalidMachineLearningOutlierDetector(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      machineLearningOutlierDetectorInvalid,

--- a/provider/resource_oncall_escalation_test.go
+++ b/provider/resource_oncall_escalation_test.go
@@ -20,7 +20,7 @@ func TestAccOnCallEscalation_basic(t *testing.T) {
 	reDuration := 300
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccCheckOnCallEscalationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -40,7 +40,7 @@ func TestAccOnCallEscalation_basic(t *testing.T) {
 }
 
 func testAccCheckOnCallEscalationResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).OnCallClient
+	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "grafana_oncall_escalation" {
 			continue
@@ -91,7 +91,7 @@ func testAccCheckOnCallEscalationResourceExists(name string) resource.TestCheckF
 			return fmt.Errorf("No Escalation ID is set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).OnCallClient
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
 		found, _, err := client.Escalations.GetEscalation(rs.Primary.ID, &onCallAPI.GetEscalationOptions{})
 		if err != nil {

--- a/provider/resource_oncall_escalation_test.go
+++ b/provider/resource_oncall_escalation_test.go
@@ -6,13 +6,14 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOnCallEscalation_basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	riName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 	reType := "wait"

--- a/provider/resource_oncall_integration_test.go
+++ b/provider/resource_oncall_integration_test.go
@@ -19,7 +19,7 @@ func TestAccOnCallIntegration_basic(t *testing.T) {
 	rType := "grafana"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccCheckOnCallIntegrationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +36,7 @@ func TestAccOnCallIntegration_basic(t *testing.T) {
 }
 
 func testAccCheckOnCallIntegrationResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).OnCallClient
+	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "grafana_oncall_integration" {
 			continue
@@ -76,7 +76,7 @@ func testAccCheckOnCallIntegrationResourceExists(name string) resource.TestCheck
 			return fmt.Errorf("No Integration ID is set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).OnCallClient
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
 		found, _, err := client.Integrations.GetIntegration(rs.Primary.ID, &onCallAPI.GetIntegrationOptions{})
 		if err != nil {

--- a/provider/resource_oncall_integration_test.go
+++ b/provider/resource_oncall_integration_test.go
@@ -6,13 +6,14 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOnCallIntegration_basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	rName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 	rType := "grafana"

--- a/provider/resource_oncall_on_call_shift_test.go
+++ b/provider/resource_oncall_on_call_shift_test.go
@@ -19,7 +19,7 @@ func TestAccOnCallOnCallShift_basic(t *testing.T) {
 	shiftName := fmt.Sprintf("shift-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccCheckOnCallOnCallShiftResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -33,7 +33,7 @@ func TestAccOnCallOnCallShift_basic(t *testing.T) {
 }
 
 func testAccCheckOnCallOnCallShiftResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).OnCallClient
+	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "grafana_oncall_on_call_shift" {
 			continue
@@ -78,7 +78,7 @@ func testAccCheckOnCallOnCallShiftResourceExists(name string) resource.TestCheck
 			return fmt.Errorf("No OnCallShift ID is set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).OnCallClient
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
 		found, _, err := client.OnCallShifts.GetOnCallShift(rs.Primary.ID, &onCallAPI.GetOnCallShiftOptions{})
 		if err != nil {

--- a/provider/resource_oncall_on_call_shift_test.go
+++ b/provider/resource_oncall_on_call_shift_test.go
@@ -6,13 +6,14 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOnCallOnCallShift_basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	scheduleName := fmt.Sprintf("schedule-%s", acctest.RandString(8))
 	shiftName := fmt.Sprintf("shift-%s", acctest.RandString(8))

--- a/provider/resource_oncall_outgoing_webhook_test.go
+++ b/provider/resource_oncall_outgoing_webhook_test.go
@@ -6,13 +6,14 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOnCallOutgoingWebhook_basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	webhookName := fmt.Sprintf("name-%s", acctest.RandString(8))
 

--- a/provider/resource_oncall_outgoing_webhook_test.go
+++ b/provider/resource_oncall_outgoing_webhook_test.go
@@ -18,7 +18,7 @@ func TestAccOnCallOutgoingWebhook_basic(t *testing.T) {
 	webhookName := fmt.Sprintf("name-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccCheckOnCallOutgoingWebhookResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -32,7 +32,7 @@ func TestAccOnCallOutgoingWebhook_basic(t *testing.T) {
 }
 
 func testAccCheckOnCallOutgoingWebhookResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).OnCallClient
+	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "grafana_oncall_outgoing_webhook" {
 			continue
@@ -69,7 +69,7 @@ func testAccCheckOnCallOutgoingWebhookResourceExists(name string) resource.TestC
 			return fmt.Errorf("No OutgoingWebhook ID is set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).OnCallClient
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
 		found, _, err := client.CustomActions.GetCustomAction(rs.Primary.ID, &onCallAPI.GetCustomActionOptions{})
 		if err != nil {

--- a/provider/resource_oncall_route_test.go
+++ b/provider/resource_oncall_route_test.go
@@ -6,13 +6,14 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOnCallRoute_basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	riName := fmt.Sprintf("integration-%s", acctest.RandString(8))
 	rrRegex := fmt.Sprintf("regex-%s", acctest.RandString(8))

--- a/provider/resource_oncall_route_test.go
+++ b/provider/resource_oncall_route_test.go
@@ -20,7 +20,7 @@ func TestAccOnCallRoute_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccCheckOnCallRouteResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -34,7 +34,7 @@ func TestAccOnCallRoute_basic(t *testing.T) {
 }
 
 func testAccCheckOnCallRouteResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).OnCallClient
+	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "grafana_oncall_route" {
 			continue
@@ -91,7 +91,7 @@ func testAccCheckOnCallRouteResourceExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("No Route ID is set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).OnCallClient
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
 		found, _, err := client.Routes.GetRoute(rs.Primary.ID, &onCallAPI.GetRouteOptions{})
 		if err != nil {

--- a/provider/resource_oncall_schedule_test.go
+++ b/provider/resource_oncall_schedule_test.go
@@ -18,7 +18,7 @@ func TestAccOnCallSchedule_basic(t *testing.T) {
 	scheduleName := fmt.Sprintf("schedule-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccCheckOnCallScheduleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -32,7 +32,7 @@ func TestAccOnCallSchedule_basic(t *testing.T) {
 }
 
 func testAccCheckOnCallScheduleResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).OnCallClient
+	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "grafana_oncall_schedule" {
 			continue
@@ -65,7 +65,7 @@ func testAccCheckOnCallScheduleResourceExists(name string) resource.TestCheckFun
 			return fmt.Errorf("No Schedule ID is set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).OnCallClient
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
 		found, _, err := client.Schedules.GetSchedule(rs.Primary.ID, &onCallAPI.GetScheduleOptions{})
 		if err != nil {

--- a/provider/resource_oncall_schedule_test.go
+++ b/provider/resource_oncall_schedule_test.go
@@ -6,13 +6,14 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOnCallSchedule_basic(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	scheduleName := fmt.Sprintf("schedule-%s", acctest.RandString(8))
 

--- a/provider/resource_organization_preferences_test.go
+++ b/provider/resource_organization_preferences_test.go
@@ -9,20 +9,21 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceOrganizationPreferences_WithDashboardID(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 	testAccResourceOrganizationPreferences(t, false)
 }
 
 func TestAccResourceOrganizationPreferences_WithDashboardUID(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.0.0") // UID support was added in 9.0.0
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0") // UID support was added in 9.0.0
 	testAccResourceOrganizationPreferences(t, true)
 }
 

--- a/provider/resource_organization_preferences_test.go
+++ b/provider/resource_organization_preferences_test.go
@@ -55,7 +55,7 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationPreferencesCheckDestroy(),
 		Steps: []resource.TestStep{
 			{
@@ -110,7 +110,7 @@ func testAccOrganizationPreferencesCheckExists(rn string, prefs gapi.Preferences
 		if err != nil {
 			return fmt.Errorf("error parsing org_id: %s", err)
 		}
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI.WithOrgID(id)
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(id)
 		p, err := client.OrgPreferences()
 		if err != nil {
 			return fmt.Errorf("error getting organization preferences: %s", err)
@@ -137,7 +137,7 @@ func testAccOrganizationPreferencesCheckExists(rn string, prefs gapi.Preferences
 
 func testAccOrganizationPreferencesCheckDestroy() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		prefs, err := client.OrgPreferences()
 		if err != nil {
 			return err

--- a/provider/resource_organization_test.go
+++ b/provider/resource_organization_test.go
@@ -19,7 +19,7 @@ func TestAccOrganization_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
 			{
@@ -73,7 +73,7 @@ func TestAccOrganization_users(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
 			{
@@ -141,7 +141,7 @@ func TestAccOrganization_createManyUsers(t *testing.T) {
 
 	// Don't make this test parallel, it's already creating 1000+ users
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
 			{Config: testAccOrganizationConfig_usersCreateMany_1},
@@ -168,7 +168,7 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
 			{
@@ -229,7 +229,7 @@ func TestAccOrganization_externalUser(t *testing.T) {
 	var org gapi.Org
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
 		Steps: []resource.TestStep{
 			{
@@ -275,7 +275,7 @@ func testAccOrganizationCheckExists(rn string, a *gapi.Org) resource.TestCheckFu
 			return fmt.Errorf("resource id is malformed")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		org, err := client.Org(id)
 		if err != nil {
 			return fmt.Errorf("error getting data source: %s", err)
@@ -289,7 +289,7 @@ func testAccOrganizationCheckExists(rn string, a *gapi.Org) resource.TestCheckFu
 
 func testAccOrganizationCheckDestroy(a *gapi.Org) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		org, err := client.Org(a.ID)
 		if err == nil && org.Name != "" {
 			return fmt.Errorf("organization still exists")

--- a/provider/resource_organization_test.go
+++ b/provider/resource_organization_test.go
@@ -7,12 +7,13 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccOrganization_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var org gapi.Org
 
@@ -66,7 +67,7 @@ func TestAccOrganization_basic(t *testing.T) {
 }
 
 func TestAccOrganization_users(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var org gapi.Org
 
@@ -134,7 +135,7 @@ func TestAccOrganization_users(t *testing.T) {
 }
 
 func TestAccOrganization_createManyUsers(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var org gapi.Org
 
@@ -161,7 +162,7 @@ func TestAccOrganization_createManyUsers(t *testing.T) {
 }
 
 func TestAccOrganization_defaultAdmin(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var org gapi.Org
 
@@ -223,7 +224,7 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 }
 
 func TestAccOrganization_externalUser(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var org gapi.Org
 

--- a/provider/resource_playlist_test.go
+++ b/provider/resource_playlist_test.go
@@ -20,7 +20,7 @@ func TestAccPlaylist_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccPlaylist_update(t *testing.T) {
 	updatedName := "updated name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -103,7 +103,7 @@ func TestAccPlaylist_disappears(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccPlaylistDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -129,7 +129,7 @@ func testAccPlaylistCheckExists() resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		_, err := client.Playlist(rs.Primary.ID)
 		if err != nil {
@@ -151,14 +151,14 @@ func testAccPlaylistDisappears() resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		return client.DeletePlaylist(rs.Primary.ID)
 	}
 }
 
 func testAccPlaylistDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "grafana_playlist" {

--- a/provider/resource_playlist_test.go
+++ b/provider/resource_playlist_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -14,7 +15,7 @@ import (
 const paylistResource = "grafana_playlist.test"
 
 func TestAccPlaylist_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -49,7 +50,7 @@ func TestAccPlaylist_basic(t *testing.T) {
 }
 
 func TestAccPlaylist_update(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	updatedName := "updated name"
@@ -97,7 +98,7 @@ func TestAccPlaylist_update(t *testing.T) {
 }
 
 func TestAccPlaylist_disappears(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 

--- a/provider/resource_report_test.go
+++ b/provider/resource_report_test.go
@@ -18,7 +18,7 @@ func TestAccResourceReport(t *testing.T) {
 	var report gapi.Report
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccReportCheckDestroy(&report),
 		Steps: []resource.TestStep{
 			{
@@ -103,7 +103,7 @@ func TestAccResourceReport_CreateFromDashboardID(t *testing.T) {
 	var report gapi.Report
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccReportCheckDestroy(&report),
 		Steps: []resource.TestStep{
 			{
@@ -129,7 +129,7 @@ func testAccReportCheckExists(rn string, report *gapi.Report) resource.TestCheck
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {
 			return err
@@ -151,7 +151,7 @@ func testAccReportCheckExists(rn string, report *gapi.Report) resource.TestCheck
 
 func testAccReportCheckDestroy(report *gapi.Report) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.Report(report.ID)
 		if err == nil {
 			return fmt.Errorf("report still exists")

--- a/provider/resource_report_test.go
+++ b/provider/resource_report_test.go
@@ -7,12 +7,13 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceReport(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	var report gapi.Report
 
@@ -21,7 +22,7 @@ func TestAccResourceReport(t *testing.T) {
 		CheckDestroy:      testAccReportCheckDestroy(&report),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_report/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_report/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccReportCheckExists("grafana_report.test", &report),
 					resource.TestCheckResourceAttrSet("grafana_report.test", "id"),
@@ -42,7 +43,7 @@ func TestAccResourceReport(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_report/all-options.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_report/all-options.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					func(s *terraform.State) error {
 						// Check that the ID and dashboard ID are the same as the first run
@@ -69,7 +70,7 @@ func TestAccResourceReport(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_report/monthly.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_report/monthly.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccReportCheckExists("grafana_report.test", &report),
 					resource.TestCheckResourceAttrSet("grafana_report.test", "id"),
@@ -97,7 +98,7 @@ func TestAccResourceReport(t *testing.T) {
 // Testing the deprecated case of using a dashboard ID instead of a dashboard UID
 // TODO: Remove in next major version
 func TestAccResourceReport_CreateFromDashboardID(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	var report gapi.Report
 

--- a/provider/resource_role_assignment_test.go
+++ b/provider/resource_role_assignment_test.go
@@ -17,7 +17,7 @@ func TestRoleAssignments(t *testing.T) {
 	var roleAssignment gapi.RoleAssignments
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testRoleAssignmentCheckDestroy(&roleAssignment),
 		Steps: []resource.TestStep{
 			{
@@ -58,7 +58,7 @@ func testRoleAssignmentCheckExists(rn string, ra *gapi.RoleAssignments) resource
 			return fmt.Errorf("resource UID not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		role, err := client.GetRoleAssignments(uid)
 		if err != nil {
 			return fmt.Errorf("error getting role assignments: %s", err)
@@ -72,7 +72,7 @@ func testRoleAssignmentCheckExists(rn string, ra *gapi.RoleAssignments) resource
 
 func testRoleAssignmentCheckDestroy(ra *gapi.RoleAssignments) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		role, err := client.GetRoleAssignments(ra.RoleUID)
 		if err == nil && (len(role.Users) > 0 || len(role.ServiceAccounts) > 0 || len(role.Teams) > 0) {
 			return fmt.Errorf("role is still assigned")

--- a/provider/resource_role_assignment_test.go
+++ b/provider/resource_role_assignment_test.go
@@ -9,10 +9,11 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 )
 
 func TestRoleAssignments(t *testing.T) {
-	CheckEnterpriseTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 	var roleAssignment gapi.RoleAssignments
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/provider/resource_role_test.go
+++ b/provider/resource_role_test.go
@@ -18,7 +18,7 @@ func TestAccRole(t *testing.T) {
 	var role gapi.Role
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccRoleCheckDestroy(&role),
 		Steps: []resource.TestStep{
 			{
@@ -108,7 +108,7 @@ func testAccRoleCheckExists(rn string, r *gapi.Role) resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		role, err := client.GetRole(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error getting role: %s", err)
@@ -122,7 +122,7 @@ func testAccRoleCheckExists(rn string, r *gapi.Role) resource.TestCheckFunc {
 
 func testAccRoleCheckDestroy(r *gapi.Role) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		role, err := client.GetRole(r.UID)
 		if err == nil && role.Name != "" {
 			return fmt.Errorf("role still exists")

--- a/provider/resource_role_test.go
+++ b/provider/resource_role_test.go
@@ -9,10 +9,11 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 )
 
 func TestAccRole(t *testing.T) {
-	CheckEnterpriseTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var role gapi.Role
 

--- a/provider/resource_service_account_permission_test.go
+++ b/provider/resource_service_account_permission_test.go
@@ -20,7 +20,7 @@ func TestAccServiceAccountPermission(t *testing.T) {
 	var saPermission gapi.ServiceAccountPermission
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccServiceAccountPermissionsCheckDestroy(saPermission.ID),
 		Steps: []resource.TestStep{
 			{
@@ -54,7 +54,7 @@ func testServiceAccountPermissionsCheckExists(rn string, saPerm *gapi.ServiceAcc
 			return fmt.Errorf("resource id is malformed")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		perms, err := client.GetServiceAccountPermissions(id)
 		if err != nil {
 			return fmt.Errorf("error getting role assignments: %s", err)
@@ -70,7 +70,7 @@ func testServiceAccountPermissionsCheckExists(rn string, saPerm *gapi.ServiceAcc
 
 func testAccServiceAccountPermissionsCheckDestroy(id int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		saPerms, err := client.GetServiceAccountPermissions(id)
 		if err != nil {
 			return err

--- a/provider/resource_service_account_permission_test.go
+++ b/provider/resource_service_account_permission_test.go
@@ -10,11 +10,12 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 )
 
 func TestAccServiceAccountPermission(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.2.4")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.2.4")
 
 	var saPermission gapi.ServiceAccountPermission
 	// TODO: Make parallelizable

--- a/provider/resource_service_account_test.go
+++ b/provider/resource_service_account_test.go
@@ -20,7 +20,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 
 	sa := gapi.ServiceAccountDTO{}
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccServiceAccountCheckDestroy(&sa),
 		Steps: []resource.TestStep{
 			{
@@ -51,7 +51,7 @@ func TestAccServiceAccount_invalid_role(t *testing.T) {
 	sa := gapi.ServiceAccountDTO{}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccServiceAccountCheckDestroy(&sa),
 		Steps: []resource.TestStep{
 			{
@@ -75,7 +75,7 @@ func testAccServiceAccountCheckExists(rn string, a *gapi.ServiceAccountDTO) reso
 		if err != nil {
 			return fmt.Errorf("resource id is malformed")
 		}
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		sas, err := client.GetServiceAccounts()
 		for _, sa := range sas {
 			if sa.ID == id {
@@ -97,7 +97,7 @@ func testAccServiceAccountCheckExists(rn string, a *gapi.ServiceAccountDTO) reso
 
 func testAccServiceAccountCheckDestroy(a *gapi.ServiceAccountDTO) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		sas, err := client.GetServiceAccounts()
 		if err != nil {
 			return err

--- a/provider/resource_service_account_test.go
+++ b/provider/resource_service_account_test.go
@@ -11,11 +11,12 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 )
 
 func TestAccServiceAccount_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	sa := gapi.ServiceAccountDTO{}
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,7 +46,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 }
 
 func TestAccServiceAccount_invalid_role(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	sa := gapi.ServiceAccountDTO{}
 

--- a/provider/resource_service_account_token_test.go
+++ b/provider/resource_service_account_token_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccServiceAccountToken_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
-	CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_service_account_token_test.go
+++ b/provider/resource_service_account_token_test.go
@@ -16,7 +16,7 @@ func TestAccServiceAccountToken_basic(t *testing.T) {
 	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccServiceAccountTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +36,7 @@ func TestAccServiceAccountToken_basic(t *testing.T) {
 }
 
 func testAccServiceAccountTokenCheckDestroy(s *terraform.State) error {
-	c := testAccProvider.Meta().(*common.Client).GrafanaAPI
+	c := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "grafana_service_account_token" {

--- a/provider/resource_synthetic_monitoring_check_test.go
+++ b/provider/resource_synthetic_monitoring_check_test.go
@@ -17,7 +17,7 @@ func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/dns_basic.tf"),
@@ -69,7 +69,7 @@ func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
@@ -128,7 +128,7 @@ func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/ping_basic.tf"),
@@ -166,7 +166,7 @@ func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/tcp_basic.tf"),
@@ -212,7 +212,7 @@ func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/traceroute_basic.tf"),
@@ -253,14 +253,14 @@ func TestAccResourceSyntheticMonitoringCheck_recreate(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
 				Check: func(s *terraform.State) error {
 					rs := s.RootModule().Resources["grafana_synthetic_monitoring_check.http"]
 					id, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
-					return testAccProvider.Meta().(*common.Client).SMAPI.DeleteCheck(context.Background(), id)
+					return testutils.Provider.Meta().(*common.Client).SMAPI.DeleteCheck(context.Background(), id)
 				},
 				ExpectNonEmptyPlan: true,
 			},
@@ -286,7 +286,7 @@ func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceSyntheticMonitoringCheck_noSettings,
@@ -301,7 +301,7 @@ func TestAccResourceSyntheticMonitoringCheck_multiple(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceSyntheticMonitoringCheck_multiple,

--- a/provider/resource_synthetic_monitoring_check_test.go
+++ b/provider/resource_synthetic_monitoring_check_test.go
@@ -7,19 +7,20 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/dns_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/dns_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.dns", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.dns", "tenant_id"),
@@ -35,7 +36,7 @@ func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/dns_complex.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/dns_complex.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.dns", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.dns", "tenant_id"),
@@ -64,14 +65,14 @@ func TestAccResourceSyntheticMonitoringCheck_dns(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.http", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.http", "tenant_id"),
@@ -85,7 +86,7 @@ func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/http_complex.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/http_complex.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.http", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.http", "tenant_id"),
@@ -123,14 +124,14 @@ func TestAccResourceSyntheticMonitoringCheck_http(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/ping_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/ping_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.ping", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.ping", "tenant_id"),
@@ -142,7 +143,7 @@ func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/ping_complex.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/ping_complex.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.ping", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.ping", "tenant_id"),
@@ -161,14 +162,14 @@ func TestAccResourceSyntheticMonitoringCheck_ping(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/tcp_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/tcp_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.tcp", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.tcp", "tenant_id"),
@@ -181,7 +182,7 @@ func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/tcp_complex.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/tcp_complex.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.tcp", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.tcp", "tenant_id"),
@@ -207,14 +208,14 @@ func TestAccResourceSyntheticMonitoringCheck_tcp(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/traceroute_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/traceroute_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.traceroute", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.traceroute", "tenant_id"),
@@ -228,7 +229,7 @@ func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/traceroute_complex.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/traceroute_complex.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.traceroute", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.traceroute", "tenant_id"),
@@ -248,14 +249,14 @@ func TestAccResourceSyntheticMonitoringCheck_traceroute(t *testing.T) {
 
 // Test that a check is recreated if deleted outside the Terraform process
 func TestAccResourceSyntheticMonitoringCheck_recreate(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
 				Check: func(s *terraform.State) error {
 					rs := s.RootModule().Resources["grafana_synthetic_monitoring_check.http"]
 					id, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
@@ -264,7 +265,7 @@ func TestAccResourceSyntheticMonitoringCheck_recreate(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.http", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.http", "tenant_id"),
@@ -282,7 +283,7 @@ func TestAccResourceSyntheticMonitoringCheck_recreate(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
@@ -297,7 +298,7 @@ func TestAccResourceSyntheticMonitoringCheck_noSettings(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringCheck_multiple(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_synthetic_monitoring_installation_test.go
+++ b/provider/resource_synthetic_monitoring_installation_test.go
@@ -22,7 +22,7 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 	apiKeyName := apiKeyPrefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{

--- a/provider/resource_synthetic_monitoring_installation_test.go
+++ b/provider/resource_synthetic_monitoring_installation_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccSyntheticMonitoringInstallation(t *testing.T) {
-	CheckCloudAPITestsEnabled(t)
+	testutils.CheckCloudAPITestsEnabled(t)
 
 	var stack gapi.Stack
 	stackPrefix := "tfsminstalltest"

--- a/provider/resource_synthetic_monitoring_probe_helper_test.go
+++ b/provider/resource_synthetic_monitoring_probe_helper_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestImportProbeStateWithToken(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	testcases := map[string]struct {
 		input             string

--- a/provider/resource_synthetic_monitoring_probe_test.go
+++ b/provider/resource_synthetic_monitoring_probe_test.go
@@ -18,7 +18,7 @@ func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
@@ -55,14 +55,14 @@ func TestAccResourceSyntheticMonitoringProbe_recreate(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
 				Check: func(s *terraform.State) error {
 					rs := s.RootModule().Resources["grafana_synthetic_monitoring_probe.main"]
 					id, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
-					return testAccProvider.Meta().(*common.Client).SMAPI.DeleteProbe(context.Background(), id)
+					return testutils.Provider.Meta().(*common.Client).SMAPI.DeleteProbe(context.Background(), id)
 				},
 				ExpectNonEmptyPlan: true,
 			},
@@ -111,7 +111,7 @@ func TestAccResourceSyntheticMonitoringProbe_InvalidLabels(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		Steps:             steps,
 	})
 }

--- a/provider/resource_synthetic_monitoring_probe_test.go
+++ b/provider/resource_synthetic_monitoring_probe_test.go
@@ -8,19 +8,20 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
@@ -33,7 +34,7 @@ func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource_update.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource_update.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
@@ -51,13 +52,13 @@ func TestAccResourceSyntheticMonitoringProbe(t *testing.T) {
 
 // Test that a probe is recreated if deleted outside the Terraform process
 func TestAccResourceSyntheticMonitoringProbe_recreate(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
 				Check: func(s *terraform.State) error {
 					rs := s.RootModule().Resources["grafana_synthetic_monitoring_probe.main"]
 					id, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
@@ -66,7 +67,7 @@ func TestAccResourceSyntheticMonitoringProbe_recreate(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
@@ -83,7 +84,7 @@ func TestAccResourceSyntheticMonitoringProbe_recreate(t *testing.T) {
 }
 
 func TestAccResourceSyntheticMonitoringProbe_InvalidLabels(t *testing.T) {
-	CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	var steps []resource.TestStep
 	for _, tc := range []struct {

--- a/provider/resource_team_external_group_test.go
+++ b/provider/resource_team_external_group_test.go
@@ -17,7 +17,7 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 	teamID := int64(-1)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccTeamExternalGroupCheckDestroy(),
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func testAccTeamExternalGroupCheckExists(rn string, teamID *int64) resource.Test
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 		gotTeamID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
 		if err != nil {

--- a/provider/resource_team_external_group_test.go
+++ b/provider/resource_team_external_group_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccTeamExternalGroup_basic(t *testing.T) {
-	CheckEnterpriseTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	teamID := int64(-1)
 

--- a/provider/resource_team_preferences_test.go
+++ b/provider/resource_team_preferences_test.go
@@ -3,12 +3,13 @@ package provider
 import (
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccTeamPreferences_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_team_preferences_test.go
+++ b/provider/resource_team_preferences_test.go
@@ -12,7 +12,7 @@ func TestAccTeamPreferences_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccTeamPreferencesCheckDestroy(),
 		Steps: []resource.TestStep{
 			{

--- a/provider/resource_team_test.go
+++ b/provider/resource_team_test.go
@@ -8,13 +8,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccTeam_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var team gapi.Team
 	teamName := acctest.RandString(5)
@@ -53,7 +54,7 @@ func TestAccTeam_basic(t *testing.T) {
 }
 
 func TestAccTeam_Members(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var team gapi.Team
 	teamName := acctest.RandString(5)
@@ -120,7 +121,7 @@ func TestAccTeam_Members(t *testing.T) {
 
 // Test that deleted users can still be removed as members of a team
 func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 	client := testAccProvider.Meta().(*common.Client).GrafanaAPI
 
 	var team gapi.Team

--- a/provider/resource_team_test.go
+++ b/provider/resource_team_test.go
@@ -22,7 +22,7 @@ func TestAccTeam_basic(t *testing.T) {
 	teamNameUpdated := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{
 			{
@@ -60,7 +60,7 @@ func TestAccTeam_Members(t *testing.T) {
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{
 			{
@@ -122,14 +122,14 @@ func TestAccTeam_Members(t *testing.T) {
 // Test that deleted users can still be removed as members of a team
 func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
-	client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+	client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
 	var team gapi.Team
 	var userID int64 = -1
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccTeamCheckDestroy(&team),
 		Steps: []resource.TestStep{
 			{
@@ -186,7 +186,7 @@ func testAccTeamCheckExists(rn string, a *gapi.Team) resource.TestCheckFunc {
 			return fmt.Errorf("resource id is malformed")
 		}
 
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		team, err := client.Team(id)
 		if err != nil {
 			return fmt.Errorf("error getting data source: %s", err)
@@ -200,7 +200,7 @@ func testAccTeamCheckExists(rn string, a *gapi.Team) resource.TestCheckFunc {
 
 func testAccTeamCheckDestroy(a *gapi.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		team, err := client.Team(a.ID)
 		if err == nil && team.Name != "" {
 			return fmt.Errorf("team still exists")

--- a/provider/resource_user_test.go
+++ b/provider/resource_user_test.go
@@ -18,7 +18,7 @@ func TestAccUser_basic(t *testing.T) {
 
 	var user gapi.User
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testAccProviderFactories,
+		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccUserCheckDestroy(&user),
 		Steps: []resource.TestStep{
 			{
@@ -86,7 +86,7 @@ func testAccUserCheckExists(rn string, a *gapi.User) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("resource id is malformed")
 		}
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		user, err := client.User(id)
 		if err != nil {
 			return fmt.Errorf("error getting data source: %s", err)
@@ -98,7 +98,7 @@ func testAccUserCheckExists(rn string, a *gapi.User) resource.TestCheckFunc {
 
 func testAccUserCheckDestroy(a *gapi.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		user, err := client.User(a.ID)
 		if err == nil && user.Email != "" {
 			return fmt.Errorf("user still exists")

--- a/provider/resource_user_test.go
+++ b/provider/resource_user_test.go
@@ -10,10 +10,11 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/provider/common"
+	"github.com/grafana/terraform-provider-grafana/provider/testutils"
 )
 
 func TestAccUser_basic(t *testing.T) {
-	CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t)
 
 	var user gapi.User
 	resource.ParallelTest(t, resource.TestCase{

--- a/provider/testutils/provider.go
+++ b/provider/testutils/provider.go
@@ -1,0 +1,147 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// TestAccExample returns an example config from the examples directory.
+// Examples are used for both documentation and acceptance tests.
+func TestAccExample(t *testing.T, path string) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not get current file")
+	}
+	example, err := os.ReadFile(filepath.Join(filepath.Dir(currentFile), "..", "..", "examples", path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(example)
+}
+
+// TestAccExampleWithReplace works like testAccExample, but replaces strings in the example.
+func TestAccExampleWithReplace(t *testing.T, path string, replaceMap map[string]string) string {
+	t.Helper()
+
+	example := TestAccExample(t, path)
+	for k, v := range replaceMap {
+		example = strings.ReplaceAll(example, k, v)
+	}
+	return example
+}
+
+func AccTestsEnabled(envVarName string) bool {
+	v, ok := os.LookupEnv(envVarName)
+	if !ok {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		panic(fmt.Sprintf("%s must be set to a boolean value", envVarName))
+	}
+
+	return enabled
+}
+
+func CheckEnvVarsSet(t *testing.T, envVars ...string) {
+	t.Helper()
+
+	for _, envVar := range envVars {
+		if os.Getenv(envVar) == "" {
+			t.Fatalf("%s must be set", envVar)
+		}
+	}
+}
+
+func IsUnitTest(t *testing.T) {
+	t.Helper()
+
+	if AccTestsEnabled("TF_ACC") {
+		t.Skip("Skipping acceptance tests")
+	}
+}
+
+// CheckOSSTestsEnabled checks if the OSS acceptance tests are enabled. This should be the first line of any test that uses Grafana OSS features only
+func CheckOSSTestsEnabled(t *testing.T) {
+	t.Helper()
+
+	if !AccTestsEnabled("TF_ACC_OSS") {
+		t.Skip("TF_ACC_OSS must be set to a truthy value for OSS acceptance tests")
+	}
+
+	CheckEnvVarsSet(t,
+		"GRAFANA_URL",
+		"GRAFANA_AUTH",
+		"GRAFANA_ORG_ID",
+		"GRAFANA_VERSION",
+	)
+}
+
+// CheckOSSTestsSemver allows to skip tests that are not supported by the Grafana OSS version
+func CheckOSSTestsSemver(t *testing.T, semverConstraint string) {
+	t.Helper()
+
+	versionStr := os.Getenv("GRAFANA_VERSION")
+	if semverConstraint != "" && versionStr != "" {
+		version := semver.MustParse(versionStr)
+		c, err := semver.NewConstraint(semverConstraint)
+		if err != nil {
+			t.Fatalf("invalid constraint %s: %v", semverConstraint, err)
+		}
+		if !c.Check(version) {
+			t.Skipf("skipping test for Grafana version `%s`, constraint `%s`", versionStr, semverConstraint)
+		}
+	}
+}
+
+// CheckCloudTestsEnabled checks if the cloud tests are enabled. This should be the first line of any test that tests Cloud API features
+func CheckCloudAPITestsEnabled(t *testing.T) {
+	t.Helper()
+
+	if !AccTestsEnabled("TF_ACC_CLOUD_API") {
+		t.Skip("TF_ACC_CLOUD_API must be set to a truthy value for Cloud API acceptance tests")
+	}
+
+	CheckEnvVarsSet(t, "GRAFANA_CLOUD_API_KEY", "GRAFANA_CLOUD_ORG")
+}
+
+// CheckCloudInstanceTestsEnabled checks if tests that run on cloud instances are enabled. This should be the first line of any test that tests Grafana Cloud Pro features
+func CheckCloudInstanceTestsEnabled(t *testing.T) {
+	t.Helper()
+
+	if !AccTestsEnabled("TF_ACC_CLOUD_INSTANCE") {
+		t.Skip("TF_ACC_CLOUD_INSTANCE must be set to a truthy value for Cloud instance acceptance tests")
+	}
+
+	CheckEnvVarsSet(t,
+		"GRAFANA_URL",
+		"GRAFANA_AUTH",
+		"GRAFANA_ORG_ID",
+		"GRAFANA_SM_ACCESS_TOKEN",
+		"GRAFANA_ONCALL_ACCESS_TOKEN",
+	)
+}
+
+// CheckEnterpriseTestsEnabled checks if the enterprise tests are enabled. This should be the first line of any test that tests Grafana Enterprise features
+func CheckEnterpriseTestsEnabled(t *testing.T) {
+	t.Helper()
+
+	if !AccTestsEnabled("TF_ACC_ENTERPRISE") {
+		t.Skip("TF_ACC_ENTERPRISE must be set to a truthy value for Enterprise acceptance tests")
+	}
+
+	CheckEnvVarsSet(t,
+		"GRAFANA_URL",
+		"GRAFANA_AUTH",
+		"GRAFANA_ORG_ID",
+	)
+}

--- a/provider/testutils/provider.go
+++ b/provider/testutils/provider.go
@@ -10,7 +10,22 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// ProviderFactories is a static map containing only the main provider instance
+// It is configured from the main provider package when the test suite is initialized
+// but it is used in tests of every package
+var ProviderFactories map[string]func() (*schema.Provider, error)
+
+// Provider is the "main" provider instance
+//
+// This Provider can be used in testing code for API calls without requiring
+// the use of saving and referencing specific ProviderFactories instances.
+//
+// It is configured from the main provider package when the test suite is initialized
+// but it is used in tests of every package
+var Provider *schema.Provider
 
 // TestAccExample returns an example config from the examples directory.
 // Examples are used for both documentation and acceptance tests.


### PR DESCRIPTION
Follow-up to https://github.com/grafana/terraform-provider-grafana/pull/806 

This is the last part before being able to split by provider "section" 
These are all functions that are widely used in tests and will be shared