### PR TITLE
Datasource: Add `org_id` attribute

### DIFF
--- a/docs/data-sources/data_source.md
+++ b/docs/data-sources/data_source.md
@@ -51,6 +51,7 @@ data "grafana_data_source" "from_uid" {
 ### Optional
 
 - `name` (String)
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `uid` (String)
 
 ### Read-Only

--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -100,6 +100,7 @@ resource "grafana_data_source" "prometheus" {
 - `http_headers` (Map of String, Sensitive) Custom HTTP headers
 - `is_default` (Boolean) Whether to set the data source as default. This should only be `true` to a single data source. Defaults to `false`.
 - `json_data_encoded` (String) Serialized JSON string containing the json data. This attribute can be used to pass configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `secure_json_data_encoded` (String, Sensitive) Serialized JSON string containing the secure json data. This attribute can be used to pass secure configuration options to the data source. To figure out what options a datasource has available, see its docs or inspect the network data when saving it from the Grafana UI. Note that keys in this map are usually camelCased.
 - `uid` (String) Unique identifier. If unset, this will be automatically generated.
 - `url` (String) The URL for the data source. The type of URL required varies depending on the chosen data source type.

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -54,8 +54,12 @@ resource "grafana_data_source_permission" "fooPermissions" {
 
 ### Required
 
-- `datasource_id` (Number) ID of the datasource to apply permissions to.
+- `datasource_id` (String) ID of the datasource to apply permissions to.
 - `permissions` (Block Set, Min: 1) The permission items to add/update. Items that are omitted from the list will be removed. (see [below for nested schema](#nestedblock--permissions))
+
+### Optional
+
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only
 

--- a/internal/resources/grafana/data_source_data_source.go
+++ b/internal/resources/grafana/data_source_data_source.go
@@ -15,6 +15,7 @@ func DatasourceDatasource() *schema.Resource {
 		Description: "Get details about a Grafana Datasource querying by either name, uid or ID",
 		ReadContext: datasourceDatasourceRead,
 		Schema: common.CloneResourceSchemaForDatasource(ResourceDataSource(), map[string]*schema.Schema{
+			"org_id": orgIDAttribute(),
 			"id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -40,7 +41,7 @@ func DatasourceDatasource() *schema.Resource {
 }
 
 func datasourceDatasourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client, _ := ClientFromNewOrgResource(meta, d)
 
 	var (
 		dataSource *gapi.DataSource
@@ -54,7 +55,8 @@ func datasourceDatasourceRead(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		dataSource, err = client.DataSource(id)
 	} else if id, ok := d.GetOk("id"); ok {
-		idInt, parseErr := strconv.ParseInt(id.(string), 10, 64)
+		_, idStr := SplitOrgResourceID(id.(string))
+		idInt, parseErr := strconv.ParseInt(idStr, 10, 64)
 		if parseErr != nil {
 			return diag.FromErr(parseErr)
 		}

--- a/internal/resources/grafana/data_source_data_source_test.go
+++ b/internal/resources/grafana/data_source_data_source_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -16,17 +15,17 @@ func TestAccDatasourceDatasource(t *testing.T) {
 	checks := []resource.TestCheckFunc{
 		testAccDataSourceCheckExists("grafana_data_source.prometheus", &dataSource),
 
-		resource.TestMatchResourceAttr("data.grafana_data_source.from_name", "id", common.IDRegexp),
+		resource.TestMatchResourceAttr("data.grafana_data_source.from_name", "id", defaultOrgIDRegexp),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_name", "name", "prometheus-ds-test"),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_name", "uid", "prometheus-ds-test-uid"),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_name", "json_data_encoded", `{"httpMethod":"POST","prometheusType":"Mimir","prometheusVersion":"2.4.0"}`),
 
-		resource.TestMatchResourceAttr("data.grafana_data_source.from_uid", "id", common.IDRegexp),
+		resource.TestMatchResourceAttr("data.grafana_data_source.from_uid", "id", defaultOrgIDRegexp),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_uid", "name", "prometheus-ds-test"),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_uid", "uid", "prometheus-ds-test-uid"),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_uid", "json_data_encoded", `{"httpMethod":"POST","prometheusType":"Mimir","prometheusVersion":"2.4.0"}`),
 
-		resource.TestMatchResourceAttr("data.grafana_data_source.from_id", "id", common.IDRegexp),
+		resource.TestMatchResourceAttr("data.grafana_data_source.from_id", "id", defaultOrgIDRegexp),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_id", "name", "prometheus-ds-test"),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_id", "uid", "prometheus-ds-test-uid"),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_id", "json_data_encoded", `{"httpMethod":"POST","prometheusType":"Mimir","prometheusVersion":"2.4.0"}`),
@@ -34,7 +33,7 @@ func TestAccDatasourceDatasource(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource),
+		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource, 0),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_data_source/data-source.tf"),

--- a/internal/resources/grafana/resource_data_source_permission_test.go
+++ b/internal/resources/grafana/resource_data_source_permission_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -46,9 +47,10 @@ func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) res
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		orgID, datasourceIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
 
-		gotDatasourceID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		gotDatasourceID, err := strconv.ParseInt(datasourceIDStr, 10, 64)
 		if err != nil {
 			return fmt.Errorf("datasource id is malformed")
 		}


### PR DESCRIPTION
Issue: #747
Allows a datasource to be created and managed in a separate organization without needing two provider blocks 
Also adds tests that a datasource can be created and managed in an org