### PR TITLE
Team: Support `org_id` attribute

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -38,6 +38,7 @@ data "grafana_team" "from_name" {
 
 ### Optional
 
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `read_team_sync` (Boolean) Whether to read the team sync settings. This is only available in Grafana Enterprise. Defaults to `false`.
 
 ### Read-Only

--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -54,6 +54,7 @@ resource "grafana_dashboard_permission" "collectionPermission" {
 
 - `dashboard_id` (Number, Deprecated) ID of the dashboard to apply permissions to. Deprecated: use `dashboard_uid` instead.
 - `dashboard_uid` (String) UID of the dashboard to apply permissions to.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only
 
@@ -69,7 +70,7 @@ Required:
 Optional:
 
 - `role` (String) Manage permissions for `Viewer` or `Editor` roles.
-- `team_id` (Number) ID of the team to manage permissions for. Defaults to `0`.
+- `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
 - `user_id` (Number) ID of the user to manage permissions for. Defaults to `0`.
 
 ## Import

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -75,5 +75,5 @@ Required:
 Optional:
 
 - `built_in_role` (String) Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`. Can only be set from Grafana v9.2.3+. Defaults to ``.
-- `team_id` (Number) ID of the team to manage permissions for. Defaults to `0`.
+- `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
 - `user_id` (Number) ID of the user to manage permissions for. Defaults to `0`.

--- a/docs/resources/folder_permission.md
+++ b/docs/resources/folder_permission.md
@@ -69,5 +69,5 @@ Required:
 Optional:
 
 - `role` (String) Manage permissions for `Viewer` or `Editor` roles.
-- `team_id` (Number) ID of the team to manage permissions for. Defaults to `0`.
+- `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
 - `user_id` (Number) ID of the user to manage permissions for. Defaults to `0`.

--- a/docs/resources/role_assignment.md
+++ b/docs/resources/role_assignment.md
@@ -62,7 +62,7 @@ resource "grafana_role_assignment" "test" {
 ### Optional
 
 - `service_accounts` (Set of Number) IDs of service accounts that the role should be assigned to.
-- `teams` (Set of Number) IDs of teams that the role should be assigned to.
+- `teams` (Set of String) IDs of teams that the role should be assigned to.
 - `users` (Set of Number) IDs of users that the role should be assigned to.
 
 ### Read-Only

--- a/docs/resources/service_account_permission.md
+++ b/docs/resources/service_account_permission.md
@@ -54,6 +54,10 @@ resource "grafana_service_account_permission" "test_permissions" {
 - `permissions` (Block Set, Min: 1) The permission items to add/update. Items that are omitted from the list will be removed. (see [below for nested schema](#nestedblock--permissions))
 - `service_account_id` (String) The id of the service account.
 
+### Optional
+
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.
@@ -67,5 +71,5 @@ Required:
 
 Optional:
 
-- `team_id` (Number) ID of the team to manage permissions for. Specify either this or `user_id`. Defaults to `0`.
+- `team_id` (String) ID of the team to manage permissions for. Specify either this or `user_id`. Defaults to `0`.
 - `user_id` (Number) ID of the user to manage permissions for. Specify either this or `team_id`. Defaults to `0`.

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -38,6 +38,7 @@ Team Sync can be provisioned using [grafana_team_external_group resource](https:
  Defaults to `true`.
 - `members` (Set of String) A set of email addresses corresponding to users who should be given membership
 to the team. Note: users specified here must already exist in Grafana.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `preferences` (Block List, Max: 1) (see [below for nested schema](#nestedblock--preferences))
 - `team_sync` (Block List, Max: 1) Sync external auth provider groups with this Grafana team. Only available in Grafana Enterprise.
 	* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/)

--- a/docs/resources/team_external_group.md
+++ b/docs/resources/team_external_group.md
@@ -28,7 +28,7 @@ resource "grafana_team_external_group" "test-team-group" {
 ### Required
 
 - `groups` (Set of String) The team external groups list
-- `team_id` (Number) The Team ID
+- `team_id` (String) The Team ID
 
 ### Read-Only
 

--- a/internal/resources/grafana/data_source_team.go
+++ b/internal/resources/grafana/data_source_team.go
@@ -16,6 +16,7 @@ func DatasourceTeam() *schema.Resource {
 `,
 		ReadContext: dataSourceTeamRead,
 		Schema: common.CloneResourceSchemaForDatasource(ResourceTeam(), map[string]*schema.Schema{
+			"org_id": orgIDAttribute(),
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -33,7 +34,7 @@ func DatasourceTeam() *schema.Resource {
 }
 
 func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client, _ := ClientFromNewOrgResource(meta, d)
 	name := d.Get("name").(string)
 	searchTeam, err := client.SearchTeam(name)
 	if err != nil {
@@ -42,7 +43,7 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	for _, r := range searchTeam.Teams {
 		if r.Name == name {
-			return readTeamFromID(r.ID, d, meta, d.Get("read_team_sync").(bool))
+			return readTeamFromID(client, r.ID, d, d.Get("read_team_sync").(bool))
 		}
 	}
 

--- a/internal/resources/grafana/data_source_team_test.go
+++ b/internal/resources/grafana/data_source_team_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -16,7 +15,7 @@ func TestAccDatasourceTeam(t *testing.T) {
 	checks := []resource.TestCheckFunc{
 		testAccTeamCheckExists("grafana_team.test", &team),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "name", "test-team"),
-		resource.TestMatchResourceAttr("data.grafana_team.from_name", "id", common.IDRegexp),
+		resource.TestMatchResourceAttr("data.grafana_team.from_name", "id", defaultOrgIDRegexp),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "email", "test-team-email@test.com"),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "members.#", "0"),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "preferences.#", "1"),
@@ -43,7 +42,7 @@ func TestAccDatasourceTeam_teamSync(t *testing.T) {
 	checks := []resource.TestCheckFunc{
 		testAccTeamCheckExists("grafana_team.test", &team),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "name", "test-team"),
-		resource.TestMatchResourceAttr("data.grafana_team.from_name", "id", common.IDRegexp),
+		resource.TestMatchResourceAttr("data.grafana_team.from_name", "id", defaultOrgIDRegexp),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "email", "test-team-email@test.com"),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "members.#", "0"),
 		resource.TestCheckResourceAttr("data.grafana_team.from_name", "preferences.#", "1"),

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -76,9 +77,8 @@ func testAccDashboardPermissionsCheckExistsUID(rn string, dashboardUID *string) 
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
-
-		gotDashboardUID := rs.Primary.ID
+		orgID, gotDashboardUID := grafana.SplitOrgResourceID(rs.Primary.ID)
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
 
 		_, err := client.DashboardPermissionsByUID(gotDashboardUID)
 		if err != nil {
@@ -102,9 +102,10 @@ func testAccDashboardPermissionsCheckExists(rn string, dashboardID *int64) resou
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		orgID, dashboardIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
 
-		gotDashboardID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		gotDashboardID, err := strconv.ParseInt(dashboardIDStr, 10, 64)
 		if err != nil {
 			return fmt.Errorf("dashboard id is malformed")
 		}

--- a/internal/resources/grafana/resource_data_source_permission.go
+++ b/internal/resources/grafana/resource_data_source_permission.go
@@ -37,12 +37,18 @@ func ResourceDatasourcePermission() *schema.Resource {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
+				// Ignore the org ID of the team when hashing. It works with or without it.
+				Set: func(i interface{}) int {
+					m := i.(map[string]interface{})
+					_, teamID := SplitOrgResourceID(m["team_id"].(string))
+					return schema.HashString(m["built_in_role"].(string) + teamID + strconv.Itoa(m["user_id"].(int)) + m["permission"].(string))
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"team_id": {
-							Type:        schema.TypeInt,
+							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     0,
+							Default:     "0",
 							Description: "ID of the team to manage permissions for.",
 						},
 						"user_id": {
@@ -86,8 +92,10 @@ func UpdateDatasourcePermissions(ctx context.Context, d *schema.ResourceData, me
 	for _, permission := range v.(*schema.Set).List() {
 		permission := permission.(map[string]interface{})
 		permissionItem := gapi.DatasourcePermissionAddPayload{}
-		if permission["team_id"].(int) != -1 {
-			permissionItem.TeamID = int64(permission["team_id"].(int))
+		_, teamIDStr := SplitOrgResourceID(permission["team_id"].(string))
+		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
+		if teamID > 0 {
+			permissionItem.TeamID = teamID
 		}
 		if permission["user_id"].(int) != -1 {
 			permissionItem.UserID = int64(permission["user_id"].(int))
@@ -128,7 +136,7 @@ func ReadDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta
 	for i, permission := range response.Permissions {
 		permissionItem := make(map[string]interface{})
 		permissionItem["built_in_role"] = permission.BuiltInRole
-		permissionItem["team_id"] = permission.TeamID
+		permissionItem["team_id"] = strconv.FormatInt(permission.TeamID, 10)
 		permissionItem["user_id"] = permission.UserID
 
 		if permissionItem["permission"], err = mapDatasourcePermissionTypeToString(permission.Permission); err != nil {

--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -8,6 +8,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -31,7 +32,8 @@ func TestAccTeam_basic(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamName),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamName+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_team.test", "org_id", "1"),
 				),
 			},
 			{
@@ -40,7 +42,8 @@ func TestAccTeam_basic(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamNameUpdated),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamNameUpdated+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_team.test", "org_id", "1"),
 				),
 			},
 			{
@@ -71,7 +74,8 @@ func TestAccTeam_preferences(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamName),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamName+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_team.test", "org_id", "1"),
 					resource.TestCheckNoResourceAttr("grafana_team.test", "preferences.0.home_dashboard_uid"),
 					resource.TestCheckNoResourceAttr("grafana_team.test", "preferences.0.theme"),
 					resource.TestCheckNoResourceAttr("grafana_team.test", "preferences.0.timezone"),
@@ -83,7 +87,8 @@ func TestAccTeam_preferences(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamNameUpdated),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamNameUpdated+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_team.test", "org_id", "1"),
 					resource.TestMatchResourceAttr("grafana_team.test", "preferences.0.home_dashboard_uid", common.UIDRegexp),
 					resource.TestCheckResourceAttr("grafana_team.test", "preferences.0.theme", "dark"),
 					resource.TestCheckResourceAttr("grafana_team.test", "preferences.0.timezone", "utc"),
@@ -117,7 +122,7 @@ func TestAccTeam_teamSync(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamName),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamName+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.#", "0"),
 				),
 			},
@@ -128,7 +133,7 @@ func TestAccTeam_teamSync(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamName),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamName+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.#", "2"),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.0", "group1"),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.1", "group2"),
@@ -141,7 +146,7 @@ func TestAccTeam_teamSync(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamName),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamName+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.#", "2"),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.0", "group2"),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.1", "group3"),
@@ -154,7 +159,7 @@ func TestAccTeam_teamSync(t *testing.T) {
 					testAccTeamCheckExists("grafana_team.test", &team),
 					resource.TestCheckResourceAttr("grafana_team.test", "name", teamName),
 					resource.TestCheckResourceAttr("grafana_team.test", "email", teamName+"@example.com"),
-					resource.TestMatchResourceAttr("grafana_team.test", "id", common.IDRegexp),
+					resource.TestMatchResourceAttr("grafana_team.test", "id", defaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_team.test", "team_sync.0.groups.#", "0"),
 				),
 			},
@@ -280,6 +285,32 @@ func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
 	})
 }
 
+func TestAccResourceTeam_InOrg(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	var team gapi.Team
+	var org gapi.Org
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		CheckDestroy:      testAccTeamCheckDestroy(&team),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamInOrganization(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccTeamCheckExists("grafana_team.test", &team),
+
+					// Check that the team is in the correct organization
+					resource.TestMatchResourceAttr("grafana_team.test", "id", nonDefaultOrgIDRegexp),
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					checkResourceIsInOrg("grafana_team.test", "grafana_organization.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTeamCheckExists(rn string, a *gapi.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -290,15 +321,26 @@ func testAccTeamCheckExists(rn string, a *gapi.Team) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
 		}
-		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+
+		orgID, teamIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
+		id, err := strconv.ParseInt(teamIDStr, 10, 64)
 		if err != nil {
 			return fmt.Errorf("resource id is malformed")
 		}
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		// If the org ID is set, check that the team doesn't exist in the default org
+		if orgID > 1 {
+			team, err := client.Team(id)
+			if err == nil || team != nil {
+				return fmt.Errorf("team %d exists in the default org", id)
+			}
+			client = client.WithOrgID(orgID)
+		}
+
 		team, err := client.Team(id)
 		if err != nil {
-			return fmt.Errorf("error getting data source: %s", err)
+			return fmt.Errorf("error getting team: %s", err)
 		}
 
 		*a = *team
@@ -376,4 +418,18 @@ resource "grafana_user" "users" {
 	}
 
 	return definition
+}
+
+func testAccTeamInOrganization(orgName string) string {
+	return fmt.Sprintf(`
+resource "grafana_organization" "test" {
+	name = "%[1]s"
+}
+
+resource "grafana_team" "test" {
+	org_id  = grafana_organization.test.id
+	name    = "%[1]s"
+	email   = "%[1]s@example.com"
+	members = [ ]
+}`, orgName)
 }

--- a/internal/resources/grafana/zzz_deprecated_resource_team_external_group.go
+++ b/internal/resources/grafana/zzz_deprecated_resource_team_external_group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,10 +27,15 @@ func ResourceTeamExternalGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The Team ID",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, old = SplitOrgResourceID(old)
+					_, new = SplitOrgResourceID(new)
+					return old == "0" && new == "" || old == "" && new == "0" || old == new
+				},
 			},
 
 			"groups": {
@@ -45,18 +51,22 @@ func ResourceTeamExternalGroup() *schema.Resource {
 }
 
 func CreateTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	teamID := d.Get("team_id").(int)
-	d.SetId(strconv.FormatInt(int64(teamID), 10))
-	if err := manageTeamExternalGroup(d, meta, "groups"); err != nil {
+	orgID, teamIDStr := SplitOrgResourceID(d.Get("team_id").(string))
+	teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
+	d.SetId(MakeOrgResourceID(orgID, teamID))
+	client, _, _ := ClientFromExistingOrgResource(meta, d.Id())
+
+	if err := manageTeamExternalGroup(client, teamID, d, "groups"); err != nil {
 		return diag.FromErr(err)
 	}
 
-	return diag.Diagnostics{}
+	return ReadTeamExternalGroup(ctx, d, meta)
 }
 
 func ReadTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
-	teamID, _ := strconv.ParseInt(d.Id(), 10, 64)
+	client, orgID, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	teamID, _ := strconv.ParseInt(idStr, 10, 64)
+
 	teamGroups, err := client.TeamGroups(teamID)
 	if err, shouldReturn := common.CheckReadError("team groups", d, err); shouldReturn {
 		return err
@@ -66,25 +76,26 @@ func ReadTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta int
 	for _, teamGroup := range teamGroups {
 		groupIDs = append(groupIDs, teamGroup.GroupID)
 	}
-	d.Set("team_id", teamID)
+	d.SetId(MakeOrgResourceID(orgID, teamID))
+	d.Set("team_id", d.Id())
 	d.Set("groups", groupIDs)
 
 	return diag.Diagnostics{}
 }
 
 func UpdateTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if err := manageTeamExternalGroup(d, meta, "groups"); err != nil {
+	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	teamID, _ := strconv.ParseInt(idStr, 10, 64)
+
+	if err := manageTeamExternalGroup(client, teamID, d, "groups"); err != nil {
 		return diag.FromErr(err)
 	}
 
-	return diag.Diagnostics{}
+	return ReadTeamExternalGroup(ctx, d, meta)
 }
 
-func manageTeamExternalGroup(d *schema.ResourceData, meta interface{}, groupsAttr string) error {
-	client := meta.(*common.Client).GrafanaAPI
-
+func manageTeamExternalGroup(client *gapi.Client, teamID int64, d *schema.ResourceData, groupsAttr string) error {
 	addGroups, removeGroups := groupChangesTeamExternalGroup(d, groupsAttr)
-	teamID, _ := strconv.ParseInt(d.Id(), 10, 64)
 
 	for _, group := range addGroups {
 		err := client.NewTeamGroup(teamID, group)

--- a/internal/resources/grafana/zzz_deprecated_resource_team_external_group_test.go
+++ b/internal/resources/grafana/zzz_deprecated_resource_team_external_group_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -61,9 +62,10 @@ func testAccTeamExternalGroupCheckExists(rn string, teamID *int64) resource.Test
 			return fmt.Errorf("Resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		orgID, teamIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
+		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
 
-		gotTeamID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		gotTeamID, err := strconv.ParseInt(teamIDStr, 10, 64)
 		if err != nil {
 			return fmt.Errorf("team id is malformed")
 		}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/747
Final resource to receive the `org_id`
Allows a team to be created and managed in a separate organization without needing two provider blocks
Also adds tests that a team can be created and managed in an org

Note: `*_permissions` are a bit messy. I'm planning on refactoring them afterwards, they mostly follow the same pattern so it should be possible to make them much nicer