### PR TITLE
CI: Run tests on sub-pathed Grafana

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -44,19 +44,21 @@ jobs:
         version: ['10.2.0', '10.1.5', '9.5.13', '8.5.27']
         with_enterprise_license: [false]
         with_tls_proxy: [false]
+        with_subpath: [false]
         runner: ['ubuntu-latest-16-cores']
         include:
           # TLS proxy tests, run only on latest version
           - version: '10.2.0'
-            with_enterprise_license: false
             with_tls_proxy: true
-            runner: 'ubuntu-latest' # Smaller instance for TLS proxy tests
+            runner: 'ubuntu-latest' # Smaller instance
+          # Sub-path tests. Runs tests on localhost:3000/grafana/
+          - version: '10.2.0'
+            with_subpath: true
           # Enterprise tests, run only on latest version
           - version: '10.2.0'
             with_enterprise_license: true
-            with_tls_proxy: false
-            runner: 'ubuntu-latest' # Smaller instance for TLS proxy tests
-    name: ${{ matrix.version }}${{ matrix.with_enterprise_license && ' - Enterprise' || '' }}${{ matrix.with_tls_proxy && ' - TLS Proxy' || '' }}
+            runner: 'ubuntu-latest' # Smaller instance
+    name: ${{ matrix.version }}${{ matrix.with_enterprise_license && ' - Enterprise' || '' }}${{ matrix.with_tls_proxy && ' - TLS Proxy' || '' }}${{ matrix.with_subpath && ' - Subpath' || '' }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +75,7 @@ jobs:
         with:
           repo_secrets: |
             GF_ENTERPRISE_LICENSE_TEXT=enterprise:license
-      - run: make testacc-${{ matrix.with_enterprise_license && 'enterprise' || 'oss' }}-docker${{ matrix.with_tls_proxy && '-tls' || '' }}
+      - run: make testacc-${{ matrix.with_enterprise_license && 'enterprise' || 'oss' }}-docker${{ matrix.with_tls_proxy && '-tls' || '' }}${{ matrix.with_subpath && '-subpath' || '' }}
         env:
           GRAFANA_VERSION: ${{ matrix.version }}
           TESTARGS: ${{ matrix.with_tls_proxy && '-run ".*_basic"' || '' }} # Run subset of tests for TLS proxy, it's slower

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -40,25 +40,24 @@ jobs:
     strategy:
       fail-fast: false # Let all versions run, even if one fails
       matrix:
-          # OSS tests, run on all versions
+        # OSS tests, run on all versions
         version: ['10.2.0', '10.1.5', '9.5.13', '8.5.27']
-        with_enterprise_license: [false]
-        with_tls_proxy: [false]
-        with_subpath: [false]
+        type: ['oss']
         runner: ['ubuntu-latest-16-cores']
         include:
           # TLS proxy tests, run only on latest version
           - version: '10.2.0'
-            with_tls_proxy: true
+            type: 'tls'
             runner: 'ubuntu-latest' # Smaller instance
           # Sub-path tests. Runs tests on localhost:3000/grafana/
           - version: '10.2.0'
-            with_subpath: true
+            type: 'subpath'
+            runner: 'ubuntu-latest-16-cores'
           # Enterprise tests, run only on latest version
           - version: '10.2.0'
-            with_enterprise_license: true
+            type: 'enterprise'
             runner: 'ubuntu-latest' # Smaller instance
-    name: ${{ matrix.version }}${{ matrix.with_enterprise_license && ' - Enterprise' || '' }}${{ matrix.with_tls_proxy && ' - TLS Proxy' || '' }}${{ matrix.with_subpath && ' - Subpath' || '' }}
+    name: ${{ matrix.version }} - ${{ matrix.type }}
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -71,11 +70,11 @@ jobs:
           version: '2.23.0'
       - name: Get Enterprise License
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        if: matrix.with_enterprise_license
+        if: matrix.type == 'enterprise'
         with:
           repo_secrets: |
             GF_ENTERPRISE_LICENSE_TEXT=enterprise:license
-      - run: make testacc-${{ matrix.with_enterprise_license && 'enterprise' || 'oss' }}-docker${{ matrix.with_tls_proxy && '-tls' || '' }}${{ matrix.with_subpath && '-subpath' || '' }}
+      - run: make testacc-${{ matrix.type }}-docker
         env:
           GRAFANA_VERSION: ${{ matrix.version }}
-          TESTARGS: ${{ matrix.with_tls_proxy && '-run ".*_basic"' || '' }} # Run subset of tests for TLS proxy, it's slower
+          TESTARGS: ${{ matrix.type == 'tls' && '-run ".*_basic"' || '' }} # Run subset of tests for TLS proxy, it's slower

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@ testacc-oss-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://$$(docker compose port grafana 3000)" \
+	GRAFANA_URL="http://localhost:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-oss
 
@@ -33,7 +33,7 @@ testacc-enterprise-docker:
 	GRAFANA_IMAGE=grafana/grafana-enterprise GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://$$(docker compose port grafana 3000)" \
+	GRAFANA_URL="http://localhost:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-enterprise
 
@@ -44,7 +44,7 @@ testacc-oss-docker-tls:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose --profile tls up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="https://$$(docker compose port mtls-proxy 3001)" \
+	GRAFANA_URL="https://localhost:3001" \
 	GRAFANA_AUTH="admin:admin" \
 	GRAFANA_TLS_KEY=$$(pwd)/testdata/client.key \
     GRAFANA_TLS_CERT=$$(pwd)/testdata/client.crt \
@@ -52,6 +52,16 @@ testacc-oss-docker-tls:
 	make testacc-oss
 
 	docker compose --profile tls down
+
+testacc-oss-docker-subpath:
+	GRAFANA_VERSION=$(GRAFANA_VERSION) GRAFANA_SUBPATH=/grafana/ GF_SERVER_SERVE_FROM_SUB_PATH=true docker compose up --force-recreate --detach --remove-orphans --wait
+
+	GRAFANA_VERSION=$(GRAFANA_VERSION) \
+	GRAFANA_URL="http://localhost:3000/grafana" \
+	GRAFANA_AUTH="admin:admin" \
+	make testacc-oss
+
+	docker compose down
 
 release:
 	@test $${RELEASE_VERSION?Please set environment variable RELEASE_VERSION}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,7 +39,7 @@ testacc-enterprise-docker:
 
 	docker compose down
 
-testacc-oss-docker-tls:
+testacc-tls-docker:
 	make -C testdata generate
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose --profile tls up --force-recreate --detach --remove-orphans --wait
 
@@ -53,7 +53,7 @@ testacc-oss-docker-tls:
 
 	docker compose --profile tls down
 
-testacc-oss-docker-subpath:
+testacc-subpath-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) GRAFANA_SUBPATH=/grafana/ GF_SERVER_SERVE_FROM_SUB_PATH=true docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@ testacc-oss-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://localhost:3000" \
+	GRAFANA_URL="http://127.0.0.1:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-oss
 
@@ -33,7 +33,7 @@ testacc-enterprise-docker:
 	GRAFANA_IMAGE=grafana/grafana-enterprise GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://localhost:3000" \
+	GRAFANA_URL="http://127.0.0.1:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-enterprise
 
@@ -44,7 +44,7 @@ testacc-tls-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose --profile tls up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="https://localhost:3001" \
+	GRAFANA_URL="https://127.0.0.1:3001" \
 	GRAFANA_AUTH="admin:admin" \
 	GRAFANA_TLS_KEY=$$(pwd)/testdata/client.key \
     GRAFANA_TLS_CERT=$$(pwd)/testdata/client.crt \
@@ -57,7 +57,7 @@ testacc-subpath-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) GRAFANA_SUBPATH=/grafana/ GF_SERVER_SERVE_FROM_SUB_PATH=true docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://localhost:3000/grafana" \
+	GRAFANA_URL="http://127.0.0.1:3000/grafana" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-oss
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@ testacc-oss-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://127.0.0.1:3000" \
+	GRAFANA_URL="http://0.0.0.0:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-oss
 
@@ -33,7 +33,7 @@ testacc-enterprise-docker:
 	GRAFANA_IMAGE=grafana/grafana-enterprise GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://127.0.0.1:3000" \
+	GRAFANA_URL="http://0.0.0.0:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-enterprise
 
@@ -44,7 +44,7 @@ testacc-tls-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) docker compose --profile tls up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="https://127.0.0.1:3001" \
+	GRAFANA_URL="http://0.0.0.0:3000" \
 	GRAFANA_AUTH="admin:admin" \
 	GRAFANA_TLS_KEY=$$(pwd)/testdata/client.key \
     GRAFANA_TLS_CERT=$$(pwd)/testdata/client.crt \
@@ -57,7 +57,7 @@ testacc-subpath-docker:
 	GRAFANA_VERSION=$(GRAFANA_VERSION) GRAFANA_SUBPATH=/grafana/ GF_SERVER_SERVE_FROM_SUB_PATH=true docker compose up --force-recreate --detach --remove-orphans --wait
 
 	GRAFANA_VERSION=$(GRAFANA_VERSION) \
-	GRAFANA_URL="http://127.0.0.1:3000/grafana" \
+	GRAFANA_URL="http://0.0.0.0:3000/grafana" \
 	GRAFANA_AUTH="admin:admin" \
 	make testacc-oss
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       - 3000:3000
     image: ${GRAFANA_IMAGE:-grafana/grafana}:${GRAFANA_VERSION}
     environment:
-      - GF_SERVER_ROOT_URL=http://127.0.0.1:3000${GRAFANA_SUBPATH:-}
+      - GF_SERVER_ROOT_URL=http://0.0.0.0:3000${GRAFANA_SUBPATH:-}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
       - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:3000${GRAFANA_SUBPATH:-}/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000${GRAFANA_SUBPATH:-}/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s
       retries: 10
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       - 3000:3000
     image: ${GRAFANA_IMAGE:-grafana/grafana}:${GRAFANA_VERSION}
     environment:
-      - GF_SERVER_ROOT_URL=http://0.0.0.0:3000${GRAFANA_SUBPATH:-}
+      - GF_SERVER_ROOT_URL=http://127.0.0.1:3000${GRAFANA_SUBPATH:-}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
       - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000${GRAFANA_SUBPATH:-}/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:3000${GRAFANA_SUBPATH:-}/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s
       retries: 10
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,14 @@ version: '3'
 services:
   grafana:
     ports:
-      - 3000
+      - 3000:3000
     image: ${GRAFANA_IMAGE:-grafana/grafana}:${GRAFANA_VERSION}
     environment:
-      - GF_SERVER_ROOT_URL=http://0.0.0.0:3000
+      - GF_SERVER_ROOT_URL=http://0.0.0.0:3000${GRAFANA_SUBPATH:-}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
+      - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000${GRAFANA_SUBPATH:-}/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s
       retries: 10
       start_period: 10s
@@ -30,5 +31,4 @@ services:
     volumes:
       - ./testdata:/certs
     ports:
-      - 3001
-  
+      - 3001:3001

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"net/url"
+	"strings"
 	"sync"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
@@ -11,10 +13,11 @@ import (
 )
 
 type Client struct {
-	GrafanaAPIURL    string
-	GrafanaAPIConfig *gapi.Config
-	GrafanaAPI       *gapi.Client
-	GrafanaCloudAPI  *gapi.Client
+	GrafanaAPIURL       string
+	GrafanaAPIURLParsed *url.URL
+	GrafanaAPIConfig    *gapi.Config
+	GrafanaAPI          *gapi.Client
+	GrafanaCloudAPI     *gapi.Client
 
 	GrafanaOAPI *goapi.GrafanaHTTPAPI
 
@@ -25,4 +28,9 @@ type Client struct {
 	OnCallClient *onCallAPI.Client
 
 	AlertingMutex sync.Mutex
+}
+
+func (c *Client) GrafanaSubpath(path string) string {
+	path = strings.TrimPrefix(path, c.GrafanaAPIURLParsed.Path)
+	return c.GrafanaAPIURLParsed.JoinPath(path).String()
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -331,6 +331,9 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			if err != nil {
 				return nil, diag.FromErr(err)
 			}
+			if c.GrafanaAPIURLParsed, err = url.Parse(c.GrafanaAPIURL); err != nil {
+				return nil, diag.FromErr(err)
+			}
 			c.GrafanaOAPI, err = createGrafanaOAPIClient(c.GrafanaAPIURL, d)
 			if err != nil {
 				return nil, diag.FromErr(err)

--- a/internal/resources/grafana/data_source_dashboard.go
+++ b/internal/resources/grafana/data_source_dashboard.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -96,7 +95,7 @@ func findDashboardWithID(client *gapi.Client, id int64) (*gapi.FolderDashboardSe
 }
 
 func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	gapiURL := meta.(*common.Client).GrafanaAPIURL
+	metaClient := meta.(*common.Client)
 	var dashboard *gapi.Dashboard
 	client := meta.(*common.Client).GrafanaAPI
 
@@ -129,7 +128,7 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("folder", dashboard.FolderID)
 	d.Set("is_starred", dashboard.Meta.IsStarred)
 	d.Set("slug", dashboard.Meta.Slug)
-	d.Set("url", strings.TrimRight(gapiURL, "/")+dashboard.Meta.URL)
+	d.Set("url", metaClient.GrafanaSubpath(dashboard.Meta.URL))
 
 	return nil
 }

--- a/internal/resources/grafana/data_source_folder.go
+++ b/internal/resources/grafana/data_source_folder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -61,7 +60,7 @@ func findFolderWithTitle(client *gapi.Client, title string) (*gapi.Folder, error
 }
 
 func dataSourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	gapiURL := meta.(*common.Client).GrafanaAPIURL
+	metaClient := meta.(*common.Client)
 	client := meta.(*common.Client).GrafanaAPI
 	title := d.Get("title").(string)
 	folder, err := findFolderWithTitle(client, title)
@@ -74,7 +73,7 @@ func dataSourceFolderRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.SetId(id)
 	d.Set("uid", folder.UID)
 	d.Set("title", folder.Title)
-	d.Set("url", strings.TrimRight(gapiURL, "/")+folder.URL)
+	d.Set("url", metaClient.GrafanaSubpath(folder.URL))
 
 	return nil
 }

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -110,7 +109,7 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 }
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	gapiURL := meta.(*common.Client).GrafanaAPIURL
+	metaClient := meta.(*common.Client)
 	client, orgID, uid := ClientFromExistingOrgResource(meta, d.Id())
 
 	dashboard, err := client.DashboardByUID(uid)
@@ -123,7 +122,7 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 	d.Set("uid", dashboard.Model["uid"].(string))
 	d.Set("dashboard_id", int64(dashboard.Model["id"].(float64)))
 	d.Set("version", int64(dashboard.Model["version"].(float64)))
-	d.Set("url", strings.TrimRight(gapiURL, "/")+dashboard.Meta.URL)
+	d.Set("url", metaClient.GrafanaSubpath(dashboard.Meta.URL))
 
 	// If the folder was originally set to a numeric ID, we read the folder ID
 	// Othwerwise, we read the folder UID

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
-	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	goapi "github.com/grafana/grafana-openapi-client-go/client/folders"
@@ -110,7 +109,7 @@ func UpdateFolder(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	gapiURL := meta.(*common.Client).GrafanaAPIURL
+	metaClient := meta.(*common.Client)
 	client, orgID, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 
 	folder, err := GetFolderByIDorUID(client.Folders, idStr)
@@ -122,7 +121,7 @@ func ReadFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	d.Set("org_id", strconv.FormatInt(orgID, 10))
 	d.Set("title", folder.Title)
 	d.Set("uid", folder.UID)
-	d.Set("url", strings.TrimRight(gapiURL, "/")+folder.URL)
+	d.Set("url", metaClient.GrafanaSubpath(folder.URL))
 
 	return nil
 }


### PR DESCRIPTION
Seems like some resources misbehave when Grafana is served from a subpath 
This adds the CI run for that case + fixes the resources where there are errors