### PR TITLE
Cloud Access Policy: Remove scope validation

### DIFF
--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -192,16 +192,9 @@ func DeleteCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func validateCloudAccessPolicyScope(v interface{}, path cty.Path) diag.Diagnostics {
-	service, permission, found := strings.Cut(v.(string), ":")
+	_, permission, found := strings.Cut(v.(string), ":")
 	if !found || strings.ContainsRune(permission, ':') {
 		return diag.Errorf("invalid scope: %s. Should be in the `service:permission` format", v.(string))
-	}
-
-	// Validate service
-	switch service {
-	case "metrics", "logs", "traces", "alerts", "rules", "accesspolicies":
-	default:
-		return diag.Errorf("invalid scope: %s. Service should be one of `metrics`, `logs`, `traces`, `alerts`, `rules`, `accesspolicies`", v.(string))
 	}
 
 	// Validate permission


### PR DESCRIPTION
Scopes can be added at any time on Grafana.com, so we should remove them to not have the provider lag behind 
Closes https://github.com/grafana/terraform-provider-grafana/issues/993 
Closes https://github.com/grafana/terraform-provider-grafana/issues/1004