### PR TITLE
Oncall: Stop reading password and auth header

### DIFF
--- a/docs/resources/oncall_outgoing_webhook.md
+++ b/docs/resources/oncall_outgoing_webhook.md
@@ -30,10 +30,10 @@ resource "grafana_oncall_outgoing_webhook" "test-acc-outgoing_webhook" {
 
 ### Optional
 
-- `authorization_header` (String) The auth data of the webhook. Used in Authorization header instead of user/password auth.
+- `authorization_header` (String, Sensitive) The auth data of the webhook. Used in Authorization header instead of user/password auth.
 - `data` (String) The data of the webhook.
 - `forward_whole_payload` (Boolean) Forwards whole payload of the alert to the webhook's url as POST data.
-- `password` (String) The auth data of the webhook. Used for Basic authentication
+- `password` (String, Sensitive) The auth data of the webhook. Used for Basic authentication
 - `team_id` (String) The ID of the OnCall team. To get one, create a team in Grafana, and navigate to the OnCall plugin (to sync the team with OnCall). You can then get the ID using the `grafana_oncall_team` datasource.
 - `user` (String) The auth data of the webhook. Used for Basic authentication.
 

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -54,11 +54,13 @@ func ResourceOutgoingWebhook() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The auth data of the webhook. Used for Basic authentication",
+				Sensitive:   true,
 			},
 			"authorization_header": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The auth data of the webhook. Used in Authorization header instead of user/password auth.",
+				Sensitive:   true,
 			},
 			"forward_whole_payload": {
 				Type:        schema.TypeBool,
@@ -134,8 +136,6 @@ func ResourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m 
 	d.Set("url", outgoingWebhook.Url)
 	d.Set("data", outgoingWebhook.Data)
 	d.Set("user", outgoingWebhook.User)
-	d.Set("password", outgoingWebhook.Password)
-	d.Set("authorization_header", outgoingWebhook.AuthorizationHeader)
 	d.Set("forward_whole_payload", outgoingWebhook.ForwardWholePayload)
 
 	return nil


### PR DESCRIPTION
Tests are failing because it seems like the API doesn't return the password anymore 
This makes these attributes sensitive and stops reading them (because the API returns stars instead of the real value)