### PR TITLE
Service Accounts: Support `org_id`

### DIFF
--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -34,6 +34,7 @@ resource "grafana_service_account" "admin" {
 ### Optional
 
 - `is_disabled` (Boolean) The disabled status for the service account. Defaults to `false`.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `role` (String) The basic role of the service account in the organization.
 
 ### Read-Only

--- a/docs/resources/service_account_permission.md
+++ b/docs/resources/service_account_permission.md
@@ -52,7 +52,7 @@ resource "grafana_service_account_permission" "test_permissions" {
 ### Required
 
 - `permissions` (Block Set, Min: 1) The permission items to add/update. Items that are omitted from the list will be removed. (see [below for nested schema](#nestedblock--permissions))
-- `service_account_id` (Number) The id of the service account.
+- `service_account_id` (String) The id of the service account.
 
 ### Read-Only
 

--- a/docs/resources/service_account_token.md
+++ b/docs/resources/service_account_token.md
@@ -45,7 +45,7 @@ output "service_account_token_bar" {
 ### Required
 
 - `name` (String)
-- `service_account_id` (Number)
+- `service_account_id` (String)
 
 ### Optional
 

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -30,7 +30,7 @@ func ResourceServiceAccountToken() *schema.Resource {
 				ForceNew: true,
 			},
 			"service_account_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
@@ -57,11 +57,15 @@ func ResourceServiceAccountToken() *schema.Resource {
 }
 
 func serviceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	name := d.Get("name").(string)
-	serviceAccountID := d.Get("service_account_id").(int)
-	ttl := d.Get("seconds_to_live").(int)
+	orgID, serviceAccountIDStr := SplitOrgResourceID(d.Get("service_account_id").(string))
+	c := m.(*common.Client).GrafanaAPI.WithOrgID(orgID)
+	serviceAccountID, err := strconv.ParseInt(serviceAccountIDStr, 10, 64)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	c := m.(*common.Client).GrafanaAPI
+	name := d.Get("name").(string)
+	ttl := d.Get("seconds_to_live").(int)
 
 	request := gapi.CreateServiceAccountTokenRequest{
 		Name:             name,
@@ -84,10 +88,14 @@ func serviceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func serviceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	serviceAccountID := d.Get("service_account_id").(int)
-	c := m.(*common.Client).GrafanaAPI
+	orgID, serviceAccountIDStr := SplitOrgResourceID(d.Get("service_account_id").(string))
+	c := m.(*common.Client).GrafanaAPI.WithOrgID(orgID)
+	serviceAccountID, err := strconv.ParseInt(serviceAccountIDStr, 10, 64)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	response, err := c.GetServiceAccountTokens(int64(serviceAccountID))
+	response, err := c.GetServiceAccountTokens(serviceAccountID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -122,13 +130,17 @@ func serviceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func serviceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	serviceAccountID := d.Get("service_account_id").(int)
-	id, err := strconv.ParseInt(d.Id(), 10, 32)
+	orgID, serviceAccountIDStr := SplitOrgResourceID(d.Get("service_account_id").(string))
+	c := m.(*common.Client).GrafanaAPI.WithOrgID(orgID)
+	serviceAccountID, err := strconv.ParseInt(serviceAccountIDStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	c := m.(*common.Client).GrafanaAPI
+	id, err := strconv.ParseInt(d.Id(), 10, 32)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	_, err = c.DeleteServiceAccountToken(int64(serviceAccountID), id)
 	if err != nil {

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -69,7 +69,7 @@ func serviceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	request := gapi.CreateServiceAccountTokenRequest{
 		Name:             name,
-		ServiceAccountID: int64(serviceAccountID),
+		ServiceAccountID: serviceAccountID,
 		SecondsToLive:    int64(ttl),
 	}
 	response, err := c.CreateServiceAccountToken(request)
@@ -142,7 +142,7 @@ func serviceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	_, err = c.DeleteServiceAccountToken(int64(serviceAccountID), id)
+	_, err = c.DeleteServiceAccountToken(serviceAccountID, id)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/grafana/resource_service_account_token_test.go
+++ b/internal/resources/grafana/resource_service_account_token_test.go
@@ -5,8 +5,10 @@ import (
 	"strconv"
 	"testing"
 
+	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -15,20 +17,75 @@ func TestAccServiceAccountToken_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
+	name := acctest.RandString(10)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccServiceAccountTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceAccountTokenBasicConfig,
+				Config: testAccServiceAccountTokenConfig(name, "Editor", 0, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccServiceAccountTokenCheckFields("grafana_service_account_token.foo", "foo-name", false),
+					testAccServiceAccountCheckExists,
+					resource.TestCheckResourceAttr("grafana_service_account.test", "name", name),
+					resource.TestCheckResourceAttr("grafana_service_account.test", "role", "Editor"),
+					resource.TestCheckResourceAttr("grafana_service_account_token.test", "name", name),
+					resource.TestCheckNoResourceAttr("grafana_service_account_token.test", "expiration"),
 				),
 			},
 			{
-				Config: testAccServiceAccountTokenExpandedConfig,
+				Config: testAccServiceAccountTokenConfig(name+"-updated", "Viewer", 300, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccServiceAccountTokenCheckFields("grafana_service_account_token.bar", "bar-name", true),
+					testAccServiceAccountCheckExists,
+					resource.TestCheckResourceAttr("grafana_service_account.test", "name", name+"-updated"),
+					resource.TestCheckResourceAttr("grafana_service_account.test", "role", "Viewer"),
+					resource.TestCheckResourceAttr("grafana_service_account_token.test", "name", name+"-updated"),
+					resource.TestCheckResourceAttrSet("grafana_service_account_token.test", "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServiceAccountToken_inOrg(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+
+	name := acctest.RandString(10)
+	var org gapi.Org
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		CheckDestroy:      testAccServiceAccountTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceAccountTokenConfig(name, "Editor", 0, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccServiceAccountCheckExists,
+					resource.TestCheckResourceAttr("grafana_service_account.test", "name", name),
+					resource.TestCheckResourceAttr("grafana_service_account.test", "role", "Editor"),
+					resource.TestCheckResourceAttr("grafana_service_account_token.test", "name", name),
+					resource.TestCheckNoResourceAttr("grafana_service_account_token.test", "expiration"),
+
+					// Check that the service account is in the correct organization
+					resource.TestMatchResourceAttr("grafana_service_account.test", "id", nonDefaultOrgIDRegexp),
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					checkResourceIsInOrg("grafana_service_account.test", "grafana_organization.test"),
+				),
+			},
+			{
+				Config: testAccServiceAccountTokenConfig(name+"-updated", "Viewer", 300, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccServiceAccountCheckExists,
+					resource.TestCheckResourceAttr("grafana_service_account.test", "name", name+"-updated"),
+					resource.TestCheckResourceAttr("grafana_service_account.test", "role", "Viewer"),
+					resource.TestCheckResourceAttr("grafana_service_account_token.test", "name", name+"-updated"),
+					resource.TestCheckResourceAttrSet("grafana_service_account_token.test", "expiration"),
+
+					// Check that the service account is in the correct organization
+					resource.TestMatchResourceAttr("grafana_service_account.test", "id", nonDefaultOrgIDRegexp),
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					checkResourceIsInOrg("grafana_service_account.test", "grafana_organization.test"),
 				),
 			},
 		},
@@ -64,67 +121,35 @@ func testAccServiceAccountTokenCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccServiceAccountTokenCheckFields(n string, name string, expires bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
+func testAccServiceAccountTokenConfig(name, role string, secondsToLive int, inOrg bool) string {
+	config := ""
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		if rs.Primary.Attributes["key"] == "" {
-			return fmt.Errorf("no key is set")
-		}
-
-		if rs.Primary.Attributes["name"] != name {
-			return fmt.Errorf("incorrect name field found: %s", rs.Primary.Attributes["name"])
-		}
-
-		_, err := strconv.ParseInt(rs.Primary.Attributes["service_account_id"], 10, 64)
-		if err != nil {
-			return err
-		}
-		expiration := rs.Primary.Attributes["expiration"]
-		if expires && expiration == "" {
-			return fmt.Errorf("no expiration date set")
-		}
-
-		if !expires && expiration != "" {
-			return fmt.Errorf("expiration date set")
-		}
-
-		return nil
+	secondsToLiveAttr := ""
+	if secondsToLive > 0 {
+		secondsToLiveAttr = fmt.Sprintf("seconds_to_live = %d", secondsToLive)
 	}
+
+	orgIDAttr := ""
+	if inOrg {
+		config = fmt.Sprintf(`
+resource "grafana_organization" "test" {
+	name = "%s"
+}
+`, name)
+		orgIDAttr = "org_id = grafana_organization.test.id"
+	}
+
+	return config + fmt.Sprintf(`
+resource "grafana_service_account" "test" {
+	name     = "%[1]s"
+	role     = "%[2]s"
+	%[4]s
 }
 
-const testAccServiceAccountOne = `
-resource "grafana_service_account" "sa_one" {
-  name     = "SA One"
-  role     = "Editor"
+resource "grafana_service_account_token" "test" {
+	name = "%[1]s"
+	service_account_id = grafana_service_account.test.id
+	%[3]s
 }
-`
-
-const testAccServiceAccountTwo = `
-resource "grafana_service_account" "sa_two" {
-  name     = "SA Two"
-  role     = "Viewer"
+`, name, role, secondsToLiveAttr, orgIDAttr)
 }
-`
-
-const testAccServiceAccountTokenBasicConfig = testAccServiceAccountOne + `
-resource "grafana_service_account_token" "foo" {
-	name = "foo-name"
-	service_account_id = grafana_service_account.sa_one.id
-}
-`
-
-const testAccServiceAccountTokenExpandedConfig = testAccServiceAccountTwo + `
-resource "grafana_service_account_token" "bar" {
-	name 			= "bar-name"
-	service_account_id = grafana_service_account.sa_two.id
-	seconds_to_live = 300
-}
-`


### PR DESCRIPTION
Allows service accounts to be created within a specific org (other than the one at provider-level)