### PR TITLE
add callout for grafana_notification_policy

### DIFF
--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -14,7 +14,9 @@ import (
 func ResourceNotificationPolicy() *schema.Resource {
 	return &schema.Resource{
 		Description: `
-Sets the global notification policy for Grafana. Note that this resource manages the entire notification policy tree, and will overwrite any existing policies.
+Sets the global notification policy for Grafana.
+
+!> This resource manages the entire notification policy tree, and will overwrite any existing policies.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/manage-notifications/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/)


### PR DESCRIPTION
This PR adds a clearer callout so people can avoid repeating the mistake I made 🙄 

<img width="699" alt="Screenshot 2023-04-12 at 15 11 23" src="https://user-images.githubusercontent.com/32618/231597451-ac58f334-17d9-415f-b7b1-6889b0611192.png">

You can preview doc changes [here](https://registry.terraform.io/tools/doc-preview) and the documentation for callouts is [here](https://developer.hashicorp.com/terraform/registry/providers/docs#callouts).