### PR TITLE
Permissions: Support service account in `user_id` field

### DIFF
--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -71,7 +71,7 @@ Optional:
 
 - `role` (String) Manage permissions for `Viewer` or `Editor` roles.
 - `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
-- `user_id` (Number) ID of the user to manage permissions for. Defaults to `0`.
+- `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.
 
 ## Import
 

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -39,6 +39,11 @@ resource "grafana_user" "user" {
   password = "hunter2"
 }
 
+resource "grafana_service_account" "sa" {
+  name = "test-ds-permissions"
+  role = "Viewer"
+}
+
 resource "grafana_data_source_permission" "fooPermissions" {
   datasource_id = grafana_data_source.foo.id
   permissions {
@@ -52,6 +57,10 @@ resource "grafana_data_source_permission" "fooPermissions" {
   permissions {
     built_in_role = "Viewer"
     permission    = "Query"
+  }
+  permissions {
+    user_id    = grafana_service_account.sa.id
+    permission = "Query"
   }
 }
 ```
@@ -83,4 +92,4 @@ Optional:
 
 - `built_in_role` (String) Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`. Can only be set from Grafana v9.2.3+. Defaults to ``.
 - `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
-- `user_id` (Number) ID of the user to manage permissions for. Defaults to `0`.
+- `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.

--- a/docs/resources/folder_permission.md
+++ b/docs/resources/folder_permission.md
@@ -70,4 +70,4 @@ Optional:
 
 - `role` (String) Manage permissions for `Viewer` or `Editor` roles.
 - `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
-- `user_id` (Number) ID of the user to manage permissions for. Defaults to `0`.
+- `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.

--- a/docs/resources/service_account_permission.md
+++ b/docs/resources/service_account_permission.md
@@ -72,4 +72,4 @@ Required:
 Optional:
 
 - `team_id` (String) ID of the team to manage permissions for. Specify either this or `user_id`. Defaults to `0`.
-- `user_id` (Number) ID of the user to manage permissions for. Specify either this or `team_id`. Defaults to `0`.
+- `user_id` (String) ID of the user or service account to manage permissions for. Specify either this or `team_id`. Defaults to `0`.

--- a/examples/resources/grafana_data_source_permission/resource.tf
+++ b/examples/resources/grafana_data_source_permission/resource.tf
@@ -24,6 +24,11 @@ resource "grafana_user" "user" {
   password = "hunter2"
 }
 
+resource "grafana_service_account" "sa" {
+  name = "test-ds-permissions"
+  role = "Viewer"
+}
+
 resource "grafana_data_source_permission" "fooPermissions" {
   datasource_id = grafana_data_source.foo.id
   permissions {
@@ -37,5 +42,9 @@ resource "grafana_data_source_permission" "fooPermissions" {
   permissions {
     built_in_role = "Viewer"
     permission    = "Query"
+  }
+  permissions {
+    user_id    = grafana_service_account.sa.id
+    permission = "Query"
   }
 }

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -26,7 +26,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 				Config: testAccDashboardPermissionConfig_Basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDashboardPermissionsCheckExistsUID("grafana_dashboard_permission.testPermission", &dashboardUID),
-					resource.TestCheckResourceAttr("grafana_dashboard_permission.testPermission", "permissions.#", "4"),
+					resource.TestCheckResourceAttr("grafana_dashboard_permission.testPermission", "permissions.#", "5"),
 				),
 			},
 			{
@@ -159,6 +159,11 @@ resource "grafana_user" "testAdminUser" {
   password = "zyx987"
 }
 
+resource "grafana_service_account" "test" {
+	name        = "terraform-test-service-account-dashboard-perms"
+	role 	    = "Editor"
+}
+
 resource "grafana_dashboard_permission" "testPermission" {
   dashboard_uid = grafana_dashboard.testDashboard.uid
   permissions {
@@ -176,6 +181,10 @@ resource "grafana_dashboard_permission" "testPermission" {
   permissions {
     user_id    = grafana_user.testAdminUser.id
     permission = "Admin"
+  }
+  permissions {
+	user_id    = grafana_service_account.test.id
+	permission = "Admin"
   }
 }
 `

--- a/internal/resources/grafana/resource_data_source_permission_test.go
+++ b/internal/resources/grafana/resource_data_source_permission_test.go
@@ -24,7 +24,7 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 				Config: testutils.TestAccExample(t, "resources/grafana_data_source_permission/resource.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDatasourcePermissionsCheckExists("grafana_data_source_permission.fooPermissions", &datasourceID),
-					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "3"),
+					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "4"),
 				),
 			},
 			{
@@ -35,7 +35,6 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 	})
 }
 
-//nolint:unused
 func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -66,7 +65,6 @@ func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) res
 	}
 }
 
-//nolint:unused
 func testAccDatasourcePermissionCheckDestroy(datasourceID *int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -37,11 +37,12 @@ func ResourceFolderPermission() *schema.Resource {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
-				// Ignore the org ID of the team when hashing. It works with or without it.
+				// Ignore the org ID of the team/SA when hashing. It works with or without it.
 				Set: func(i interface{}) int {
 					m := i.(map[string]interface{})
 					_, teamID := SplitOrgResourceID(m["team_id"].(string))
-					return schema.HashString(m["role"].(string) + teamID + strconv.Itoa(m["user_id"].(int)) + m["permission"].(string))
+					_, userID := SplitOrgResourceID(m["user_id"].(string))
+					return schema.HashString(m["role"].(string) + teamID + userID + m["permission"].(string))
 				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -58,10 +59,10 @@ func ResourceFolderPermission() *schema.Resource {
 							Description: "ID of the team to manage permissions for.",
 						},
 						"user_id": {
-							Type:        schema.TypeInt,
+							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     0,
-							Description: "ID of the user to manage permissions for.",
+							Default:     "0",
+							Description: "ID of the user or service account to manage permissions for.",
 						},
 						"permission": {
 							Type:         schema.TypeString,
@@ -95,8 +96,10 @@ func UpdateFolderPermissions(ctx context.Context, d *schema.ResourceData, meta i
 		if teamID > 0 {
 			permissionItem.TeamID = teamID
 		}
-		if permission["user_id"].(int) != -1 {
-			permissionItem.UserID = int64(permission["user_id"].(int))
+		_, userIDStr := SplitOrgResourceID(permission["user_id"].(string))
+		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
+		if userID > 0 {
+			permissionItem.UserID = userID
 		}
 		permissionItem.Permission = mapPermissionStringToInt64(permission["permission"].(string))
 		permissionList.Items = append(permissionList.Items, &permissionItem)
@@ -129,7 +132,7 @@ func ReadFolderPermissions(ctx context.Context, d *schema.ResourceData, meta int
 			permissionItem := make(map[string]interface{})
 			permissionItem["role"] = permission.Role
 			permissionItem["team_id"] = strconv.FormatInt(permission.TeamID, 10)
-			permissionItem["user_id"] = permission.UserID
+			permissionItem["user_id"] = strconv.FormatInt(permission.UserID, 10)
 			permissionItem["permission"] = mapPermissionInt64ToString(permission.Permission)
 
 			permissionItems[count] = permissionItem

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -24,7 +24,7 @@ func TestAccFolderPermission_basic(t *testing.T) {
 				Config: testAccFolderPermissionConfig_Basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccFolderPermissionsCheckExists("grafana_folder_permission.testPermission", &folderUID),
-					resource.TestCheckResourceAttr("grafana_folder_permission.testPermission", "permissions.#", "4"),
+					resource.TestCheckResourceAttr("grafana_folder_permission.testPermission", "permissions.#", "5"),
 				),
 			},
 			{
@@ -100,6 +100,12 @@ resource "grafana_user" "testAdminUser" {
   password = "zyx987"
 }
 
+resource "grafana_service_account" "test" {
+	name        = "terraform-test-service-account-folder-perms"
+	role        = "Editor"
+	is_disabled = false
+}
+
 resource "grafana_folder_permission" "testPermission" {
   folder_uid = grafana_folder.testFolder.uid
   permissions {
@@ -117,6 +123,10 @@ resource "grafana_folder_permission" "testPermission" {
   permissions {
     user_id    = grafana_user.testAdminUser.id
     permission = "Admin"
+  }
+  permissions {
+	user_id    = grafana_service_account.test.id
+	permission = "Admin"
   }
 }
 `

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccFolderPermission_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=9.0.0") // Folder permissions only work for service accounts in Grafana 9+, so we're just not testing versions before 9.
 
 	folderUID := "uninitialized"
 


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/994 
This seems like an undocumented feature that's known to users. You can set a service account ID in the `user_id` field of permissions resources

In this PR:
 - Make this behavior work with the new ID format (`<org>:<id>`)
 - Document that the field supports an SA
 - Add tests to make sure we don't regress it again