### PR TITLE
Document `grafana_cloud_access_policy` import

### DIFF
--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -84,4 +84,10 @@ Required:
 
 - `selector` (String) The label selector to match in metrics or logs query. Should be in PromQL or LogQL format.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_cloud_access_policy.policyname {{region}}/{{policy_id}}
+```

--- a/examples/resources/grafana_cloud_access_policy/import.sh
+++ b/examples/resources/grafana_cloud_access_policy/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_cloud_access_policy.policyname {{region}}/{{policy_id}}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/902 
It's supported already, just not documented