### PR TITLE
Fix the (still hardcoded) value of 'algorithm' for ML jobs

### DIFF
--- a/internal/resources/machinelearning/resource_job.go
+++ b/internal/resources/machinelearning/resource_job.go
@@ -194,7 +194,7 @@ func makeMLJob(d *schema.ResourceData, meta interface{}) (mlapi.Job, error) {
 		DatasourceType:    d.Get("datasource_type").(string),
 		QueryParams:       d.Get("query_params").(map[string]interface{}),
 		Interval:          uint(d.Get("interval").(int)),
-		Algorithm:         "Prophet",
+		Algorithm:         "grafana_prophet_1_0_1",
 		HyperParams:       d.Get("hyper_params").(map[string]interface{}),
 		TrainingWindow:    uint(d.Get("training_window").(int)),
 		TrainingFrequency: uint(24 * time.Hour / time.Second),


### PR DESCRIPTION
Eventually we will make this configurable with validation in the TF
schema but since there's only one algorithm right now this just fixes
the hardcoded value.
