### PR TITLE
Dashboard: Remove `slug` and its migration

### DIFF
--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -69,5 +69,3 @@ Read-Only:
 
 - `action` (String)
 - `scope` (String)
-
-

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -40,7 +40,6 @@ resource "grafana_dashboard" "metrics" {
 
 - `dashboard_id` (Number) The numeric ID of the dashboard computed by Grafana.
 - `id` (String) The ID of this resource.
-- `slug` (String, Deprecated) URL friendly version of the dashboard title. This field is deprecated, please use `uid` instead.
 - `uid` (String) The unique identifier of a dashboard. This is used to construct its URL. It's automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs.
 - `url` (String) The full URL of the dashboard.
 - `version` (Number) Whenever you save a version of your dashboard, a copy of that version is saved so that previous versions of your dashboard are not lost.


### PR DESCRIPTION
This field is no longer used and the migration was needed for Grafana 7 -> 8 
I don't think we need to carry this code anymore. Especially considering that users can do a two-step upgrade if they do have issues