### PR TITLE
Role: Allow auto incrementing version

### DIFF
--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -61,7 +61,7 @@ data "grafana_role" "from_name" {
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `permissions` (Set of Object) Specific set of actions granted by the role. (see [below for nested schema](#nestedatt--permissions))
 - `uid` (String) Unique identifier of the role. Used for assignments.
-- `version` (Number) Version of the role. A role is updated only on version increase.
+- `version` (Number) Version of the role. A role is updated only on version increase. This field or `auto_increment_version` should be set.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -45,10 +45,10 @@ resource "grafana_role" "super_user" {
 ### Required
 
 - `name` (String) Name of the role
-- `version` (Number) Version of the role. A role is updated only on version increase.
 
 ### Optional
 
+- `auto_increment_version` (Boolean) Whether the role version should be incremented automatically on updates (and set to 1 on creation). This field or `version` should be set.
 - `description` (String) Description of the role.
 - `display_name` (String) Display name of the role. Available with Grafana 8.5+.
 - `global` (Boolean) Boolean to state whether the role is available across all organizations or not. Defaults to `false`.
@@ -57,6 +57,7 @@ resource "grafana_role" "super_user" {
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `permissions` (Block Set) Specific set of actions granted by the role. (see [below for nested schema](#nestedblock--permissions))
 - `uid` (String) Unique identifier of the role. Used for assignments.
+- `version` (Number) Version of the role. A role is updated only on version increase. This field or `auto_increment_version` should be set.
 
 ### Read-Only
 

--- a/internal/common/schema.go
+++ b/internal/common/schema.go
@@ -40,6 +40,7 @@ func CloneResourceSchemaForDatasource(r *schema.Resource, updates map[string]*sc
 		clone[k].ValidateDiagFunc = nil
 		clone[k].ValidateFunc = nil
 		clone[k].ConflictsWith = nil
+		clone[k].ExactlyOneOf = nil
 		clone[k].MaxItems = 0
 	}
 	for k, v := range updates {

--- a/internal/resources/grafana/data_source_role.go
+++ b/internal/resources/grafana/data_source_role.go
@@ -23,6 +23,7 @@ func DatasourceRole() *schema.Resource {
 				Required:    true,
 				Description: "Name of the role",
 			},
+			"auto_increment_version": nil,
 		}),
 	}
 }


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1074 
Currently, the `version` attribute has to be set manually in `grafana_role` 
This is a required attribute on API calls so it needs to be incremented 
This PR adds a field to manage the versioning automatically. The `version` field stays unchanged because it still shows the current version (whether incremented automatically or manually)