### PR TITLE
data_source_dashboards: Use OpenAPI client

### DIFF
--- a/examples/data-sources/grafana_dashboards/data-source.tf
+++ b/examples/data-sources/grafana_dashboards/data-source.tf
@@ -1,45 +1,53 @@
+resource "grafana_organization" "test" {
+  name = "testing dashboards data source"
+}
+
 resource "grafana_folder" "data_source_dashboards" {
+  org_id = grafana_organization.test.id
+
   title = "test folder data_source_dashboards"
 }
 
-// retrieve dashboards by tags, folderIDs, or both
 resource "grafana_dashboard" "data_source_dashboards1" {
+  org_id = grafana_organization.test.id
+
   folder = grafana_folder.data_source_dashboards.id
   config_json = jsonencode({
-    id            = 23456
-    title         = "data_source_dashboards 1"
-    tags          = ["data_source_dashboards"]
-    timezone      = "browser"
-    schemaVersion = 16
+    uid   = "data-source-dashboards-1"
+    title = "data_source_dashboards 1"
+    tags  = ["dev"]
+  })
+}
+
+resource "grafana_dashboard" "data_source_dashboards2" {
+  org_id = grafana_organization.test.id
+
+  config_json = jsonencode({
+    uid   = "data-source-dashboards-2"
+    title = "data_source_dashboards 2"
+    tags  = ["prod"]
   })
 }
 
 data "grafana_dashboards" "tags" {
-  tags = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
+  org_id = grafana_organization.test.id
+  tags   = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
 }
 
 data "grafana_dashboards" "folder_ids" {
+  org_id     = grafana_organization.test.id
   folder_ids = [grafana_dashboard.data_source_dashboards1.folder]
 }
 
 data "grafana_dashboards" "folder_ids_tags" {
+  org_id     = grafana_organization.test.id
   folder_ids = [grafana_dashboard.data_source_dashboards1.folder]
   tags       = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
 }
 
-resource "grafana_dashboard" "data_source_dashboards2" {
-  folder = 0 // General folder
-  config_json = jsonencode({
-    id            = 23456
-    title         = "data_source_dashboards 2"
-    tags          = ["prod"]
-    timezone      = "browser"
-    schemaVersion = 16
-  })
-}
-
 // use depends_on to wait for dashboard resource to be created before searching
 data "grafana_dashboards" "all" {
+  org_id = grafana_organization.test.id
   depends_on = [
     grafana_dashboard.data_source_dashboards1,
     grafana_dashboard.data_source_dashboards2
@@ -48,7 +56,16 @@ data "grafana_dashboards" "all" {
 
 // get only one result
 data "grafana_dashboards" "limit_one" {
-  limit = 1
+  org_id = grafana_organization.test.id
+  limit  = 1
+  depends_on = [
+    grafana_dashboard.data_source_dashboards1,
+    grafana_dashboard.data_source_dashboards2
+  ]
+}
+
+// The dashboards are not in the default org so this should return an empty list
+data "grafana_dashboards" "wrong_org" {
   depends_on = [
     grafana_dashboard.data_source_dashboards1,
     grafana_dashboard.data_source_dashboards2

--- a/internal/common/adapters.go
+++ b/internal/common/adapters.go
@@ -20,20 +20,20 @@ func SetToStringSlice(src *schema.Set) []string {
 	return ListToStringSlice(src.List())
 }
 
-func ListToIntSlice(src []interface{}) []int {
-	dst := make([]int, 0, len(src))
+func ListToIntSlice[T int | int64](src []interface{}) []T {
+	dst := make([]T, 0, len(src))
 	for _, s := range src {
 		val, ok := s.(int)
 		if !ok {
 			val = 0
 		}
-		dst = append(dst, val)
+		dst = append(dst, T(val))
 	}
 	return dst
 }
 
-func SetToIntSlice(src *schema.Set) []int {
-	return ListToIntSlice(src.List())
+func SetToIntSlice[T int | int64](src *schema.Set) []T {
+	return ListToIntSlice[T](src.List())
 }
 
 func StringSliceToList(list []string) []interface{} {

--- a/internal/resources/grafana/data_source_dashboards_test.go
+++ b/internal/resources/grafana/data_source_dashboards_test.go
@@ -1,10 +1,8 @@
 package grafana_test
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -12,30 +10,42 @@ import (
 func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	params := url.Values{
-		"limit": {"5000"},
-		"type":  {"dash-db"},
-	}
-	idAll := grafana.HashDashboardSearchParameters(params)
-
-	params["tag"] = []string{"data_source_dashboards"}
-	idTags := grafana.HashDashboardSearchParameters(params)
-
-	checks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr("data.grafana_dashboards.all", "id", idAll),
-		resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "id", idTags),
-		resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.#", "1"),
-		resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.#", "1"),
-		resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.#", "1"),
-		resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.#", "1"),
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_dashboards/data-source.tf"),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.#", "1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.#", "1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.#", "1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+
+					resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.#", "1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.#", "2"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.1.uid", "data-source-dashboards-2"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.1.title", "data_source_dashboards 2"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.all", "dashboards.1.folder_title", ""),
+
+					resource.TestCheckResourceAttr("data.grafana_dashboards.wrong_org", "dashboards.#", "0"),
+				),
 			},
 		},
 	})

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -250,7 +250,7 @@ func ResourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, m in
 	byMonthData, byMonthOk := d.GetOk("by_month")
 	if byMonthOk {
 		if typeData != singleEvent {
-			byMonthDataSlice := common.SetToIntSlice(byMonthData.(*schema.Set))
+			byMonthDataSlice := common.SetToIntSlice[int](byMonthData.(*schema.Set))
 			createOptions.ByMonth = &byMonthDataSlice
 		} else {
 			return diag.Errorf("by_month can not be set with type: %s", typeData)
@@ -260,7 +260,7 @@ func ResourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, m in
 	byMonthdayData, byMonthdayOk := d.GetOk("by_monthday")
 	if byMonthdayOk {
 		if typeData != singleEvent {
-			byMonthdayDataSlice := common.SetToIntSlice(byMonthdayData.(*schema.Set))
+			byMonthdayDataSlice := common.SetToIntSlice[int](byMonthdayData.(*schema.Set))
 			createOptions.ByMonthday = &byMonthdayDataSlice
 		} else {
 			return diag.Errorf("by_monthday can not be set with type: %s", typeData)
@@ -373,7 +373,7 @@ func ResourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, m in
 	byMonthData, byMonthOk := d.GetOk("by_month")
 	if byMonthOk {
 		if typeData != singleEvent {
-			byMonthDataSlice := common.SetToIntSlice(byMonthData.(*schema.Set))
+			byMonthDataSlice := common.SetToIntSlice[int](byMonthData.(*schema.Set))
 			updateOptions.ByMonth = &byMonthDataSlice
 		} else {
 			return diag.Errorf("by_month can not be set with type: %s", typeData)
@@ -383,7 +383,7 @@ func ResourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, m in
 	byMonthDayData, byMonthDayOk := d.GetOk("by_monthday")
 	if byMonthDayOk {
 		if typeData != singleEvent {
-			byMonthDayData := common.SetToIntSlice(byMonthDayData.(*schema.Set))
+			byMonthDayData := common.SetToIntSlice[int](byMonthDayData.(*schema.Set))
 			updateOptions.ByMonthday = &byMonthDayData
 		} else {
 			return diag.Errorf("by_monthday can not be set with type: %s", typeData)


### PR DESCRIPTION
Use https://github.com/grafana/grafana-openapi-client-go instead of the manually generated client

Also in this PR:
- Add `org_id` parameter
- Rework the tests so that all the features are actually tested