### PR TITLE
Cloud stack: Allow read operations from either slug or ID

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -339,9 +339,6 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 }
 
 func FlattenStack(d *schema.ResourceData, stack gapi.Stack) error {
-	id := strconv.FormatInt(stack.ID, 10)
-
-	d.SetId(id)
 	d.Set("name", stack.Name)
 	d.Set("slug", stack.Slug)
 	d.Set("url", stack.URL)

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -390,7 +390,7 @@ func FlattenStack(d *schema.ResourceData, stack gapi.Stack) error {
 
 func getStackFromIDOrSlug(client *gapi.Client, id string) (*gapi.Stack, error) {
 	numericalID, err := strconv.ParseInt(id, 10, 64)
-	if err == nil {
+	if err != nil {
 		// If the ID is not a number, then it may be a slug
 		stack, err := client.StackBySlug(id)
 		if err != nil {

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -3,6 +3,7 @@ package cloud_test
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"strconv"
 	"testing"
@@ -53,6 +54,7 @@ func TestResourceStack_Basic(t *testing.T) {
 				// Terraform should detect that it's gone and recreate it (status should be active at all times)
 				PreConfig: func() {
 					testAccDeleteExistingStacks(t, prefix)
+					time.Sleep(10 * time.Second)
 				},
 				Config: testAccStackConfigBasic(resourceName, resourceName),
 				Check: resource.ComposeTestCheckFunc(
@@ -74,6 +76,7 @@ func TestResourceStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 				),
 			},
+			// Test import from ID
 			{
 				ResourceName:      "grafana_cloud_stack.test",
 				ImportState:       true,


### PR DESCRIPTION
Currently, the logic is in the importer but that doesn't work for Crossplane that doesn't use import but instead seems to custom build a state 
This will be functionally the same but the slug is now usable at all points in the process, instead of being translated in the importer