### PR TITLE
Fix flaky `grafana_dashboards` test

### DIFF
--- a/docs/data-sources/dashboards.md
+++ b/docs/data-sources/dashboards.md
@@ -66,10 +66,6 @@ data "grafana_dashboards" "all" {
   ]
 }
 
-data "grafana_dashboard" "from_data_source" {
-  uid = data.grafana_dashboards.all.dashboards[0].uid
-}
-
 // get only one result
 data "grafana_dashboards" "limit_one" {
   limit = 1

--- a/examples/data-sources/grafana_dashboards/data-source.tf
+++ b/examples/data-sources/grafana_dashboards/data-source.tf
@@ -46,10 +46,6 @@ data "grafana_dashboards" "all" {
   ]
 }
 
-data "grafana_dashboard" "from_data_source" {
-  uid = data.grafana_dashboards.all.dashboards[0].uid
-}
-
 // get only one result
 data "grafana_dashboards" "limit_one" {
   limit = 1

--- a/internal/resources/grafana/data_source_dashboards_test.go
+++ b/internal/resources/grafana/data_source_dashboards_test.go
@@ -28,7 +28,6 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 		resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.#", "1"),
 		resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.#", "1"),
 		resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.#", "1"),
-		resource.TestCheckResourceAttrSet("data.grafana_dashboard.from_data_source", "config_json"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
We often get the following failure:
```
=== NAME  TestAccDataSourceDashboardsAllAndByFolderID
    data_source_dashboards_test.go:34: Step 1/1 error: Error running post-apply plan: exit status 1

        Error: status: 404, body: {"message":"Dashboard not found","traceID":""}

          with data.grafana_dashboard.from_data_source,
          on terraform_plugin_test.tf line 49, in data "grafana_dashboard" "from_data_source":
          49: data "grafana_dashboard" "from_data_source" {
```

The `data.grafana_dashboard.from_data_source` is out of place there. It can be removed and that should make the test less flaky