### PR TITLE
Add org support for role None

### DIFF
--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -67,7 +67,7 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
-- `users_without_access` (Set of String) A list of email addresses corresponding to users who who should be given none access to the organization.
+- `users_without_access` (Set of String) A list of email addresses corresponding to users who should be given none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
 set to true.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -15,7 +15,7 @@ description: |-
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
 
 This resource represents an instance-scoped resource and uses Grafana's admin APIs.
-It does not work with API tokens or service accounts which are org-scoped. 
+It does not work with API tokens or service accounts which are org-scoped.
 You must use basic auth.
 
 ## Example Usage
@@ -67,6 +67,9 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
+- `nones` (Set of String) A list of email addresses corresponding to users who has no basic role assigned.
+Note: users specified here must already exist in Grafana, unless 'create_users' is
+set to true.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -67,9 +67,9 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
-- `users_without_access` (Set of String) A list of email addresses corresponding to users who who
-should be given none access to the organization. Note: users specified here must already exist in
-Grafana, unless 'create_users' is set to true.
+- `users_without_access` (Set of String) A list of email addresses corresponding to users who who should be given none access to the organization.
+Note: users specified here must already exist in Grafana, unless 'create_users' is
+set to true.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -67,9 +67,9 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
-- `nones` (Set of String) A list of email addresses corresponding to users who who should be given none access to the organization.
-Note: users specified here must already exist in Grafana, unless 'create_users' is
-set to true.
+- `users_without_access` (Set of String) A list of email addresses corresponding to users who who
+should be given none access to the organization. Note: users specified here must already exist in
+Grafana, unless 'create_users' is set to true.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -67,7 +67,7 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
-- `nones` (Set of String) A list of email addresses corresponding to users who has no basic role assigned.
+- `nones` (Set of String) A list of email addresses corresponding to users who should be given the none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
 set to true.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -67,7 +67,7 @@ already exist in Grafana.
 - `editors` (Set of String) A list of email addresses corresponding to users who should be given editor
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
-- `nones` (Set of String) A list of email addresses corresponding to users who should be given the none access to the organization.
+- `nones` (Set of String) A list of email addresses corresponding to users who who should be given none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
 set to true.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -69,7 +69,7 @@ access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
 - `users_without_access` (Set of String) A list of email addresses corresponding to users who should be given none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
-set to true.
+set to true. This feature is only available in Grafana 10.2+.
 - `viewers` (Set of String) A list of email addresses corresponding to users who should be given viewer
 access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -134,7 +134,7 @@ Grafana unless 'create_users' is set to true.
 					Type: schema.TypeString,
 				},
 				Description: `
-A list of email addresses corresponding to users who who should be given none access to the organization.
+A list of email addresses corresponding to users who should be given none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
 set to true.
 `,

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -43,7 +43,7 @@ func ResourceOrganization() *schema.Resource {
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
 
 This resource represents an instance-scoped resource and uses Grafana's admin APIs.
-It does not work with API tokens or service accounts which are org-scoped. 
+It does not work with API tokens or service accounts which are org-scoped.
 You must use basic auth.
 `,
 
@@ -127,6 +127,18 @@ access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
 `,
 			},
+			"nones": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: `
+A list of email addresses corresponding to users who has no basic role assigned.
+Note: users specified here must already exist in Grafana, unless 'create_users' is
+set to true.
+`,
+			},
 		},
 	}
 }
@@ -198,7 +210,7 @@ func ReadUsers(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	roleMap := map[string][]string{"Admin": nil, "Editor": nil, "Viewer": nil}
+	roleMap := map[string][]string{"Admin": nil, "Editor": nil, "Viewer": nil, "None": nil}
 	grafAdmin := d.Get("admin_user")
 	for _, orgUser := range orgUsers {
 		if orgUser.Login != grafAdmin {
@@ -226,7 +238,7 @@ func UpdateUsers(d *schema.ResourceData, meta interface{}) error {
 }
 
 func collectUsers(d *schema.ResourceData) (map[string]OrgUser, map[string]OrgUser, error) {
-	roles := []string{"admins", "editors", "viewers"}
+	roles := []string{"admins", "editors", "viewers", "nones"}
 	stateUsers, configUsers := make(map[string]OrgUser), make(map[string]OrgUser)
 	for _, role := range roles {
 		caser := cases.Title(language.English)

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -134,7 +134,7 @@ Grafana unless 'create_users' is set to true.
 					Type: schema.TypeString,
 				},
 				Description: `
-A list of email addresses corresponding to users who has no basic role assigned.
+A list of email addresses corresponding to users who who should be given none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
 set to true.
 `,

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -35,6 +35,13 @@ const (
 	Remove
 )
 
+var rolesToLists = map[string]string{
+	"Admin":  "admins",
+	"Editor": "editors",
+	"Viewer": "viewers",
+	"None":   "users_without_role",
+}
+
 func ResourceOrganization() *schema.Resource {
 	return &schema.Resource{
 
@@ -127,7 +134,7 @@ access to the organization. Note: users specified here must already exist in
 Grafana unless 'create_users' is set to true.
 `,
 			},
-			"nones": {
+			"users_without_access": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
@@ -218,7 +225,7 @@ func ReadUsers(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	for k, v := range roleMap {
-		d.Set(fmt.Sprintf("%ss", strings.ToLower(k)), v)
+		d.Set(rolesToLists[k], v)
 	}
 	return nil
 }
@@ -238,7 +245,7 @@ func UpdateUsers(d *schema.ResourceData, meta interface{}) error {
 }
 
 func collectUsers(d *schema.ResourceData) (map[string]OrgUser, map[string]OrgUser, error) {
-	roles := []string{"admins", "editors", "viewers", "nones"}
+	roles := []string{"admins", "editors", "viewers", "users_without_access"}
 	stateUsers, configUsers := make(map[string]OrgUser), make(map[string]OrgUser)
 	for _, role := range roles {
 		caser := cases.Title(language.English)

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -136,7 +136,7 @@ Grafana unless 'create_users' is set to true.
 				Description: `
 A list of email addresses corresponding to users who should be given none access to the organization.
 Note: users specified here must already exist in Grafana, unless 'create_users' is
-set to true.
+set to true. This feature is only available in Grafana 10.2+.
 `,
 			},
 		},

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -92,6 +92,9 @@ func TestAccOrganization_users(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						"grafana_organization.test", "viewers.#",
 					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "nones.#",
+					),
 				),
 			},
 			{
@@ -110,6 +113,9 @@ func TestAccOrganization_users(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						"grafana_organization.test", "viewers.#",
 					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "nones.#",
+					),
 				),
 			},
 			{
@@ -127,6 +133,9 @@ func TestAccOrganization_users(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "viewers.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "nones.#", "0",
 					),
 				),
 			},

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -119,6 +119,27 @@ func TestAccOrganization_users(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccOrganizationConfig_usersUpdate_2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "admins.#",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "editors.#", "0",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "viewers.#",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "nones.#", "1",
+					),
+				),
+			},
+			{
 				Config: testAccOrganizationConfig_usersRemove,
 				Check: resource.ComposeTestCheckFunc(
 					testAccOrganizationCheckExists("grafana_organization.test", &org),
@@ -338,6 +359,18 @@ resource "grafana_organization" "test" {
     ]
 }
 `
+const testAccOrganizationConfig_usersUpdate_2 = `
+resource "grafana_organization" "test" {
+    name = "terraform-acc-test"
+    admin_user = "admin"
+    create_users = false
+		editors = []
+    nones = [
+        "john.doe@example.com",
+    ]
+}
+`
+
 const testAccOrganizationConfig_usersRemove = `
 resource "grafana_organization" "test" {
     name = "terraform-acc-test"

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -119,27 +119,6 @@ func TestAccOrganization_users(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccOrganizationConfig_usersUpdate_2,
-				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "name", "terraform-acc-test",
-					),
-					resource.TestCheckNoResourceAttr(
-						"grafana_organization.test", "admins.#",
-					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "editors.#", "0",
-					),
-					resource.TestCheckNoResourceAttr(
-						"grafana_organization.test", "viewers.#",
-					),
-					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "nones.#", "1",
-					),
-				),
-			},
-			{
 				Config: testAccOrganizationConfig_usersRemove,
 				Check: resource.ComposeTestCheckFunc(
 					testAccOrganizationCheckExists("grafana_organization.test", &org),
@@ -154,6 +133,62 @@ func TestAccOrganization_users(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "viewers.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "nones.#", "0",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrganization_roleNoneUser(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	var org gapi.Org
+
+	testutils.CheckOSSTestsSemver(t, ">=10.2.0")
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationConfig_usersCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "1",
+					),
+				),
+			},
+			{
+				Config: testAccOrganization_roleNoneUsersUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "name", "terraform-acc-test",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "admins.#",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "editors.#",
+					),
+					resource.TestCheckNoResourceAttr(
+						"grafana_organization.test", "viewers.#",
+					),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "nones.#", "1",
+					),
+				),
+			},
+			{
+				Config: testAccOrganizationConfig_usersRemove,
+				Check: resource.ComposeTestCheckFunc(
+					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					resource.TestCheckResourceAttr(
+						"grafana_organization.test", "admins.#", "0",
 					),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "nones.#", "0",
@@ -359,7 +394,7 @@ resource "grafana_organization" "test" {
     ]
 }
 `
-const testAccOrganizationConfig_usersUpdate_2 = `
+const testAccOrganization_roleNoneUsersUpdate = `
 resource "grafana_organization" "test" {
     name = "terraform-acc-test"
     admin_user = "admin"

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -93,7 +93,7 @@ func TestAccOrganization_users(t *testing.T) {
 						"grafana_organization.test", "viewers.#",
 					),
 					resource.TestCheckNoResourceAttr(
-						"grafana_organization.test", "nones.#",
+						"grafana_organization.test", "users_without_access.#",
 					),
 				),
 			},
@@ -114,7 +114,7 @@ func TestAccOrganization_users(t *testing.T) {
 						"grafana_organization.test", "viewers.#",
 					),
 					resource.TestCheckNoResourceAttr(
-						"grafana_organization.test", "nones.#",
+						"grafana_organization.test", "users_without_access.#",
 					),
 				),
 			},
@@ -135,7 +135,7 @@ func TestAccOrganization_users(t *testing.T) {
 						"grafana_organization.test", "viewers.#", "0",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "nones.#", "0",
+						"grafana_organization.test", "users_without_access.#", "0",
 					),
 				),
 			},
@@ -179,7 +179,7 @@ func TestAccOrganization_roleNoneUser(t *testing.T) {
 						"grafana_organization.test", "viewers.#",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "nones.#", "1",
+						"grafana_organization.test", "users_without_access.#", "1",
 					),
 				),
 			},
@@ -191,7 +191,7 @@ func TestAccOrganization_roleNoneUser(t *testing.T) {
 						"grafana_organization.test", "admins.#", "0",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "nones.#", "0",
+						"grafana_organization.test", "users_without_access.#", "0",
 					),
 				),
 			},
@@ -400,7 +400,7 @@ resource "grafana_organization" "test" {
     admin_user = "admin"
     create_users = false
 		editors = []
-    nones = [
+    users_without_access = [
         "john.doe@example.com",
     ]
 }

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -144,11 +144,10 @@ func TestAccOrganization_users(t *testing.T) {
 }
 
 func TestAccOrganization_roleNoneUser(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t, ">=10.2.0")
 
 	var org gapi.Org
 
-	testutils.CheckOSSTestsSemver(t, ">=10.2.0")
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccOrganizationCheckDestroy(&org),


### PR DESCRIPTION
Git card:
https://github.com/grafana/identity-access-team/issues/302

In the UI, the new user looks as follows:
<img width="949" alt="image" src="https://github.com/grafana/terraform-provider-grafana/assets/11213785/59746be1-4abb-4ece-91a6-c3853dcac3ae">
Not sure if anything should be done here to display "None" in the "Role" box.

In the DB, the org_user looks as follows:
<img width="591" alt="image" src="https://github.com/grafana/terraform-provider-grafana/assets/11213785/564f9030-a647-48ee-8e12-b14c0bffaa37">

The target version >= 10.2.0 is not yet configured in the CI, so to see that the new unit test is running, I did this locally, against the latest Grafana `main` branch:
```
mattia.buccarella at Mattias-Grafana-Macbook in ~/workspace/terraform-provider-grafana (buccarel/support-role-none)
$ GRAFANA_VERSION=10.2.0 TF_ACC_OSS=true GRAFANA_URL=http://localhost:3000 GRAFANA_AUTH=admin:admin TESTARGS="-run TestAccOrganization_roleNoneUser" make testacc | grep roleNone
TF_ACC=1 go test ./... -v -run TestAccOrganization_roleNoneUser -timeout 120m
=== RUN   TestAccOrganization_roleNoneUser
--- PASS: TestAccOrganization_roleNoneUser (1.82s)

mattia.buccarella at Mattias-Grafana-Macbook in ~/workspace/terraform-provider-grafana (buccarel/support-role-none)
$
```
