### PR TITLE
Switch report and datasource permissions tests to Enterprise

### DIFF
--- a/internal/resources/grafana/resource_datasource_permission_test.go
+++ b/internal/resources/grafana/resource_datasource_permission_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAccDatasourcePermission_basic(t *testing.T) {
-	t.Skip("This test is failing in Grafana Cloud 9.3+")
-	testutils.CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	datasourceID := int64(-1)
 

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccResourceReport(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var report gapi.Report
 
@@ -98,7 +98,7 @@ func TestAccResourceReport(t *testing.T) {
 // Testing the deprecated case of using a dashboard ID instead of a dashboard UID
 // TODO: Remove in next major version
 func TestAccResourceReport_CreateFromDashboardID(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var report gapi.Report
 


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/755

They were using the cloud instance rather than the enterprise instance which we have setup in CI now 
This will lead to more predictable failures (cloud can be auto-updated)