### PR TITLE
Fix Synthetic monitoring http versions documentation to HTTP/2.0

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -199,7 +199,7 @@ EOS
       valid_http_versions = [
         "HTTP/1.0",
         "HTTP/1.1",
-        "HTTP/2",
+        "HTTP/2.0",
       ]
 
       fail_if_body_matches_regexp = [
@@ -508,7 +508,7 @@ Optional:
 - `no_follow_redirects` (Boolean) Do not follow redirects. Defaults to `false`.
 - `proxy_url` (String) Proxy URL.
 - `tls_config` (Block Set, Max: 1) TLS config. (see [below for nested schema](#nestedblock--settings--http--tls_config))
-- `valid_http_versions` (Set of String) List of valid HTTP versions. Options include `HTTP/1.0`, `HTTP/1.1`, `HTTP/2`
+- `valid_http_versions` (Set of String) List of valid HTTP versions. Options include `HTTP/1.0`, `HTTP/1.1`, `HTTP/2.0`
 - `valid_status_codes` (Set of Number) Accepted status codes. If unset, defaults to 2xx.
 
 <a id="nestedblock--settings--http--basic_auth"></a>

--- a/examples/resources/grafana_synthetic_monitoring_check/http_complex.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/http_complex.tf
@@ -73,7 +73,7 @@ EOS
       valid_http_versions = [
         "HTTP/1.0",
         "HTTP/1.1",
-        "HTTP/2",
+        "HTTP/2.0",
       ]
 
       fail_if_body_matches_regexp = [

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -260,7 +260,7 @@ var (
 				},
 			},
 			"valid_http_versions": {
-				Description: "List of valid HTTP versions. Options include `HTTP/1.0`, `HTTP/1.1`, `HTTP/2`",
+				Description: "List of valid HTTP versions. Options include `HTTP/1.0`, `HTTP/1.1`, `HTTP/2.0`",
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Schema{

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -111,7 +111,7 @@ func TestAccResourceCheck_http(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.valid_status_codes.1", "201"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.valid_http_versions.0", "HTTP/1.0"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.valid_http_versions.1", "HTTP/1.1"),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.valid_http_versions.2", "HTTP/2"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.valid_http_versions.2", "HTTP/2.0"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.fail_if_body_matches_regexp.0", "*bad stuff*"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.fail_if_body_not_matches_regexp.0", "*good stuff*"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.fail_if_header_matches_regexp.0.header", "Content-Type"),


### PR DESCRIPTION
For the `valid_http_versions` field in  `grafana_synthetic_monitoring_checks`, passing a value of `HTTP/2` breaks any checks that actually return HTTP/2, since the Grafana check actually checks for the value of `HTTP/2.0` instead. Grafana Synthetics API blindly accepts whatever value is passed in and stores it, but the backend expects the value of `HTTP/2.0` (with the point-0 in the text), as seen by the errors in the following anonymized error after the change:

```
level=error target=https://foobar.example.com/ probe=SanFrancisco region=AMER instance=https://foobar/example.com job=check check_name=http source=synthetic-monitoring-agent label_cluster=prod msg="Invalid HTTP version number" version=HTTP/2.0
```

My organization found this out the hard way, since we imported existing checks into Terraform, ran the apply on what should've been a no-op, and found all our checks break simultaneously.

Even though the Grafana Synthetics UI shows `HTTP/2` as an option, checking the payload sent to the server shows a value of `HTTP/2.0` being sent. Also, when querying the API, or pulling the synthetics using a tool like Grizzly, the valid http versions showed the value of HTTP/2 before readding the value in the UI and `HTTP/2.0` afterwards.

This PR changes the documentation and the tests to use the correct value "HTTP/2.0". 
This is a followup to https://github.com/grafana/terraform-provider-grafana/issues/512 which tested that the provider was sending and receiving the value `HTTP/2` but never checked whether it was the expected value on the server side.
