### PR TITLE
`synthetic_monitoring_installation`: Better integration with stack

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -121,17 +121,14 @@ resource "grafana_cloud_api_key" "metrics_publish" {
 resource "grafana_synthetic_monitoring_installation" "sm_stack" {
   provider = grafana.cloud
 
-  stack_id              = grafana_cloud_stack.sm_stack.id
-  metrics_instance_id   = grafana_cloud_stack.sm_stack.prometheus_user_id
-  logs_instance_id      = grafana_cloud_stack.sm_stack.logs_user_id
-  metrics_publisher_key = grafana_cloud_api_key.metrics_publish.key
+  stack_id = grafana_cloud_stack.sm_stack.id
 }
 
 // Step 3: Interact with Synthetic Monitoring
 provider "grafana" {
   alias           = "sm"
   sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
-  sm_url          = "<synthetic-monitoring-api-url>"
+  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
 }
 
 data "grafana_synthetic_monitoring_probes" "main" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ resource "grafana_synthetic_monitoring_installation" "sm_stack" {
 provider "grafana" {
   alias           = "sm"
   sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
-  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
+  sm_url          = grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url
 }
 
 data "grafana_synthetic_monitoring_probes" "main" {

--- a/docs/resources/synthetic_monitoring_installation.md
+++ b/docs/resources/synthetic_monitoring_installation.md
@@ -44,7 +44,7 @@ resource "grafana_synthetic_monitoring_installation" "sm_stack" {
 provider "grafana" {
   alias           = "sm"
   sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
-  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
+  sm_url          = grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url
 }
 ```
 

--- a/examples/provider/provider-sm.tf
+++ b/examples/provider/provider-sm.tf
@@ -32,7 +32,7 @@ resource "grafana_synthetic_monitoring_installation" "sm_stack" {
 provider "grafana" {
   alias           = "sm"
   sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
-  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
+  sm_url          = grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url
 }
 
 data "grafana_synthetic_monitoring_probes" "main" {

--- a/examples/provider/provider-sm.tf
+++ b/examples/provider/provider-sm.tf
@@ -25,17 +25,14 @@ resource "grafana_cloud_api_key" "metrics_publish" {
 resource "grafana_synthetic_monitoring_installation" "sm_stack" {
   provider = grafana.cloud
 
-  stack_id              = grafana_cloud_stack.sm_stack.id
-  metrics_instance_id   = grafana_cloud_stack.sm_stack.prometheus_user_id
-  logs_instance_id      = grafana_cloud_stack.sm_stack.logs_user_id
-  metrics_publisher_key = grafana_cloud_api_key.metrics_publish.key
+  stack_id = grafana_cloud_stack.sm_stack.id
 }
 
 // Step 3: Interact with Synthetic Monitoring
 provider "grafana" {
   alias           = "sm"
   sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
-  sm_url          = "<synthetic-monitoring-api-url>"
+  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
 }
 
 data "grafana_synthetic_monitoring_probes" "main" {

--- a/examples/resources/grafana_synthetic_monitoring_installation/resource.tf
+++ b/examples/resources/grafana_synthetic_monitoring_installation/resource.tf
@@ -11,8 +11,12 @@ resource "grafana_cloud_api_key" "metrics_publish" {
 }
 
 resource "grafana_synthetic_monitoring_installation" "sm_stack" {
-  stack_id              = grafana_cloud_stack.sm_stack.id
-  metrics_instance_id   = grafana_cloud_stack.sm_stack.prometheus_user_id
-  logs_instance_id      = grafana_cloud_stack.sm_stack.logs_user_id
-  metrics_publisher_key = grafana_cloud_api_key.metrics_publish.key
+  stack_id = grafana_cloud_stack.sm_stack.id
+}
+
+// Create a new provider instance to interact with Synthetic Monitoring
+provider "grafana" {
+  alias           = "sm"
+  sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
+  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
 }

--- a/examples/resources/grafana_synthetic_monitoring_installation/resource.tf
+++ b/examples/resources/grafana_synthetic_monitoring_installation/resource.tf
@@ -18,5 +18,5 @@ resource "grafana_synthetic_monitoring_installation" "sm_stack" {
 provider "grafana" {
   alias           = "sm"
   sm_access_token = grafana_synthetic_monitoring_installation.sm_stack.sm_access_token
-  sm_url          = "grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url"
+  sm_url          = grafana_synthetic_monitoring_installation.sm_stack.stack_sm_api_url
 }

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -15,8 +15,7 @@ type Client struct {
 	GrafanaAPI       *gapi.Client
 	GrafanaCloudAPI  *gapi.Client
 
-	SMAPI    *SMAPI.Client
-	SMAPIURL string
+	SMAPI *SMAPI.Client
 
 	MLAPI *mlapi.Client
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -318,9 +318,8 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 				return nil, diag.FromErr(err)
 			}
 		}
-		c.SMAPIURL = d.Get("sm_url").(string)
 		if smToken := d.Get("sm_access_token").(string); smToken != "" {
-			c.SMAPI = SMAPI.NewClient(c.SMAPIURL, smToken, nil)
+			c.SMAPI = SMAPI.NewClient(d.Get("sm_url").(string), smToken, nil)
 		}
 		if d.Get("oncall_access_token").(string) != "" {
 			var onCallClient *onCallAPI.Client

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation.go
@@ -14,6 +14,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// TODO: Automate finding the correct API URL based on the stack region
+var smAPIURLs = map[string]string{
+	"us":                  "https://synthetic-monitoring-api.grafana.net",
+	"us-azure":            "https://synthetic-monitoring-api-us-central2.grafana.net",
+	"eu":                  "https://synthetic-monitoring-api-eu-west.grafana.net",
+	"au":                  "https://synthetic-monitoring-api-au-southeast.grafana.net",
+	"prod-ap-southeast-0": "https://synthetic-monitoring-api-ap-southeast-0.grafana.net",
+	"prod-gb-south-0":     "https://synthetic-monitoring-api-gb-south.grafana.net",
+	"prod-eu-west-2":      "https://synthetic-monitoring-api-eu-west-2.grafana.net",
+	"prod-eu-west-3":      "https://synthetic-monitoring-api-eu-west-3.grafana.net",
+	"prod-ap-south-0":     "https://synthetic-monitoring-api-ap-south-0.grafana.net",
+	"prod-sa-east-0":      "https://synthetic-monitoring-api-sa-east-0.grafana.net",
+	"prod-us-east-0":      "https://synthetic-monitoring-api-us-east-0.grafana.net",
+}
+
 func ResourceInstallation() *schema.Resource {
 	return &schema.Resource{
 
@@ -88,22 +103,9 @@ func ResourceInstallationCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	// TODO: Automate finding the correct API URL based on the stack region
 	apiURL := d.Get("stack_sm_api_url").(string)
 	if apiURL == "" {
-		apiURL = map[string]string{
-			"us":                  "https://synthetic-monitoring-api.grafana.net",
-			"us-azure":            "https://synthetic-monitoring-api-us-central2.grafana.net",
-			"eu":                  "https://synthetic-monitoring-api-eu-west.grafana.net",
-			"au":                  "https://synthetic-monitoring-api-au-southeast.grafana.net",
-			"prod-ap-southeast-0": "https://synthetic-monitoring-api-ap-southeast-0.grafana.net",
-			"prod-gb-south-0":     "https://synthetic-monitoring-api-gb-south.grafana.net",
-			"prod-eu-west-2":      "https://synthetic-monitoring-api-eu-west-2.grafana.net",
-			"prod-eu-west-3":      "https://synthetic-monitoring-api-eu-west-3.grafana.net",
-			"prod-ap-south-0":     "https://synthetic-monitoring-api-ap-south-0.grafana.net",
-			"prod-sa-east-0":      "https://synthetic-monitoring-api-sa-east-0.grafana.net",
-			"prod-us-east-0":      "https://synthetic-monitoring-api-us-east-0.grafana.net",
-		}[stack.RegionSlug]
+		apiURL = smAPIURLs[stack.RegionSlug]
 	}
 	if apiURL == "" {
 		return diag.Errorf("could not find a valid SM API URL for stack region %s", stack.RegionSlug)

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 
+	gapi "github.com/grafana/grafana-api-golang-client"
 	SMAPI "github.com/grafana/synthetic-monitoring-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -19,13 +22,16 @@ Sets up Synthetic Monitoring on a Grafana cloud stack and generates a token.
 Once a Grafana Cloud stack is created, a user can either use this resource or go into the UI to install synthetic monitoring.
 This resource cannot be imported but it can be used on an existing Synthetic Monitoring installation without issues.
 
+**Note that this resource must be used on a provider configured with Grafana Cloud credentials.**
+
 * [Official documentation](https://grafana.com/docs/grafana-cloud/synthetic-monitoring/installation/)
 * [API documentation](https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md#apiv1registerinstall)
 `,
 		CreateContext: ResourceInstallationCreate,
+		ReadContext:   ResourceInstallationRead,
+		UpdateContext: ResourceInstallationRead,
 		DeleteContext: ResourceInstallationDelete,
 
-		ReadContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics { return nil },
 		Schema: map[string]*schema.Schema{
 			"metrics_publisher_key": {
 				Type:        schema.TypeString,
@@ -34,23 +40,30 @@ This resource cannot be imported but it can be used on an existing Synthetic Mon
 				ForceNew:    true,
 				Description: "The Cloud API Key with the `MetricsPublisher` role used to publish metrics to the SM API",
 			},
+			"stack_sm_api_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The URL of the SM API to install SM on. This depends on the stack region, find the list of API URLs here: https://grafana.com/docs/grafana-cloud/synthetic-monitoring/private-probes/#probe-api-server-url. A static mapping exists in the provider but it may not contain all the regions. If it does contain the stack's region, this field is computed automatically and readable.",
+			},
 			"stack_id": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The ID of the stack to install SM on.",
+				Description: "The ID or slug of the stack to install SM on.",
 			},
 			"metrics_instance_id": {
 				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the metrics instance to install SM on (stack's `prometheus_user_id` attribute).",
+				Optional:    true,
+				Deprecated:  "Not used anymore.",
+				Description: "Deprecated: Not used anymore.",
 			},
 			"logs_instance_id": {
 				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the logs instance to install SM on (stack's `logs_user_id` attribute).",
+				Optional:    true,
+				Deprecated:  "Not used anymore.",
+				Description: "Deprecated: Not used anymore.",
 			},
 			"sm_access_token": {
 				Type:        schema.TypeString,
@@ -62,22 +75,57 @@ This resource cannot be imported but it can be used on an existing Synthetic Mon
 }
 
 func ResourceInstallationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := SMAPI.NewClient(meta.(*common.Client).SMAPIURL, "", nil)
-	stackID, metricsID, logsID := d.Get("stack_id").(int), d.Get("metrics_instance_id").(int), d.Get("logs_instance_id").(int)
-	resp, err := c.Install(ctx, int64(stackID), int64(metricsID), int64(logsID), d.Get("metrics_publisher_key").(string))
+	cloudClient := meta.(*common.Client).GrafanaCloudAPI
+	var stack gapi.Stack
+
+	stackIDInt, err := strconv.ParseInt(d.Get("stack_id").(string), 10, 64)
+	if err == nil {
+		stack, err = cloudClient.StackByID(stackIDInt)
+	} else {
+		stack, err = cloudClient.StackBySlug(d.Get("stack_id").(string))
+	}
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(fmt.Sprintf("%d-%d-%d", stackID, metricsID, logsID))
+
+	// TODO: Automate finding the correct API URL based on the stack region
+	apiURL := d.Get("stack_sm_api_url").(string)
+	if apiURL == "" {
+		apiURL = map[string]string{
+			"us":                  "https://synthetic-monitoring-api.grafana.net",
+			"us-azure":            "https://synthetic-monitoring-api-us-central2.grafana.net",
+			"eu":                  "https://synthetic-monitoring-api-eu-west.grafana.net",
+			"au":                  "https://synthetic-monitoring-api-au-southeast.grafana.net",
+			"prod-ap-southeast-0": "https://synthetic-monitoring-api-ap-southeast-0.grafana.net",
+			"prod-gb-south-0":     "https://synthetic-monitoring-api-gb-south.grafana.net",
+			"prod-eu-west-2":      "https://synthetic-monitoring-api-eu-west-2.grafana.net",
+			"prod-eu-west-3":      "https://synthetic-monitoring-api-eu-west-3.grafana.net",
+			"prod-ap-south-0":     "https://synthetic-monitoring-api-ap-south-0.grafana.net",
+			"prod-sa-east-0":      "https://synthetic-monitoring-api-sa-east-0.grafana.net",
+			"prod-us-east-0":      "https://synthetic-monitoring-api-us-east-0.grafana.net",
+		}[stack.RegionSlug]
+	}
+	if apiURL == "" {
+		return diag.Errorf("could not find a valid SM API URL for stack region %s", stack.RegionSlug)
+	}
+
+	smClient := SMAPI.NewClient(apiURL, "", nil)
+	stackID, metricsID, logsID := stack.ID, int64(stack.HmInstancePromID), int64(stack.HlInstanceID)
+	resp, err := smClient.Install(ctx, stackID, metricsID, logsID, d.Get("metrics_publisher_key").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(fmt.Sprintf("%s;%d", apiURL, stackID))
 	d.Set("sm_access_token", resp.AccessToken)
-	return nil
+	d.Set("stack_sm_api_url", apiURL)
+	return ResourceInstallationRead(ctx, d, meta)
 }
 
 // Management of the installation is a one-off operation. The state cannot be updated through a read operation.
 // This read function will only invalidate the state (forcing recreation) if the installation has been deleted.
 func ResourceInstallationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	provider := meta.(*common.Client)
-	tempClient := SMAPI.NewClient(provider.SMAPIURL, d.Get("sm_access_token").(string), nil)
+	apiURL := strings.Split(d.Id(), ";")[0]
+	tempClient := SMAPI.NewClient(apiURL, d.Get("sm_access_token").(string), nil)
 	if err := tempClient.ValidateToken(ctx); err != nil {
 		log.Printf("[WARN] removing SM installation from state because it is no longer valid")
 		d.SetId("")
@@ -87,8 +135,8 @@ func ResourceInstallationRead(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func ResourceInstallationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	provider := meta.(*common.Client)
-	tempClient := SMAPI.NewClient(provider.SMAPIURL, d.Get("sm_access_token").(string), nil)
+	apiURL := strings.Split(d.Id(), ";")[0]
+	tempClient := SMAPI.NewClient(apiURL, d.Get("sm_access_token").(string), nil)
 	if err := tempClient.DeleteToken(ctx); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
@@ -30,6 +30,7 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_installation.test", "sm_access_token"),
+					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_installation.test", "stack_sm_api_url"),
 				),
 			},
 			// Test deletion
@@ -50,8 +51,6 @@ func testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName string) string
 		`
 	resource "grafana_synthetic_monitoring_installation" "test" {
 		stack_id              = grafana_cloud_stack.test.id
-		metrics_instance_id   = grafana_cloud_stack.test.prometheus_user_id
-		logs_instance_id      = grafana_cloud_stack.test.logs_user_id
 		metrics_publisher_key = grafana_cloud_api_key.test.key
 	}
 	`


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/867 

Currently, the way to configure this is very convoluted:
- It requires three attributes from the stack
- It doesn't set the SM API URL. For that, the user must use the provider level sm_api_url. This isn't easy to figure out

In this PR, I squashed all three stack attributes into one and added a way to configure the SM API URL