### PR TITLE
Alerting: Update Discord contact point to treat URL as a secure field

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -174,9 +174,10 @@ var _ notifier = (*discordNotifier)(nil)
 
 func (d discordNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:   "discord",
-		typeStr: "discord",
-		desc:    "A contact point that sends notifications as Discord messages",
+		field:        "discord",
+		typeStr:      "discord",
+		desc:         "A contact point that sends notifications as Discord messages",
+		secureFields: []string{"url"},
 	}
 }
 
@@ -227,6 +228,8 @@ func (d discordNotifier) pack(p gapi.ContactPoint, data *schema.ResourceData) (i
 		notifier["use_discord_username"] = v.(bool)
 		delete(p.Settings, "use_discord_username")
 	}
+
+	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, d, p.UID), d.meta().secureFields)
 
 	notifier["settings"] = packSettings(&p)
 	return notifier, nil


### PR DESCRIPTION
The field `url` in the Discord contact point declaration is declared as sensitive but in reality, it is treated as a regular setting. This PR updates the Discord contact point to treat `url` field as a secure field. 

This is part of the fix for https://github.com/grafana/grafana/issues/40148. 

### Testing
I tested it against the current version of Grafana which treats the URL field as a regular setting, and it does not change the behavior. Then I upgraded to https://github.com/grafana/grafana/pull/69588 and included https://github.com/grafana/alerting/pull/90 and checked that the `terraform plan` still has 0 changes. Then I changed one field (can be URL or any other), applied the plan and verified that change went through and the follow-up plan has 0 changes.