### PR TITLE
Avoid test resource conflicts

### DIFF
--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -32,6 +32,13 @@ resource "grafana_data_source" "foo" {
   })
 }
 
+resource "grafana_user" "user" {
+  name     = "test-ds-permissions"
+  email    = "test-ds-permissions@example.com"
+  login    = "test-ds-permissions"
+  password = "hunter2"
+}
+
 resource "grafana_data_source_permission" "fooPermissions" {
   datasource_id = grafana_data_source.foo.id
   permissions {
@@ -39,7 +46,7 @@ resource "grafana_data_source_permission" "fooPermissions" {
     permission = "Query"
   }
   permissions {
-    user_id    = 3 // 3 is the admin user in cloud. It can't be queried
+    user_id    = grafana_user.user.id
     permission = "Edit"
   }
   permissions {

--- a/examples/resources/grafana_data_source_permission/resource.tf
+++ b/examples/resources/grafana_data_source_permission/resource.tf
@@ -17,6 +17,13 @@ resource "grafana_data_source" "foo" {
   })
 }
 
+resource "grafana_user" "user" {
+  name     = "test-ds-permissions"
+  email    = "test-ds-permissions@example.com"
+  login    = "test-ds-permissions"
+  password = "hunter2"
+}
+
 resource "grafana_data_source_permission" "fooPermissions" {
   datasource_id = grafana_data_source.foo.id
   permissions {
@@ -24,7 +31,7 @@ resource "grafana_data_source_permission" "fooPermissions" {
     permission = "Query"
   }
   permissions {
-    user_id    = 3 // 3 is the admin user in cloud. It can't be queried
+    user_id    = grafana_user.user.id
     permission = "Edit"
   }
   permissions {

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -27,7 +27,7 @@ func TestAccAnnotation_basic(t *testing.T) {
 	var annotation gapi.Annotation
 	var org gapi.Org
 
-	orgName := acctest.RandString(10)
+	orgName := acctest.RandomWithPrefix("annotations")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -125,7 +125,7 @@ func TestAccAnnotation_dashboardUID(t *testing.T) {
 	var annotation gapi.Annotation
 	var org gapi.Org
 
-	orgName := acctest.RandString(10)
+	orgName := acctest.RandomWithPrefix("annotations-db-uid")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_api_key_test.go
+++ b/internal/resources/grafana/resource_api_key_test.go
@@ -18,7 +18,7 @@ import (
 func TestAccGrafanaAuthKey(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	testName := acctest.RandString(10)
+	testName := acctest.RandomWithPrefix("auth-key")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -55,7 +55,7 @@ func TestAccGrafanaAuthKey_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var org gapi.Org
-	testName := acctest.RandString(10)
+	testName := acctest.RandomWithPrefix("auth-key-org")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -222,7 +222,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 	var folder gapi.Folder
 	var org gapi.Org
 
-	orgName := acctest.RandString(10)
+	orgName := acctest.RandomWithPrefix("db-org")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_data_source_test.go
+++ b/internal/resources/grafana/resource_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccDataSource_Loki(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var dataSource gapi.DataSource
-	dsName := acctest.RandString(10)
+	dsName := acctest.RandomWithPrefix("ds-loki")
 
 	config := fmt.Sprintf(`
 	resource "grafana_data_source" "tempo" {
@@ -125,7 +125,7 @@ func TestAccDataSource_TestData(t *testing.T) {
 
 	var dataSource gapi.DataSource
 
-	dsName := acctest.RandString(10)
+	dsName := acctest.RandomWithPrefix("ds-testdata")
 	config := fmt.Sprintf(`
 	resource "grafana_data_source" "testdata" {
 		type                = "testdata"
@@ -175,7 +175,7 @@ func TestAccDataSource_Influx(t *testing.T) {
 
 	var dataSource gapi.DataSource
 
-	dsName := acctest.RandString(10)
+	dsName := acctest.RandomWithPrefix("ds-influx")
 	config := fmt.Sprintf(`
 	resource "grafana_data_source" "influx" {
 		type         = "influxdb"
@@ -277,7 +277,7 @@ func TestAccDatasource_inOrg(t *testing.T) {
 	var datasource gapi.DataSource
 	var org gapi.Org
 
-	orgName := acctest.RandString(10)
+	orgName := acctest.RandomWithPrefix("ds-org")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -104,7 +104,7 @@ func TestAccFolder_basic(t *testing.T) {
 func TestAccFolder_PreventDeletion(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	name := acctest.RandomWithPrefix("folder")
 	var folder gapi.Folder
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -140,7 +140,7 @@ func TestAccLibraryPanel_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
-	orgName := acctest.RandString(10)
+	orgName := acctest.RandomWithPrefix("panel")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_organization_preferences_test.go
+++ b/internal/resources/grafana/resource_organization_preferences_test.go
@@ -46,7 +46,7 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 		WeekStart: "Monday",
 	}
 
-	testRandName := acctest.RandString(10)
+	testRandName := acctest.RandomWithPrefix("org-prefs")
 
 	// In versions < 9.0.0, the home dashboard UID is not returned by the API
 	dashboardCheck := resource.TestMatchResourceAttr("grafana_organization_preferences.test", "home_dashboard_id", common.IDRegexp)

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -130,7 +130,7 @@ func TestAccResourceReport_InOrg(t *testing.T) {
 
 	var report gapi.Report
 	var org gapi.Org
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	name := acctest.RandomWithPrefix("report-org")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_role_assignment_test.go
+++ b/internal/resources/grafana/resource_role_assignment_test.go
@@ -17,7 +17,7 @@ func TestRoleAssignments(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t)
 	var roleAssignment gapi.RoleAssignments
 
-	testName := acctest.RandString(10)
+	testName := acctest.RandomWithPrefix("role-assignment")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_service_account_permission_test.go
+++ b/internal/resources/grafana/resource_service_account_permission_test.go
@@ -20,7 +20,7 @@ func TestAccServiceAccountPermission(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	testutils.CheckOSSTestsSemver(t, ">=9.2.4")
 
-	name := acctest.RandString(10)
+	name := acctest.RandomWithPrefix("sa-permissions")
 
 	var saPermission gapi.ServiceAccountPermission
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/resources/grafana/resource_service_account_test.go
+++ b/internal/resources/grafana/resource_service_account_test.go
@@ -20,7 +20,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
-	name := acctest.RandString(10)
+	name := acctest.RandomWithPrefix("sa")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -45,7 +45,7 @@ func TestAccServiceAccount_many(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
-	name := acctest.RandString(10)
+	name := acctest.RandomWithPrefix("sa-many")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_service_account_token_test.go
+++ b/internal/resources/grafana/resource_service_account_token_test.go
@@ -17,7 +17,7 @@ func TestAccServiceAccountToken_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
-	name := acctest.RandString(10)
+	name := acctest.RandomWithPrefix("sa-token")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -51,7 +51,7 @@ func TestAccServiceAccountToken_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
-	name := acctest.RandString(10)
+	name := acctest.RandomWithPrefix("sa-token-org")
 	var org gapi.Org
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -19,8 +19,8 @@ func TestAccTeam_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var team gapi.Team
-	teamName := acctest.RandString(5)
-	teamNameUpdated := acctest.RandString(5)
+	teamName := acctest.RandomWithPrefix("team")
+	teamNameUpdated := acctest.RandomWithPrefix("team-updated")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -61,8 +61,8 @@ func TestAccTeam_preferences(t *testing.T) {
 	testutils.CheckOSSTestsSemver(t, ">= 9.0.0") // Dashboard UID is only available in Grafana 9.0.0+
 
 	var team gapi.Team
-	teamName := acctest.RandString(5)
-	teamNameUpdated := acctest.RandString(5)
+	teamName := acctest.RandomWithPrefix("team-pref")
+	teamNameUpdated := acctest.RandomWithPrefix("team-pref-updated")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -109,7 +109,7 @@ func TestAccTeam_teamSync(t *testing.T) {
 	testutils.CheckOSSTestsSemver(t, ">= 8.0.0")
 
 	var team gapi.Team
-	teamName := acctest.RandString(5)
+	teamName := acctest.RandomWithPrefix("team-sync")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -171,7 +171,7 @@ func TestAccTeam_Members(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var team gapi.Team
-	teamName := acctest.RandString(5)
+	teamName := acctest.RandomWithPrefix("team-members")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -240,7 +240,7 @@ func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
 
 	var team gapi.Team
 	var userID int64 = -1
-	teamName := acctest.RandString(5)
+	teamName := acctest.RandomWithPrefix("team-remove")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -290,7 +290,7 @@ func TestAccResourceTeam_InOrg(t *testing.T) {
 
 	var team gapi.Team
 	var org gapi.Org
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	name := acctest.RandomWithPrefix("team-org")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,


### PR DESCRIPTION
WIP: Built on top of https://github.com/grafana/terraform-provider-grafana/pull/1038

I suspect that some random failures are due to naming conflicts 
Random isn't really random, depending on how the acctest lib is built, if two random value are seeded at the same time, then the RNG will output the same value 

Using specific prefixes will make sure there is never any conflict