### PR TITLE
Docs: Add dashboard example in the main provider page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,16 @@ resource "grafana_folder" "my_folder" {
   org_id = grafana_organization.my_org.org_id
   title  = "Test Folder"
 }
+
+resource "grafana_dashboard" "test_folder" {
+  org_id = grafana_organization.my_org.org_id
+  folder = grafana_folder.my_folder.id
+  config_json = jsonencode({
+    "title" : "My Dashboard Title",
+    "uid" : "my-dashboard-uid"
+    // ... other dashboard properties
+  })
+}
 ```
 
 ### Creating a Grafana Cloud stack provider

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -13,3 +13,13 @@ resource "grafana_folder" "my_folder" {
   org_id = grafana_organization.my_org.org_id
   title  = "Test Folder"
 }
+
+resource "grafana_dashboard" "test_folder" {
+  org_id = grafana_organization.my_org.org_id
+  folder = grafana_folder.my_folder.id
+  config_json = jsonencode({
+    "title" : "My Dashboard Title",
+    "uid" : "my-dashboard-uid"
+    // ... other dashboard properties
+  })
+}


### PR DESCRIPTION
Dashboards are the main thing a user wants to do in Grafana, let's mention it at the forefront of the docs