### PR TITLE
Fix `grafana_cloud_stack_api_key` panic

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_api_key.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key.go
@@ -3,11 +3,13 @@ package cloud
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -77,13 +79,24 @@ func resourceStackAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m in
 	defer cleanup()
 
 	request := gapi.CreateAPIKeyRequest{Name: name, Role: role, SecondsToLive: int64(ttl)}
-	response, err := c.CreateAPIKey(request)
+	err = resource.RetryContext(ctx, 2*time.Minute, func() *resource.RetryError {
+		response, err := c.CreateAPIKey(request)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "Your instance is loading, and will be ready shortly.") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		d.SetId(strconv.FormatInt(response.ID, 10))
+		d.Set("key", response.Key)
+		return nil
+	})
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(strconv.FormatInt(response.ID, 10))
-	d.Set("key", response.Key)
 
 	// Fill the true resource's state after a create by performing a read
 	return resourceStackAPIKeyRead(ctx, d, m)

--- a/internal/resources/cloud/resource_cloud_stack_api_key.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key.go
@@ -147,5 +147,5 @@ func resourceStackAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m in
 
 func getClientForAPIKeyManagement(d *schema.ResourceData, m interface{}) (c *gapi.Client, cleanup func() error, err error) {
 	cloudClient := m.(*common.Client).GrafanaCloudAPI
-	return cloudClient.CreateTemporaryStackGrafanaClient(d.Get("stack-slug").(string), "terraform-temp-", 60*time.Second)
+	return cloudClient.CreateTemporaryStackGrafanaClient(d.Get("stack_slug").(string), "terraform-temp-", 60*time.Second)
 }

--- a/internal/resources/cloud/resource_cloud_stack_api_key_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key_test.go
@@ -32,10 +32,10 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 				Config: testAccGrafanaAuthKeyFromCloud(slug, slug),
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
-					resource.TestCheckResourceAttrSet("grafana_api_key.foo", "key"),
-					resource.TestCheckResourceAttr("grafana_api_key.foo", "name", "management-key"),
-					resource.TestCheckResourceAttr("grafana_api_key.foo", "role", "Admin"),
-					resource.TestCheckNoResourceAttr("grafana_api_key.foo", "expiration"),
+					resource.TestCheckResourceAttrSet("grafana_cloud_stack_api_key.management", "key"),
+					resource.TestCheckResourceAttr("grafana_cloud_stack_api_key.management", "name", "management-key"),
+					resource.TestCheckResourceAttr("grafana_cloud_stack_api_key.management", "role", "Admin"),
+					resource.TestCheckNoResourceAttr("grafana_cloud_stack_api_key.management", "expiration"),
 				),
 			},
 			{
@@ -48,7 +48,7 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 
 func testAccGrafanaAuthKeyFromCloud(name, slug string) string {
 	return testAccStackConfigBasic(name, slug) + `
-	resource "grafana_api_key" "management" {
+	resource "grafana_cloud_stack_api_key" "management" {
 		stack_slug = grafana_cloud_stack.test.slug
 		name       = "management-key"
 		role       = "Admin"


### PR DESCRIPTION
The resource wasn't even tested, because the tests were still using `grafana_api_key`