### PR TITLE
Support `org_id` in the playlist resource

### DIFF
--- a/docs/resources/playlist.md
+++ b/docs/resources/playlist.md
@@ -22,10 +22,13 @@ description: |-
 - `item` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--item))
 - `name` (String) The name of the playlist.
 
+### Optional
+
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `org_id` (String)
 
 <a id="nestedblock--item"></a>
 ### Nested Schema for `item`

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -211,7 +211,6 @@ func testAccPlaylistDisappears() resource.TestCheckFunc {
 }
 
 func testAccPlaylistDestroy(s *terraform.State) error {
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "grafana_playlist" {
 			continue


### PR DESCRIPTION
There was already an `org_id` attribute but it wasn't hooked up to anything 
This converts that attribute from read-only to optional