### PR TITLE
fix(`grafana_role_assignment`): Support new service account ID format

### DIFF
--- a/docs/resources/role_assignment.md
+++ b/docs/resources/role_assignment.md
@@ -61,7 +61,7 @@ resource "grafana_role_assignment" "test" {
 
 ### Optional
 
-- `service_accounts` (Set of Number) IDs of service accounts that the role should be assigned to.
+- `service_accounts` (Set of String) IDs of service accounts that the role should be assigned to.
 - `teams` (Set of String) IDs of teams that the role should be assigned to.
 - `users` (Set of Number) IDs of users that the role should be assigned to.
 

--- a/internal/resources/grafana/resource_role_assignment_test.go
+++ b/internal/resources/grafana/resource_role_assignment_test.go
@@ -34,7 +34,7 @@ func TestRoleAssignments(t *testing.T) {
 						"grafana_role_assignment.test", "users.#", "2",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_role_assignment.test", "service_accounts.#", "0",
+						"grafana_role_assignment.test", "service_accounts.#", "1",
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_role_assignment.test", "teams.#", "1",
@@ -113,10 +113,17 @@ resource "grafana_user" "test_user2" {
 	password = "12345"
 }
 
+resource "grafana_service_account" "test" {
+	name        = "%[1]s-terraform-test"
+	role        = "Editor"
+	is_disabled = false
+  }
+
 resource "grafana_role_assignment" "test" {
   role_uid = grafana_role.test.uid
   users = [grafana_user.test_user.id, grafana_user.test_user2.id]
   teams = [grafana_team.test_team.id]
+  service_accounts = [grafana_service_account.test.id]
 }
 `, name)
 }


### PR DESCRIPTION
When https://github.com/grafana/terraform-provider-grafana/pull/824 was done, this was missed because there were no tests for it