### PR TITLE
Testing: Common `Exists` and `Destroy` helpers

### DIFF
--- a/internal/common/errcheck.go
+++ b/internal/common/errcheck.go
@@ -20,7 +20,7 @@ func CheckReadError(resourceType string, d *schema.ResourceData, err error) (ret
 		return nil, false
 	}
 
-	if !strings.Contains(err.Error(), NotFoundError) {
+	if !IsNotFoundError(err) {
 		return diag.Errorf("error reading %s with ID`%s`: %v", resourceType, d.Id(), err), true
 	}
 
@@ -33,4 +33,8 @@ func CheckReadError(resourceType string, d *schema.ResourceData, err error) (ret
 	})
 	d.SetId("")
 	return diags, true
+}
+
+func IsNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), NotFoundError)
 }

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -74,8 +74,8 @@ func (h *checkExistsHelper[T]) exists(rn string, v *T) resource.TestCheckFunc {
 // destroyed checks that the resource doesn't exist in the given orgs (and the default one).
 func (h *checkExistsHelper[T]) destroyed(v *T, orgs ...int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		orgsAndDefault := append(orgs, 1)
-		for _, orgID := range orgsAndDefault {
+		orgs = append(orgs, 1)
+		for _, orgID := range orgs {
 			client := testutils.Provider.Meta().(*common.Client).GrafanaOAPI.WithOrgID(orgID)
 			id := h.getIDFunc(v)
 			_, err := h.getResourceFunc(client, id)

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -1,0 +1,90 @@
+package grafana_test
+
+import (
+	"fmt"
+
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
+	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Helpers that check if a resource exists or doesn't. To define a new one, use the newCheckExistsHelper function.
+// A function that gets a resource by their Terraform ID is required.
+var (
+	folderCheckExists = newCheckExistsHelper(
+		func(f *models.Folder) string { return f.UID },
+		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Folder, error) {
+			return grafana.GetFolderByIDorUID(client.Folders, id)
+		},
+	)
+)
+
+type checkExistsGetResourceFunc[T interface{}] func(client *goapi.GrafanaHTTPAPI, id string) (*T, error)
+type checkExistsGetIDFunc[T interface{}] func(*T) string
+
+type checkExistsHelper[T interface{}] struct {
+	getIDFunc       func(*T) string
+	getResourceFunc checkExistsGetResourceFunc[T]
+}
+
+func newCheckExistsHelper[T interface{}](getIDFunc checkExistsGetIDFunc[T], getResourceFunc checkExistsGetResourceFunc[T]) checkExistsHelper[T] {
+	return checkExistsHelper[T]{getIDFunc: getIDFunc, getResourceFunc: getResourceFunc}
+}
+
+// exists checks that the resource exists in the correct org.
+// If the org is not the default one, it also checks that the resource doesn't exist in the default org.
+func (h *checkExistsHelper[T]) exists(rn string, v *T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		orgID, idStr := grafana.SplitOrgResourceID(rs.Primary.ID)
+
+		// If the org ID is set, check that the resource doesn't exist in the default org
+		client := testutils.Provider.Meta().(*common.Client).GrafanaOAPI.WithOrgID(1)
+		if orgID > 1 {
+			_, err := h.getResourceFunc(client, idStr)
+			if err == nil {
+				return fmt.Errorf("resource %s with ID %q exists in org %d, but should not", rn, rs.Primary.ID, orgID)
+			} else if !common.IsNotFoundError(err) {
+				return fmt.Errorf("error checking if resource %s with ID %q exists in org %d: %s", rn, rs.Primary.ID, orgID, err)
+			}
+			client = client.WithOrgID(orgID)
+		}
+
+		obj, err := h.getResourceFunc(client, idStr)
+		if err != nil {
+			return fmt.Errorf("error getting resource %s with ID %q: %s", rn, rs.Primary.ID, err)
+		}
+
+		*v = *obj
+		return nil
+	}
+}
+
+// destroyed checks that the resource doesn't exist in the given orgs (and the default one).
+func (h *checkExistsHelper[T]) destroyed(v *T, orgs ...int64) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		orgsAndDefault := append(orgs, 1)
+		for _, orgID := range orgsAndDefault {
+			client := testutils.Provider.Meta().(*common.Client).GrafanaOAPI.WithOrgID(orgID)
+			id := h.getIDFunc(v)
+			_, err := h.getResourceFunc(client, id)
+			if err == nil {
+				return fmt.Errorf("resource %s still exists in org %d", id, orgID)
+			} else if !common.IsNotFoundError(err) {
+				return fmt.Errorf("error checking if resource %s exists in org %d: %s", id, orgID, err)
+			}
+		}
+		return nil
+	}
+}

--- a/internal/resources/grafana/data_source_folder_test.go
+++ b/internal/resources/grafana/data_source_folder_test.go
@@ -16,7 +16,7 @@ func TestAccDatasourceFolder(t *testing.T) {
 
 	var folder goapi.Folder
 	checks := []resource.TestCheckFunc{
-		testAccFolderCheckExists("grafana_folder.test", &folder),
+		folderCheckExists.exists("grafana_folder.test", &folder),
 		resource.TestCheckResourceAttr(
 			"data.grafana_folder.from_title", "title", "test-folder",
 		),
@@ -33,7 +33,7 @@ func TestAccDatasourceFolder(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccFolderCheckDestroy(&folder, 0),
+		CheckDestroy:      folderCheckExists.destroyed(&folder),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_folder/data-source.tf"),

--- a/internal/resources/grafana/data_source_folders_test.go
+++ b/internal/resources/grafana/data_source_folders_test.go
@@ -16,8 +16,8 @@ func TestAccDatasourceFolders(t *testing.T) {
 	titleBase := "test-folder-"
 	uidBase := "test-ds-folder-uid-"
 	checks := []resource.TestCheckFunc{
-		testAccFolderCheckExists("grafana_folder.test_a", &folderA),
-		testAccFolderCheckExists("grafana_folder.test_b", &folderB),
+		folderCheckExists.exists("grafana_folder.test_a", &folderA),
+		folderCheckExists.exists("grafana_folder.test_b", &folderB),
 		resource.TestCheckResourceAttr(
 			"data.grafana_folders.test", "folders.#", "2",
 		),
@@ -35,8 +35,8 @@ func TestAccDatasourceFolders(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccFolderCheckDestroy(&folderA, 0),
-			testAccFolderCheckDestroy(&folderB, 0),
+			folderCheckExists.destroyed(&folderA),
+			folderCheckExists.destroyed(&folderB),
 		),
 		Steps: []resource.TestStep{
 			{

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -174,7 +174,7 @@ func TestAccDashboard_folder(t *testing.T) {
 				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_folder.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
-					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
+					folderCheckExists.exists("grafana_folder.test_folder", &folder),
 					testAccDashboardCheckExistsInFolder(&dashboard, &folder),
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "1:folder-dashboard-test-ref-with-id"), // <org id>:<uid>
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "uid", "folder-dashboard-test-ref-with-id"),
@@ -199,7 +199,7 @@ func TestAccDashboard_folder_uid(t *testing.T) {
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_folder_uid_ref.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
+					folderCheckExists.exists("grafana_folder.test_folder", &folder),
 					testAccDashboardCheckExists("grafana_dashboard.test_folder", &dashboard),
 					testAccDashboardCheckExistsInFolder(&dashboard, &folder),
 					resource.TestCheckResourceAttr("grafana_dashboard.test_folder", "id", "1:folder-dashboard-test-ref-with-uid"), // <org id>:<uid>
@@ -229,7 +229,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccDashboardCheckDestroy(&dashboard, org.ID),
-			testAccFolderCheckDestroy(&folder, org.ID),
+			folderCheckExists.destroyed(&folder, org.ID),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -237,7 +237,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccOrganizationCheckExists("grafana_organization.test", &org),
 					// Check that the folder is in the correct organization
-					testAccFolderCheckExists("grafana_folder.test", &folder),
+					folderCheckExists.exists("grafana_folder.test", &folder),
 					resource.TestCheckResourceAttr("grafana_folder.test", "uid", "folder-"+orgName),
 					resource.TestMatchResourceAttr("grafana_folder.test", "id", nonDefaultOrgIDRegexp),
 					checkResourceIsInOrg("grafana_folder.test", "grafana_organization.test"),

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -98,7 +98,7 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("grafana_library_panel.test_folder", "id", defaultOrgIDRegexp),
 					testAccLibraryPanelCheckExists("grafana_library_panel.test_folder", &panel),
-					testAccFolderCheckExists("grafana_folder.test_folder", &folder),
+					folderCheckExists.exists("grafana_folder.test_folder", &folder),
 					testAccLibraryPanelCheckExistsInFolder(&panel, &folder),
 					resource.TestCheckResourceAttr("grafana_library_panel.test_folder", "name", "test-folder"),
 					resource.TestMatchResourceAttr(


### PR DESCRIPTION
**!!11!!11! GENERICS !1!!!!!1111!!!**

These functions are repeated in all tests and are always the same pattern:
- Exists: Check that the resource can be queried in the correct org (and if not in the default org, that it can't be found in the default org)
- Destroy: Check that the resource can't be queried anywhere

To enable this, we only need two things:
- A short function that gets us the TF ID from an API model
- A short function that gets a resource from the API from a given ID

Benefits of this approach:
- Easier to add new helpers for resources
- Since `exists` and `destroyed` are opposites, if an error is made, it will usually fail in one of the two. This makes mistakes harder to make than with two manually composed functions
- It will allow us to migrate to the new generated client more easily
- Removes a bunch of code (once we have more than one resource using this pattern)