### PR TITLE
Alerting: Add `details` field to pagerduty contact point

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -212,6 +212,7 @@ Optional:
 
 - `class` (String) The class or type of event, for example `ping failure`.
 - `component` (String) The component being affected by the event.
+- `details` (Map of String) A set of arbitrary key/value pairs that provide further detail about the incident.
 - `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
 - `group` (String) The group to which the provided component belongs to.
 - `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -56,9 +56,9 @@ resource "grafana_contact_point" "receiver_types" {
     component       = "mysql"
     group           = "my service"
     summary         = "message"
-    details         = {
-        "one" = "two"
-        "three" = "four"
+    details = {
+      "one"   = "two"
+      "three" = "four"
     }
   }
 

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -56,6 +56,10 @@ resource "grafana_contact_point" "receiver_types" {
     component       = "mysql"
     group           = "my service"
     summary         = "message"
+    details         = {
+        "one" = "two"
+        "three" = "four"
+    }
   }
 
   pushover {

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -201,6 +201,8 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.component", "mysql"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.group", "my service"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.summary", "message"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.details.one", "two"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pagerduty.0.details.three", "four"),
 					// pushover
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "pushover.0.user_key", "userkey"),


### PR DESCRIPTION
Grafana recently added a new `details` field to pagerduty in https://github.com/grafana/alerting/pull/65/files

Add it to the provider.