### PR TITLE
Alerting: Fix grafana_contact_point ignores changes in secure fields

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -221,7 +221,6 @@ func unpackContactPoints(data *schema.ResourceData) []statePair {
 					tfState: p.(map[string]interface{}),
 					gfState: unpackPointConfig(n, p, name),
 				})
-
 			}
 		}
 	}

--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -60,7 +60,7 @@ func (a alertmanagerNotifier) pack(p gapi.ContactPoint, data *schema.ResourceDat
 		delete(p.Settings, "basicAuthPassword")
 	}
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, a.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, a, p.UID), a.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -547,7 +547,7 @@ func (o opsGenieNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (
 		delete(p.Settings, "sendTagsAs")
 	}
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, o.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, o, p.UID), o.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -663,7 +663,7 @@ func (n pagerDutyNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) 
 		delete(p.Settings, "summary")
 	}
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, n.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, n, p.UID), n.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -827,7 +827,7 @@ func (n pushoverNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (
 		delete(p.Settings, "message")
 	}
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, n.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, n, p.UID), n.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -958,7 +958,7 @@ func (s sensugoNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (i
 		delete(p.Settings, "message")
 	}
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, s.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, s, p.UID), s.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1090,9 +1090,10 @@ func (s slackNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (int
 	packNotifierStringField(&p.Settings, &notifier, "mentionUsers", "mention_users")
 	packNotifierStringField(&p.Settings, &notifier, "mentionGroups", "mention_groups")
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, s.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, s, p.UID), s.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
+
 	return notifier, nil
 }
 
@@ -1231,7 +1232,7 @@ func (t telegramNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (
 	packNotifierStringField(&p.Settings, &notifier, "chatid", "chat_id")
 	packNotifierStringField(&p.Settings, &notifier, "message", "message")
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, t.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, t, p.UID), t.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1295,7 +1296,7 @@ func (t threemaNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (i
 	packNotifierStringField(&p.Settings, &notifier, "recipient_id", "recipient_id")
 	packNotifierStringField(&p.Settings, &notifier, "api_secret", "api_secret")
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, t.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, t, p.UID), t.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1447,7 +1448,7 @@ func (w webhookNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (i
 		delete(p.Settings, "maxAlerts")
 	}
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, w.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, w, p.UID), w.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1524,7 +1525,7 @@ func (w wecomNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (int
 	packNotifierStringField(&p.Settings, &notifier, "message", "message")
 	packNotifierStringField(&p.Settings, &notifier, "title", "title")
 
-	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, w.meta().secureFields)
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, w, p.UID), w.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil

--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -17,9 +17,10 @@ var _ notifier = (*alertmanagerNotifier)(nil)
 
 func (a alertmanagerNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "alertmanager",
-		typeStr: "prometheus-alertmanager",
-		desc:    "A contact point that sends notifications to other Alertmanager instances.",
+		field:        "alertmanager",
+		typeStr:      "prometheus-alertmanager",
+		desc:         "A contact point that sends notifications to other Alertmanager instances.",
+		secureFields: []string{"basic_auth_password"},
 	}
 }
 
@@ -36,16 +37,15 @@ func (a alertmanagerNotifier) schema() *schema.Resource {
 		Description: "The username component of the basic auth credentials to use.",
 	}
 	r.Schema["basic_auth_password"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The password component of the basic auth credentials to use.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Sensitive:   true,
+		Description: "The password component of the basic auth credentials to use.",
 	}
 	return r
 }
 
-func (a alertmanagerNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (a alertmanagerNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -59,6 +59,9 @@ func (a alertmanagerNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 		notifier["basic_auth_password"] = v.(string)
 		delete(p.Settings, "basicAuthPassword")
 	}
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, a.meta().secureFields)
+
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
 }
@@ -115,7 +118,7 @@ func (d dingDingNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (d dingDingNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (d dingDingNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -194,7 +197,7 @@ func (d discordNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (d discordNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (d discordNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -285,7 +288,7 @@ func (e emailNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (e emailNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (e emailNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["addresses"]; ok && v != nil {
 		notifier["addresses"] = packAddrs(v.(string))
@@ -371,7 +374,7 @@ func (g googleChatNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (g googleChatNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (g googleChatNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -430,7 +433,7 @@ func (k kafkaNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (k kafkaNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (k kafkaNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["kafkaRestProxy"]; ok && v != nil {
 		notifier["rest_proxy_url"] = v.(string)
@@ -465,9 +468,10 @@ var _ notifier = (*opsGenieNotifier)(nil)
 
 func (o opsGenieNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "opsgenie",
-		typeStr: "opsgenie",
-		desc:    "A contact point that sends notifications to OpsGenie.",
+		field:        "opsgenie",
+		typeStr:      "opsgenie",
+		desc:         "A contact point that sends notifications to OpsGenie.",
+		secureFields: []string{"api_key"},
 	}
 }
 
@@ -479,11 +483,10 @@ func (o opsGenieNotifier) schema() *schema.Resource {
 		Description: "Allows customization of the OpsGenie API URL.",
 	}
 	r.Schema["api_key"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The OpsGenie API key to use.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The OpsGenie API key to use.",
 	}
 	r.Schema["message"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -513,7 +516,7 @@ func (o opsGenieNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (o opsGenieNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (o opsGenieNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["apiUrl"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -543,6 +546,9 @@ func (o opsGenieNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 		notifier["send_tags_as"] = v.(string)
 		delete(p.Settings, "sendTagsAs")
 	}
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, o.meta().secureFields)
+
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
 }
@@ -587,20 +593,20 @@ var _ notifier = (*pagerDutyNotifier)(nil)
 
 func (n pagerDutyNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "pagerduty",
-		typeStr: "pagerduty",
-		desc:    "A contact point that sends notifications to PagerDuty.",
+		field:        "pagerduty",
+		typeStr:      "pagerduty",
+		desc:         "A contact point that sends notifications to PagerDuty.",
+		secureFields: []string{"integration_key"},
 	}
 }
 
 func (n pagerDutyNotifier) schema() *schema.Resource {
 	r := commonNotifierResource()
 	r.Schema["integration_key"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The PagerDuty API key.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The PagerDuty API key.",
 	}
 	r.Schema["severity"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -630,7 +636,7 @@ func (n pagerDutyNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (n pagerDutyNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (n pagerDutyNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["integrationKey"]; ok && v != nil {
 		notifier["integration_key"] = v.(string)
@@ -656,6 +662,9 @@ func (n pagerDutyNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 		notifier["summary"] = v.(string)
 		delete(p.Settings, "summary")
 	}
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, n.meta().secureFields)
+
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
 }
@@ -695,27 +704,26 @@ var _ notifier = (*pushoverNotifier)(nil)
 
 func (n pushoverNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "pushover",
-		typeStr: "pushover",
-		desc:    "A contact point that sends notifications to Pushover.",
+		field:        "pushover",
+		typeStr:      "pushover",
+		desc:         "A contact point that sends notifications to Pushover.",
+		secureFields: []string{"user_key", "api_token"},
 	}
 }
 
 func (n pushoverNotifier) schema() *schema.Resource {
 	r := commonNotifierResource()
 	r.Schema["user_key"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The Pushover user key.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The Pushover user key.",
 	}
 	r.Schema["api_token"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The Pushover API token.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The Pushover API token.",
 	}
 	r.Schema["priority"] = &schema.Schema{
 		Type:        schema.TypeInt,
@@ -760,7 +768,7 @@ func (n pushoverNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (n pushoverNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (n pushoverNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["userKey"]; ok && v != nil {
 		notifier["user_key"] = v.(string)
@@ -818,6 +826,9 @@ func (n pushoverNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 		notifier["message"] = v.(string)
 		delete(p.Settings, "message")
 	}
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, n.meta().secureFields)
+
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
 }
@@ -868,9 +879,10 @@ var _ notifier = (*sensugoNotifier)(nil)
 
 func (s sensugoNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "sensugo",
-		typeStr: "sensugo",
-		desc:    "A contact point that sends notifications to SensuGo.",
+		field:        "sensugo",
+		typeStr:      "sensugo",
+		desc:         "A contact point that sends notifications to SensuGo.",
+		secureFields: []string{"api_key"},
 	}
 }
 
@@ -882,11 +894,10 @@ func (s sensugoNotifier) schema() *schema.Resource {
 		Description: "The SensuGo URL to send requests to.",
 	}
 	r.Schema["api_key"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The SensuGo API key.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The SensuGo API key.",
 	}
 	r.Schema["entity"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -916,7 +927,7 @@ func (s sensugoNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (s sensugoNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (s sensugoNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 	if v, ok := p.Settings["url"]; ok && v != nil {
 		notifier["url"] = v.(string)
@@ -946,6 +957,9 @@ func (s sensugoNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 		notifier["message"] = v.(string)
 		delete(p.Settings, "message")
 	}
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, s.meta().secureFields)
+
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
 }
@@ -986,9 +1000,10 @@ var _ notifier = (*slackNotifier)(nil)
 
 func (s slackNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "slack",
-		typeStr: "slack",
-		desc:    "A contact point that sends notifications to Slack.",
+		field:        "slack",
+		typeStr:      "slack",
+		desc:         "A contact point that sends notifications to Slack.",
+		secureFields: []string{"url", "token"},
 	}
 }
 
@@ -1000,18 +1015,16 @@ func (s slackNotifier) schema() *schema.Resource {
 		Description: "Use this to override the Slack API endpoint URL to send requests to.",
 	}
 	r.Schema["url"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "A Slack webhook URL,for sending messages via the webhook method.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Sensitive:   true,
+		Description: "A Slack webhook URL,for sending messages via the webhook method.",
 	}
 	r.Schema["token"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "A Slack API token,for sending messages directly without the webhook method.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Sensitive:   true,
+		Description: "A Slack API token,for sending messages directly without the webhook method.",
 	}
 	r.Schema["recipient"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -1061,7 +1074,7 @@ func (s slackNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (s slackNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (s slackNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "endpointUrl", "endpoint_url")
@@ -1076,6 +1089,8 @@ func (s slackNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 	packNotifierStringField(&p.Settings, &notifier, "mentionChannel", "mention_channel")
 	packNotifierStringField(&p.Settings, &notifier, "mentionUsers", "mention_users")
 	packNotifierStringField(&p.Settings, &notifier, "mentionGroups", "mention_groups")
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, s.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1145,7 +1160,7 @@ func (t teamsNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (t teamsNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (t teamsNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "url", "url")
@@ -1181,20 +1196,20 @@ var _ notifier = (*telegramNotifier)(nil)
 
 func (t telegramNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "telegram",
-		typeStr: "telegram",
-		desc:    "A contact point that sends notifications to Telegram.",
+		field:        "telegram",
+		typeStr:      "telegram",
+		desc:         "A contact point that sends notifications to Telegram.",
+		secureFields: []string{"token"},
 	}
 }
 
 func (t telegramNotifier) schema() *schema.Resource {
 	r := commonNotifierResource()
 	r.Schema["token"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The Telegram bot token.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The Telegram bot token.",
 	}
 	r.Schema["chat_id"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -1209,12 +1224,14 @@ func (t telegramNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (t telegramNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (t telegramNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "bottoken", "token")
 	packNotifierStringField(&p.Settings, &notifier, "chatid", "chat_id")
 	packNotifierStringField(&p.Settings, &notifier, "message", "message")
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, t.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1243,9 +1260,10 @@ var _ notifier = (*threemaNotifier)(nil)
 
 func (t threemaNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "threema",
-		typeStr: "threema",
-		desc:    "A contact point that sends notifications to Threema.",
+		field:        "threema",
+		typeStr:      "threema",
+		desc:         "A contact point that sends notifications to Threema.",
+		secureFields: []string{"api_secret"},
 	}
 }
 
@@ -1262,21 +1280,22 @@ func (t threemaNotifier) schema() *schema.Resource {
 		Description: "The ID of the recipient of the message.",
 	}
 	r.Schema["api_secret"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The Threema API key.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The Threema API key.",
 	}
 	return r
 }
 
-func (t threemaNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (t threemaNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "gateway_id", "gateway_id")
 	packNotifierStringField(&p.Settings, &notifier, "recipient_id", "recipient_id")
 	packNotifierStringField(&p.Settings, &notifier, "api_secret", "api_secret")
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, t.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1326,7 +1345,7 @@ func (v victorOpsNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (v victorOpsNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (v victorOpsNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "url", "url")
@@ -1358,9 +1377,10 @@ var _ notifier = (*webhookNotifier)(nil)
 
 func (w webhookNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "webhook",
-		typeStr: "webhook",
-		desc:    "A contact point that sends notifications to an arbitrary webhook, using the Prometheus webhook format defined here: https://prometheus.io/docs/alerting/latest/configuration/#webhook_config",
+		field:        "webhook",
+		typeStr:      "webhook",
+		desc:         "A contact point that sends notifications to an arbitrary webhook, using the Prometheus webhook format defined here: https://prometheus.io/docs/alerting/latest/configuration/#webhook_config",
+		secureFields: []string{"basic_auth_password", "authorization_credentials"},
 	}
 }
 
@@ -1382,11 +1402,10 @@ func (w webhookNotifier) schema() *schema.Resource {
 		Description: "The username to use in basic auth headers attached to the request. If omitted, basic auth will not be used.",
 	}
 	r.Schema["basic_auth_password"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The username to use in basic auth headers attached to the request. If omitted, basic auth will not be used.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Sensitive:   true,
+		Description: "The username to use in basic auth headers attached to the request. If omitted, basic auth will not be used.",
 	}
 	r.Schema["authorization_scheme"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -1394,11 +1413,10 @@ func (w webhookNotifier) schema() *schema.Resource {
 		Description: "Allows a custom authorization scheme - attaches an auth header with this name. Do not use in conjunction with basic auth parameters.",
 	}
 	r.Schema["authorization_credentials"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "Allows a custom authorization scheme - attaches an auth header with this value. Do not use in conjunction with basic auth parameters.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Sensitive:   true,
+		Description: "Allows a custom authorization scheme - attaches an auth header with this value. Do not use in conjunction with basic auth parameters.",
 	}
 	r.Schema["max_alerts"] = &schema.Schema{
 		Type:        schema.TypeInt,
@@ -1408,7 +1426,7 @@ func (w webhookNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (w webhookNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (w webhookNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "url", "url")
@@ -1428,6 +1446,8 @@ func (w webhookNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
 		}
 		delete(p.Settings, "maxAlerts")
 	}
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, w.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil
@@ -1469,20 +1489,20 @@ var _ notifier = (*wecomNotifier)(nil)
 
 func (w wecomNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "wecom",
-		typeStr: "wecom",
-		desc:    "A contact point that sends notifications to WeCom.",
+		field:        "wecom",
+		typeStr:      "wecom",
+		desc:         "A contact point that sends notifications to WeCom.",
+		secureFields: []string{"url"},
 	}
 }
 
 func (w wecomNotifier) schema() *schema.Resource {
 	r := commonNotifierResource()
 	r.Schema["url"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		Sensitive:        true,
-		DiffSuppressFunc: redactedContactPointDiffSuppress,
-		Description:      "The WeCom webhook URL.",
+		Type:        schema.TypeString,
+		Required:    true,
+		Sensitive:   true,
+		Description: "The WeCom webhook URL.",
 	}
 	r.Schema["message"] = &schema.Schema{
 		Type:        schema.TypeString,
@@ -1497,12 +1517,14 @@ func (w wecomNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (w wecomNotifier) pack(p gapi.ContactPoint) (interface{}, error) {
+func (w wecomNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (interface{}, error) {
 	notifier := packCommonNotifierFields(&p)
 
 	packNotifierStringField(&p.Settings, &notifier, "url", "url")
 	packNotifierStringField(&p.Settings, &notifier, "message", "message")
 	packNotifierStringField(&p.Settings, &notifier, "title", "title")
+
+	packSecureFields(&notifier, unpackContactPoint(data, p.UID).Settings, w.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -158,7 +158,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.url", "http://my-am"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.basic_auth_user", "user"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.basic_auth_password", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "alertmanager.0.basic_auth_password", "password"),
 					// dingding
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "dingding.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "dingding.0.url", "http://dingding-url"),
@@ -187,7 +187,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					// opsgenie
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.url", "http://opsgenie-api"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.api_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.api_key", "token"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.message", "message"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.description", "description"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.auto_close", "true"),
@@ -195,7 +195,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "opsgenie.0.send_tags_as", "both"),
 					// pagerduty
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.#", "1"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.integration_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.integration_key", "token"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.severity", "critical"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.class", "ping failure"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.component", "mysql"),
@@ -203,8 +203,8 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.summary", "message"),
 					// pushover
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.#", "1"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.user_key", "[REDACTED]"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.api_token", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.user_key", "userkey"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.api_token", "token"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.priority", "0"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.ok_priority", "0"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.retry", "45"),
@@ -216,7 +216,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					// sensugo
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.url", "http://sensugo-url"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.api_key", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.api_key", "key"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.entity", "entity"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.check", "check"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "sensugo.0.namespace", "namespace"),
@@ -225,7 +225,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					// slack
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.endpoint_url", "http://custom-slack-url"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.token", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.token", "xoxb-token"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.recipient", "#channel"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.text", "message"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.title", "title"),
@@ -243,14 +243,14 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.section_title", "section"),
 					// telegram
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.#", "1"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.token", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.token", "token"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.chat_id", "chat-id"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "telegram.0.message", "message"),
 					// threema
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.gateway_id", "*gateway"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.recipient_id", "*target1"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.api_secret", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "threema.0.api_secret", "secret"),
 					// victorops
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "victorops.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "victorops.0.url", "http://victor-ops-url"),
@@ -260,11 +260,11 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "webhook.0.url", "http://my-url"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "webhook.0.http_method", "POST"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "webhook.0.basic_auth_user", "user"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "webhook.0.basic_auth_password", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "webhook.0.basic_auth_password", "password"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "webhook.0.max_alerts", "100"),
 					// wecom
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "wecom.#", "1"),
-					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "wecom.0.url", "[REDACTED]"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "wecom.0.url", "http://wecom-url"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "wecom.0.message", "message"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "wecom.0.title", "title"),
 				),


### PR DESCRIPTION
Previously we suppressed the comparison of secure fields and stored "[REDACTED]" in state. This change will instead store the unredacted values in state on create/update and patch them during read.

This way, Terraform can identify and update changed secure field values.

Fixes: #713