### PR TITLE
Merge `CheckOSSTestsEnabled` and `CheckOSSTestsSemver` helpers

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_service_account_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestAccGrafanaServiceAccountFromCloud(t *testing.T) {
 	testutils.CheckCloudAPITestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
 
 	var stack gapi.Stack
 	prefix := "tfserviceaccounttest"

--- a/internal/resources/grafana/data_source_library_panel_test.go
+++ b/internal/resources/grafana/data_source_library_panel_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestAccDatasourceLibraryPanel(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	// var dashboard gapi.Dashboard

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestAccContactPoint_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
 	var points []gapi.ContactPoint
 
@@ -72,8 +71,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 }
 
 func TestAccContactPoint_compound(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
 	var points []gapi.ContactPoint
 
@@ -141,8 +139,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 }
 
 func TestAccContactPoint_notifiers(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var points []gapi.ContactPoint
 
@@ -344,8 +341,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 }
 
 func TestAccContactPoint_empty(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAccMessageTemplate_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
 	var tmpl gapi.AlertingMessageTemplate
 

--- a/internal/resources/grafana/resource_alerting_mute_timing_test.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAccMuteTiming_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">9.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">9.0.0")
 
 	var mt gapi.MuteTiming
 

--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestAccNotificationPolicy_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	// TODO: Make parallizable
 	resource.Test(t, resource.TestCase{

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestAccAlertRule_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var group gapi.RuleGroup
 
@@ -103,8 +102,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 }
 
 func TestAccAlertRule_model(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var group gapi.RuleGroup
 
@@ -148,8 +146,7 @@ func TestAccAlertRule_model(t *testing.T) {
 }
 
 func TestAccAlertRule_compound(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var group gapi.RuleGroup
 

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -119,8 +119,7 @@ func TestAccAnnotation_basic(t *testing.T) {
 }
 
 func TestAccAnnotation_dashboardUID(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
 	var annotation gapi.Annotation
 	var org gapi.Org

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestAccDashboardPermission_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0") // Dashboard UIDs are only available as references in Grafana 9+
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Dashboard UIDs are only available as references in Grafana 9+
 
 	dashboardUID := ""
 

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -186,8 +186,7 @@ func TestAccDashboard_folder(t *testing.T) {
 }
 
 func TestAccDashboard_folder_uid(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0") // UID in folders were added in v8
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0") // UID in folders were added in v8
 
 	var dashboard gapi.Dashboard
 	var folder goapi.Folder

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAccFolderPermission_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0") // Folder permissions only work for service accounts in Grafana 9+, so we're just not testing versions before 9.
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Folder permissions only work for service accounts in Grafana 9+, so we're just not testing versions before 9.
 
 	folderUID := "uninitialized"
 

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -158,8 +158,7 @@ func TestAccFolder_PreventDeletion(t *testing.T) {
 
 // This is a bug in Grafana, not the provider. It was fixed in 9.2.7+ and 9.3.0+, this test will check for regressions
 func TestAccFolder_createFromDifferentRoles(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.2.7")
+	testutils.CheckOSSTestsEnabled(t, ">=9.2.7")
 
 	for _, tc := range []struct {
 		role        string

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAccLibraryPanel_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 
@@ -58,8 +57,7 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 }
 
 func TestAccLibraryPanel_computed_config(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 
@@ -82,8 +80,7 @@ func TestAccLibraryPanel_computed_config(t *testing.T) {
 }
 
 func TestAccLibraryPanel_folder(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	var folder goapi.Folder
@@ -111,8 +108,7 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 }
 
 func TestAccLibraryPanel_dashboard(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	var dashboard gapi.Dashboard
@@ -137,8 +133,7 @@ func TestAccLibraryPanel_dashboard(t *testing.T) {
 }
 
 func TestAccLibraryPanel_inOrg(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 
 	var panel gapi.LibraryPanel
 	orgName := acctest.RandString(10)

--- a/internal/resources/grafana/resource_organization_preferences_test.go
+++ b/internal/resources/grafana/resource_organization_preferences_test.go
@@ -16,14 +16,12 @@ import (
 )
 
 func TestAccResourceOrganizationPreferences_WithDashboardID(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
 	testAccResourceOrganizationPreferences(t, false)
 }
 
 func TestAccResourceOrganizationPreferences_WithDashboardUID(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.0.0") // UID support was added in 9.0.0
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // UID support was added in 9.0.0
 	testAccResourceOrganizationPreferences(t, true)
 }
 

--- a/internal/resources/grafana/resource_service_account_permission_test.go
+++ b/internal/resources/grafana/resource_service_account_permission_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestAccServiceAccountPermission(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.2.4")
+	testutils.CheckOSSTestsEnabled(t, ">=9.2.4")
 
 	name := acctest.RandString(10)
 

--- a/internal/resources/grafana/resource_service_account_test.go
+++ b/internal/resources/grafana/resource_service_account_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestAccServiceAccount_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var sa gapi.ServiceAccountDTO
 	var updatedSA gapi.ServiceAccountDTO
@@ -63,8 +62,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 }
 
 func TestAccServiceAccount_many(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	name := acctest.RandString(10)
 

--- a/internal/resources/grafana/resource_service_account_token_test.go
+++ b/internal/resources/grafana/resource_service_account_token_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestAccServiceAccountToken_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	name := acctest.RandString(10)
 	var sa gapi.ServiceAccountDTO
@@ -49,8 +48,7 @@ func TestAccServiceAccountToken_basic(t *testing.T) {
 }
 
 func TestAccServiceAccountToken_inOrg(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	name := acctest.RandString(10)
 	var org gapi.Org

--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -57,8 +57,7 @@ func TestAccTeam_basic(t *testing.T) {
 }
 
 func TestAccTeam_preferences(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">= 9.0.0") // Dashboard UID is only available in Grafana 9.0.0+
+	testutils.CheckOSSTestsEnabled(t, ">= 9.0.0") // Dashboard UID is only available in Grafana 9.0.0+
 
 	var team gapi.Team
 	teamName := acctest.RandString(5)
@@ -105,8 +104,7 @@ func TestAccTeam_preferences(t *testing.T) {
 }
 
 func TestAccTeam_teamSync(t *testing.T) {
-	testutils.CheckEnterpriseTestsEnabled(t)
-	testutils.CheckOSSTestsSemver(t, ">= 8.0.0")
+	testutils.CheckEnterpriseTestsEnabled(t, ">= 8.0.0")
 
 	var team gapi.Team
 	teamName := acctest.RandString(5)


### PR DESCRIPTION
I saw the semver function being used in a cloud test, which is invalid 
This should prevent that happening