### PR TITLE
Document that a stack's trace URL is the base URL

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -63,7 +63,7 @@ available at “https://<stack_slug>.grafana.net".
 - `status` (String) Status of the stack.
 - `traces_name` (String)
 - `traces_status` (String)
-- `traces_url` (String)
+- `traces_url` (String) Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL.
 - `traces_user_id` (Number)
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -65,7 +65,7 @@ available at “https://<stack_slug>.grafana.net".
 - `status` (String) Status of the stack.
 - `traces_name` (String)
 - `traces_status` (String)
-- `traces_url` (String)
+- `traces_url` (String) Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL.
 - `traces_user_id` (Number)
 
 ## Import

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -206,8 +206,9 @@ available at “https://<stack_slug>.grafana.net".`,
 				Computed: true,
 			},
 			"traces_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL.",
 			},
 			"traces_status": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/891 

I will recommend that this user open an issue to `grafana/grafana` instead
1. If the `loki` datasource supports a bare URL and not the tempo datasource, then it seems like a feature gap
2. We can't change the traces URL now, it will break existing setups
3. I think it's better to reflect what the API sends us