### PR TITLE
Team: Migrate to generated OpenAPI client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/grafana/amixr-api-go-client v0.0.10
 	github.com/grafana/grafana-api-golang-client v0.24.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231027173713-f32301dd8933
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231031181526-6f78415901a3
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.18.3
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/grafana/amixr-api-go-client v0.0.10 h1:L2Wc1aETiG7ORqmB+XSCBJdncHM/V0
 github.com/grafana/amixr-api-go-client v0.0.10/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.24.0 h1:9cUvft7xCMnnL/Uscwy7eoldn16Gz5TH4T1MymuVs8E=
 github.com/grafana/grafana-api-golang-client v0.24.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231027173713-f32301dd8933 h1:f9T8CpjLy13ADmBeE3W6Lj+FWaDYBNb+f/MU33/cUig=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231027173713-f32301dd8933/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231031181526-6f78415901a3 h1:jZrhPmoUBL+kwwV5e2AIalKnxV0VW/e0QZ7aHP7Zg3c=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231031181526-6f78415901a3/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.18.3 h1:yPCWz7YFP7NU2rlZ5WPnEcZXWD8OnrGdNjRLsUZUgsw=

--- a/internal/resources/grafana/data_source_team.go
+++ b/internal/resources/grafana/data_source_team.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 
+	"github.com/grafana/grafana-openapi-client-go/client/teams"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,12 +35,15 @@ func DatasourceTeam() *schema.Resource {
 }
 
 func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _ := ClientFromNewOrgResource(meta, d)
+	client, _ := OAPIClientFromNewOrgResource(meta, d)
 	name := d.Get("name").(string)
-	searchTeam, err := client.SearchTeam(name)
+
+	params := teams.NewSearchTeamsParams().WithName(&name)
+	resp, err := client.Teams.SearchTeams(params, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	searchTeam := resp.GetPayload()
 
 	for _, r := range searchTeam.Teams {
 		if r.Name == name {

--- a/internal/resources/grafana/zzz_deprecated_resource_team_external_group.go
+++ b/internal/resources/grafana/zzz_deprecated_resource_team_external_group.go
@@ -112,6 +112,7 @@ func manageTeamExternalGroup(client *goapi.GrafanaHTTPAPI, teamID int64, d *sche
 	}
 
 	for _, group := range removeGroups {
+		group := group
 		// Post 10.2, the group is a query param
 		params := teamsSync.NewRemoveTeamGroupAPIQueryParams().WithTeamID(teamID).WithGroupID(&group)
 		_, newAPIErr := client.SyncTeamGroups.RemoveTeamGroupAPIQuery(params, nil)

--- a/internal/resources/grafana/zzz_deprecated_resource_team_external_group.go
+++ b/internal/resources/grafana/zzz_deprecated_resource_team_external_group.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	teamsSync "github.com/grafana/grafana-openapi-client-go/client/sync_team_groups"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -54,7 +56,7 @@ func CreateTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta i
 	orgID, teamIDStr := SplitOrgResourceID(d.Get("team_id").(string))
 	teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
 	d.SetId(MakeOrgResourceID(orgID, teamID))
-	client, _, _ := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, _ := OAPIClientFromExistingOrgResource(meta, d.Id())
 
 	if err := manageTeamExternalGroup(client, teamID, d, "groups"); err != nil {
 		return diag.FromErr(err)
@@ -64,13 +66,15 @@ func CreateTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func ReadTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, orgID, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 	teamID, _ := strconv.ParseInt(idStr, 10, 64)
 
-	teamGroups, err := client.TeamGroups(teamID)
+	params := teamsSync.NewGetTeamGroupsAPIParams().WithTeamID(teamID)
+	resp, err := client.SyncTeamGroups.GetTeamGroupsAPI(params, nil)
 	if err, shouldReturn := common.CheckReadError("team groups", d, err); shouldReturn {
 		return err
 	}
+	teamGroups := resp.GetPayload()
 
 	groupIDs := make([]string, 0, len(teamGroups))
 	for _, teamGroup := range teamGroups {
@@ -84,7 +88,7 @@ func ReadTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func UpdateTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 	teamID, _ := strconv.ParseInt(idStr, 10, 64)
 
 	if err := manageTeamExternalGroup(client, teamID, d, "groups"); err != nil {
@@ -94,19 +98,21 @@ func UpdateTeamExternalGroup(ctx context.Context, d *schema.ResourceData, meta i
 	return ReadTeamExternalGroup(ctx, d, meta)
 }
 
-func manageTeamExternalGroup(client *gapi.Client, teamID int64, d *schema.ResourceData, groupsAttr string) error {
+func manageTeamExternalGroup(client *goapi.GrafanaHTTPAPI, teamID int64, d *schema.ResourceData, groupsAttr string) error {
 	addGroups, removeGroups := groupChangesTeamExternalGroup(d, groupsAttr)
 
 	for _, group := range addGroups {
-		err := client.NewTeamGroup(teamID, group)
-		if err != nil {
+		params := teamsSync.NewAddTeamGroupAPIParams().WithTeamID(teamID).WithBody(&models.TeamGroupMapping{
+			GroupID: group,
+		})
+		if _, err := client.SyncTeamGroups.AddTeamGroupAPI(params, nil); err != nil {
 			return fmt.Errorf("error adding group %s to team %d: %w", group, teamID, err)
 		}
 	}
 
 	for _, group := range removeGroups {
-		err := client.DeleteTeamGroup(teamID, group)
-		if err != nil {
+		params := teamsSync.NewRemoveTeamGroupAPIParams().WithTeamID(teamID).WithGroupID(group)
+		if _, err := client.SyncTeamGroups.RemoveTeamGroupAPI(params, nil); err != nil {
 			return fmt.Errorf("error removing group %s from team %d: %w", group, teamID, err)
 		}
 	}


### PR DESCRIPTION
Hoping this will fix the issues with Grafana 10.2, seems like the old client is broken for the team sync resource/attribute
**Tests are unmodified, so everything works the same as before**