### PR TITLE
Add alert pausing

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -43,7 +43,6 @@ resource "grafana_rule_group" "my_alert_rule" {
       "e" = "f"
       "g" = "h"
     }
-    paused = false
     data {
       ref_id     = "A"
       query_type = ""

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -138,6 +138,7 @@ Optional:
 - `for` (String) The amount of time for which the rule must be breached for the rule to be considered to be Firing. Before this time has elapsed, the rule is only considered to be Pending. Defaults to `0`.
 - `labels` (Map of String) Key-value pairs to attach to the alert rule that can be used in matching, grouping, and routing. Defaults to `map[]`.
 - `no_data_state` (String) Describes what state to enter when the rule's query returns No Data. Options are OK, NoData, and Alerting. Defaults to `NoData`.
+- `paused` (Boolean) Sets whether the alert should be paused or not. Defaults to `false`.
 
 Read-Only:
 

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -43,6 +43,7 @@ resource "grafana_rule_group" "my_alert_rule" {
       "e" = "f"
       "g" = "h"
     }
+    paused = false
     data {
       ref_id     = "A"
       query_type = ""

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -43,7 +43,7 @@ resource "grafana_rule_group" "my_alert_rule" {
       "e" = "f"
       "g" = "h"
     }
-    paused = false
+    is_paused = false
     data {
       ref_id     = "A"
       query_type = ""
@@ -137,9 +137,9 @@ Optional:
 - `annotations` (Map of String) Key-value pairs of metadata to attach to the alert rule that may add user-defined context, but cannot be used for matching, grouping, or routing. Defaults to `map[]`.
 - `exec_err_state` (String) Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are OK, Error, and Alerting. Defaults to `Alerting`.
 - `for` (String) The amount of time for which the rule must be breached for the rule to be considered to be Firing. Before this time has elapsed, the rule is only considered to be Pending. Defaults to `0`.
+- `is_paused` (Boolean) Sets whether the alert should be paused or not. Defaults to `false`.
 - `labels` (Map of String) Key-value pairs to attach to the alert rule that can be used in matching, grouping, and routing. Defaults to `map[]`.
 - `no_data_state` (String) Describes what state to enter when the rule's query returns No Data. Options are OK, NoData, and Alerting. Defaults to `NoData`.
-- `paused` (Boolean) Sets whether the alert should be paused or not. Defaults to `false`.
 
 Read-Only:
 

--- a/examples/resources/grafana_rule_group/resource.tf
+++ b/examples/resources/grafana_rule_group/resource.tf
@@ -21,6 +21,7 @@ resource "grafana_rule_group" "my_alert_rule" {
       "e" = "f"
       "g" = "h"
     }
+    paused = false
     data {
       ref_id     = "A"
       query_type = ""

--- a/examples/resources/grafana_rule_group/resource.tf
+++ b/examples/resources/grafana_rule_group/resource.tf
@@ -21,7 +21,6 @@ resource "grafana_rule_group" "my_alert_rule" {
       "e" = "f"
       "g" = "h"
     }
-    paused = false
     data {
       ref_id     = "A"
       query_type = ""

--- a/examples/resources/grafana_rule_group/resource.tf
+++ b/examples/resources/grafana_rule_group/resource.tf
@@ -21,7 +21,7 @@ resource "grafana_rule_group" "my_alert_rule" {
       "e" = "f"
       "g" = "h"
     }
-    paused = false
+    is_paused = false
     data {
       ref_id     = "A"
       query_type = ""

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/grafana/amixr-api-go-client v0.0.6
-	github.com/grafana/grafana-api-golang-client v0.18.2
+	github.com/grafana/grafana-api-golang-client v0.18.3
 	github.com/grafana/machine-learning-go-client v0.4.0
 	github.com/grafana/synthetic-monitoring-agent v0.14.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/grafana/amixr-api-go-client v0.0.6 h1:dDKSROgxg2NUuNBeF3L/0cfD9nG815O
 github.com/grafana/amixr-api-go-client v0.0.6/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.18.2 h1:WPYT4Cyw0uqBHAyO619HykzNsQ98yHKFmPuJonfiW8c=
 github.com/grafana/grafana-api-golang-client v0.18.2/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
+github.com/grafana/grafana-api-golang-client v0.18.3 h1:z0AhbGG6suChLb8t2fADpEO9ckPWnweYPYoCW3WpF6k=
+github.com/grafana/grafana-api-golang-client v0.18.3/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/machine-learning-go-client v0.4.0 h1:UAkJPE7xujzFTm0d9ctbX/FsCID8rqejWjnkRPGNM6E=
 github.com/grafana/machine-learning-go-client v0.4.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.14.1 h1:UyTCDTFr2gIJujJrspYR9MHGptdNQrbTM5Td36nDinA=

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -168,6 +168,12 @@ This resource requires Grafana 9.1.0 or later.
 								Type: schema.TypeString,
 							},
 						},
+						"paused": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Sets whether the alert should be paused or not.",
+						},
 					},
 				},
 			},
@@ -325,6 +331,7 @@ func packAlertRule(r gapi.AlertRule) (interface{}, error) {
 		"labels":         r.Labels,
 		"annotations":    r.Annotations,
 		"data":           data,
+		"paused":         r.IsPaused,
 	}
 	return json, nil
 }
@@ -349,6 +356,7 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 		Condition:    json["condition"].(string),
 		Labels:       unpackMap(json["labels"]),
 		Annotations:  unpackMap(json["annotations"]),
+		IsPaused:     json["paused"].(bool),
 	}, nil
 }
 

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -168,7 +168,7 @@ This resource requires Grafana 9.1.0 or later.
 								Type: schema.TypeString,
 							},
 						},
-						"paused": {
+						"is_paused": {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,
@@ -331,7 +331,7 @@ func packAlertRule(r gapi.AlertRule) (interface{}, error) {
 		"labels":         r.Labels,
 		"annotations":    r.Annotations,
 		"data":           data,
-		"paused":         r.IsPaused,
+		"is_paused":      r.IsPaused,
 	}
 	return json, nil
 }
@@ -356,7 +356,7 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 		Condition:    json["condition"].(string),
 		Labels:       unpackMap(json["labels"]),
 		Annotations:  unpackMap(json["annotations"]),
-		IsPaused:     json["paused"].(bool),
+		IsPaused:     json["is_paused"].(bool),
 	}, nil
 }
 

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -53,6 +53,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.name", "A Different Rule"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.for", "2m"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.paused", "false"),
 				),
 			},
 			// Test rename group.
@@ -79,6 +80,19 @@ func TestAccAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "interval_seconds", "360"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
+				),
+			},
+			// Test change pause.
+			{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
+					"false": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testRuleGroupCheckExists("grafana_rule_group.my_alert_rule", &group),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.name", "My Alert Rule 1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.paused", "true"),
 				),
 			},
 			// Test re-parent folder.

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -53,7 +53,6 @@ func TestAccAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.name", "A Different Rule"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.for", "2m"),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.paused", "false"),
 				),
 			},
 			// Test rename group.
@@ -80,19 +79,6 @@ func TestAccAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "interval_seconds", "360"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
-				),
-			},
-			// Test change pause.
-			{
-				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
-					"false": "true",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testRuleGroupCheckExists("grafana_rule_group.my_alert_rule", &group),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.name", "My Alert Rule 1"),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.paused", "true"),
 				),
 			},
 			// Test re-parent folder.


### PR DESCRIPTION
- Change github.com/grafana/grafana-api-golang-client from `v0.18.2` to `v0.18.3`
- Add `is_paused` attribute to be able to create a paused alert rule

I tested it with 3 rules:
- One was created without the attribute `is_paused `, so it took the default (`false`).
- One was created with the attribute `is_paused ` to `true`.
- One was created with the attribute `is_paused ` to `false`.

<img width="1401" alt="Captura de pantalla 2023-02-08 a las 9 50 59" src="https://user-images.githubusercontent.com/2112640/217481290-194ee0d3-9223-4d1b-b24c-288de742a328.png">
