### PR TITLE
Do not run all tests with the TLS proxy

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -184,6 +184,7 @@ local localTestPipeline(
       GRAFANA_TLS_KEY: '%s/client.key' % certPath,
       GRAFANA_TLS_CERT: '%s/client.crt' % certPath,
       GRAFANA_CA_CERT: '%s/ca.crt' % certPath,
+      TESTARGS: '-run ".*_basic"',  // Tests are slower behind the proxy, let's just run the basic (smaller) ones
     }
   ) + {
     steps: [

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -165,6 +165,7 @@ steps:
     GRAFANA_TLS_KEY: /drone/terraform-provider-grafana/testdata/client.key
     GRAFANA_URL: https://mtls-proxy:3001
     GRAFANA_VERSION: 10.1.2
+    TESTARGS: -run ".*_basic"
     TF_ACC_TERRAFORM_PATH: /drone/terraform-provider-grafana/terraform
   image: golang:1.20
   name: tests
@@ -369,6 +370,6 @@ kind: secret
 name: grafana-sm-token
 ---
 kind: signature
-hmac: 55829f21755c37ab833aeac2d1dad643d5d7e427535ff8ce21bad8d6d4644f96
+hmac: 6a5e700d76831a894501bb945671d533ab9738bb4058212eda478427fe6efefe
 
 ...


### PR DESCRIPTION
Tests are way slower behind the proxy
We just want to validate that the APIs still work when Grafana is behind a proxy We only need to run basic tests (not the large or complex ones)