### PR TITLE
`org_id`: Better helper function names

### DIFF
--- a/internal/resources/grafana/data_source_library_panel.go
+++ b/internal/resources/grafana/data_source_library_panel.go
@@ -13,11 +13,7 @@ func DatasourceLibraryPanel() *schema.Resource {
 		Description: "Data source for retrieving a single library panel by name or uid.",
 		ReadContext: dataSourceLibraryPanelRead,
 		Schema: common.CloneResourceSchemaForDatasource(ResourceLibraryPanel(), map[string]*schema.Schema{
-			"org_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
-			},
+			"org_id": orgIDAttribute(),
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -33,7 +29,7 @@ func DatasourceLibraryPanel() *schema.Resource {
 }
 
 func dataSourceLibraryPanelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromOrgIDAttr(meta, d)
+	client, orgID := clientFromNewOrgResource(meta, d)
 	uid := d.Get("uid").(string)
 
 	// get UID from name if specified
@@ -46,7 +42,7 @@ func dataSourceLibraryPanelRead(ctx context.Context, d *schema.ResourceData, met
 		uid = panel.UID
 	}
 
-	d.SetId(MakeOSSOrgID(orgID, uid))
+	d.SetId(makeOrgResourceID(orgID, uid))
 
 	return readLibraryPanel(ctx, d, meta)
 }

--- a/internal/resources/grafana/data_source_library_panel.go
+++ b/internal/resources/grafana/data_source_library_panel.go
@@ -29,7 +29,7 @@ func DatasourceLibraryPanel() *schema.Resource {
 }
 
 func dataSourceLibraryPanelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := clientFromNewOrgResource(meta, d)
+	client, orgID := ClientFromNewOrgResource(meta, d)
 	uid := d.Get("uid").(string)
 
 	// get UID from name if specified
@@ -42,7 +42,7 @@ func dataSourceLibraryPanelRead(ctx context.Context, d *schema.ResourceData, met
 		uid = panel.UID
 	}
 
-	d.SetId(makeOrgResourceID(orgID, uid))
+	d.SetId(MakeOrgResourceID(orgID, uid))
 
 	return readLibraryPanel(ctx, d, meta)
 }

--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -22,13 +22,13 @@ func orgIDAttribute() *schema.Schema {
 	}
 }
 
-// makeOrgResourceID creates a resource ID for an org-scoped resource
-func makeOrgResourceID(orgID int64, resourceID interface{}) string {
+// MakeOrgResourceID creates a resource ID for an org-scoped resource
+func MakeOrgResourceID(orgID int64, resourceID interface{}) string {
 	return fmt.Sprintf("%d:%s", orgID, fmt.Sprint(resourceID))
 }
 
-// splitOrgResourceID splits into two parts (org ID and resource ID) the ID of an org-scoped resource
-func splitOrgResourceID(id string) (int64, string) {
+// SplitOrgResourceID splits into two parts (org ID and resource ID) the ID of an org-scoped resource
+func SplitOrgResourceID(id string) (int64, string) {
 	if strings.ContainsRune(id, ':') {
 		parts := strings.SplitN(id, ":", 2)
 		orgID, _ := strconv.ParseInt(parts[0], 10, 64)
@@ -38,10 +38,10 @@ func splitOrgResourceID(id string) (int64, string) {
 	return 0, id
 }
 
-// clientFromExistingOrgResource creates a client from the ID of an org-scoped resource
+// ClientFromExistingOrgResource creates a client from the ID of an org-scoped resource
 // Those IDs are in the <orgID>:<resourceID> format
-func clientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, int64, string) {
-	orgID, restOfID := splitOrgResourceID(id)
+func ClientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, int64, string) {
+	orgID, restOfID := SplitOrgResourceID(id)
 	client := meta.(*common.Client).GrafanaAPI
 	if orgID > 0 {
 		client = client.WithOrgID(orgID)
@@ -49,9 +49,9 @@ func clientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, i
 	return client, orgID, restOfID
 }
 
-// clientFromNewOrgResource creates a client from the `org_id` attribute of a resource
+// ClientFromNewOrgResource creates a client from the `org_id` attribute of a resource
 // This client is meant to be used in `Create` functions when the ID hasn't already been baked into the resource ID
-func clientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
+func ClientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
 	orgID, _ := strconv.ParseInt(d.Get("org_id").(string), 10, 64)
 	client := meta.(*common.Client).GrafanaAPI
 	if orgID > 0 {

--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -10,11 +10,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func MakeOSSOrgID(orgID int64, resourceID interface{}) string {
+func orgIDAttribute() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+		ForceNew:    true,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return new == "" // Ignore the case where we have a global org_id set
+		},
+	}
+}
+
+// makeOrgResourceID creates a resource ID for an org-scoped resource
+func makeOrgResourceID(orgID int64, resourceID interface{}) string {
 	return fmt.Sprintf("%d:%s", orgID, fmt.Sprint(resourceID))
 }
 
-func SplitOSSOrgID(id string) (int64, string) {
+// splitOrgResourceID splits into two parts (org ID and resource ID) the ID of an org-scoped resource
+func splitOrgResourceID(id string) (int64, string) {
 	if strings.ContainsRune(id, ':') {
 		parts := strings.SplitN(id, ":", 2)
 		orgID, _ := strconv.ParseInt(parts[0], 10, 64)
@@ -24,8 +38,10 @@ func SplitOSSOrgID(id string) (int64, string) {
 	return 0, id
 }
 
-func ClientFromOSSOrgID(meta interface{}, id string) (*gapi.Client, int64, string) {
-	orgID, restOfID := SplitOSSOrgID(id)
+// clientFromExistingOrgResource creates a client from the ID of an org-scoped resource
+// Those IDs are in the <orgID>:<resourceID> format
+func clientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, int64, string) {
+	orgID, restOfID := splitOrgResourceID(id)
 	client := meta.(*common.Client).GrafanaAPI
 	if orgID > 0 {
 		client = client.WithOrgID(orgID)
@@ -33,7 +49,9 @@ func ClientFromOSSOrgID(meta interface{}, id string) (*gapi.Client, int64, strin
 	return client, orgID, restOfID
 }
 
-func ClientFromOrgIDAttr(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
+// clientFromNewOrgResource creates a client from the `org_id` attribute of a resource
+// This client is meant to be used in `Create` functions when the ID hasn't already been baked into the resource ID
+func clientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
 	orgID, _ := strconv.ParseInt(d.Get("org_id").(string), 10, 64)
 	client := meta.(*common.Client).GrafanaAPI
 	if orgID > 0 {

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -40,12 +40,7 @@ Manages Grafana dashboards.
 		},
 
 		Schema: map[string]*schema.Schema{
-			"org_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
-				ForceNew:    true,
-			},
+			"org_id": orgIDAttribute(),
 			"uid": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -187,7 +182,7 @@ func resourceDashboardStateUpgradeV0(ctx context.Context, rawState map[string]in
 }
 
 func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromOrgIDAttr(meta, d)
+	client, orgID := clientFromNewOrgResource(meta, d)
 
 	dashboard, err := makeDashboard(d)
 	if err != nil {
@@ -197,13 +192,13 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(MakeOSSOrgID(orgID, resp.UID))
+	d.SetId(makeOrgResourceID(orgID, resp.UID))
 	return ReadDashboard(ctx, d, meta)
 }
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	gapiURL := meta.(*common.Client).GrafanaAPIURL
-	client, _, uid := ClientFromOSSOrgID(meta, d.Id())
+	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
 
 	dashboard, err := client.DashboardByUID(uid)
 	var diags diag.Diagnostics
@@ -265,7 +260,7 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 }
 
 func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromOrgIDAttr(meta, d)
+	client, orgID := clientFromNewOrgResource(meta, d)
 
 	dashboard, err := makeDashboard(d)
 	if err != nil {
@@ -277,12 +272,12 @@ func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(MakeOSSOrgID(orgID, resp.UID))
+	d.SetId(makeOrgResourceID(orgID, resp.UID))
 	return ReadDashboard(ctx, d, meta)
 }
 
 func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := ClientFromOSSOrgID(meta, d.Id())
+	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
 
 	err := client.DeleteDashboardByUID(uid)
 	var diags diag.Diagnostics

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -182,7 +182,7 @@ func resourceDashboardStateUpgradeV0(ctx context.Context, rawState map[string]in
 }
 
 func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := clientFromNewOrgResource(meta, d)
+	client, orgID := ClientFromNewOrgResource(meta, d)
 
 	dashboard, err := makeDashboard(d)
 	if err != nil {
@@ -192,13 +192,13 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(makeOrgResourceID(orgID, resp.UID))
+	d.SetId(MakeOrgResourceID(orgID, resp.UID))
 	return ReadDashboard(ctx, d, meta)
 }
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	gapiURL := meta.(*common.Client).GrafanaAPIURL
-	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
 
 	dashboard, err := client.DashboardByUID(uid)
 	var diags diag.Diagnostics
@@ -260,7 +260,7 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 }
 
 func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := clientFromNewOrgResource(meta, d)
+	client, orgID := ClientFromNewOrgResource(meta, d)
 
 	dashboard, err := makeDashboard(d)
 	if err != nil {
@@ -272,12 +272,12 @@ func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(makeOrgResourceID(orgID, resp.UID))
+	d.SetId(MakeOrgResourceID(orgID, resp.UID))
 	return ReadDashboard(ctx, d, meta)
 }
 
 func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
 
 	err := client.DeleteDashboardByUID(uid)
 	var diags diag.Diagnostics

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -222,7 +222,7 @@ func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-		orgID, dashboardUID := grafana.splitOrgResourceID(rs.Primary.ID)
+		orgID, dashboardUID := grafana.SplitOrgResourceID(rs.Primary.ID)
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		// If the org ID is set, check that the dashboard doesn't exist in the default org

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -222,7 +222,7 @@ func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-		orgID, dashboardUID := grafana.SplitOSSOrgID(rs.Primary.ID)
+		orgID, dashboardUID := grafana.splitOrgResourceID(rs.Primary.ID)
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		// If the org ID is set, check that the dashboard doesn't exist in the default org

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -45,15 +45,7 @@ Manages Grafana library panels.
 				Computed:    true,
 				Description: "The numeric ID of the library panel computed by Grafana.",
 			},
-			"org_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
-				ForceNew:    true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return new == "" // Ignore the case where we have a global org_id set
-				},
-			},
+			"org_id": orgIDAttribute(),
 			"folder_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -117,19 +109,19 @@ Manages Grafana library panels.
 }
 
 func createLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _ := ClientFromOrgIDAttr(meta, d)
+	client, _ := clientFromNewOrgResource(meta, d)
 
 	panel := makeLibraryPanel(d)
 	resp, err := client.NewLibraryPanel(panel)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(MakeOSSOrgID(resp.OrgID, resp.UID))
+	d.SetId(makeOrgResourceID(resp.OrgID, resp.UID))
 	return readLibraryPanel(ctx, d, meta)
 }
 
 func readLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := ClientFromOSSOrgID(meta, d.Id())
+	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
 
 	panel, err := client.LibraryPanelByUID(uid)
 	var diags diag.Diagnostics
@@ -186,19 +178,19 @@ func readLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interfac
 }
 
 func updateLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := ClientFromOSSOrgID(meta, d.Id())
+	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
 	panel := makeLibraryPanel(d)
 
 	resp, err := client.PatchLibraryPanel(uid, panel)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(MakeOSSOrgID(resp.OrgID, resp.UID))
+	d.SetId(makeOrgResourceID(resp.OrgID, resp.UID))
 	return readLibraryPanel(ctx, d, meta)
 }
 
 func deleteLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := ClientFromOSSOrgID(meta, d.Id())
+	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
 	_, err := client.DeleteLibraryPanel(uid)
 	return diag.FromErr(err)
 }

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -109,19 +109,19 @@ Manages Grafana library panels.
 }
 
 func createLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _ := clientFromNewOrgResource(meta, d)
+	client, _ := ClientFromNewOrgResource(meta, d)
 
 	panel := makeLibraryPanel(d)
 	resp, err := client.NewLibraryPanel(panel)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(makeOrgResourceID(resp.OrgID, resp.UID))
+	d.SetId(MakeOrgResourceID(resp.OrgID, resp.UID))
 	return readLibraryPanel(ctx, d, meta)
 }
 
 func readLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
 
 	panel, err := client.LibraryPanelByUID(uid)
 	var diags diag.Diagnostics
@@ -178,19 +178,19 @@ func readLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interfac
 }
 
 func updateLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
 	panel := makeLibraryPanel(d)
 
 	resp, err := client.PatchLibraryPanel(uid, panel)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(makeOrgResourceID(resp.OrgID, resp.UID))
+	d.SetId(MakeOrgResourceID(resp.OrgID, resp.UID))
 	return readLibraryPanel(ctx, d, meta)
 }
 
 func deleteLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := clientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
 	_, err := client.DeleteLibraryPanel(uid)
 	return diag.FromErr(err)
 }

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -166,7 +166,7 @@ func testAccLibraryPanelCheckExists(rn string, panel *gapi.LibraryPanel) resourc
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-		client, _, uid := grafana.ClientFromOSSOrgID(testutils.Provider.Meta(), rs.Primary.ID)
+		client, _, uid := grafana.clientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
 		gotLibraryPanel, err := client.LibraryPanelByUID(uid)
 		if err != nil {
 			return fmt.Errorf("error getting panel: %s", err)

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -166,7 +166,7 @@ func testAccLibraryPanelCheckExists(rn string, panel *gapi.LibraryPanel) resourc
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-		client, _, uid := grafana.clientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
+		client, _, uid := grafana.ClientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
 		gotLibraryPanel, err := client.LibraryPanelByUID(uid)
 		if err != nil {
 			return fmt.Errorf("error getting panel: %s", err)

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -72,7 +72,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 }
 
 func CreateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := clientFromNewOrgResource(meta, d)
+	client, orgID := ClientFromNewOrgResource(meta, d)
 
 	_, err := client.UpdateAllOrgPreferences(gapi.Preferences{
 		Theme:            d.Get("theme").(string),

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -28,12 +28,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"org_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
-				ForceNew:    true,
-			},
+			"org_id": orgIDAttribute(),
 			"theme": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -77,7 +72,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 }
 
 func CreateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromOrgIDAttr(meta, d)
+	client, orgID := clientFromNewOrgResource(meta, d)
 
 	_, err := client.UpdateAllOrgPreferences(gapi.Preferences{
 		Theme:            d.Get("theme").(string),

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -71,7 +71,7 @@ func ResourcePlaylist() *schema.Resource {
 }
 
 func CreatePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := clientFromNewOrgResource(meta, d)
+	client, orgID := ClientFromNewOrgResource(meta, d)
 
 	playlist := gapi.Playlist{
 		Name:     d.Get("name").(string),
@@ -85,13 +85,13 @@ func CreatePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error creating Playlist: %v", err)
 	}
 
-	d.SetId(makeOrgResourceID(orgID, id))
+	d.SetId(MakeOrgResourceID(orgID, id))
 
 	return ReadPlaylist(ctx, d, meta)
 }
 
 func ReadPlaylist(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID, id := clientFromExistingOrgResource(meta, d.Id())
+	client, orgID, id := ClientFromExistingOrgResource(meta, d.Id())
 
 	resp, err := client.Playlist(id)
 
@@ -115,7 +115,7 @@ func ReadPlaylist(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func UpdatePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, id := clientFromExistingOrgResource(meta, d.Id())
+	client, _, id := ClientFromExistingOrgResource(meta, d.Id())
 
 	playlist := gapi.Playlist{
 		Name:     d.Get("name").(string),
@@ -139,7 +139,7 @@ func UpdatePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{
 }
 
 func DeletePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, id := clientFromExistingOrgResource(meta, d.Id())
+	client, _, id := ClientFromExistingOrgResource(meta, d.Id())
 
 	if err := client.DeletePlaylist(id); err != nil {
 		if strings.HasPrefix(err.Error(), "status: 404") {

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -7,7 +7,6 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
-	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -173,7 +172,7 @@ func testAccPlaylistCheckExists() resource.TestCheckFunc {
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
-		orgID, playlistID := grafana.SplitOSSOrgID(rs.Primary.ID)
+		orgID, playlistID := grafana.splitOrgResourceID(rs.Primary.ID)
 
 		// If the org ID is set, check that the playlist doesn't exist in the default org
 		if orgID > 0 {
@@ -204,7 +203,7 @@ func testAccPlaylistDisappears() resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client, _, playlistID := grafana.ClientFromOSSOrgID(testutils.Provider.Meta(), rs.Primary.ID)
+		client, _, playlistID := grafana.clientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
 
 		return client.DeletePlaylist(playlistID)
 	}
@@ -216,7 +215,7 @@ func testAccPlaylistDestroy(s *terraform.State) error {
 			continue
 		}
 
-		client, _, playlistID := grafana.ClientFromOSSOrgID(testutils.Provider.Meta(), rs.Primary.ID)
+		client, _, playlistID := grafana.clientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
 		playlist, err := client.Playlist(playlistID)
 
 		if err != nil {

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -7,6 +7,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -172,7 +172,7 @@ func testAccPlaylistCheckExists() resource.TestCheckFunc {
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
-		orgID, playlistID := grafana.splitOrgResourceID(rs.Primary.ID)
+		orgID, playlistID := grafana.SplitOrgResourceID(rs.Primary.ID)
 
 		// If the org ID is set, check that the playlist doesn't exist in the default org
 		if orgID > 0 {
@@ -203,7 +203,7 @@ func testAccPlaylistDisappears() resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client, _, playlistID := grafana.clientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
+		client, _, playlistID := grafana.ClientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
 
 		return client.DeletePlaylist(playlistID)
 	}
@@ -215,7 +215,7 @@ func testAccPlaylistDestroy(s *terraform.State) error {
 			continue
 		}
 
-		client, _, playlistID := grafana.clientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
+		client, _, playlistID := grafana.ClientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
 		playlist, err := client.Playlist(playlistID)
 
 		if err != nil {


### PR DESCRIPTION
I've now done a good amount of resources and a pattern has emerged:
- One function is used for new resources (getting the `org_id` attribute and using it to _create_ a resource) 
- Another is used for existing resource (getting the org ID from the resource ID 
- Also, the `org_id` attribute is always the same in every resource, so I've made a function for that