### PR TITLE
Service Accounts: Use OpenAPI client

### DIFF
--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -2,14 +2,19 @@ package grafana
 
 import (
 	"context"
-	"log"
 	"strconv"
+	"sync"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+// Service Accounts have issues with concurrent creation, so we need to lock them.
+var serviceAccountCreateMutex sync.Mutex
 
 func ResourceServiceAccount() *schema.Resource {
 	return &schema.Resource{
@@ -51,68 +56,56 @@ func ResourceServiceAccount() *schema.Resource {
 }
 
 func CreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
-	isDisabled := d.Get("is_disabled").(bool)
-	req := gapi.CreateServiceAccountRequest{
+	serviceAccountCreateMutex.Lock()
+	defer serviceAccountCreateMutex.Unlock()
+
+	client, orgID := OAPIClientFromNewOrgResource(meta, d)
+	req := models.CreateServiceAccountForm{
 		Name:       d.Get("name").(string),
 		Role:       d.Get("role").(string),
-		IsDisabled: &isDisabled,
+		IsDisabled: d.Get("is_disabled").(bool),
 	}
-	sa, err := client.CreateServiceAccount(req)
+
+	params := service_accounts.NewCreateServiceAccountParams().WithBody(&req)
+	resp, err := client.ServiceAccounts.CreateServiceAccount(params, nil)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	d.SetId(MakeOrgResourceID(orgID, resp.Payload.ID))
 
-	d.SetId(MakeOrgResourceID(orgID, sa.ID))
 	return ReadServiceAccount(ctx, d, meta)
 }
 
 func ReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	sas, err := client.GetServiceAccounts()
-	if err != nil {
-		return diag.FromErr(err)
+	params := service_accounts.NewRetrieveServiceAccountParams().WithServiceAccountID(id)
+	resp, err := client.ServiceAccounts.RetrieveServiceAccount(params, nil)
+	if err, shouldReturn := common.CheckReadError("service account", d, err); shouldReturn {
+		return err
 	}
+	sa := resp.Payload
 
-	for _, sa := range sas {
-		if sa.ID == id {
-			d.SetId(MakeOrgResourceID(sa.OrgID, id))
-			d.Set("org_id", strconv.FormatInt(sa.OrgID, 10))
-			err = d.Set("name", sa.Name)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			err = d.Set("role", sa.Role)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			err = d.Set("is_disabled", sa.IsDisabled)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			return nil
-		}
-	}
-	log.Printf("[WARN] removing service account %d from state because it no longer exists in grafana", id)
-	d.SetId("")
-
+	d.SetId(MakeOrgResourceID(sa.OrgID, id))
+	d.Set("org_id", strconv.FormatInt(sa.OrgID, 10))
+	d.Set("name", sa.Name)
+	d.Set("role", sa.Role)
+	d.Set("is_disabled", sa.IsDisabled)
 	return nil
 }
 
 func UpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	updateRequest := gapi.UpdateServiceAccountRequest{}
+	updateRequest := models.UpdateServiceAccountForm{}
 	if d.HasChange("name") {
 		updateRequest.Name = d.Get("name").(string)
 	}
@@ -120,11 +113,13 @@ func UpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 		updateRequest.Role = d.Get("role").(string)
 	}
 	if d.HasChange("is_disabled") {
-		isDisabled := d.Get("is_disabled").(bool)
-		updateRequest.IsDisabled = &isDisabled
+		updateRequest.IsDisabled = d.Get("is_disabled").(bool)
 	}
 
-	if _, err := client.UpdateServiceAccount(id, updateRequest); err != nil {
+	params := service_accounts.NewUpdateServiceAccountParams().
+		WithBody(&updateRequest).
+		WithServiceAccountID(id)
+	if _, err := client.ServiceAccounts.UpdateServiceAccount(params, nil); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -132,12 +127,13 @@ func UpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func DeleteServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	_, err = client.DeleteServiceAccount(id)
+	params := service_accounts.NewDeleteServiceAccountParams().WithServiceAccountID(id)
+	_, err = client.ServiceAccounts.DeleteServiceAccount(params, nil)
 	return diag.FromErr(err)
 }


### PR DESCRIPTION
Use https://github.com/grafana/grafana-openapi-client-go instead of the manually generated client

Also:
- Uses a get-by-id call to read service accounts instead of a list
- This change exacerbated a long-standing issue with service accounts. They sometimes fail when creating in parallel. The list call gave it just enough slowness to not fail very often. By making it more efficient, it now reliably fails. To fix that, I added a mutex on service account creation