### PR TITLE
Refactor TLS config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/grafana/amixr-api-go-client v0.0.9
 	github.com/grafana/grafana-api-golang-client v0.24.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20230914111743-66765674683b
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20230918131703-659d2cff09a7
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.17.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,10 @@ github.com/grafana/grafana-api-golang-client v0.24.0 h1:9cUvft7xCMnnL/Uscwy7eold
 github.com/grafana/grafana-api-golang-client v0.24.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20230914111743-66765674683b h1:UI49lvb/o1kfVtLPKZMZkozkRIxczD+qDUoHC41TvnM=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20230914111743-66765674683b/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20230918123310-e81801151dbd h1:y4K34xlu2mD0uBWbW2iqNwQBU93Y2/QoZ9vSMUGuScw=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20230918123310-e81801151dbd/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20230918131703-659d2cff09a7 h1:LPPNA/l6jCMRheMWvMPdni3WlOGL6Wjw3d/A1IbWCVg=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20230918131703-659d2cff09a7/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.17.1 h1:2IKA8QzgWA+tqmE3AMzSwQBhZ6Pa4whgOHTs6tk3V6I=


### PR DESCRIPTION
Refactor TLS config to use in both manual and generated client (see https://github.com/grafana/terraform-provider-grafana/pull/1013 & https://github.com/grafana/grafana-openapi-client-go/pull/8)