### PR TITLE
Drone: Update test versions

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -1,4 +1,4 @@
-local grafanaVersions = ['10.0.1', '9.5.5', '9.4.13', '9.3.16', '8.5.27', '7.5.17'];
+local grafanaVersions = ['10.1.2', '10.0.6', '9.5.10', '8.5.27'];
 local images = {
   go: 'golang:1.20',
   python: 'python:3.11-alpine',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -174,7 +174,7 @@ services:
     GF_ENTERPRISE_LICENSE_TEXT:
       from_secret: grafana-enterprise-license
     GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana-enterprise:10.0.1
+  image: grafana/grafana-enterprise:10.1.2
   name: grafana
 steps:
 - commands:
@@ -188,7 +188,7 @@ steps:
   environment:
     GRAFANA_AUTH: admin:admin
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 10.0.1
+    GRAFANA_VERSION: 10.1.2
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -211,7 +211,7 @@ services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
     GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana:10.0.1
+  image: grafana/grafana:10.1.2
   name: grafana
 steps:
 - commands:
@@ -252,7 +252,7 @@ steps:
     GRAFANA_TLS_CERT: /drone/terraform-provider-grafana/testdata/client.crt
     GRAFANA_TLS_KEY: /drone/terraform-provider-grafana/testdata/client.key
     GRAFANA_URL: https://mtls-proxy:3001
-    GRAFANA_VERSION: 10.0.1
+    GRAFANA_VERSION: 10.1.2
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -267,7 +267,7 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 10.0.1'
+name: 'oss tests: 10.1.2'
 platform:
   arch: amd64
   os: linux
@@ -275,7 +275,7 @@ services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
     GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana:10.0.1
+  image: grafana/grafana:10.1.2
   name: grafana
 steps:
 - commands:
@@ -289,7 +289,7 @@ steps:
   environment:
     GRAFANA_AUTH: admin:admin
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 10.0.1
+    GRAFANA_VERSION: 10.1.2
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -304,7 +304,7 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 9.5.5'
+name: 'oss tests: 10.0.6'
 platform:
   arch: amd64
   os: linux
@@ -312,7 +312,7 @@ services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
     GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana:9.5.5
+  image: grafana/grafana:10.0.6
   name: grafana
 steps:
 - commands:
@@ -326,7 +326,7 @@ steps:
   environment:
     GRAFANA_AUTH: admin:admin
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 9.5.5
+    GRAFANA_VERSION: 10.0.6
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -341,7 +341,7 @@ workspace:
   path: /drone/terraform-provider-grafana
 ---
 kind: pipeline
-name: 'oss tests: 9.4.13'
+name: 'oss tests: 9.5.10'
 platform:
   arch: amd64
   os: linux
@@ -349,7 +349,7 @@ services:
 - environment:
     GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
     GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana:9.4.13
+  image: grafana/grafana:9.5.10
   name: grafana
 steps:
 - commands:
@@ -363,44 +363,7 @@ steps:
   environment:
     GRAFANA_AUTH: admin:admin
     GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 9.4.13
-    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
-  image: golang:1.20
-  name: tests
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
-  - push
-type: docker
-workspace:
-  path: /drone/terraform-provider-grafana
----
-kind: pipeline
-name: 'oss tests: 9.3.16'
-platform:
-  arch: amd64
-  os: linux
-services:
-- environment:
-    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-    GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana:9.3.16
-  name: grafana
-steps:
-- commands:
-  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
-  - chmod a+x /drone/terraform-provider-grafana/terraform
-  image: hashicorp/terraform
-  name: download-terraform
-- commands:
-  - sleep 5
-  - make testacc-oss
-  environment:
-    GRAFANA_AUTH: admin:admin
-    GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 9.3.16
+    GRAFANA_VERSION: 9.5.10
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -438,43 +401,6 @@ steps:
     GRAFANA_AUTH: admin:admin
     GRAFANA_URL: http://grafana:3000
     GRAFANA_VERSION: 8.5.27
-    TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
-  image: golang:1.20
-  name: tests
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
-  - push
-type: docker
-workspace:
-  path: /drone/terraform-provider-grafana
----
-kind: pipeline
-name: 'oss tests: 7.5.17'
-platform:
-  arch: amd64
-  os: linux
-services:
-- environment:
-    GF_DATABASE_URL: sqlite3:///var/lib/grafana/grafana.db?cache=private&mode=rwc&_journal_mode=WAL
-    GF_SERVER_ROOT_URL: http://grafana:3000
-  image: grafana/grafana:7.5.17
-  name: grafana
-steps:
-- commands:
-  - cp /bin/terraform /drone/terraform-provider-grafana/terraform
-  - chmod a+x /drone/terraform-provider-grafana/terraform
-  image: hashicorp/terraform
-  name: download-terraform
-- commands:
-  - sleep 5
-  - make testacc-oss
-  environment:
-    GRAFANA_AUTH: admin:admin
-    GRAFANA_URL: http://grafana:3000
-    GRAFANA_VERSION: 7.5.17
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -531,6 +457,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: 8b3b69d2646974fbaa2e07c2d895dc94ef715495e61a216ebc7dd67f81bfcf78
+hmac: 108ab6145d969be75761768779516b1679bdf6455f4d3e7c8afdc55ed5452e18
 
 ...


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1015 
Add 10.1, update patches, take out 9.4, 9.3 and 7.5