### PR TITLE
Role tests: Use OpenAPI client

### DIFF
--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -6,6 +6,7 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/access_control"
 	"github.com/grafana/grafana-openapi-client-go/client/annotations"
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
@@ -53,6 +54,14 @@ var (
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.LibraryElementResponse, error) {
 			params := library_elements.NewGetLibraryElementByUIDParams().WithLibraryElementUID(id)
 			resp, err := client.LibraryElements.GetLibraryElementByUID(params, nil)
+			return payloadOrError(resp, err)
+		},
+	)
+	roleCheckExists = newCheckExistsHelper(
+		func(r *models.RoleDTO) string { return r.UID },
+		func(client *goapi.GrafanaHTTPAPI, id string) (*models.RoleDTO, error) {
+			params := access_control.NewGetRoleParams().WithRoleUID(id)
+			resp, err := client.AccessControl.GetRole(params, nil)
 			return payloadOrError(resp, err)
 		},
 	)

--- a/internal/resources/grafana/data_source_role_test.go
+++ b/internal/resources/grafana/data_source_role_test.go
@@ -3,7 +3,7 @@ package grafana_test
 import (
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -11,9 +11,9 @@ import (
 func TestAccDatasourceRole_basic(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t)
 
-	var role gapi.Role
+	var role models.RoleDTO
 	checks := []resource.TestCheckFunc{
-		testAccRoleCheckExists("grafana_role.test", &role),
+		roleCheckExists.exists("grafana_role.test", &role),
 		resource.TestCheckResourceAttr("data.grafana_role.from_name", "name", "test-role"),
 		resource.TestCheckResourceAttr("data.grafana_role.from_name", "description", "test-role description"),
 		resource.TestCheckResourceAttr("data.grafana_role.from_name", "uid", "test-ds-role-uid"),
@@ -30,7 +30,7 @@ func TestAccDatasourceRole_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccRoleCheckDestroy(&role),
+		CheckDestroy:      roleCheckExists.destroyed(&role, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_role/data-source.tf"),


### PR DESCRIPTION
Gets rid of the manually written checkers in favor of the new ones that use the OpenAPI client