### PR TITLE
Cloud Stack: Fix 404 check

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -306,7 +306,7 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	stack, err := getStackFromIDOrSlug(client, d.Id())
 
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "status: 404") {
+		if strings.Contains(err.Error(), "404") {
 			log.Printf("[WARN] removing stack %s from state because it no longer exists in grafana", d.Get("name").(string))
 			d.SetId("")
 			return nil


### PR DESCRIPTION
This is something that probably occurs in Crossplane. 
On the first read of the cloud stack resource, it doesn't exist so it 404s, but I broke the 404 mechanism in https://github.com/grafana/terraform-provider-grafana/pull/884