### PR TITLE
Add enable web overrides option to oncall schedules

### DIFF
--- a/docs/resources/oncall_schedule.md
+++ b/docs/resources/oncall_schedule.md
@@ -54,6 +54,7 @@ resource "grafana_oncall_schedule" "example_schedule" {
 
 ### Optional
 
+- `enable_web_overrides` (Boolean) Enable overrides via web UI (it will ignore ical_url_overrides).
 - `ical_url_overrides` (String) The URL of external iCal calendar which override primary events.
 - `ical_url_primary` (String) The URL of the external calendar iCal file.
 - `shifts` (Set of String) The list of ID's of on-call shifts.

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -64,6 +64,11 @@ func ResourceSchedule() *schema.Resource {
 				Optional:    true,
 				Description: "The URL of external iCal calendar which override primary events.",
 			},
+			"enable_web_overrides": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enable overrides via web UI (it will ignore ical_url_overrides).",
+			},
 			"slack": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -127,6 +132,12 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, m inter
 		createOptions.ICalUrlOverrides = &url
 	}
 
+	enableWebOverridesData, enableWebOverridesOk := d.GetOk("enable_web_overrides")
+	if enableWebOverridesOk {
+		enable := enableWebOverridesData.(bool)
+		createOptions.EnableWebOverrides = enable
+	}
+
 	shiftsData, shiftsOk := d.GetOk("shifts")
 	if shiftsOk {
 		if typeData == "calendar" {
@@ -184,6 +195,12 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	if iCalURLOverridesOk {
 		url := iCalURLOverridesData.(string)
 		updateOptions.ICalUrlOverrides = &url
+	}
+
+	enableWebOverridesData, enableWebOverridesOk := d.GetOk("enable_web_overrides")
+	if enableWebOverridesOk {
+		enable := enableWebOverridesData.(bool)
+		updateOptions.EnableWebOverrides = enable
 	}
 
 	timeZoneData, timeZoneOk := d.GetOk("time_zone")

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -250,6 +250,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interfa
 	d.Set("type", schedule.Type)
 	d.Set("ical_url_primary", schedule.ICalUrlPrimary)
 	d.Set("ical_url_overrides", schedule.ICalUrlOverrides)
+	d.Set("enable_web_overrides", schedule.EnableWebOverrides)
 	d.Set("time_zone", schedule.TimeZone)
 	d.Set("slack", flattenScheduleSlack(schedule.Slack))
 	d.Set("shifts", schedule.Shifts)

--- a/internal/resources/oncall/resource_schedule_test.go
+++ b/internal/resources/oncall/resource_schedule_test.go
@@ -70,7 +70,7 @@ resource "grafana_oncall_schedule" "test-acc-schedule" {
 `, scheduleName)
 }
 
-func testAccOnCallScheduleConfigOverrides(scheduleName string, enable_web_overrides bool) string {
+func testAccOnCallScheduleConfigOverrides(scheduleName string, enableWebOverrides bool) string {
 	return fmt.Sprintf(`
 resource "grafana_oncall_schedule" "test-acc-schedule" {
 	name = "%s"
@@ -78,7 +78,7 @@ resource "grafana_oncall_schedule" "test-acc-schedule" {
 	time_zone = "America/New_York"
 	enable_web_overrides = "%t"
 }
-`, scheduleName, enable_web_overrides)
+`, scheduleName, enableWebOverrides)
 }
 
 func testAccCheckOnCallScheduleResourceExists(name string) resource.TestCheckFunc {

--- a/internal/resources/oncall/resource_schedule_test.go
+++ b/internal/resources/oncall/resource_schedule_test.go
@@ -25,6 +25,21 @@ func TestAccOnCallSchedule_basic(t *testing.T) {
 				Config: testAccOnCallScheduleConfig(scheduleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOnCallScheduleResourceExists("grafana_oncall_schedule.test-acc-schedule"),
+					resource.TestCheckResourceAttr("grafana_oncall_schedule.test-acc-schedule", "enable_web_overrides", "false"),
+				),
+			},
+			{
+				Config: testAccOnCallScheduleConfigOverrides(scheduleName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallScheduleResourceExists("grafana_oncall_schedule.test-acc-schedule"),
+					resource.TestCheckResourceAttr("grafana_oncall_schedule.test-acc-schedule", "enable_web_overrides", "true"),
+				),
+			},
+			{
+				Config: testAccOnCallScheduleConfigOverrides(scheduleName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallScheduleResourceExists("grafana_oncall_schedule.test-acc-schedule"),
+					resource.TestCheckResourceAttr("grafana_oncall_schedule.test-acc-schedule", "enable_web_overrides", "false"),
 				),
 			},
 		},
@@ -53,6 +68,17 @@ resource "grafana_oncall_schedule" "test-acc-schedule" {
 	time_zone = "America/New_York"
 }
 `, scheduleName)
+}
+
+func testAccOnCallScheduleConfigOverrides(scheduleName string, enable_web_overrides bool) string {
+	return fmt.Sprintf(`
+resource "grafana_oncall_schedule" "test-acc-schedule" {
+	name = "%s"
+	type = "calendar"
+	time_zone = "America/New_York"
+	enable_web_overrides = "%t"
+}
+`, scheduleName, enable_web_overrides)
 }
 
 func testAccCheckOnCallScheduleResourceExists(name string) resource.TestCheckFunc {


### PR DESCRIPTION
This depends on https://github.com/grafana/amixr-api-go-client/pull/14

Related to https://github.com/grafana/terraform-provider-grafana/issues/1002