### PR TITLE
Linkchecking: Fix all redirects

### DIFF
--- a/docs/data-sources/cloud_organization.md
+++ b/docs/data-sources/cloud_organization.md
@@ -3,13 +3,12 @@
 page_title: "grafana_cloud_organization Data Source - terraform-provider-grafana"
 subcategory: "Cloud"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-organizations/HTTP API https://grafana.com/docs/grafana/latest/http_api/org/
+  
 ---
 
 # grafana_cloud_organization (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/org/)
+
 
 ## Example Usage
 

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -3,14 +3,14 @@
 page_title: "grafana_dashboard Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/Folder/Dashboard Search HTTP API https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/Dashboard HTTP API https://grafana.com/docs/grafana/latest/http_api/dashboard/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/Folder/Dashboard Search HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/Dashboard HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/
 ---
 
 # grafana_dashboard (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/)
-* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
+* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/)
+* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 
 ## Example Usage
 

--- a/docs/data-sources/dashboards.md
+++ b/docs/data-sources/dashboards.md
@@ -4,7 +4,7 @@ page_title: "grafana_dashboards Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Datasource for retrieving all dashboards. Specify list of folder IDs to search in for dashboards.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/Folder/Dashboard Search HTTP API https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/Dashboard HTTP API https://grafana.com/docs/grafana/latest/http_api/dashboard/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/Folder/Dashboard Search HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/Dashboard HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/
 ---
 
 # grafana_dashboards (Data Source)
@@ -12,8 +12,8 @@ description: |-
 Datasource for retrieving all dashboards. Specify list of folder IDs to search in for dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/)
-* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
+* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/)
+* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 
 ## Example Usage
 

--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -3,13 +3,13 @@
 page_title: "grafana_folder Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/HTTP API https://grafana.com/docs/grafana/latest/http_api/folder/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
 ---
 
 # grafana_folder (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 
 ## Example Usage
 

--- a/docs/data-sources/folders.md
+++ b/docs/data-sources/folders.md
@@ -3,12 +3,12 @@
 page_title: "grafana_folders Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
 ---
 
 # grafana_folders (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 
 ## Example Usage

--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -3,13 +3,13 @@
 page_title: "grafana_organization Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-organizations/HTTP API https://grafana.com/docs/grafana/latest/http_api/org/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/org/
 ---
 
 # grafana_organization (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/org/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
 
 ## Example Usage
 

--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -3,12 +3,12 @@
 page_title: "grafana_organization_preferences Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-organizations/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs
 ---
 
 # grafana_organization_preferences (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
 
 ## Example Usage

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -3,13 +3,13 @@
 page_title: "grafana_team Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-teams/HTTP API https://grafana.com/docs/grafana/latest/http_api/team/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/team-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/team/
 ---
 
 # grafana_team (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-teams/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
 
 ## Example Usage
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -3,15 +3,15 @@
 page_title: "grafana_user Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/HTTP API https://grafana.com/docs/grafana/latest/http_api/user/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/user/
   This data source uses Grafana's admin APIs for reading users which
   does not currently work with API Tokens. You must use basic auth.
 ---
 
 # grafana_user (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
 
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -3,15 +3,15 @@
 page_title: "grafana_users Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/HTTP API https://grafana.com/docs/grafana/latest/http_api/user/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/user/
   This data source uses Grafana's admin APIs for reading users which
   does not currently work with API Tokens. You must use basic auth.
 ---
 
 # grafana_users (Data Source)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
 		
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/docs/index.md
+++ b/docs/index.md
@@ -228,7 +228,7 @@ One, or many, of the following authentication settings must be set. Each authent
 ### `auth`
 
 This can be a Grafana API key, basic auth `username:password`, or a
-[Grafana API key](https://grafana.com/docs/grafana/latest/http_api/create-api-tokens-for-org/).
+[Grafana API key](https://grafana.com/docs/grafana/latest/developers/http_api/create-api-tokens-for-org/).
 
 ### `cloud_api_key`
 

--- a/docs/resources/alert_notification.md
+++ b/docs/resources/alert_notification.md
@@ -4,13 +4,13 @@ page_title: "grafana_alert_notification Resource - terraform-provider-grafana"
 subcategory: "Deprecated"
 description: |-
   This resource is used to configure the legacy alerting system which has been replaced by the unified alerting system https://grafana.com/docs/grafana/latest/alerting/ in Grafana 9+. See resources in the Alerting section https://registry.terraform.io/providers/grafana/grafana/latest/docs for info on how to configure alerting with Terraform.
-  * HTTP API https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/
+  * HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_notification_channels/
 ---
 
 # grafana_alert_notification (Resource)
 
 This resource is used to configure the legacy alerting system which has been replaced by the [unified alerting system](https://grafana.com/docs/grafana/latest/alerting/) in Grafana 9+. See resources in the [Alerting section](https://registry.terraform.io/providers/grafana/grafana/latest/docs) for info on how to configure alerting with Terraform.
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_notification_channels/)
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "grafana_alert_notification" "email_someteam" {
 - `is_default` (Boolean) Is this the default channel for all your alerts. Defaults to `false`.
 - `secure_settings` (Map of String, Sensitive) Additional secure settings, for full reference lookup [Grafana Supported Settings documentation](https://grafana.com/docs/grafana/latest/administration/provisioning/#supported-settings).
 - `send_reminder` (Boolean) Whether to send reminders for triggered alerts. Defaults to `false`.
-- `settings` (Map of String) Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).
+- `settings` (Map of String) Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_notification_channels/).
 - `uid` (String) Unique identifier. If unset, this will be automatically generated.
 
 ### Read-Only

--- a/docs/resources/annotation.md
+++ b/docs/resources/annotation.md
@@ -3,13 +3,13 @@
 page_title: "grafana_annotation Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/annotations/HTTP API https://grafana.com/docs/grafana/latest/http_api/annotations/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/annotations/
 ---
 
 # grafana_annotation (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/annotations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/annotations/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/annotations/)
 
 ## Example Usage
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -4,14 +4,14 @@ page_title: "grafana_api_key Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana API Keys.
-  HTTP API https://grafana.com/docs/grafana/latest/http_api/auth/
+  HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/auth/
 ---
 
 # grafana_api_key (Resource)
 
 Manages Grafana API Keys.
 
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/auth/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/auth/)
 
 ## Example Usage
 

--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -4,7 +4,7 @@ page_title: "grafana_contact_point Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting contact points.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/contact-pointsHTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
+  Official documentation https://grafana.com/docs/grafana/next/alerting/fundamentals/contact-points/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting contact points.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/contact-points)
+* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/contact-points/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -4,7 +4,7 @@ page_title: "grafana_dashboard Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana dashboards.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/HTTP API https://grafana.com/docs/grafana/latest/http_api/dashboard/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/
 ---
 
 # grafana_dashboard (Resource)
@@ -12,7 +12,7 @@ description: |-
 Manages Grafana dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 
 ## Example Usage
 

--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -3,13 +3,13 @@
 page_title: "grafana_dashboard_permission Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/HTTP API https://grafana.com/docs/grafana/latest/http_api/dashboard_permissions/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/
 ---
 
 # grafana_dashboard_permission (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard_permissions/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -3,7 +3,7 @@
 page_title: "grafana_data_source Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/datasources/HTTP API https://grafana.com/docs/grafana/latest/http_api/data_source/
+  Official documentation https://grafana.com/docs/grafana/latest/datasources/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/data_source/
   The required arguments for this resource vary depending on the type of data
   source selected (via the 'type' argument).
 ---
@@ -11,7 +11,7 @@ description: |-
 # grafana_data_source (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/datasources/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/data_source/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/)
 
 The required arguments for this resource vary depending on the type of data
 source selected (via the 'type' argument).

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -3,12 +3,12 @@
 page_title: "grafana_data_source_permission Resource - terraform-provider-grafana"
 subcategory: "Grafana Enterprise"
 description: |-
-  HTTP API https://grafana.com/docs/grafana/latest/http_api/datasource_permissions/
+  HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/
 ---
 
 # grafana_data_source_permission (Resource)
 
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/datasource_permissions/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -3,13 +3,13 @@
 page_title: "grafana_folder Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/HTTP API https://grafana.com/docs/grafana/latest/http_api/folder/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
 ---
 
 # grafana_folder (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 
 ## Example Usage
 

--- a/docs/resources/folder_permission.md
+++ b/docs/resources/folder_permission.md
@@ -3,13 +3,13 @@
 page_title: "grafana_folder_permission Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/HTTP API https://grafana.com/docs/grafana/latest/http_api/folder_permissions/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/
 ---
 
 # grafana_folder_permission (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder_permissions/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -4,15 +4,15 @@ page_title: "grafana_library_panel Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana library panels.
-  Official documentation https://grafana.com/docs/grafana/latest/panels/panel-library/HTTP API https://grafana.com/docs/grafana/latest/http_api/library_element/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/library_element/
 ---
 
 # grafana_library_panel (Resource)
 
 Manages Grafana library panels.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/panels/panel-library/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/library_element/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/library_element/)
 
 ## Example Usage
 

--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -4,7 +4,7 @@ page_title: "grafana_message_template Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting message templates.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/contact-points/message-templating/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates
+  Official documentation https://grafana.com/docs/grafana/next/alerting/manage-notifications/create-message-template/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting message templates.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/contact-points/message-templating/)
+* [Official documentation](https://grafana.com/docs/grafana/next/alerting/manage-notifications/create-message-template/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates)
 
 This resource requires Grafana 9.1.0 or later.

--- a/docs/resources/mute_timing.md
+++ b/docs/resources/mute_timing.md
@@ -4,7 +4,7 @@ page_title: "grafana_mute_timing Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting mute timings.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/notifications/mute-timings/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/manage-notifications/mute-timings/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting mute timings.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/notifications/mute-timings/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/manage-notifications/mute-timings/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings)
 
 This resource requires Grafana 9.1.0 or later.

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -4,7 +4,7 @@ page_title: "grafana_notification_policy Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/notifications/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/manage-notifications/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,8 +12,8 @@ description: |-
 
 Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/notifications/)
-* [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/manage-notifications/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -3,13 +3,13 @@
 page_title: "grafana_organization Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-organizations/HTTP API https://grafana.com/docs/grafana/latest/http_api/org/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/org/
 ---
 
 # grafana_organization (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/org/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
 
 ## Example Usage
 

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -3,12 +3,12 @@
 page_title: "grafana_organization_preferences Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-organizations/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs
 ---
 
 # grafana_organization_preferences (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
 
 ## Example Usage

--- a/docs/resources/playlist.md
+++ b/docs/resources/playlist.md
@@ -3,13 +3,13 @@
 page_title: "grafana_playlist Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/playlist/HTTP API https://grafana.com/docs/grafana/latest/http_api/playlist/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/playlist/
 ---
 
 # grafana_playlist (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/playlist/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/playlist/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/playlist/)
 
 
 

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -4,15 +4,15 @@ page_title: "grafana_report Resource - terraform-provider-grafana"
 subcategory: "Grafana Enterprise"
 description: |-
   Note: This resource is available only with Grafana Enterprise 7.+.
-  Official documentation https://grafana.com/docs/grafana/latest/enterprise/reporting/HTTP API https://grafana.com/docs/grafana/latest/http_api/reporting/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-reports/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/reporting/
 ---
 
 # grafana_report (Resource)
 
 **Note:** This resource is available only with Grafana Enterprise 7.+.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/reporting/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/reporting/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-reports/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/reporting/)
 
 ## Example Usage
 

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -4,7 +4,7 @@ page_title: "grafana_rule_group Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting rule groups.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/alerting-rulesHTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/alerting-rules/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting rule groups.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
 
 This resource requires Grafana 9.1.0 or later.

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -3,13 +3,13 @@
 page_title: "grafana_team Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-teams/HTTP API https://grafana.com/docs/grafana/latest/http_api/team/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/team-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/team/
 ---
 
 # grafana_team (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-teams/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
 
 ## Example Usage
 
@@ -33,7 +33,7 @@ resource "grafana_team" "test-team" {
 ### Optional
 
 - `email` (String) An email address for the team.
-- `ignore_externally_synced_members` (Boolean) Ignores team members that have been added to team by [Team Sync](https://grafana.com/docs/grafana/latest/enterprise/team-sync/).
+- `ignore_externally_synced_members` (Boolean) Ignores team members that have been added to team by [Team Sync](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/).
 Team Sync can be provisioned using [grafana_team_external_group resource](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/team_external_group).
  Defaults to `true`.
 - `members` (Set of String) A set of email addresses corresponding to users who should be given membership

--- a/docs/resources/team_external_group.md
+++ b/docs/resources/team_external_group.md
@@ -3,13 +3,13 @@
 page_title: "grafana_team_external_group Resource - terraform-provider-grafana"
 subcategory: "Grafana Enterprise"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/enterprise/team-sync/HTTP API https://grafana.com/docs/grafana/latest/http_api/external_group_sync/
+  Official documentation https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/external_group_sync/
 ---
 
 # grafana_team_external_group (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/team-sync/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/external_group_sync/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/external_group_sync/)
 
 ## Example Usage
 

--- a/docs/resources/team_preferences.md
+++ b/docs/resources/team_preferences.md
@@ -3,13 +3,13 @@
 page_title: "grafana_team_preferences Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/preferences/HTTP API https://grafana.com/docs/grafana/latest/http_api/team/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-preferences/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/team/
 ---
 
 # grafana_team_preferences (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/preferences/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-preferences/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
 
 ## Example Usage
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,15 +3,15 @@
 page_title: "grafana_user Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/HTTP API https://grafana.com/docs/grafana/latest/http_api/user/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/user/
   This resource uses Grafana's admin APIs for creating and updating users which
   does not currently work with API Tokens. You must use basic auth.
 ---
 
 # grafana_user (Resource)
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
 
 This resource uses Grafana's admin APIs for creating and updating users which
 does not currently work with API Tokens. You must use basic auth.

--- a/internal/resources/cloud/data_source_cloud_organization.go
+++ b/internal/resources/cloud/data_source_cloud_organization.go
@@ -12,10 +12,6 @@ import (
 
 func DataSourceOrganization() *schema.Resource {
 	return &schema.Resource{
-		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/org/)
-`,
 		ReadContext: DataSourceOrganizationRead,
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/internal/resources/grafana/data_source_dashboard.go
+++ b/internal/resources/grafana/data_source_dashboard.go
@@ -18,8 +18,8 @@ func DatasourceDashboard() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/)
-* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
+* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/)
+* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 `,
 		ReadContext: dataSourceDashboardRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_dashboards.go
+++ b/internal/resources/grafana/data_source_dashboards.go
@@ -19,8 +19,8 @@ func DatasourceDashboards() *schema.Resource {
 Datasource for retrieving all dashboards. Specify list of folder IDs to search in for dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder_dashboard_search/)
-* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
+* [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/)
+* [Dashboard HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 `,
 		ReadContext: dataSourceReadDashboards,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_folder.go
+++ b/internal/resources/grafana/data_source_folder.go
@@ -15,8 +15,8 @@ import (
 func DatasourceFolder() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 `,
 		ReadContext: dataSourceFolderRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_folders.go
+++ b/internal/resources/grafana/data_source_folders.go
@@ -17,7 +17,7 @@ func DatasourceFolders() *schema.Resource {
 		},
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 `,
 

--- a/internal/resources/grafana/data_source_organization.go
+++ b/internal/resources/grafana/data_source_organization.go
@@ -14,8 +14,8 @@ import (
 func DatasourceOrganization() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/org/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
 `,
 		ReadContext: dataSourceOrganizationRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_organization_preferences.go
+++ b/internal/resources/grafana/data_source_organization_preferences.go
@@ -11,7 +11,7 @@ import (
 func DatasourceOrganizationPreferences() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
 `,
 		ReadContext: dataSourceOrganizationPreferencesRead,

--- a/internal/resources/grafana/data_source_team.go
+++ b/internal/resources/grafana/data_source_team.go
@@ -14,8 +14,8 @@ import (
 func DatasourceTeam() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-teams/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
 `,
 		ReadContext: dataSourceTeamRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_user.go
+++ b/internal/resources/grafana/data_source_user.go
@@ -13,8 +13,8 @@ import (
 func DatasourceUser() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
 
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/internal/resources/grafana/data_source_users.go
+++ b/internal/resources/grafana/data_source_users.go
@@ -17,8 +17,8 @@ func DatasourceUsers() *schema.Resource {
 		},
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
 		
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/internal/resources/grafana/resource_alert_notification.go
+++ b/internal/resources/grafana/resource_alert_notification.go
@@ -23,7 +23,7 @@ func ResourceAlertNotification() *schema.Resource {
 
 		Description: `
 This resource is used to configure the legacy alerting system which has been replaced by the [unified alerting system](https://grafana.com/docs/grafana/latest/alerting/) in Grafana 9+. See resources in the [Alerting section](https://registry.terraform.io/providers/grafana/grafana/latest/docs) for info on how to configure alerting with Terraform.
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_notification_channels/)
 `,
 
 		CreateContext: CreateAlertNotification,
@@ -72,7 +72,7 @@ This resource is used to configure the legacy alerting system which has been rep
 			"settings": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				Description: "Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/http_api/alerting_notification_channels/).",
+				Description: "Additional settings, for full reference see [Grafana HTTP API documentation](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_notification_channels/).",
 			},
 
 			"secure_settings": {

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -37,7 +37,7 @@ func ResourceContactPoint() *schema.Resource {
 		Description: `
 Manages Grafana Alerting contact points.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/contact-points)
+* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/contact-points/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.

--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -15,7 +15,7 @@ func ResourceMessageTemplate() *schema.Resource {
 		Description: `
 Manages Grafana Alerting message templates.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/contact-points/message-templating/)
+* [Official documentation](https://grafana.com/docs/grafana/next/alerting/manage-notifications/create-message-template/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates)
 
 This resource requires Grafana 9.1.0 or later.

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -17,7 +17,7 @@ func ResourceMuteTiming() *schema.Resource {
 		Description: `
 Manages Grafana Alerting mute timings.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/notifications/mute-timings/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/manage-notifications/mute-timings/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings)
 
 This resource requires Grafana 9.1.0 or later.

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -16,8 +16,8 @@ func ResourceNotificationPolicy() *schema.Resource {
 		Description: `
 Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/notifications/)
-* [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#notification-policies)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/manage-notifications/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/)
 
 This resource requires Grafana 9.1.0 or later.
 `,

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -20,7 +20,7 @@ func ResourceRuleGroup() *schema.Resource {
 		Description: `
 Manages Grafana Alerting rule groups.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
 
 This resource requires Grafana 9.1.0 or later.

--- a/internal/resources/grafana/resource_annotation.go
+++ b/internal/resources/grafana/resource_annotation.go
@@ -17,8 +17,8 @@ func ResourceAnnotation() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/annotations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/annotations/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/annotations/)
 `,
 
 		CreateContext: CreateAnnotation,

--- a/internal/resources/grafana/resource_api_key.go
+++ b/internal/resources/grafana/resource_api_key.go
@@ -17,7 +17,7 @@ func ResourceAPIKey() *schema.Resource {
 		Description: `
 Manages Grafana API Keys.
 
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/auth/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/auth/)
 `,
 
 		CreateContext: resourceAPIKeyCreate,

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -28,7 +28,7 @@ func ResourceDashboard() *schema.Resource {
 Manages Grafana dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 `,
 
 		CreateContext: CreateDashboard,

--- a/internal/resources/grafana/resource_dashboard_permission.go
+++ b/internal/resources/grafana/resource_dashboard_permission.go
@@ -18,8 +18,8 @@ func ResourceDashboardPermission() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/dashboard_permissions/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/)
 `,
 
 		CreateContext: UpdateDashboardPermissions,

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -24,7 +24,7 @@ func ResourceDataSource() *schema.Resource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/datasources/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/data_source/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/)
 
 The required arguments for this resource vary depending on the type of data
 source selected (via the 'type' argument).

--- a/internal/resources/grafana/resource_datasource_permission.go
+++ b/internal/resources/grafana/resource_datasource_permission.go
@@ -19,7 +19,7 @@ func ResourceDatasourcePermission() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/datasource_permissions/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/)
 `,
 
 		CreateContext: UpdateDatasourcePermissions,

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -19,8 +19,8 @@ func ResourceFolder() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-folders/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 `,
 
 		CreateContext: CreateFolder,

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -17,8 +17,8 @@ func ResourceFolderPermission() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/folder_permissions/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)
 `,
 
 		CreateContext: UpdateFolderPermissions,

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -19,8 +19,8 @@ func ResourceLibraryPanel() *schema.Resource {
 		Description: `
 Manages Grafana library panels.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/panels/panel-library/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/library_element/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/library_element/)
 `,
 
 		CreateContext: CreateLibraryPanel,

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -39,8 +39,8 @@ func ResourceOrganization() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/org/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
 `,
 
 		CreateContext: CreateOrganization,

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -15,7 +15,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-organizations/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
 `,
 

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -23,8 +23,8 @@ func ResourcePlaylist() *schema.Resource {
 		},
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/playlist/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/playlist/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/playlist/)
 `,
 
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -46,8 +46,8 @@ func ResourceReport() *schema.Resource {
 		Description: `
 **Note:** This resource is available only with Grafana Enterprise 7.+.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/reporting/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/reporting/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-reports/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/reporting/)
 `,
 		CreateContext: CreateReport,
 		UpdateContext: UpdateReport,

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -33,8 +33,8 @@ func ResourceTeam() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-teams/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
 `,
 
 		CreateContext: CreateTeam,
@@ -83,7 +83,7 @@ to the team. Note: users specified here must already exist in Grafana.
 				Optional: true,
 				Default:  true,
 				Description: `
-Ignores team members that have been added to team by [Team Sync](https://grafana.com/docs/grafana/latest/enterprise/team-sync/).
+Ignores team members that have been added to team by [Team Sync](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/).
 Team Sync can be provisioned using [grafana_team_external_group resource](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/team_external_group).
 `,
 			},

--- a/internal/resources/grafana/resource_team_external_group.go
+++ b/internal/resources/grafana/resource_team_external_group.go
@@ -13,8 +13,8 @@ func ResourceTeamExternalGroup() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/enterprise/team-sync/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/external_group_sync/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/external_group_sync/)
 `,
 
 		CreateContext: CreateTeamExternalGroup,

--- a/internal/resources/grafana/resource_team_preferences.go
+++ b/internal/resources/grafana/resource_team_preferences.go
@@ -17,8 +17,8 @@ func ResourceTeamPreferences() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/preferences/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/team/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-preferences/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
 `,
 
 		CreateContext: UpdateTeamPreferences,

--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -16,8 +16,8 @@ func ResourceUser() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-* [Official documentation](https://grafana.com/docs/grafana/latest/administration/manage-users-and-permissions/manage-server-users/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/http_api/user/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
 
 This resource uses Grafana's admin APIs for creating and updating users which
 does not currently work with API Tokens. You must use basic auth.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -41,7 +41,7 @@ One, or many, of the following authentication settings must be set. Each authent
 ### `auth`
 
 This can be a Grafana API key, basic auth `username:password`, or a
-[Grafana API key](https://grafana.com/docs/grafana/latest/http_api/create-api-tokens-for-org/).
+[Grafana API key](https://grafana.com/docs/grafana/latest/developers/http_api/create-api-tokens-for-org/).
 
 ### `cloud_api_key`
 


### PR DESCRIPTION
I noticed that lots of links were broken in a weird way. 
Links are marked as `latest` but redirect to v8.4 docs, which is extremely annoying 
The naming scheme changed with the new docs website so I assume that it fails to find the new reference and badly redirects 

I used https://github.com/linkchecker/linkchecker/pull/619 to find all redirects. I should help to get that merged. Linkchecker is still active but not that PR