### PR TITLE
Add new attributes to OnCall outgoing webhook

### DIFF
--- a/docs/resources/oncall_outgoing_webhook.md
+++ b/docs/resources/oncall_outgoing_webhook.md
@@ -32,10 +32,16 @@ resource "grafana_oncall_outgoing_webhook" "test-acc-outgoing_webhook" {
 
 - `authorization_header` (String, Sensitive) The auth data of the webhook. Used in Authorization header instead of user/password auth.
 - `data` (String) The data of the webhook.
-- `forward_whole_payload` (Boolean) Forwards whole payload of the alert to the webhook's url as POST data.
+- `forward_whole_payload` (Boolean) Toggle to send the entire webhook payload instead of using the values in the Data field.
+- `headers` (String) Headers to add to the outgoing webhook request.
+- `http_method` (String) The HTTP method used in the request made by the outgoing webhook. Defaults to `POST`.
+- `integration_filter` (List of String) Restricts the outgoing webhook to only trigger if the event came from a selected integration. If no integrations are selected the outgoing webhook will trigger for any integration.
+- `is_webhook_enabled` (Boolean) Controls whether the outgoing webhook will trigger or is ignored. The default is `true`.
 - `password` (String, Sensitive) The auth data of the webhook. Used for Basic authentication
 - `team_id` (String) The ID of the OnCall team. To get one, create a team in Grafana, and navigate to the OnCall plugin (to sync the team with OnCall). You can then get the ID using the `grafana_oncall_team` datasource.
-- `user` (String) The auth data of the webhook. Used for Basic authentication.
+- `trigger_template` (String) A template used to dynamically determine whether the webhook should execute based on the content of the payload.
+- `trigger_type` (String) The type of event that will cause this outgoing webhook to execute. The types of triggers are: `escalation`, `alert group created`, `acknowledge`, `resolve`, `silence`, `unsilence`, `unresolve`, `unacknowledge`. Defaults to `escalation`.
+- `user` (String) Username to use when making the outgoing webhook request.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.1
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/go-openapi/strfmt v0.21.7
-	github.com/grafana/amixr-api-go-client v0.0.10
+	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.26.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20231031181526-6f78415901a3
 	github.com/grafana/machine-learning-go-client v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/amixr-api-go-client v0.0.10 h1:L2Wc1aETiG7ORqmB+XSCBJdncHM/V0Nq2pJ6m/lV5xg=
-github.com/grafana/amixr-api-go-client v0.0.10/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
+github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCySuWyNGdfLMGdhE=
+github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.25.0 h1:jDxnR0U5xgIwKzE+IliZJvjMUUTQxGq+c1s+3M46flI=
 github.com/grafana/grafana-api-golang-client v0.25.0/go.mod h1:24W29gPe9yl0/3A9X624TPkAOR8DpHno490cPwnkv8E=
 github.com/grafana/grafana-api-golang-client v0.26.0 h1:Eu2YsfUezYngy8ifvmLybgluIcn/2IS9u1xkzuYstEM=

--- a/internal/resources/oncall/data_source_outgoing_webhook.go
+++ b/internal/resources/oncall/data_source_outgoing_webhook.go
@@ -28,23 +28,23 @@ func DataSourceOutgoingWebhook() *schema.Resource {
 
 func DataSourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*common.Client).OnCallClient
-	options := &onCallAPI.ListCustomActionOptions{}
+	options := &onCallAPI.ListWebhookOptions{}
 	name := d.Get("name").(string)
 
 	options.Name = name
 
-	outgoingWebhookResponse, _, err := client.CustomActions.ListCustomActions(options)
+	outgoingWebhookResponse, _, err := client.Webhooks.ListWebhooks(options)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if len(outgoingWebhookResponse.CustomActions) == 0 {
+	if len(outgoingWebhookResponse.Webhooks) == 0 {
 		return diag.Errorf("couldn't find an outgoing webhook matching: %s", options.Name)
-	} else if len(outgoingWebhookResponse.CustomActions) != 1 {
+	} else if len(outgoingWebhookResponse.Webhooks) != 1 {
 		return diag.Errorf("more than one outgoing webhook found matching: %s", options.Name)
 	}
 
-	outgoingWebhook := outgoingWebhookResponse.CustomActions[0]
+	outgoingWebhook := outgoingWebhookResponse.Webhooks[0]
 
 	d.SetId(outgoingWebhook.ID)
 	d.Set("name", outgoingWebhook.Name)

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -167,10 +167,10 @@ func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 	if integrationFilterOk {
 		f := integrationFilter.([]interface{})
 		integrationFilterSlice := make([]string, len(f))
-		createOptions.IntegrationFilter = &integrationFilterSlice
 		for i := range f {
-			(*createOptions.IntegrationFilter)[i] = f[i].(string)
+			integrationFilterSlice[i] = f[i].(string)
 		}
+		createOptions.IntegrationFilter = &integrationFilterSlice
 	}
 
 	outgoingWebhook, _, err := client.Webhooks.CreateWebhook(createOptions)
@@ -274,10 +274,10 @@ func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 	if integrationFilterOk {
 		f := integrationFilter.([]interface{})
 		integrationFilterSlice := make([]string, len(f))
-		updateOptions.IntegrationFilter = &integrationFilterSlice
 		for i := range f {
-			(*updateOptions.IntegrationFilter)[i] = f[i].(string)
+			integrationFilterSlice[i] = f[i].(string)
 		}
+		updateOptions.IntegrationFilter = &integrationFilterSlice
 	}
 
 	outgoingWebhook, _, err := client.Webhooks.UpdateWebhook(d.Id(), updateOptions)

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -48,7 +48,7 @@ func ResourceOutgoingWebhook() *schema.Resource {
 			"user": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The auth data of the webhook. Used for Basic authentication.",
+				Description: "Username to use when making the outgoing webhook request.",
 			},
 			"password": {
 				Type:        schema.TypeString,
@@ -65,7 +65,40 @@ func ResourceOutgoingWebhook() *schema.Resource {
 			"forward_whole_payload": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Forwards whole payload of the alert to the webhook's url as POST data.",
+				Description: "Toggle to send the entire webhook payload instead of using the values in the Data field.",
+			},
+			"trigger_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of event that will cause this outgoing webhook to execute. The types of triggers are: `escalation`, `alert group created`, `acknowledge`, `resolve`, `silence`, `unsilence`, `unresolve`, `unacknowledge`.",
+				Default:     "escalation",
+			},
+			"http_method": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The HTTP method used in the request made by the outgoing webhook.",
+				Default:     "POST",
+			},
+			"trigger_template": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A template used to dynamically determine whether the webhook should execute based on the content of the payload.",
+			},
+			"headers": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Headers to add to the outgoing webhook request.",
+			},
+			"integration_filter": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "Restricts the outgoing webhook to only trigger if the event came from a selected integration. If no integrations are selected the outgoing webhook will trigger for any integration.",
+			},
+			"is_webhook_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Controls whether the outgoing webhook will trigger or is ignored. The default is `true`.",
 			},
 		},
 	}
@@ -79,11 +112,11 @@ func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 	url := d.Get("url").(string)
 	forwardWholePayload := d.Get("forward_whole_payload").(bool)
 
-	createOptions := &onCallAPI.CreateCustomActionOptions{
-		Name:                name,
-		TeamId:              teamID,
-		Url:                 url,
-		ForwardWholePayload: forwardWholePayload,
+	createOptions := &onCallAPI.CreateWebhookOptions{
+		Name:       name,
+		Team:       teamID,
+		Url:        url,
+		ForwardAll: forwardWholePayload,
 	}
 
 	data, dataOk := d.GetOk("data")
@@ -94,7 +127,7 @@ func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 	user, userOk := d.GetOk("user")
 	if userOk {
 		u := user.(string)
-		createOptions.User = &u
+		createOptions.Username = &u
 	}
 
 	password, passwordOk := d.GetOk("password")
@@ -108,7 +141,39 @@ func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 		createOptions.AuthorizationHeader = &a
 	}
 
-	outgoingWebhook, _, err := client.CustomActions.CreateCustomAction(createOptions)
+	triggerType, triggerTypeOk := d.GetOk("trigger_type")
+	if triggerTypeOk {
+		createOptions.TriggerType = triggerType.(string)
+	}
+
+	httpMethod, httpMethodOk := d.GetOk("http_method")
+	if httpMethodOk {
+		createOptions.HttpMethod = httpMethod.(string)
+	}
+
+	triggerTemplate, triggerTemplateOk := d.GetOk("trigger_template")
+	if triggerTemplateOk {
+		t := triggerTemplate.(string)
+		createOptions.TriggerTemplate = &t
+	}
+
+	headers, headersOk := d.GetOk("headers")
+	if headersOk {
+		h := headers.(string)
+		createOptions.Headers = &h
+	}
+
+	integrationFilter, integrationFilterOk := d.GetOk("integration_filter")
+	if integrationFilterOk {
+		f := integrationFilter.([]interface{})
+		integrationFilterSlice := make([]string, len(f))
+		createOptions.IntegrationFilter = &integrationFilterSlice
+		for i := range f {
+			(*createOptions.IntegrationFilter)[i] = f[i].(string)
+		}
+	}
+
+	outgoingWebhook, _, err := client.Webhooks.CreateWebhook(createOptions)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -121,7 +186,7 @@ func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 func ResourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*common.Client).OnCallClient
 
-	outgoingWebhook, r, err := client.CustomActions.GetCustomAction(d.Id(), &onCallAPI.GetCustomActionOptions{})
+	outgoingWebhook, r, err := client.Webhooks.GetWebhook(d.Id(), &onCallAPI.GetWebhookOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
 			log.Printf("[WARN] removing outgoingWebhook %s from state because it no longer exists", d.Get("name").(string))
@@ -132,11 +197,16 @@ func ResourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	d.Set("name", outgoingWebhook.Name)
-	d.Set("team_id", outgoingWebhook.TeamId)
+	d.Set("team_id", outgoingWebhook.Team)
 	d.Set("url", outgoingWebhook.Url)
 	d.Set("data", outgoingWebhook.Data)
-	d.Set("user", outgoingWebhook.User)
-	d.Set("forward_whole_payload", outgoingWebhook.ForwardWholePayload)
+	d.Set("user", outgoingWebhook.Username)
+	d.Set("forward_whole_payload", outgoingWebhook.ForwardAll)
+	d.Set("trigger_type", outgoingWebhook.TriggerType)
+	d.Set("http_method", outgoingWebhook.HttpMethod)
+	d.Set("trigger_template", outgoingWebhook.TriggerTemplate)
+	d.Set("headers", outgoingWebhook.Headers)
+	d.Set("integration_filter", outgoingWebhook.IntegrationFilter)
 
 	return nil
 }
@@ -149,11 +219,11 @@ func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 	url := d.Get("url").(string)
 	forwardWholePayload := d.Get("forward_whole_payload").(bool)
 
-	updateOptions := &onCallAPI.UpdateCustomActionOptions{
-		Name:                name,
-		TeamId:              teamID,
-		Url:                 url,
-		ForwardWholePayload: forwardWholePayload,
+	updateOptions := &onCallAPI.UpdateWebhookOptions{
+		Name:       name,
+		Team:       teamID,
+		Url:        url,
+		ForwardAll: forwardWholePayload,
 	}
 
 	data, dataOk := d.GetOk("data")
@@ -164,7 +234,7 @@ func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 	user, userOk := d.GetOk("user")
 	if userOk {
 		u := user.(string)
-		updateOptions.User = &u
+		updateOptions.Username = &u
 	}
 
 	password, passwordOk := d.GetOk("password")
@@ -178,7 +248,39 @@ func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 		updateOptions.AuthorizationHeader = &a
 	}
 
-	outgoingWebhook, _, err := client.CustomActions.UpdateCustomAction(d.Id(), updateOptions)
+	triggerType, triggerTypeOk := d.GetOk("trigger_type")
+	if triggerTypeOk {
+		updateOptions.TriggerType = triggerType.(string)
+	}
+
+	httpMethod, httpMethodOk := d.GetOk("http_method")
+	if httpMethodOk {
+		updateOptions.HttpMethod = httpMethod.(string)
+	}
+
+	triggerTemplate, triggerTemplateOk := d.GetOk("trigger_template")
+	if triggerTemplateOk {
+		t := triggerTemplate.(string)
+		updateOptions.TriggerTemplate = &t
+	}
+
+	headers, headersOk := d.GetOk("headers")
+	if headersOk {
+		h := headers.(string)
+		updateOptions.Headers = &h
+	}
+
+	integrationFilter, integrationFilterOk := d.GetOk("integration_filter")
+	if integrationFilterOk {
+		f := integrationFilter.([]interface{})
+		integrationFilterSlice := make([]string, len(f))
+		updateOptions.IntegrationFilter = &integrationFilterSlice
+		for i := range f {
+			(*updateOptions.IntegrationFilter)[i] = f[i].(string)
+		}
+	}
+
+	outgoingWebhook, _, err := client.Webhooks.UpdateWebhook(d.Id(), updateOptions)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -190,7 +292,7 @@ func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 func ResourceOutgoingWebhookDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*common.Client).OnCallClient
 
-	_, err := client.CustomActions.DeleteCustomAction(d.Id(), &onCallAPI.DeleteCustomActionOptions{})
+	_, err := client.Webhooks.DeleteWebhook(d.Id(), &onCallAPI.DeleteWebhookOptions{})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/oncall/resource_outgoing_webhook_test.go
+++ b/internal/resources/oncall/resource_outgoing_webhook_test.go
@@ -59,7 +59,7 @@ resource "grafana_oncall_outgoing_webhook" "test-acc-outgoing_webhook" {
 	http_method = "POST"
 	trigger_template = "123"
 	headers = jsonencode({ "test" = "test123" })
-	integration_filter = ["123"]
+	integration_filter = []
 	is_webhook_enabled = true
 }
 `, webhookName)

--- a/internal/resources/oncall/resource_outgoing_webhook_test.go
+++ b/internal/resources/oncall/resource_outgoing_webhook_test.go
@@ -38,7 +38,7 @@ func testAccCheckOnCallOutgoingWebhookResourceDestroy(s *terraform.State) error 
 			continue
 		}
 
-		if _, _, err := client.CustomActions.GetCustomAction(r.Primary.ID, &onCallAPI.GetCustomActionOptions{}); err == nil {
+		if _, _, err := client.Webhooks.GetWebhook(r.Primary.ID, &onCallAPI.GetWebhookOptions{}); err == nil {
 			return fmt.Errorf("OutgoingWebhook still exists")
 		}
 	}
@@ -55,6 +55,12 @@ resource "grafana_oncall_outgoing_webhook" "test-acc-outgoing_webhook" {
 	password = "test"
 	authorization_header = "Authorization"
 	forward_whole_payload = false
+	trigger_type = "escalation"
+	http_method = "POST"
+	trigger_template = "123"
+	headers = jsonencode({ "test" = "test123" })
+	integration_filter = ["123"]
+	is_webhook_enabled = true
 }
 `, webhookName)
 }
@@ -71,7 +77,7 @@ func testAccCheckOnCallOutgoingWebhookResourceExists(name string) resource.TestC
 
 		client := testutils.Provider.Meta().(*common.Client).OnCallClient
 
-		found, _, err := client.CustomActions.GetCustomAction(rs.Primary.ID, &onCallAPI.GetCustomActionOptions{})
+		found, _, err := client.Webhooks.GetWebhook(rs.Primary.ID, &onCallAPI.GetWebhookOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
https://github.com/grafana/oncall/issues/2864

Adds new optional attributes for resource `grafana_oncall_outgoing_webhook`:
- `headers`
- `http_method`
- `integration_filter`
- `is_webhook_enabled`
- `trigger_template`
- `trigger_type`