### PR TITLE
Provider: MaxConnsPerHost tests with creating 60 service accounts

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -340,6 +340,7 @@ func createGrafanaClient(d *schema.ResourceData) (string, *gapi.Config, *gapi.Cl
 	auth := strings.SplitN(d.Get("auth").(string), ":", 2)
 	cli := cleanhttp.DefaultClient()
 	transport := cleanhttp.DefaultTransport()
+	transport.MaxConnsPerHost = 2
 	transport.TLSClientConfig = &tls.Config{}
 
 	// TLS Config

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -340,8 +340,10 @@ func createGrafanaClient(d *schema.ResourceData) (string, *gapi.Config, *gapi.Cl
 	auth := strings.SplitN(d.Get("auth").(string), ":", 2)
 	cli := cleanhttp.DefaultClient()
 	transport := cleanhttp.DefaultTransport()
-	transport.MaxConnsPerHost = 2
 	transport.TLSClientConfig = &tls.Config{}
+	// limiting the amount of concurrent HTTP connections from the provider
+	// makes it not overload the API and DB
+	transport.MaxConnsPerHost = 2
 
 	// TLS Config
 	tlsKey := d.Get("tls_key").(string)


### PR DESCRIPTION
**why/what**
We have seen that too many simultaneous calls to grafana API can cause the DB to be congested.

**Features**
- tests for creating 60 service accounts
- limit the number of HTTP connections that each provider can have open

**downside**
might slow down terraform providers for our users

**fixes**
https://github.com/grafana/terraform-provider-grafana/issues/827