### PR TITLE
Folder: Add `org_id` attribute

### DIFF
--- a/docs/data-sources/library_panel.md
+++ b/docs/data-sources/library_panel.md
@@ -97,7 +97,7 @@ data "grafana_dashboard" "from_library_panel_connection" {
 - `created` (String) Timestamp when the library panel was created.
 - `dashboard_ids` (List of Number) Numerical IDs of Grafana dashboards containing the library panel.
 - `description` (String) Description of the library panel.
-- `folder_id` (Number) ID of the folder where the library panel is stored.
+- `folder_id` (String) ID of the folder where the library panel is stored.
 - `folder_name` (String) Name of the folder containing the library panel.
 - `folder_uid` (String) Unique ID (UID) of the folder containing the library panel.
 - `id` (String) The ID of this resource.

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -43,12 +43,13 @@ resource "grafana_folder" "test_folder_with_uid" {
 
 ### Optional
 
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `prevent_destroy_if_not_empty` (Boolean) Prevent deletion of the folder if it is not empty (contains dashboards or alert rules). Defaults to `false`.
 - `uid` (String) Unique identifier.
 
 ### Read-Only
 
-- `id` (String) Unique internal identifier.
+- `id` (String) The ID of this resource.
 - `url` (String) The full URL of the folder.
 
 ## Import

--- a/docs/resources/folder_permission.md
+++ b/docs/resources/folder_permission.md
@@ -51,6 +51,10 @@ resource "grafana_folder_permission" "collectionPermission" {
 - `folder_uid` (String) The UID of the folder.
 - `permissions` (Block Set, Min: 1) The permission items to add/update. Items that are omitted from the list will be removed. (see [below for nested schema](#nestedblock--permissions))
 
+### Optional
+
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -37,7 +37,7 @@ resource "grafana_library_panel" "test" {
 
 ### Optional
 
-- `folder_id` (Number) ID of the folder where the library panel is stored.
+- `folder_id` (String) ID of the folder where the library panel is stored.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `uid` (String) The unique identifier (UID) of a library panel uniquely identifies library panels between multiple Grafana installs. It’s automatically generated unless you specify it during library panel creation.The UID provides consistent URLs for accessing library panels and when syncing library panels between multiple Grafana installs.
 

--- a/internal/resources/grafana/data_source_folder_test.go
+++ b/internal/resources/grafana/data_source_folder_test.go
@@ -33,7 +33,7 @@ func TestAccDatasourceFolder(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccFolderCheckDestroy(&folder),
+		CheckDestroy:      testAccFolderCheckDestroy(&folder, 0),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_folder/data-source.tf"),

--- a/internal/resources/grafana/data_source_folders_test.go
+++ b/internal/resources/grafana/data_source_folders_test.go
@@ -35,8 +35,8 @@ func TestAccDatasourceFolders(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccFolderCheckDestroy(&folderA),
-			testAccFolderCheckDestroy(&folderB),
+			testAccFolderCheckDestroy(&folderA, 0),
+			testAccFolderCheckDestroy(&folderB, 0),
 		),
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -47,9 +48,9 @@ func testAccFolderPermissionsCheckExists(rn string, folderUID *string) resource.
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		orgID, gotFolderUID := grafana.SplitOrgResourceID(rs.Primary.ID)
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
 
-		gotFolderUID := rs.Primary.ID
 		_, err := client.FolderPermissions(gotFolderUID)
 		if err != nil {
 			return fmt.Errorf("Error getting folder permissions: %s", err)

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -100,7 +100,7 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 					testAccLibraryPanelCheckExistsInFolder(&panel, &folder),
 					resource.TestCheckResourceAttr("grafana_library_panel.test_folder", "name", "test-folder"),
 					resource.TestMatchResourceAttr(
-						"grafana_library_panel.test_folder", "folder_id", common.IDRegexp,
+						"grafana_library_panel.test_folder", "folder_id", defaultOrgIDRegexp,
 					),
 				),
 			},


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/747 
Allows a folder to be created and managed in a separate organization without needing two `provider` blocks 
Also adds tests that a folder can be created and managed in an org