### PR TITLE
Datasource tests: Use OpenAPI client

### DIFF
--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -7,6 +7,7 @@ import (
 	gapi "github.com/grafana/grafana-api-golang-client"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/annotations"
+	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/client/teams"
 	"github.com/grafana/grafana-openapi-client-go/client/users"
@@ -26,6 +27,14 @@ var (
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Annotation, error) {
 			params := annotations.NewGetAnnotationByIDParams().WithAnnotationID(id)
 			resp, err := client.Annotations.GetAnnotationByID(params, nil)
+			return payloadOrError(resp, err)
+		},
+	)
+	datasourceCheckExists = newCheckExistsHelper(
+		func(d *models.DataSource) string { return strconv.FormatInt(d.ID, 10) },
+		func(client *goapi.GrafanaHTTPAPI, id string) (*models.DataSource, error) {
+			params := datasources.NewGetDataSourceByIDParams().WithID(id)
+			resp, err := client.Datasources.GetDataSourceByID(params, nil)
 			return payloadOrError(resp, err)
 		},
 	)

--- a/internal/resources/grafana/data_source_data_source_test.go
+++ b/internal/resources/grafana/data_source_data_source_test.go
@@ -3,7 +3,7 @@ package grafana_test
 import (
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -11,9 +11,9 @@ import (
 func TestAccDatasourceDatasource_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var dataSource gapi.DataSource
+	var dataSource models.DataSource
 	checks := []resource.TestCheckFunc{
-		testAccDataSourceCheckExists("grafana_data_source.prometheus", &dataSource),
+		datasourceCheckExists.exists("grafana_data_source.prometheus", &dataSource),
 
 		resource.TestMatchResourceAttr("data.grafana_data_source.from_name", "id", defaultOrgIDRegexp),
 		resource.TestCheckResourceAttr("data.grafana_data_source.from_name", "name", "prometheus-ds-test"),
@@ -33,7 +33,7 @@ func TestAccDatasourceDatasource_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccDataSourceCheckDestroy(&dataSource, 0),
+		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_data_source/data-source.tf"),


### PR DESCRIPTION
Gets rid of the manually written checkers in favor of the new ones that use the OpenAPI client