### PR TITLE
Annotations: Support `org_id`

### DIFF
--- a/docs/resources/annotation.md
+++ b/docs/resources/annotation.md
@@ -28,7 +28,9 @@ resource "grafana_annotation" "test" {
 
 ### Optional
 
-- `dashboard_id` (Number) The ID of the dashboard on which to create the annotation.
+- `dashboard_id` (Number, Deprecated) The ID of the dashboard on which to create the annotation. Deprecated: Use dashboard_uid instead.
+- `dashboard_uid` (String) The ID of the dashboard on which to create the annotation.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `panel_id` (Number) The ID of the dashboard panel on which to create the annotation.
 - `tags` (Set of String) The tags to associate with the annotation.
 - `time` (String) The RFC 3339-formatted time string indicating the annotation's time.

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -88,33 +88,6 @@ func TestAccAnnotation_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				// Test resource creation with declared dashboard_uid.
-				Config: testAnnotationConfigWithDashboardUID(orgName, testAccAnnotationInitialText),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAnnotationCheckExists("grafana_annotation.test_with_dashboard_uid", &annotation),
-					resource.TestCheckResourceAttr("grafana_annotation.test_with_dashboard_uid", "text", testAccAnnotationInitialText),
-				),
-			},
-			{
-				// Updates text in resource with declared dashboard_id.
-				Config: testAnnotationConfigWithDashboardUID(orgName, testAccAnnotationUpdatedText),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAnnotationCheckExists("grafana_annotation.test_with_dashboard_uid", &annotation),
-					resource.TestCheckResourceAttr("grafana_annotation.test_with_dashboard_uid", "text", testAccAnnotationUpdatedText),
-
-					// Check that the annotation is in the correct organization
-					resource.TestMatchResourceAttr("grafana_annotation.test_with_dashboard_uid", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
-					checkResourceIsInOrg("grafana_annotation.test_with_dashboard_uid", "grafana_organization.test"),
-				),
-			},
-			{
-				// Importing matches the state of the previous step.
-				ResourceName:      "grafana_annotation.test_with_dashboard_uid",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				// Test resource creation with declared panel_id.
 				Config: testAnnotationConfigWithPanelID(orgName, testAccAnnotationInitialText),
 				Check: resource.ComposeTestCheckFunc(
@@ -138,6 +111,50 @@ func TestAccAnnotation_basic(t *testing.T) {
 			{
 				// Importing matches the state of the previous step.
 				ResourceName:      "grafana_annotation.test_with_panel_id",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAnnotation_dashboardUID(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
+
+	var annotation gapi.Annotation
+	var org gapi.Org
+
+	orgName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		CheckDestroy:      testAccAnnotationCheckDestroy(&annotation),
+		Steps: []resource.TestStep{
+			{
+				// Test resource creation with declared dashboard_uid.
+				Config: testAnnotationConfigWithDashboardUID(orgName, testAccAnnotationInitialText),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAnnotationCheckExists("grafana_annotation.test_with_dashboard_uid", &annotation),
+					resource.TestCheckResourceAttr("grafana_annotation.test_with_dashboard_uid", "text", testAccAnnotationInitialText),
+				),
+			},
+			{
+				// Updates text in resource with declared dashboard_id.
+				Config: testAnnotationConfigWithDashboardUID(orgName, testAccAnnotationUpdatedText),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAnnotationCheckExists("grafana_annotation.test_with_dashboard_uid", &annotation),
+					resource.TestCheckResourceAttr("grafana_annotation.test_with_dashboard_uid", "text", testAccAnnotationUpdatedText),
+
+					// Check that the annotation is in the correct organization
+					resource.TestMatchResourceAttr("grafana_annotation.test_with_dashboard_uid", "id", nonDefaultOrgIDRegexp),
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					checkResourceIsInOrg("grafana_annotation.test_with_dashboard_uid", "grafana_organization.test"),
+				),
+			},
+			{
+				// Importing matches the state of the previous step.
+				ResourceName:      "grafana_annotation.test_with_dashboard_uid",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -32,6 +32,7 @@ Manages Grafana library panels.
 		},
 
 		Schema: map[string]*schema.Schema{
+			"org_id": orgIDAttribute(),
 			"uid": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -45,7 +46,6 @@ Manages Grafana library panels.
 				Computed:    true,
 				Description: "The numeric ID of the library panel computed by Grafana.",
 			},
-			"org_id": orgIDAttribute(),
 			"folder_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -27,6 +27,7 @@ func ResourcePlaylist() *schema.Resource {
 `,
 
 		Schema: map[string]*schema.Schema{
+			"org_id": orgIDAttribute(),
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -65,7 +66,6 @@ func ResourcePlaylist() *schema.Resource {
 					},
 				},
 			},
-			"org_id": orgIDAttribute(),
 		},
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/747

Also, `dashboard_uid` rather than `dashboard_id`. IDs are being deprecated across the board