### PR TITLE
Fix permadiffs arising from default values in grafana_rule_group

### DIFF
--- a/examples/resources/grafana_rule_group/_acc_model_normalization.tf
+++ b/examples/resources/grafana_rule_group/_acc_model_normalization.tf
@@ -1,0 +1,115 @@
+resource "grafana_folder" "rule_folder" {
+  title = "Model Normalization Tests Folder"
+}
+
+resource "grafana_rule_group" "rg_model_params_defaults" {
+  name             = "My Rule Group 1"
+  folder_uid       = grafana_folder.rule_folder.uid
+  interval_seconds = 240
+  org_id           = 1
+  rule {
+    name           = "My Alert Rule 1"
+    for            = "2m"
+    condition      = "B"
+    no_data_state  = "NoData"
+    exec_err_state = "Alerting"
+    annotations = {
+      "a" = "b"
+      "c" = "d"
+    }
+    labels = {
+      "e" = "f"
+      "g" = "h"
+    }
+    is_paused = false
+    data {
+      ref_id     = "A"
+      query_type = ""
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      datasource_uid = "PD8C576611E62080A"
+      model = jsonencode({
+        hide          = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        refId         = "A"
+      })
+    }
+  }
+}
+
+resource "grafana_rule_group" "rg_model_params_omitted" {
+  name             = "My Rule Group 2"
+  folder_uid       = grafana_folder.rule_folder.uid
+  interval_seconds = 240
+  org_id           = 1
+  rule {
+    name           = "My Alert Rule 2"
+    for            = "2m"
+    condition      = "B"
+    no_data_state  = "NoData"
+    exec_err_state = "Alerting"
+    annotations = {
+      "a" = "b"
+      "c" = "d"
+    }
+    labels = {
+      "e" = "f"
+      "g" = "h"
+    }
+    is_paused = false
+    data {
+      ref_id     = "A"
+      query_type = ""
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      datasource_uid = "PD8C576611E62080A"
+      model = jsonencode({
+        hide  = false
+        refId = "A"
+      })
+    }
+  }
+}
+
+resource "grafana_rule_group" "rg_model_params_non_default" {
+  name             = "My Rule Group 3"
+  folder_uid       = grafana_folder.rule_folder.uid
+  interval_seconds = 240
+  org_id           = 1
+  rule {
+    name           = "My Alert Rule 3"
+    for            = "2m"
+    condition      = "B"
+    no_data_state  = "NoData"
+    exec_err_state = "Alerting"
+    annotations = {
+      "a" = "b"
+      "c" = "d"
+    }
+    labels = {
+      "e" = "f"
+      "g" = "h"
+    }
+    is_paused = false
+    data {
+      ref_id     = "A"
+      query_type = ""
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      datasource_uid = "PD8C576611E62080A"
+      model = jsonencode({
+        hide          = false
+        intervalMs    = 1001
+        maxDataPoints = 43201
+        refId         = "A"
+      })
+    }
+  }
+}

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func ResourceRuleGroup() *schema.Resource {
@@ -132,7 +133,7 @@ This resource requires Grafana 9.1.0 or later.
 										Required:     true,
 										Type:         schema.TypeString,
 										Description:  "Custom JSON data to send to the specified datasource when querying.",
-										ValidateFunc: validateModelJSON,
+										ValidateFunc: validation.StringIsJSON,
 										StateFunc:    normalizeModelJSON,
 									},
 									"relative_time_range": {
@@ -423,17 +424,6 @@ func unpackRuleData(raw interface{}) ([]*gapi.AlertQuery, error) {
 		result = append(result, stage)
 	}
 	return result, nil
-}
-
-// validateModelJSON is the ValidateFunc for `model`. It ensures its value is valid JSON.
-func validateModelJSON(model interface{}, k string) ([]string, []error) {
-	modelJSON := model.(string)
-	modelMap := map[string]interface{}{}
-	err := json.Unmarshal([]byte(modelJSON), &modelMap)
-	if err != nil {
-		return nil, []error{err}
-	}
-	return nil, nil
 }
 
 // normalizeModelJSON is the StateFunc for the `model`. It removes well-known default

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -375,7 +375,6 @@ func packRuleData(queries []*gapi.AlertQuery) (interface{}, error) {
 		if queries[i] == nil {
 			continue
 		}
-		log.Printf("[DEBUG] PACKING!!!\n")
 
 		model, err := json.Marshal(queries[i].Model)
 		if err != nil {


### PR DESCRIPTION
This change omits the `intervalMs` and `maxDataPoints` fields from the state, if they are set to the default values. This avoids permadiffs when the user does not explicitly specify the values, but just wants the default values.

Fixes #948 

<details><summary>`terraform plan` before fix:</summary>

```
Terraform will perform the following actions:

  # grafana_rule_group.test_group_1 will be updated in-place
  ~ resource "grafana_rule_group" "test_group_1" {
        id               = "a89db30c-ae41-4b31-98c4-f0027f70b0df;Test 1"
        name             = "Test 1"
        # (3 unchanged attributes hidden)

      ~ rule {
            name           = "Test 1"
            # (8 unchanged attributes hidden)

          ~ data {
              ~ model          = jsonencode(
                  ~ {
                      - intervalMs    = 1000
                      - maxDataPoints = 43200
                        # (3 unchanged attributes hidden)
                    }
                )
                # (2 unchanged attributes hidden)

                # (1 unchanged block hidden)
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
</details>

<details><summary>`terraform plan` after fix:</summary>

```
No changes. Your infrastructure matches the configuration.
```
</summary>
