### PR TITLE
add 'handleGrafanaManagedAlerts' argument for Alertmanager to docs

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -138,8 +138,9 @@ Optional:
 - `external_id` (String) (CloudWatch, Athena) If you are assuming a role in another account, that has been created with an external ID, specify the external ID here.
 - `github_url` (String) (Github) Github URL
 - `graphite_version` (String) (Graphite) Graphite version.
+- `handleGrafanaManagedAlerts` (Boolean) (Alertmanager) Allows Grafana alerts to be managed by this alertmanager data source. Defaults to `false`.
 - `http_method` (String) (Prometheus) HTTP method to use for making requests.
-- `implementation` (String) (Alertmanager) Implementation of Alertmanager. Either 'cortex' or 'prometheus'
+- `implementation` (String) (Alertmanager) Implementation of Alertmanager. Either 'mimir', 'cortex' or 'prometheus'
 - `interval` (String) (Elasticsearch) Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly'.
 - `log_level_field` (String) (Elasticsearch) Which field should be used to indicate the priority of the log message.
 - `log_message_field` (String) (Elasticsearch) Which field should be used as the log message.

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -265,7 +265,12 @@ source selected (via the 'type' argument).
 						"implementation": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "(Alertmanager) Implementation of Alertmanager. Either 'cortex' or 'prometheus'",
+							Description: "(Alertmanager) Implementation of Alertmanager. Either 'mimir', 'cortex' or 'prometheus'",
+						},
+						"handleGrafanaManagedAlerts": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "(Alertmanager) Allows Grafana alerts to be managed by this alertmanager data source. Defaults to `false`.",
 						},
 						"log_level_field": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
Hello,

I'm willing to add this argument for the *grafana_data_source* [resource documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source) that allows to check the "Receive Grafana Alerts" checkbox. It shows in the console browser network tab and works in Terraform code but it seems it hasn't been added to the docs just yet.
Also the `implementation` argument does not mention 'mimir' as an option, which appears in the GUI dropdown.

Screenshot :
![image](https://user-images.githubusercontent.com/121803364/221576028-0e3ca9ad-0771-4f26-b5fc-c2b8623171cf.png)
