### PR TITLE
Grafana OnCall: add `direct_paging` integration type

### DIFF
--- a/docs/resources/oncall_integration.md
+++ b/docs/resources/oncall_integration.md
@@ -51,7 +51,7 @@ resource "grafana_oncall_integration" "integration_with_templates" {
 
 - `default_route` (Block List, Min: 1, Max: 1) The Default route for all alerts from the given integration (see [below for nested schema](#nestedblock--default_route))
 - `name` (String) The name of the service integration.
-- `type` (String) The type of integration. Can be grafana, grafana_alerting, webhook, alertmanager, kapacitor, fabric, newrelic, datadog, pagerduty, pingdom, elastalert, amazon_sns, curler, sentry, formatted_webhook, heartbeat, demo, manual, stackdriver, uptimerobot, sentry_platform, zabbix, prtg, slack_channel, inbound_email.
+- `type` (String) The type of integration. Can be grafana, grafana_alerting, webhook, alertmanager, kapacitor, fabric, newrelic, datadog, pagerduty, pingdom, elastalert, amazon_sns, curler, sentry, formatted_webhook, heartbeat, demo, manual, stackdriver, uptimerobot, sentry_platform, zabbix, prtg, slack_channel, inbound_email, direct_paging.
 
 ### Optional
 

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -40,6 +40,7 @@ var integrationTypes = []string{
 	"prtg",
 	"slack_channel",
 	"inbound_email",
+	"direct_paging",
 }
 
 var integrationTypesVerbal = strings.Join(integrationTypes, ", ")


### PR DESCRIPTION
Adding an ability to use [`direct_paging`](https://github.com/grafana/oncall/blob/dev/engine/config_integrations/direct_paging.py) as an integration type.