### PR TITLE
Alerting: add support for on-call integration

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -49,6 +49,7 @@ resource "grafana_contact_point" "my_contact_point" {
 - `googlechat` (Block List) A contact point that sends notifications to Google Chat. (see [below for nested schema](#nestedblock--googlechat))
 - `kafka` (Block List) A contact point that publishes notifications to Apache Kafka topics. (see [below for nested schema](#nestedblock--kafka))
 - `line` (Block List) A contact point that sends notifications to LINE.me. (see [below for nested schema](#nestedblock--line))
+- `oncall` (Block List) A contact point that sends notifications to Grafana On-Call. (see [below for nested schema](#nestedblock--oncall))
 - `opsgenie` (Block List) A contact point that sends notifications to OpsGenie. (see [below for nested schema](#nestedblock--opsgenie))
 - `pagerduty` (Block List) A contact point that sends notifications to PagerDuty. (see [below for nested schema](#nestedblock--pagerduty))
 - `pushover` (Block List) A contact point that sends notifications to Pushover. (see [below for nested schema](#nestedblock--pushover))
@@ -202,6 +203,31 @@ Optional:
 - `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
 - `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
 - `title` (String) The templated title of the message.
+
+Read-Only:
+
+- `uid` (String) The UID of the contact point.
+
+
+<a id="nestedblock--oncall"></a>
+### Nested Schema for `oncall`
+
+Required:
+
+- `url` (String) The URL to send webhook requests to.
+
+Optional:
+
+- `authorization_credentials` (String, Sensitive) Allows a custom authorization scheme - attaches an auth header with this value. Do not use in conjunction with basic auth parameters.
+- `authorization_scheme` (String) Allows a custom authorization scheme - attaches an auth header with this name. Do not use in conjunction with basic auth parameters.
+- `basic_auth_password` (String, Sensitive) The username to use in basic auth headers attached to the request. If omitted, basic auth will not be used.
+- `basic_auth_user` (String) The username to use in basic auth headers attached to the request. If omitted, basic auth will not be used.
+- `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `http_method` (String) The HTTP method to use in the request. Defaults to `POST`.
+- `max_alerts` (Number) The maximum number of alerts to send in a single request. This can be helpful in limiting the size of the request body. The default is 0, which indicates no limit.
+- `message` (String) Custom message. You can use template variables.
+- `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
+- `title` (String) Templated title of the message.
 
 Read-Only:
 

--- a/examples/resources/grafana_contact_point/_acc_receiver_types_10_2.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types_10_2.tf
@@ -1,0 +1,13 @@
+resource "grafana_contact_point" "receiver_types" {
+  name = "Receiver Types since v10.2"
+
+  oncall {
+    url                 = "http://my-url"
+    http_method         = "POST"
+    basic_auth_user     = "user"
+    basic_auth_password = "password"
+    max_alerts          = 100
+    message             = "Custom message"
+    title               = "Custom title"
+  }
+}

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -21,6 +21,7 @@ var notifiers = []notifier{
 	googleChatNotifier{},
 	kafkaNotifier{},
 	lineNotifier{},
+	oncallNotifier{},
 	opsGenieNotifier{},
 	pagerDutyNotifier{},
 	pushoverNotifier{},

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -341,8 +341,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 }
 
 func TestAccContactPoint_notifiers10_2(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=10.2.0")
+	testutils.CheckOSSTestsEnabled(t, ">=10.2.0")
 
 	var points []gapi.ContactPoint
 

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -340,6 +340,37 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 	})
 }
 
+func TestAccContactPoint_notifiers10_2(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsSemver(t, ">=10.2.0")
+
+	var points []gapi.ContactPoint
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		// Implicitly tests deletion.
+		CheckDestroy: testContactPointCheckDestroy(points),
+		Steps: []resource.TestStep{
+			// Test creation.
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_receiver_types_10_2.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					testContactPointCheckExists("grafana_contact_point.receiver_types", &points, 1),
+					// oncall
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.url", "http://my-url"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.http_method", "POST"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.basic_auth_user", "user"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.basic_auth_password", "password"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.max_alerts", "100"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.message", "Custom message"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "oncall.0.title", "Custom title"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContactPoint_empty(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 


### PR DESCRIPTION
This PR adds support for a new integration introduced in Grafana 10.2. Currently, Oncall integration is the 100% copy of the webhook.