### PR TITLE
ExternalGroup: Fix import tfstate for external group

### DIFF
--- a/internal/resources/grafana/resource_team_external_group.go
+++ b/internal/resources/grafana/resource_team_external_group.go
@@ -67,6 +67,7 @@ func ReadTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta int
 	for _, teamGroup := range teamGroups {
 		groupIDs = append(groupIDs, teamGroup.GroupID)
 	}
+	d.Set("team_id", teamID)
 	d.Set("groups", groupIDs)
 
 	return diag.Diagnostics{}

--- a/internal/resources/grafana/resource_team_external_group_test.go
+++ b/internal/resources/grafana/resource_team_external_group_test.go
@@ -41,6 +41,11 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      "grafana_team_external_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/resources/grafana/resource_team_external_group_test.go
+++ b/internal/resources/grafana/resource_team_external_group_test.go
@@ -1,16 +1,13 @@
 package grafana_test
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
-	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -43,43 +40,6 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 						"grafana_team_external_group.test", "groups.#", "0",
 					),
 				),
-			},
-		},
-	})
-}
-
-func TestAccExampleThing_basic(t *testing.T) {
-	testutils.CheckEnterpriseTestsEnabled(t)
-
-	ctx := context.Background()
-	d := &schema.ResourceData{}
-	teamName := "testTeam"
-	groupName := "test"
-	d.Set("name", teamName)
-	d.Set("email", "test-team@team.com")
-	grafana.CreateTeam(ctx, d, "")
-	d.Set("groups", []string{groupName})
-	grafana.CreateTeamExternalGroup(ctx, d, "")
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		/* ... existing TestCase functions ... */
-		Steps: []resource.TestStep{
-			/* ... existing TestStep ... */
-			{
-				ResourceName:      fmt.Sprintf("grafana_team.%s", teamName),
-				ImportState:       true,
-				ImportStateId:     d.Get("team_id").(string),
-				ImportStateVerify: true,
-			},
-			{
-				ResourceName:      fmt.Sprintf("grafana_team_external_group.%s", groupName),
-				ImportState:       true,
-				ImportStateId:     d.Get("team_id").(string),
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccTeamConfig_groupRemove,
 			},
 		},
 	})

--- a/internal/resources/grafana/resource_team_external_group_test.go
+++ b/internal/resources/grafana/resource_team_external_group_test.go
@@ -1,13 +1,16 @@
 package grafana_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -40,6 +43,43 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 						"grafana_team_external_group.test", "groups.#", "0",
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestAccExampleThing_basic(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t)
+
+	ctx := context.Background()
+	d := &schema.ResourceData{}
+	teamName := "testTeam"
+	groupName := "test"
+	d.Set("name", teamName)
+	d.Set("email", "test-team@team.com")
+	grafana.CreateTeam(ctx, d, "")
+	d.Set("groups", []string{groupName})
+	grafana.CreateTeamExternalGroup(ctx, d, "")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		/* ... existing TestCase functions ... */
+		Steps: []resource.TestStep{
+			/* ... existing TestStep ... */
+			{
+				ResourceName:      fmt.Sprintf("grafana_team.%s", teamName),
+				ImportState:       true,
+				ImportStateId:     d.Get("team_id").(string),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      fmt.Sprintf("grafana_team_external_group.%s", groupName),
+				ImportState:       true,
+				ImportStateId:     d.Get("team_id").(string),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTeamConfig_groupRemove,
 			},
 		},
 	})


### PR DESCRIPTION
**what/why**
When importing a external group, the team id was not collected by terraform, this PR makes is so that when we read the import of external groups we capture the ResourceData of teamid

**Fixes**
https://github.com/grafana/terraform-provider-grafana/issues/796