### PR TITLE
Org tests: Use OpenAPI client

### DIFF
--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strconv"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/access_control"
 	"github.com/grafana/grafana-openapi-client-go/client/annotations"
 	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/client/library_elements"
+	"github.com/grafana/grafana-openapi-client-go/client/orgs"
 	"github.com/grafana/grafana-openapi-client-go/client/playlists"
 	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
 	"github.com/grafana/grafana-openapi-client-go/client/teams"
@@ -55,6 +55,14 @@ var (
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.LibraryElementResponse, error) {
 			params := library_elements.NewGetLibraryElementByUIDParams().WithLibraryElementUID(id)
 			resp, err := client.LibraryElements.GetLibraryElementByUID(params, nil)
+			return payloadOrError(resp, err)
+		},
+	)
+	orgCheckExists = newCheckExistsHelper(
+		func(o *models.OrgDetailsDTO) string { return strconv.FormatInt(o.ID, 10) },
+		func(client *goapi.GrafanaHTTPAPI, id string) (*models.OrgDetailsDTO, error) {
+			params := orgs.NewGetOrgByIDParams().WithOrgID(mustParseInt64(id))
+			resp, err := client.Orgs.GetOrgByID(params, nil)
 			return payloadOrError(resp, err)
 		},
 	)
@@ -163,7 +171,7 @@ func (h *checkExistsHelper[T]) exists(rn string, v *T) resource.TestCheckFunc {
 
 // destroyed checks that the resource doesn't exist in the default org
 // For non-default orgs, we should only check that the org was destroyed
-func (h *checkExistsHelper[T]) destroyed(v *T, org *gapi.Org) resource.TestCheckFunc {
+func (h *checkExistsHelper[T]) destroyed(v *T, org *models.OrgDetailsDTO) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		var orgID int64 = 1
 		if org != nil {

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -160,7 +160,7 @@ func (h *checkExistsHelper[T]) exists(rn string, v *T) resource.TestCheckFunc {
 		}
 
 		// Sanity check: The "destroyed" function should fail here because the resource exists
-		if err := h.destroyed(obj, &gapi.Org{ID: orgID})(s); err == nil {
+		if err := h.destroyed(obj, &models.OrgDetailsDTO{ID: orgID})(s); err == nil {
 			return fmt.Errorf("the destroyed check passed but shouldn't for resource %s with ID %q. This is a bug in the test", rn, rs.Primary.ID)
 		}
 

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -184,7 +184,7 @@ func (h *checkExistsHelper[T]) destroyed(v *T, org *models.OrgDetailsDTO) resour
 		if err == nil {
 			return fmt.Errorf("%T %s still exists in org %d", v, id, orgID)
 		} else if !common.IsNotFoundError(err) {
-			return fmt.Errorf("error checking if resource %s exists in org %d: %s", id, orgID, err)
+			return fmt.Errorf("error checking if resource %s was destroyed in org %d: %s", id, orgID, err)
 		}
 		return nil
 	}

--- a/internal/resources/grafana/data_source_organization_test.go
+++ b/internal/resources/grafana/data_source_organization_test.go
@@ -3,7 +3,7 @@ package grafana_test
 import (
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -11,9 +11,9 @@ import (
 func TestAccDatasourceOrganization_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var organization gapi.Org
+	var org models.OrgDetailsDTO
 	checks := []resource.TestCheckFunc{
-		testAccOrganizationCheckExists("grafana_organization.test", &organization),
+		orgCheckExists.exists("grafana_organization.test", &org),
 		resource.TestCheckResourceAttr(
 			"data.grafana_organization.from_name", "name", "test-org",
 		),
@@ -40,7 +40,7 @@ func TestAccDatasourceOrganization_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&organization),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_organization/data-source.tf"),

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -217,7 +218,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var group gapi.RuleGroup
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -230,7 +231,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 				Config: testAccAlertRuleGroupInOrgConfig(name, 240),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.test", &group),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_rule_group.test", "grafana_organization.test"),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "name", name),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "interval_seconds", "240"),
@@ -243,7 +244,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 				Config: testAccAlertRuleGroupInOrgConfig(name, 360),
 				Check: resource.ComposeTestCheckFunc(
 					testRuleGroupCheckExists("grafana_rule_group.test", &group),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_rule_group.test", "grafana_organization.test"),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "name", name),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "interval_seconds", "360"),

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
-	goapi "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -20,7 +19,7 @@ var (
 func TestAccAnnotation_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Annotations don't work right in OSS Grafana < 9.0.0
 
-	var annotation goapi.Annotation
+	var annotation models.Annotation
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -55,7 +54,7 @@ func TestAccAnnotation_basic(t *testing.T) {
 func TestAccAnnotation_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Annotations don't work right in OSS Grafana < 9.0.0
 
-	var annotation goapi.Annotation
+	var annotation models.Annotation
 	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)
@@ -152,7 +151,7 @@ func TestAccAnnotation_inOrg(t *testing.T) {
 func TestAccAnnotation_dashboardUID(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
-	var annotation goapi.Annotation
+	var annotation models.Annotation
 	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	goapi "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 
@@ -56,7 +56,7 @@ func TestAccAnnotation_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Annotations don't work right in OSS Grafana < 9.0.0
 
 	var annotation goapi.Annotation
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)
 
@@ -81,7 +81,7 @@ func TestAccAnnotation_inOrg(t *testing.T) {
 
 					// Check that the annotation is in the correct organization
 					resource.TestMatchResourceAttr("grafana_annotation.test", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_annotation.test", "grafana_organization.test"),
 				),
 			},
@@ -108,7 +108,7 @@ func TestAccAnnotation_inOrg(t *testing.T) {
 
 					// Check that the annotation is in the correct organization
 					resource.TestMatchResourceAttr("grafana_annotation.test_with_dashboard_id", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_annotation.test_with_dashboard_id", "grafana_organization.test"),
 				),
 			},
@@ -135,7 +135,7 @@ func TestAccAnnotation_inOrg(t *testing.T) {
 
 					// Check that the annotation is in the correct organization
 					resource.TestMatchResourceAttr("grafana_annotation.test_with_panel_id", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_annotation.test_with_panel_id", "grafana_organization.test"),
 				),
 			},
@@ -153,7 +153,7 @@ func TestAccAnnotation_dashboardUID(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
 	var annotation goapi.Annotation
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)
 
@@ -178,7 +178,7 @@ func TestAccAnnotation_dashboardUID(t *testing.T) {
 
 					// Check that the annotation is in the correct organization
 					resource.TestMatchResourceAttr("grafana_annotation.test_with_dashboard_uid", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_annotation.test_with_dashboard_uid", "grafana_organization.test"),
 				),
 			},

--- a/internal/resources/grafana/resource_api_key_test.go
+++ b/internal/resources/grafana/resource_api_key_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -54,7 +54,7 @@ func TestAccGrafanaAuthKey_basic(t *testing.T) {
 func TestAccGrafanaAuthKey_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 	testName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -72,7 +72,7 @@ func TestAccGrafanaAuthKey_inOrg(t *testing.T) {
 
 					// Check that the API key is in the correct organization
 					resource.TestMatchResourceAttr("grafana_api_key.foo", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_api_key.foo", "grafana_organization.test"),
 				),
 			},

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	goapi "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
@@ -248,7 +249,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 
 	var dashboard gapi.Dashboard
 	var folder goapi.Folder
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)
 
@@ -262,7 +263,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 			{
 				Config: testAccDashboardInOrganization(orgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					// Check that the folder is in the correct organization
 					folderCheckExists.exists("grafana_folder.test", &folder),
 					resource.TestCheckResourceAttr("grafana_folder.test", "uid", "folder-"+orgName),

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -8,7 +8,6 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	goapi "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -167,7 +166,7 @@ func TestAccDashboard_folder(t *testing.T) {
 	uid := acctest.RandString(10)
 
 	var dashboard gapi.Dashboard
-	var folder goapi.Folder
+	var folder models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -206,7 +205,7 @@ func TestAccDashboard_folder_uid(t *testing.T) {
 	uid := acctest.RandString(10)
 
 	var dashboard gapi.Dashboard
-	var folder goapi.Folder
+	var folder models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
@@ -248,7 +247,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var dashboard gapi.Dashboard
-	var folder goapi.Folder
+	var folder models.Folder
 	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)
@@ -314,7 +313,7 @@ func testAccDashboardCheckExists(rn string, dashboard *gapi.Dashboard) resource.
 	}
 }
 
-func testAccDashboardCheckExistsInFolder(dashboard *gapi.Dashboard, folder *goapi.Folder) resource.TestCheckFunc {
+func testAccDashboardCheckExistsInFolder(dashboard *gapi.Dashboard, folder *models.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if dashboard.FolderID != folder.ID && folder.ID != 0 {
 			return fmt.Errorf("dashboard.Folder(%d) does not match folder.ID(%d)", dashboard.FolderID, folder.ID)
@@ -348,7 +347,7 @@ func testAccDashboardCheckDestroy(dashboard *gapi.Dashboard, orgID int64) resour
 	}
 }
 
-func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *goapi.Folder) resource.TestCheckFunc {
+func testAccDashboardFolderCheckDestroy(dashboard *gapi.Dashboard, folder *models.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 		_, err := client.DashboardByUID(dashboard.Model["uid"].(string))

--- a/internal/resources/grafana/resource_data_source_test.go
+++ b/internal/resources/grafana/resource_data_source_test.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -276,7 +275,7 @@ func TestAccDatasource_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var dataSource models.DataSource
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	orgName := acctest.RandString(10)
 
@@ -287,7 +286,7 @@ func TestAccDatasource_inOrg(t *testing.T) {
 			{
 				Config: testAccDatasourceInOrganization(orgName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 
 					// Check that the datasource is in the correct organization
 					datasourceCheckExists.exists("grafana_data_source.test", &dataSource),

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -19,7 +19,7 @@ func TestAccOrganization_basic(t *testing.T) {
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_basic,
@@ -73,7 +73,7 @@ func TestAccOrganization_users(t *testing.T) {
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_usersCreate,
@@ -149,7 +149,7 @@ func TestAccOrganization_roleNoneUser(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_usersCreate,
@@ -208,7 +208,7 @@ func TestAccOrganization_createManyUsers_longtest(t *testing.T) {
 	// Don't make this test parallel, it's already creating 1000+ users
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{Config: testAccOrganizationConfig_usersCreateMany_1},
 			{
@@ -219,7 +219,7 @@ func TestAccOrganization_createManyUsers_longtest(t *testing.T) {
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
 					resource.TestCheckResourceAttr(
-						"grafana_organization.test", "admins.#", "1024",
+						"grafana_organization.test", "viewers.#", "125",
 					),
 				),
 			},
@@ -235,7 +235,7 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_defaultAdminNormal,
@@ -296,7 +296,7 @@ func TestAccOrganization_externalUser(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_externalUser,
@@ -427,7 +427,7 @@ resource "grafana_organization" "test" {
 
 const testAccOrganizationConfig_usersCreateMany_1 = `
 resource "grafana_user" "users" {
-	count = 1024
+	count = 125
 
 	name     = "user-${count.index}"
 	email    = "user-${count.index}@example.com"
@@ -438,7 +438,7 @@ resource "grafana_user" "users" {
 
 const testAccOrganizationConfig_usersCreateMany_2 = `
 resource "grafana_user" "users" {
-	count = 1024
+	count = 125
 
 	name     = "user-${count.index}"
 	email    = "user-${count.index}@example.com"
@@ -450,6 +450,6 @@ resource "grafana_organization" "test" {
     name         = "terraform-acc-test"
     admin_user   = "admin"
     create_users = false
-    admins       = [ for user in grafana_user.users : user.email ]
+    viewers      = [ for user in grafana_user.users : user.email ]
 }
 `

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -2,10 +2,9 @@ package grafana_test
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,17 +14,17 @@ import (
 func TestAccOrganization_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -40,7 +39,7 @@ func TestAccOrganization_basic(t *testing.T) {
 			{
 				Config: testAccOrganizationConfig_updateName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test-update",
 					),
@@ -69,17 +68,17 @@ func TestAccOrganization_basic(t *testing.T) {
 func TestAccOrganization_users(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_usersCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -100,7 +99,7 @@ func TestAccOrganization_users(t *testing.T) {
 			{
 				Config: testAccOrganizationConfig_usersUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -121,7 +120,7 @@ func TestAccOrganization_users(t *testing.T) {
 			{
 				Config: testAccOrganizationConfig_usersRemove,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -146,16 +145,16 @@ func TestAccOrganization_users(t *testing.T) {
 func TestAccOrganization_roleNoneUser(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=10.2.0")
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_usersCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "admins.#", "1",
 					),
@@ -164,7 +163,7 @@ func TestAccOrganization_roleNoneUser(t *testing.T) {
 			{
 				Config: testAccOrganization_roleNoneUsersUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -185,7 +184,7 @@ func TestAccOrganization_roleNoneUser(t *testing.T) {
 			{
 				Config: testAccOrganizationConfig_usersRemove,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "admins.#", "0",
 					),
@@ -204,18 +203,18 @@ func TestAccOrganization_createManyUsers_longtest(t *testing.T) {
 	}
 	testutils.CheckOSSTestsEnabled(t)
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	// Don't make this test parallel, it's already creating 1000+ users
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{Config: testAccOrganizationConfig_usersCreateMany_1},
 			{
 				Config: testAccOrganizationConfig_usersCreateMany_2,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -231,17 +230,17 @@ func TestAccOrganization_createManyUsers_longtest(t *testing.T) {
 func TestAccOrganization_defaultAdmin(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_defaultAdminNormal,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -262,7 +261,7 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 			{
 				Config: testAccOrganizationConfig_defaultAdminChange,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr(
 						"grafana_organization.test", "name", "terraform-acc-test",
 					),
@@ -293,16 +292,16 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 func TestAccOrganization_externalUser(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccOrganizationCheckDestroy(&org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_externalUser,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr("grafana_organization.test", "name", "terraform-acc-test-external-user"),
 					resource.TestCheckResourceAttr("grafana_organization.test", "admins.#", "1"),
 					resource.TestCheckResourceAttr("grafana_organization.test", "admins.0", "external-user@example.com"),
@@ -316,7 +315,7 @@ func TestAccOrganization_externalUser(t *testing.T) {
 			{
 				Config: testAccOrganizationConfig_externalUserRemoved,
 				Check: resource.ComposeTestCheckFunc(
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					resource.TestCheckResourceAttr("grafana_organization.test", "name", "terraform-acc-test-external-user"),
 					resource.TestCheckNoResourceAttr("grafana_organization.test", "admins.#"),
 					resource.TestCheckNoResourceAttr("grafana_organization.test", "editors.#"),
@@ -325,44 +324,6 @@ func TestAccOrganization_externalUser(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccOrganizationCheckExists(rn string, a *gapi.Org) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("resource not found: %s", rn)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("resource id not set")
-		}
-		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
-		if err != nil {
-			return fmt.Errorf("resource id is malformed")
-		}
-
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
-		org, err := client.Org(id)
-		if err != nil {
-			return fmt.Errorf("error getting data source: %s", err)
-		}
-
-		*a = org
-
-		return nil
-	}
-}
-
-func testAccOrganizationCheckDestroy(a *gapi.Org) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
-		org, err := client.Org(a.ID)
-		if err == nil && org.Name != "" {
-			return fmt.Errorf("organization still exists")
-		}
-		return nil
-	}
 }
 
 const testAccOrganizationConfig_basic = `

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/grafana-openapi-client-go/client/playlists"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
@@ -127,7 +126,7 @@ func TestAccPlaylist_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Querying org-specific playlists is broken pre-9
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 	var playlist models.Playlist
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -139,7 +138,7 @@ func TestAccPlaylist_inOrg(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Check that the playlist is in the correct organization
 					resource.TestMatchResourceAttr(paylistResource, "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg(paylistResource, "grafana_organization.test"),
 
 					playlistCheckExists.exists(paylistResource, &playlist),

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -129,7 +130,7 @@ func TestAccResourceReport_InOrg(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var report gapi.Report
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -144,7 +145,7 @@ func TestAccResourceReport_InOrg(t *testing.T) {
 
 					// Check that the dashboard is in the correct organization
 					resource.TestMatchResourceAttr("grafana_report.test", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_report.test", "grafana_organization.test"),
 				),
 			},

--- a/internal/resources/grafana/resource_role_assignment_test.go
+++ b/internal/resources/grafana/resource_role_assignment_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 )
@@ -52,7 +53,7 @@ func TestAccRoleAssignments(t *testing.T) {
 func TestAccRoleAssignments_inOrg(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t)
 	var roleAssignment gapi.RoleAssignments
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 
 	testName := acctest.RandString(10)
 
@@ -80,7 +81,7 @@ func TestAccRoleAssignments_inOrg(t *testing.T) {
 					// Check that the role is in the correct organization
 					resource.TestMatchResourceAttr("grafana_role.test", "id", nonDefaultOrgIDRegexp),
 					resource.TestMatchResourceAttr("grafana_role_assignment.test", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_role.test", "grafana_organization.test"),
 					checkResourceIsInOrg("grafana_role_assignment.test", "grafana_organization.test"),
 				),

--- a/internal/resources/grafana/resource_service_account_token_test.go
+++ b/internal/resources/grafana/resource_service_account_token_test.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -55,7 +54,7 @@ func TestAccServiceAccountToken_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	name := acctest.RandString(10)
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 	var sa models.ServiceAccountDTO
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -76,7 +75,7 @@ func TestAccServiceAccountToken_inOrg(t *testing.T) {
 
 					// Check that the service account is in the correct organization
 					resource.TestMatchResourceAttr("grafana_service_account.test", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_service_account.test", "grafana_organization.test"),
 				),
 			},
@@ -91,7 +90,7 @@ func TestAccServiceAccountToken_inOrg(t *testing.T) {
 
 					// Check that the service account is in the correct organization
 					resource.TestMatchResourceAttr("grafana_service_account.test", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_service_account.test", "grafana_organization.test"),
 				),
 			},

--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -7,7 +7,6 @@ import (
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	goapi "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -17,7 +16,7 @@ import (
 func TestAccTeam_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var team goapi.TeamDTO
+	var team models.TeamDTO
 	teamName := acctest.RandString(5)
 	teamNameUpdated := acctest.RandString(5)
 
@@ -58,7 +57,7 @@ func TestAccTeam_basic(t *testing.T) {
 func TestAccTeam_preferences(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">= 9.0.0") // Dashboard UID is only available in Grafana 9.0.0+
 
-	var team goapi.TeamDTO
+	var team models.TeamDTO
 	teamName := acctest.RandString(5)
 	teamNameUpdated := acctest.RandString(5)
 
@@ -105,7 +104,7 @@ func TestAccTeam_preferences(t *testing.T) {
 func TestAccTeam_teamSync(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t, ">= 8.0.0")
 
-	var team goapi.TeamDTO
+	var team models.TeamDTO
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -167,7 +166,7 @@ func TestAccTeam_teamSync(t *testing.T) {
 func TestAccTeam_Members(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var team goapi.TeamDTO
+	var team models.TeamDTO
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -235,7 +234,7 @@ func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 	client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
 
-	var team goapi.TeamDTO
+	var team models.TeamDTO
 	var userID int64 = -1
 	teamName := acctest.RandString(5)
 
@@ -285,7 +284,7 @@ func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
 func TestAccResourceTeam_InOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	var team goapi.TeamDTO
+	var team models.TeamDTO
 	var org models.OrgDetailsDTO
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 

--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	goapi "github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -285,7 +286,7 @@ func TestAccResourceTeam_InOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	var team goapi.TeamDTO
-	var org gapi.Org
+	var org models.OrgDetailsDTO
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -299,7 +300,7 @@ func TestAccResourceTeam_InOrg(t *testing.T) {
 
 					// Check that the team is in the correct organization
 					resource.TestMatchResourceAttr("grafana_team.test", "id", nonDefaultOrgIDRegexp),
-					testAccOrganizationCheckExists("grafana_organization.test", &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_team.test", "grafana_organization.test"),
 				),
 			},


### PR DESCRIPTION
Gets rid of the manually written checkers in favor of the new ones that use the OpenAPI client