### PR TITLE
OpenAPI: Fix API calls pointing to subpath

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
       - 3000:3000
     image: ${GRAFANA_IMAGE:-grafana/grafana}:${GRAFANA_VERSION}
     environment:
-      - GF_SERVER_ROOT_URL=http://0.0.0.0:3000${GRAFANA_SUBPATH:-}
+      - GF_SERVER_ROOT_URL=${GRAFANA_URL}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
       - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000${GRAFANA_SUBPATH:-}/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s
       retries: 10
       start_period: 10s
@@ -32,3 +32,13 @@ services:
       - ./testdata:/certs
     ports:
       - 3001:3001
+  nginx:
+    profiles:
+      - "proxy"
+    depends_on:
+      - grafana
+    image: nginx:latest
+    ports:
+      - 3001:3001
+    volumes:
+      - ./testdata/nginx.conf:/etc/nginx/nginx.conf

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -430,6 +430,10 @@ func createGrafanaOAPIClient(apiURL string, d *schema.ResourceData) (*goapi.Graf
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse API url: %v", err.Error())
 	}
+	apiPath, err := url.JoinPath(u.Path, "api")
+	if err != nil {
+		return nil, fmt.Errorf("failed to join API path: %v", err.Error())
+	}
 
 	userInfo, orgID, APIKey, err := parseAuth(d)
 	if err != nil {
@@ -438,7 +442,7 @@ func createGrafanaOAPIClient(apiURL string, d *schema.ResourceData) (*goapi.Graf
 
 	cfg := goapi.TransportConfig{
 		Host:         u.Host,
-		BasePath:     "/api",
+		BasePath:     apiPath,
 		Schemes:      []string{u.Scheme},
 		NumRetries:   d.Get("retries").(int),
 		RetryTimeout: time.Second * time.Duration(d.Get("retry_wait").(int)),

--- a/testdata/nginx.conf
+++ b/testdata/nginx.conf
@@ -1,0 +1,34 @@
+events{}
+
+http {
+    # this is required to proxy Grafana Live WebSocket connections.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    upstream grafana {
+        server grafana:3000;
+    }
+
+    server {
+        listen 3001;
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        server_name  0.0.0.0;
+
+        location /grafana/ {
+            proxy_set_header Host $host;
+            proxy_pass http://grafana;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /api/live/ {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://grafana;
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1137
Currently, the test suite is pointing to a subpath BUT Grafana redirects from the root to the subpath
The provider is badly configured but the tests still pass because of the redirect

To fix the test suite, I add a nginx proxy in this PR, so that calling the host directly fails and you have to go through the subpath

I've also reworked the Makefile so that it has more common args (less repetition of configs), so it's harder to make a mistake