### PR TITLE
Cloud Stack: Allow importing by slug

### DIFF
--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -73,5 +73,6 @@ available at “https://<stack_slug>.grafana.net".
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_cloud_stack.stack_name {{stack_id}}
+terraform import grafana_cloud_stack.stack_name {{stack_id}} // import by numerical ID
+terraform import grafana_cloud_stack.stack_name {{stack_slug}} // or import by slug
 ```

--- a/examples/resources/grafana_cloud_stack/import.sh
+++ b/examples/resources/grafana_cloud_stack/import.sh
@@ -1,1 +1,2 @@
-terraform import grafana_cloud_stack.stack_name {{stack_id}}
+terraform import grafana_cloud_stack.stack_name {{stack_id}} // import by numerical ID
+terraform import grafana_cloud_stack.stack_name {{stack_slug}} // or import by slug

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -79,6 +79,13 @@ func TestResourceStack_Basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test import from slug
+			{
+				ResourceName:      "grafana_cloud_stack.test",
+				ImportStateId:     resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
This will be useful for Crossplane where we'll be able to provide the slug and it will either create a new stack OR bring an existing one into management