### PR TITLE
Adds a Global Header to all Grafana Terraform Provider requests

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -439,7 +439,10 @@ func createOnCallClient(d *schema.ResourceData) (*onCallAPI.Client, error) {
 	return onCallAPI.New(baseURL, aToken)
 }
 
+// Sets a custom HTTP Header on all requests coming from the Grafana Terraform Provider to Grafana-Terraform-Provider: true
+// in addition to any headers set within the `http_headers` field or the `GRAFANA_HTTP_HEADERS` environment variable
 func getHTTPHeadersMap(d *schema.ResourceData) (map[string]string, error) {
+	headers := map[string]string{"Grafana-Terraform-Provider": "true"}
 	headersMap := d.Get("http_headers").(map[string]interface{})
 	if len(headersMap) == 0 {
 		// We cannot use a DefaultFunc because they do not work on maps
@@ -449,16 +452,16 @@ func getHTTPHeadersMap(d *schema.ResourceData) (map[string]string, error) {
 			return nil, fmt.Errorf("invalid http_headers config: %w", err)
 		}
 	}
+
 	if len(headersMap) > 0 {
-		headers := make(map[string]string)
 		for k, v := range headersMap {
 			if v, ok := v.(string); ok {
 				headers[k] = v
 			}
 		}
-		return headers, nil
 	}
-	return map[string]string{}, nil
+
+	return headers, nil
 }
 
 // getJSONMap is a helper function that parses the given environment variable as a JSON object

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -29,8 +29,8 @@ func TestProviderConfigure(t *testing.T) {
 	// Helper for header tests
 	checkHeaders := func(t *testing.T, provider *schema.Provider) {
 		gotHeaders := provider.Meta().(*common.Client).GrafanaAPIConfig.HTTPHeaders
-		if len(gotHeaders) != 2 {
-			t.Errorf("expected 2 HTTP header, got %d", len(gotHeaders))
+		if len(gotHeaders) != 3 {
+			t.Errorf("expected 3 HTTP header, got %d", len(gotHeaders))
 		}
 		if gotHeaders["Authorization"] != "Bearer test" {
 			t.Errorf("expected HTTP header Authorization to be \"Bearer test\", got %q", gotHeaders["Authorization"])


### PR DESCRIPTION
Proposal to add a Global HTTP Custom Header to all requests coming from the Grafana Terraform Provider.

This PR would add the custom HTTP header:
`"Grafana-Terraform-Provider" : "true"`

to all requests originating from the Terraform Provider, in addition to any other `http_headers` or custom `GRAFANA_HTTP_HEADERS` environment variables that are set by the user.