### PR TITLE
Make sure `org_id` is always set in state

### DIFF
--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -43,7 +43,9 @@ func SplitOrgResourceID(id string) (int64, string) {
 func ClientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, int64, string) {
 	orgID, restOfID := SplitOrgResourceID(id)
 	client := meta.(*common.Client).GrafanaAPI
-	if orgID > 0 {
+	if orgID == 0 {
+		orgID = meta.(*common.Client).GrafanaAPIConfig.OrgID // It's configured globally. TODO: Remove this once we drop support for the global org_id
+	} else if orgID > 0 {
 		client = client.WithOrgID(orgID)
 	}
 	return client, orgID, restOfID
@@ -54,7 +56,9 @@ func ClientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, i
 func ClientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
 	orgID, _ := strconv.ParseInt(d.Get("org_id").(string), 10, 64)
 	client := meta.(*common.Client).GrafanaAPI
-	if orgID > 0 {
+	if orgID == 0 {
+		orgID = meta.(*common.Client).GrafanaAPIConfig.OrgID // It's configured globally. TODO: Remove this once we drop support for the global org_id
+	} else if orgID > 0 {
 		client = client.WithOrgID(orgID)
 	}
 	return client, orgID

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -177,7 +177,7 @@ func testAccAnnotationCheckExists(rn string, annotation *gapi.Annotation) resour
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		// If the org ID is set, check that the annotation doesn't exist in the default org
-		if orgID > 0 {
+		if orgID > 1 {
 			annotations, err := client.Annotations(url.Values{})
 			if err != nil {
 				return fmt.Errorf("error getting annotations: %s", err)

--- a/internal/resources/grafana/resource_api_key.go
+++ b/internal/resources/grafana/resource_api_key.go
@@ -82,7 +82,7 @@ func resourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c, _, idStr := ClientFromExistingOrgResource(m, d.Id())
+	c, orgID, idStr := ClientFromExistingOrgResource(m, d.Id())
 
 	response, err := c.GetAPIKeys(true)
 	if err, shouldReturn := common.CheckReadError("API key", d, err); shouldReturn {
@@ -95,6 +95,8 @@ func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 	}
 	for _, key := range response {
 		if id == key.ID {
+			d.SetId(MakeOrgResourceID(orgID, key.ID))
+			d.Set("org_id", strconv.FormatInt(orgID, 10))
 			d.Set("name", key.Name)
 			d.Set("role", key.Role)
 

--- a/internal/resources/grafana/resource_api_key_test.go
+++ b/internal/resources/grafana/resource_api_key_test.go
@@ -29,6 +29,7 @@ func TestAccGrafanaAuthKey(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccGrafanaAuthKeyCheckExists,
 					resource.TestMatchResourceAttr("grafana_api_key.foo", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_api_key.foo", "org_id", "1"),
 					resource.TestCheckResourceAttrSet("grafana_api_key.foo", "key"),
 					resource.TestCheckResourceAttr("grafana_api_key.foo", "name", testName),
 					resource.TestCheckResourceAttr("grafana_api_key.foo", "role", "Admin"),

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -112,13 +112,15 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	gapiURL := meta.(*common.Client).GrafanaAPIURL
-	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
+	client, orgID, uid := ClientFromExistingOrgResource(meta, d.Id())
 
 	dashboard, err := client.DashboardByUID(uid)
 	if err, shouldReturn := common.CheckReadError("dashboard", d, err); shouldReturn {
 		return err
 	}
 
+	d.SetId(MakeOrgResourceID(orgID, uid))
+	d.Set("org_id", strconv.FormatInt(orgID, 10))
 	d.Set("uid", dashboard.Model["uid"].(string))
 	d.Set("dashboard_id", int64(dashboard.Model["id"].(float64)))
 	d.Set("version", int64(dashboard.Model["version"].(float64)))

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -45,7 +45,8 @@ func TestAccDashboard_basic(t *testing.T) {
 						Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_basic.tf"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
-							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "0:basic"), // <org id>:<uid>
+							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "1:basic"), // <org id>:<uid>
+							resource.TestCheckResourceAttr("grafana_dashboard.test", "org_id", "1"),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "basic"),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/d/basic/terraform-acceptance-test"),
 							resource.TestCheckResourceAttr(
@@ -58,7 +59,7 @@ func TestAccDashboard_basic(t *testing.T) {
 						Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_basic_update.tf"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
-							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "0:basic"), // <org id>:<uid>
+							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "1:basic"), // <org id>:<uid>
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "basic"),
 							resource.TestCheckResourceAttr(
 								"grafana_dashboard.test", "config_json", expectedUpdatedTitleConfig,
@@ -72,7 +73,7 @@ func TestAccDashboard_basic(t *testing.T) {
 						Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_basic_update_uid.tf"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccDashboardCheckExists("grafana_dashboard.test", &dashboard),
-							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "0:basic-update"), // <org id>:<uid>
+							resource.TestCheckResourceAttr("grafana_dashboard.test", "id", "1:basic-update"), // <org id>:<uid>
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "uid", "basic-update"),
 							resource.TestCheckResourceAttr("grafana_dashboard.test", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/d/basic-update/updated-title"),
 							resource.TestCheckResourceAttr(
@@ -174,7 +175,7 @@ func TestAccDashboard_folder(t *testing.T) {
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
 					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
 					testAccDashboardCheckExistsInFolder(&dashboard, &folder),
-					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "0:folder-dashboard-test-ref-with-id"), // <org id>:<uid>
+					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "1:folder-dashboard-test-ref-with-id"), // <org id>:<uid>
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "uid", "folder-dashboard-test-ref-with-id"),
 					resource.TestMatchResourceAttr("grafana_dashboard.test_folder", "folder", common.IDRegexp),
 				),
@@ -200,7 +201,7 @@ func TestAccDashboard_folder_uid(t *testing.T) {
 					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
 					testAccDashboardCheckExistsInFolder(&dashboard, &folder),
-					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "0:folder-dashboard-test-ref-with-uid"), // <org id>:<uid>
+					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "1:folder-dashboard-test-ref-with-uid"), // <org id>:<uid>
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "uid", "folder-dashboard-test-ref-with-uid"),
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "folder", "folder-dashboard-uid-test"),
 				),
@@ -266,7 +267,7 @@ func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		// If the org ID is set, check that the dashboard doesn't exist in the default org
-		if orgID > 0 {
+		if orgID > 1 {
 			dashboard, err := client.DashboardByUID(dashboardUID)
 			if err == nil || dashboard != nil {
 				return fmt.Errorf("dashboard %s exists in the default org", dashboardUID)

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -104,6 +104,7 @@ func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	}
 
 	d.SetId(MakeOrgResourceID(orgID, folder.ID))
+	d.Set("org_id", strconv.FormatInt(orgID, 10))
 	d.Set("title", folder.Title)
 	d.Set("uid", folder.UID)
 	d.Set("url", strings.TrimRight(gapiURL, "/")+folder.URL)

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -106,7 +107,7 @@ func UpdateFolderPermissions(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func ReadFolderPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, folderUID := ClientFromExistingOrgResource(meta, d.Id())
+	client, orgID, folderUID := ClientFromExistingOrgResource(meta, d.Id())
 
 	folderPermissions, err := client.FolderPermissions(folderUID)
 	if err, shouldReturn := common.CheckReadError("folder permissions", d, err); shouldReturn {
@@ -128,6 +129,8 @@ func ReadFolderPermissions(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
+	d.SetId(MakeOrgResourceID(orgID, folderUID))
+	d.Set("org_id", strconv.FormatInt(orgID, 10))
 	d.Set("permissions", permissionItems)
 
 	return nil

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -35,6 +35,7 @@ func TestAccFolder_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
 					resource.TestMatchResourceAttr("grafana_folder.test_folder", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_folder.test_folder", "org_id", "1"),
 					resource.TestMatchResourceAttr("grafana_folder.test_folder", "uid", common.UIDRegexp),
 					resource.TestCheckResourceAttr("grafana_folder.test_folder", "title", "Terraform Test Folder"),
 

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -143,6 +143,7 @@ func readLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 	modelJSON := normalizeLibraryPanelModelJSON(remotePanelJSON)
 
+	d.SetId(MakeOrgResourceID(orgID, uid))
 	d.Set("uid", panel.UID)
 	d.Set("panel_id", panel.ID)
 	d.Set("org_id", strconv.FormatInt(panel.OrgID, 10))

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -30,6 +30,7 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 				Config: testutils.TestAccExample(t, "resources/grafana_library_panel/_acc_basic.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("grafana_library_panel.test", "org_id", "1"),
 					testAccLibraryPanelCheckExists("grafana_library_panel.test", &panel),
 					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "basic"),
 					resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "1"),

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -101,6 +101,7 @@ func ReadOrganizationPreferences(ctx context.Context, d *schema.ResourceData, me
 		return err
 	}
 
+	d.Set("org_id", d.Id())
 	d.Set("theme", prefs.Theme)
 	d.Set("home_dashboard_id", prefs.HomeDashboardID)
 	d.Set("home_dashboard_uid", prefs.HomeDashboardUID)

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -102,6 +102,7 @@ func ReadPlaylist(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	d.SetId(MakeOrgResourceID(orgID, id))
 	d.Set("name", resp.Name)
 	d.Set("interval", resp.Interval)
 	d.Set("org_id", strconv.FormatInt(orgID, 10))

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -176,7 +176,7 @@ func testAccPlaylistCheckExists() resource.TestCheckFunc {
 		orgID, playlistID := grafana.SplitOrgResourceID(rs.Primary.ID)
 
 		// If the org ID is set, check that the playlist doesn't exist in the default org
-		if orgID > 0 {
+		if orgID > 1 {
 			playlist, err := client.Playlist(playlistID)
 			if err == nil || playlist != nil {
 				return fmt.Errorf("expected no playlist with ID %s in default org but found one", playlistID)

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -267,6 +267,7 @@ func ReadReport(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return err
 	}
 
+	d.SetId(MakeOrgResourceID(r.OrgID, id))
 	d.Set("dashboard_id", r.Dashboards[0].Dashboard.ID)
 	d.Set("dashboard_uid", r.Dashboards[0].Dashboard.UID)
 	d.Set("name", r.Name)

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -28,6 +28,7 @@ func TestAccResourceReport(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccReportCheckExists("grafana_report.test", &report),
 					resource.TestCheckResourceAttrSet("grafana_report.test", "id"),
+					resource.TestCheckResourceAttr("grafana_report.test", "org_id", "1"),
 					resource.TestCheckResourceAttrSet("grafana_report.test", "dashboard_id"),
 					resource.TestCheckResourceAttr("grafana_report.test", "name", "my report"),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboard_uid", "report"),
@@ -51,7 +52,7 @@ func TestAccResourceReport(t *testing.T) {
 						// Check that the ID and dashboard ID are the same as the first run
 						// This is a custom function to delay the report ID evaluation, because it is generated after the first run
 						return resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("grafana_report.test", "id", "0:"+strconv.FormatInt(report.ID, 10)), // <orgid>:<reportid> (0 being the default org)
+							resource.TestCheckResourceAttr("grafana_report.test", "id", "1:"+strconv.FormatInt(report.ID, 10)), // <orgid>:<reportid> (1 being the default org)
 							resource.TestCheckResourceAttr("grafana_report.test", "dashboard_id", strconv.FormatInt(report.Dashboards[0].Dashboard.ID, 10)),
 						)(s)
 					},
@@ -170,7 +171,7 @@ func testAccReportCheckExists(rn string, report *gapi.Report) resource.TestCheck
 		}
 
 		// If the org ID is set, check that the report doesn't exist in the default org
-		if orgID > 0 {
+		if orgID > 1 {
 			report, err := client.Report(reportID)
 			if err == nil || report != nil {
 				return fmt.Errorf("expected no report with ID %s in default org but found one", reportIDStr)

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -82,6 +82,8 @@ func ReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta interf
 
 	for _, sa := range sas {
 		if sa.ID == id {
+			d.SetId(MakeOrgResourceID(sa.OrgID, id))
+			d.Set("org_id", strconv.FormatInt(sa.OrgID, 10))
 			err = d.Set("name", sa.Name)
 			if err != nil {
 				return diag.FromErr(err)

--- a/internal/resources/grafana/resource_service_account_test.go
+++ b/internal/resources/grafana/resource_service_account_test.go
@@ -31,6 +31,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccServiceAccountCheckExists,
 					resource.TestCheckResourceAttr("grafana_service_account.test", "name", name),
+					resource.TestCheckResourceAttr("grafana_service_account.test", "org_id", "1"),
 					resource.TestCheckResourceAttr("grafana_service_account.test", "role", "Editor"),
 					resource.TestCheckResourceAttr("grafana_service_account.test", "is_disabled", "false"),
 					resource.TestMatchResourceAttr("grafana_service_account.test", "id", defaultOrgIDRegexp),


### PR DESCRIPTION
Once we remove `org_id`, after it's deprecated for a while (Deprecated here: https://github.com/grafana/terraform-provider-grafana/pull/980) 
The provider will need the org_id in state to reconcile. 
This PR makes sure that it is always set. This will make the migration seamless for users (just modifying their TF statements and everything should work)