### PR TITLE
Cloud Instance Checks: Use random names everywhere

### DIFF
--- a/internal/resources/machinelearning/resource_holiday_test.go
+++ b/internal/resources/machinelearning/resource_holiday_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -16,25 +17,31 @@ import (
 func TestAccResourceHoliday(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	randomName := acctest.RandomWithPrefix("holiday")
+
 	var holiday mlapi.Holiday
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccMLHolidayCheckDestroy(&holiday),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_holiday/ical_holiday.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_holiday/ical_holiday.tf", map[string]string{
+					"My iCal holiday": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLHolidayCheckExists("grafana_machine_learning_holiday.ical", &holiday),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_holiday.ical", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_holiday.ical", "name", "My iCal holiday"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_holiday.ical", "name", randomName),
 				),
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_holiday/custom_periods_holiday.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_holiday/custom_periods_holiday.tf", map[string]string{
+					"My custom periods holiday": randomName + " custom periods",
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLHolidayCheckExists("grafana_machine_learning_holiday.custom_periods", &holiday),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_holiday.custom_periods", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_holiday.custom_periods", "name", "My custom periods holiday"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_holiday.custom_periods", "name", randomName+" custom periods"),
 				),
 			},
 		},

--- a/internal/resources/machinelearning/resource_job_test.go
+++ b/internal/resources/machinelearning/resource_job_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -16,17 +17,21 @@ import (
 func TestAccResourceJob(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	randomName := acctest.RandomWithPrefix("Test Job")
+
 	var job mlapi.Job
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccMLJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/job.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_job/job.tf", map[string]string{
+					"Test Job": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLJobCheckExists("grafana_machine_learning_job.test_job", &job),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "metric", "tf_test_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_type", "prometheus"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_id", "10"),
@@ -36,10 +41,12 @@ func TestAccResourceJob(t *testing.T) {
 				),
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/datasource_uid_job.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_job/datasource_uid_job.tf", map[string]string{
+					"Test Job": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "metric", "tf_test_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_type", "prometheus"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_uid", "grafanacloud-usage"),
@@ -49,10 +56,12 @@ func TestAccResourceJob(t *testing.T) {
 				),
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/tuned_job.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_job/tuned_job.tf", map[string]string{
+					"Test Job": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "metric", "tf_test_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_type", "prometheus"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_uid", "grafanacloud-usage"),
@@ -65,10 +74,12 @@ func TestAccResourceJob(t *testing.T) {
 				),
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_job/holidays_job.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_job/holidays_job.tf", map[string]string{
+					"Test Job": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_job.test_job", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", "Test Job"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "metric", "tf_test_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_type", "prometheus"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_job.test_job", "datasource_id", "10"),

--- a/internal/resources/machinelearning/resource_outlier_detector_test.go
+++ b/internal/resources/machinelearning/resource_outlier_detector_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -16,17 +17,21 @@ import (
 func TestAccResourceOutlierDetector(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	randomName := acctest.RandomWithPrefix("Outlier Detector")
+
 	var outlier mlapi.OutlierDetector
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccMLOutlierCheckDestroy(&outlier),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_outlier_detector/mad.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_outlier_detector/mad.tf", map[string]string{
+					"My MAD outlier detector": "MAD " + randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLOutlierCheckExists("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", &outlier),
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "name", "My MAD outlier detector"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "name", "MAD "+randomName),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "metric", "tf_test_mad_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "datasource_type", "prometheus"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_mad_outlier_detector", "datasource_uid", "AbCd12345"),
@@ -37,10 +42,12 @@ func TestAccResourceOutlierDetector(t *testing.T) {
 				),
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_machine_learning_outlier_detector/dbscan.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_outlier_detector/dbscan.tf", map[string]string{
+					"My DBSCAN outlier detector": "DBSCAN " + randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "id"),
-					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "name", "My DBSCAN outlier detector"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "name", "DBSCAN "+randomName),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "metric", "tf_test_dbscan_job"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "datasource_type", "prometheus"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_outlier_detector.my_dbscan_outlier_detector", "datasource_id", "12"),

--- a/internal/resources/slo/data_source_slo_test.go
+++ b/internal/resources/slo/data_source_slo_test.go
@@ -5,11 +5,14 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceSlo(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	randomName := acctest.RandomWithPrefix("SLO Terraform Testing")
 
 	var slo gapi.Slo
 	resource.ParallelTest(t, resource.TestCase{
@@ -18,22 +21,26 @@ func TestAccDataSourceSlo(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Creates a SLO Resource
-				Config: testutils.TestAccExample(t, "resources/grafana_slo/resource.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_slo/resource.tf", map[string]string{
+					"Terraform Testing": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSloCheckExists("grafana_slo.test", &slo),
 					resource.TestCheckResourceAttrSet("grafana_slo.test", "id"),
-					resource.TestCheckResourceAttr("grafana_slo.test", "name", "Terraform Testing"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_slo.test", "description", "Terraform Description"),
 				),
 			},
 			{
 				// Verifies that the created SLO Resource is read by the Datasource Read Method
-				Config: testutils.TestAccExample(t, "data-sources/grafana_slos/data-source.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_slos/data-source.tf", map[string]string{
+					"Terraform Testing": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 
 					resource.TestCheckResourceAttrSet("data.grafana_slos.slos", "slos.0.uuid"),
-					resource.TestCheckResourceAttr("data.grafana_slos.slos", "slos.0.name", "Terraform Testing"),
-					resource.TestCheckResourceAttr("data.grafana_slos.slos", "slos.0.description", "Terraform Description"),
+					resource.TestCheckResourceAttrSet("data.grafana_slos.slos", "slos.0.name"),
+					resource.TestCheckResourceAttrSet("data.grafana_slos.slos", "slos.0.description"),
 				),
 			},
 		},

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -8,12 +8,15 @@ import (
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccResourceSlo(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	randomName := acctest.RandomWithPrefix("SLO Terraform Testing")
 
 	var slo gapi.Slo
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,11 +26,13 @@ func TestAccResourceSlo(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Tests Create
-				Config: testutils.TestAccExample(t, "resources/grafana_slo/resource.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_slo/resource.tf", map[string]string{
+					"Terraform Testing": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSloCheckExists("grafana_slo.test", &slo),
 					resource.TestCheckResourceAttrSet("grafana_slo.test", "id"),
-					resource.TestCheckResourceAttr("grafana_slo.test", "name", "Terraform Testing"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_slo.test", "description", "Terraform Description"),
 					resource.TestCheckResourceAttr("grafana_slo.test", "query.0.type", "freeform"),
 					resource.TestCheckResourceAttr("grafana_slo.test", "query.0.freeform.0.query", "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"),
@@ -37,11 +42,13 @@ func TestAccResourceSlo(t *testing.T) {
 			},
 			{
 				// Tests Update
-				Config: testutils.TestAccExample(t, "resources/grafana_slo/resource_update.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_slo/resource_update.tf", map[string]string{
+					"Terraform Testing": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSloCheckExists("grafana_slo.update", &slo),
 					resource.TestCheckResourceAttrSet("grafana_slo.update", "id"),
-					resource.TestCheckResourceAttr("grafana_slo.update", "name", "Updated - Terraform Testing"),
+					resource.TestCheckResourceAttr("grafana_slo.update", "name", "Updated - "+randomName),
 					resource.TestCheckResourceAttr("grafana_slo.update", "description", "Updated - Terraform Description"),
 					resource.TestCheckResourceAttr("grafana_slo.update", "query.0.type", "freeform"),
 					resource.TestCheckResourceAttr("grafana_slo.update", "query.0.freeform.0.query", "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"),
@@ -51,22 +58,22 @@ func TestAccResourceSlo(t *testing.T) {
 			},
 			{
 				// Tests that No Alerting Rules are Generated when No Alerting Field is defined on the Terraform State File
-				Config: noAlert,
+				Config: noAlert(randomName + " - No Alerting Check"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSloCheckExists("grafana_slo.no_alert", &slo),
 					testAlertingExists(false, "grafana_slo.no_alert", &slo),
 					resource.TestCheckResourceAttrSet("grafana_slo.no_alert", "id"),
-					resource.TestCheckResourceAttr("grafana_slo.no_alert", "name", "No Alerting Check - does not generate Alerts"),
+					resource.TestCheckResourceAttr("grafana_slo.no_alert", "name", randomName+" - No Alerting Check"),
 				),
 			},
 			{
 				// Tests that Alerting Rules are Generated when an Empty Alerting Field is defined on the Terraform State File
-				Config: emptyAlert,
+				Config: emptyAlert(randomName + " - Empty Alerting Check"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccSloCheckExists("grafana_slo.empty_alert", &slo),
 					testAlertingExists(true, "grafana_slo.empty_alert", &slo),
 					resource.TestCheckResourceAttrSet("grafana_slo.empty_alert", "id"),
-					resource.TestCheckResourceAttr("grafana_slo.empty_alert", "name", "Empty Alerting Check - generates Alerts"),
+					resource.TestCheckResourceAttr("grafana_slo.empty_alert", "name", randomName+" - Empty Alerting Check"),
 				),
 			},
 			{
@@ -157,28 +164,31 @@ resource  "grafana_slo" "invalid" {
 }
 `
 
-const emptyAlert = `
-resource "grafana_slo" "empty_alert" {
-  description = "Empty Alerting Check - generates Alerts"
-  name        = "Empty Alerting Check - generates Alerts"
-  objectives {
-    value  = 0.995
-    window = "28d"
-  }
-  query {
-    type = "freeform"
-    freeform {
-      query = "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"
-    }
-  }
-  alerting {}
+func emptyAlert(name string) string {
+	return fmt.Sprintf(`
+	resource "grafana_slo" "empty_alert" {
+	  description = "%[1]s"
+	  name        = "%[1]s"
+	  objectives {
+		value  = 0.995
+		window = "28d"
+	  }
+	  query {
+		type = "freeform"
+		freeform {
+		  query = "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"
+		}
+	  }
+	  alerting {}
+	}
+	`, name)
 }
-`
 
-const noAlert = `
+func noAlert(name string) string {
+	return fmt.Sprintf(`
 resource "grafana_slo" "no_alert" {
-  description = "No Alerting Check - does not generate Alerts"
-  name        = "No Alerting Check - does not generate Alerts"
+	description = "%[1]s"
+	name        = "%[1]s"
   objectives {
     value  = 0.995
     window = "28d"
@@ -190,7 +200,8 @@ resource "grafana_slo" "no_alert" {
     }
   }
 }
-`
+`, name)
+}
 
 func TestAccResourceInvalidSlo(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)

--- a/internal/resources/syntheticmonitoring/resource_probe_test.go
+++ b/internal/resources/syntheticmonitoring/resource_probe_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -16,16 +17,19 @@ import (
 func TestAccResourceProbe(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	// TODO: Make parallelizable
-	resource.Test(t, resource.TestCase{
+	randomName := acctest.RandomWithPrefix("My Probe")
+
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_probe/resource.tf", map[string]string{
+					"Mount Everest": randomName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", "Mount Everest"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "latitude", "27.986059188842773"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "longitude", "86.92262268066406"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "region", "APAC"),
@@ -34,11 +38,13 @@ func TestAccResourceProbe(t *testing.T) {
 				),
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource_update.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_probe/resource_update.tf", map[string]string{
+					"Mauna Loa": randomName + " Updated",
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", "Mauna Loa"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", randomName+" Updated"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "latitude", "19.479480743408203"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "longitude", "-155.60281372070312"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "region", "AMER"),
@@ -54,11 +60,16 @@ func TestAccResourceProbe(t *testing.T) {
 func TestAccResourceProbe_recreate(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	randomName := acctest.RandomWithPrefix("My Probe")
+	config := testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_probe/resource.tf", map[string]string{
+		"Mount Everest": randomName,
+	})
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Config: config,
 				Check: func(s *terraform.State) error {
 					rs := s.RootModule().Resources["grafana_synthetic_monitoring_probe.main"]
 					id, _ := strconv.ParseInt(rs.Primary.ID, 10, 64)
@@ -67,11 +78,11 @@ func TestAccResourceProbe_recreate(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_synthetic_monitoring_probe/resource.tf"),
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_probe.main", "auth_token"),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", "Mount Everest"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "name", randomName),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "latitude", "27.986059188842773"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "longitude", "86.92262268066406"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_probe.main", "region", "APAC"),


### PR DESCRIPTION
Whenever cloud instance checks get cancelled, future builds fail because of dangling resources 
This PR makes all of those tests use random names so that runs do not conflict