### PR TITLE
Remove cloud access policy scope validation

### DIFF
--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -192,17 +192,10 @@ func DeleteCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func validateCloudAccessPolicyScope(v interface{}, path cty.Path) diag.Diagnostics {
-	_, permission, found := strings.Cut(v.(string), ":")
-	if !found || strings.ContainsRune(permission, ':') {
+	if strings.Count(v.(string), ":") != 1 {
 		return diag.Errorf("invalid scope: %s. Should be in the `service:permission` format", v.(string))
 	}
 
-	// Validate permission
-	switch permission {
-	case "read", "write", "delete":
-	default:
-		return diag.Errorf("invalid scope: %s. Permission should be one of `read`, `write`, `delete`", v.(string))
-	}
 	return nil
 }
 

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -30,6 +30,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 		"accesspolicies:read",
 		"accesspolicies:write",
 		"accesspolicies:delete",
+		"datadog:validate",
 	}
 	updatedScopes := []string{
 		"metrics:write",

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -55,9 +55,9 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "accesspolicies:delete"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.1", "accesspolicies:read"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.2", "accesspolicies:write"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.3", "logs:write"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.4", "metrics:read"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.5", "datadog:validate"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.3", "datadog:validate"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.4", "logs:write"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.5", "metrics:read"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.0.type", "org"),
 

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -51,12 +51,13 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", "initial"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "display_name", "initial"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.#", "5"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.#", "6"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "accesspolicies:delete"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.1", "accesspolicies:read"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.2", "accesspolicies:write"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.3", "logs:write"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.4", "metrics:read"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.5", "datadog:validate"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.0.type", "org"),
 


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1045 
It seems like various services can add whatever. This will be more future proof