### PR TITLE
`grafana_team`: Add `org_id` attribute

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -38,6 +38,7 @@ Team Sync can be provisioned using [grafana_team_external_group resource](https:
  Defaults to `true`.
 - `members` (Set of String) A set of email addresses corresponding to users who should be given membership
 to the team. Note: users specified here must already exist in Grafana.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only
 

--- a/docs/resources/team_preferences.md
+++ b/docs/resources/team_preferences.md
@@ -35,7 +35,7 @@ resource "grafana_team_preferences" "team_preferences" {
 
 ### Required
 
-- `team_id` (Number) The numeric team ID.
+- `team_id` (String) The numeric team ID.
 
 ### Optional
 


### PR DESCRIPTION
Allows creating teams in a specific org (other than the provider config)