### PR TITLE
CI: Run TLS authentication tests

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -8,7 +8,8 @@ local images = {
   grafanaEnterprise(version): 'grafana/grafana-enterprise:' + version,
 };
 
-local terraformPath = '/drone/terraform-provider-grafana/terraform';
+local workspace = '/drone/terraform-provider-grafana';
+local terraformPath = workspace + '/terraform';
 local installTerraformStep = {
   name: 'download-terraform',
   image: images.terraform,
@@ -51,7 +52,7 @@ local pipeline(name, steps, services=[]) = {
   type: 'docker',
   name: name,
   workspace: {
-    path: '/drone/terraform-provider-grafana',
+    path: workspace,
   },
   platform: {
     os: 'linux',
@@ -75,37 +76,45 @@ local onPromoteTrigger = {
   },
 };
 
-local localTestPipeline(version, name='oss tests: %s' % version, makeTarget='testacc-oss', grafanaEnvMixin={}, grafanaImage=images.grafana) = pipeline(
-  name,
-  steps=[
-    installTerraformStep,
-    {
-      name: 'tests',
-      image: images.go,
-      commands: [
-        'sleep 5',  // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
-        'make %s' % makeTarget,
-      ],
-      environment: {
-        GRAFANA_URL: 'http://grafana:3000',
-        GRAFANA_AUTH: 'admin:admin',
-        GRAFANA_VERSION: version,
-        TF_ACC_TERRAFORM_PATH: terraformPath,
+local localTestPipeline(
+  version,
+  name='oss tests: %s' % version,
+  makeTarget='testacc-oss',
+  providerEnvMixin={},
+  grafanaEnvMixin={},
+  grafanaImage=images.grafana,
+      ) =
+  pipeline(
+    name,
+    steps=[
+      installTerraformStep,
+      {
+        name: 'tests',
+        image: images.go,
+        commands: [
+          'sleep 5',  // https://docs.drone.io/pipeline/docker/syntax/services/#initialization
+          'make %s' % makeTarget,
+        ],
+        environment: {
+          GRAFANA_URL: 'http://grafana:3000',
+          GRAFANA_AUTH: 'admin:admin',
+          GRAFANA_VERSION: version,
+          TF_ACC_TERRAFORM_PATH: terraformPath,
+        } + providerEnvMixin,
       },
-    },
-  ],
-  services=[
-    {
-      name: 'grafana',
-      image: grafanaImage(version),
-      environment: {
-        // Prevents error="database is locked"
-        GF_SERVER_ROOT_URL: 'http://grafana:3000',
-        GF_DATABASE_URL: 'sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL',
-      } + grafanaEnvMixin,
-    },
-  ],
-);
+    ],
+    services=[
+      {
+        name: 'grafana',
+        image: grafanaImage(version),
+        environment: {
+          // Prevents error="database is locked"
+          GF_SERVER_ROOT_URL: 'http://grafana:3000',
+          GF_DATABASE_URL: 'sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL',
+        } + grafanaEnvMixin,
+      },
+    ],
+  );
 
 [
   pipeline(
@@ -223,6 +232,7 @@ local localTestPipeline(version, name='oss tests: %s' % version, makeTarget='tes
   )
   + withConcurrencyLimit(1),
 
+  // Grafana Enterprise tests
   localTestPipeline(
     grafanaVersions[0],
     name='enterprise tests',
@@ -230,6 +240,47 @@ local localTestPipeline(version, name='oss tests: %s' % version, makeTarget='tes
     grafanaEnvMixin={ GF_ENTERPRISE_LICENSE_TEXT: fromSecret(secrets.enterpriseLicense) },
     grafanaImage=images.grafanaEnterprise
   ),
+
+  // Grafana OSS tests behind a TLS proxy tests
+  // This is the equivalent of `make testacc-docker-tls`
+  local certPath = workspace + '/testdata';
+  localTestPipeline(
+    grafanaVersions[0],
+    name='tls proxy tests',
+    providerEnvMixin={
+      GRAFANA_URL: 'https://mtls-proxy:3001',
+      GRAFANA_TLS_KEY: '%s/client.key' % certPath,
+      GRAFANA_TLS_CERT: '%s/client.crt' % certPath,
+      GRAFANA_CA_CERT: '%s/ca.crt' % certPath,
+    }
+  ) + {
+    steps: [
+      {
+        name: 'generate certs',
+        image: images.go,
+        commands: [
+          'cd %s && go run . && ls -lah' % certPath,
+        ],
+        depends_on: ['clone'],
+      },
+      {
+        name: 'mtls-proxy',
+        image: 'squareup/ghostunnel:v1.5.2',
+        detach: true,
+        command: [
+          'server',
+          '--listen=0.0.0.0:3001',
+          '--target=grafana:3000',
+          '--unsafe-target',
+          '--key=%s/grafana.key' % certPath,
+          '--cert=%s/grafana.crt' % certPath,
+          '--cacert=%s/ca.crt' % certPath,
+          '--allow-cn=client',
+        ],
+        depends_on: ['generate certs'],
+      },
+    ] + std.map(function(s) s { depends_on: ['generate certs'] }, super.steps),
+  },
 ]
 + [localTestPipeline(version) for version in grafanaVersions]
 + std.objectValuesAll(secrets)

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -203,6 +203,70 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
+name: tls proxy tests
+platform:
+  arch: amd64
+  os: linux
+services:
+- environment:
+    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
+    GF_SERVER_ROOT_URL: http://grafana:3000
+  image: grafana/grafana:10.0.1
+  name: grafana
+steps:
+- commands:
+  - cd /drone/terraform-provider-grafana/testdata && go run . && ls -lah
+  depends_on:
+  - clone
+  image: golang:1.20
+  name: generate certs
+- command:
+  - server
+  - --listen=0.0.0.0:3001
+  - --target=grafana:3000
+  - --unsafe-target
+  - --key=/drone/terraform-provider-grafana/testdata/grafana.key
+  - --cert=/drone/terraform-provider-grafana/testdata/grafana.crt
+  - --cacert=/drone/terraform-provider-grafana/testdata/ca.crt
+  - --allow-cn=client
+  depends_on:
+  - generate certs
+  detach: true
+  image: squareup/ghostunnel:v1.5.2
+  name: mtls-proxy
+- commands:
+  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
+  - chmod a+x /drone/terraform-provider-grafana/terraform
+  depends_on:
+  - generate certs
+  image: hashicorp/terraform
+  name: download-terraform
+- commands:
+  - sleep 5
+  - make testacc-oss
+  depends_on:
+  - generate certs
+  environment:
+    GRAFANA_AUTH: admin:admin
+    GRAFANA_CA_CERT: /drone/terraform-provider-grafana/testdata/ca.crt
+    GRAFANA_TLS_CERT: /drone/terraform-provider-grafana/testdata/client.crt
+    GRAFANA_TLS_KEY: /drone/terraform-provider-grafana/testdata/client.key
+    GRAFANA_URL: https://mtls-proxy:3001
+    GRAFANA_VERSION: 10.0.1
+    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
+  image: golang:1.20
+  name: tests
+trigger:
+  branch:
+  - master
+  event:
+  - pull_request
+  - push
+type: docker
+workspace:
+  path: /drone/terraform-provider-grafana
+---
+kind: pipeline
 name: 'oss tests: 10.0.1'
 platform:
   arch: amd64
@@ -467,6 +531,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: 81801e1fc60765938704576fee2d11b1cbd8b2f98d17342c013e526b6da5de38
+hmac: 8b3b69d2646974fbaa2e07c2d895dc94ef715495e61a216ebc7dd67f81bfcf78
 
 ...


### PR DESCRIPTION
The provider supports the case where Grafana is proxied and has TLS cert auth in front of it 
This currently not tested in CI and that makes PRs like https://github.com/grafana/terraform-provider-grafana/pull/1013 harder to test

This adds a pipeline that checks that the feature works correctly