### PR TITLE
Alerting Rule Group: Allow days in validation

### DIFF
--- a/examples/resources/grafana_rule_group/_acc_multi_rule_group.tf
+++ b/examples/resources/grafana_rule_group/_acc_multi_rule_group.tf
@@ -85,7 +85,7 @@ EOT
 
   rule {
     name           = "My Alert Rule 2"
-    for            = "4m"
+    for            = "6d"
     condition      = "B"
     no_data_state  = "NoData"
     exec_err_state = "Alerting"

--- a/examples/resources/grafana_rule_group/_acc_multi_rule_group_added.tf
+++ b/examples/resources/grafana_rule_group/_acc_multi_rule_group_added.tf
@@ -85,7 +85,7 @@ EOT
 
   rule {
     name           = "My Alert Rule 2"
-    for            = "4m"
+    for            = "144h" // 6 days
     condition      = "B"
     no_data_state  = "NoData"
     exec_err_state = "Alerting"

--- a/examples/resources/grafana_rule_group/_acc_multi_rule_group_subtracted.tf
+++ b/examples/resources/grafana_rule_group/_acc_multi_rule_group_subtracted.tf
@@ -85,7 +85,7 @@ EOT
 
   rule {
     name           = "My Alert Rule 2"
-    for            = "4m"
+    for            = "8640m" // 6 days
     condition      = "B"
     no_data_state  = "NoData"
     exec_err_state = "Alerting"

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
+	github.com/prometheus/common v0.44.0
 	golang.org/x/text v0.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -171,7 +171,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdOOfY=
+github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -280,8 +282,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/common/schema.go
+++ b/internal/common/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	promModel "github.com/prometheus/common/model"
 )
 
 // SchemaDiffFloat32 is a SchemaDiffSuppressFunc for diffing float32 values.
@@ -57,6 +58,15 @@ func AllowedValuesDescription(description string, allowedValues []string) string
 func ValidateDuration(i interface{}, p cty.Path) diag.Diagnostics {
 	v := i.(string)
 	_, err := time.ParseDuration(v)
+	if err != nil {
+		return diag.Errorf("%q is not a valid duration: %s", v, err)
+	}
+	return nil
+}
+
+func ValidateDurationWithDays(i interface{}, p cty.Path) diag.Diagnostics {
+	v := i.(string)
+	_, err := promModel.ParseDuration(v)
 	if err != nil {
 		return diag.Errorf("%q is not a valid duration: %s", v, err)
 	}

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	promModel "github.com/prometheus/common/model"
 )
 
 func ResourceRuleGroup() *schema.Resource {
@@ -81,10 +82,10 @@ This resource requires Grafana 9.1.0 or later.
 							Optional:         true,
 							Default:          0,
 							Description:      "The amount of time for which the rule must be breached for the rule to be considered to be Firing. Before this time has elapsed, the rule is only considered to be Pending.",
-							ValidateDiagFunc: common.ValidateDuration,
+							ValidateDiagFunc: common.ValidateDurationWithDays,
 							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-								oldDuration, _ := time.ParseDuration(oldValue)
-								newDuration, _ := time.ParseDuration(newValue)
+								oldDuration, _ := promModel.ParseDuration(oldValue)
+								newDuration, _ := promModel.ParseDuration(newValue)
 								return oldDuration == newDuration
 							},
 						},


### PR DESCRIPTION
Bug introduced in https://github.com/grafana/terraform-provider-grafana/pull/941 
Closes https://github.com/grafana/terraform-provider-grafana/issues/955

Turns out the duration lib used in alerting supports days and weeks. Let's use the same lib here