### PR TITLE
Add retry_status_codes to Cloud client

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -459,6 +459,9 @@ func createCloudClient(d *schema.ResourceData) (*gapi.Client, error) {
 		APIKey:     d.Get("cloud_api_key").(string),
 		NumRetries: d.Get("retries").(int),
 	}
+	if v, ok := d.GetOk("retry_status_codes"); ok {
+		cfg.RetryStatusCodes = common.SetToStringSlice(v.(*schema.Set))
+	}
 
 	var err error
 	if cfg.HTTPHeaders, err = getHTTPHeadersMap(d); err != nil {


### PR DESCRIPTION
The cloud client object doesn't have the config property `retry_status_codes` attached to it when it's initialised, so the client seems to be retrying only on the default error codes, which are 429 and 5xx.

This PR adds the retry_status_codes value to the cloud client object.
