### PR TITLE
Delete gracefully if user no longer exist in grafana

### DIFF
--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -145,7 +146,9 @@ func DeleteUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 	if err = client.DeleteUser(id); err != nil {
-		return diag.FromErr(err)
+		if !strings.Contains(err.Error(), common.NotFoundError) {
+			return diag.FromErr(err)
+		}
 	}
 
 	return diag.Diagnostics{}


### PR DESCRIPTION
When applying a terraform plan that was created with `-refresh=false` the detection of resources that no longer exist in grafana does not work, as the resources are not read at all.

Thus on apply, a deletion of a user that no longer exists in grafana fails with:
```
Error: status: 404, body: {"message":"user not found"}
```

This change modifies `DeleteUser` so that it catches this case and does not return an error.