### PR TITLE
Service Account Tokens: Use the OpenAPI client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.26.0
-	// TODO: Merge https://github.com/grafana/grafana-openapi-client-go/pull/30 and change this ref to the main branch
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231115014153-5ab050b8a616
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231115145935-79a55ef81cbf
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,8 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.26.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231112232708-b03b585a9658
+	// TODO: Merge https://github.com/grafana/grafana-openapi-client-go/pull/30 and change this ref to the main branch
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231115014153-5ab050b8a616
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.26.0 h1:Eu2YsfUezYngy8ifvmLybgluIcn/2IS9u1xkzuYstEM=
 github.com/grafana/grafana-api-golang-client v0.26.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231115014153-5ab050b8a616 h1:OHArg98Iwg3qDEg3b85UA+VpwDJB1KKEGYixpsrZLBg=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231115014153-5ab050b8a616/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231115145935-79a55ef81cbf h1:wfNE9Tiq9kl+vsnN5OIwEGjMfpfpMy97w8RPJvjmLYM=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231115145935-79a55ef81cbf/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.0 h1:ClYFFeeSj34nKltOpAb9/Z6pzSLWYUpskB4O6hICZ5g=

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.26.0 h1:Eu2YsfUezYngy8ifvmLybgluIcn/2IS9u1xkzuYstEM=
 github.com/grafana/grafana-api-golang-client v0.26.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231112232708-b03b585a9658 h1:ZneazI71K21ZQJmmg/bNq3489iIg69SkLCen3Kxy7T8=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231112232708-b03b585a9658/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231115014153-5ab050b8a616 h1:OHArg98Iwg3qDEg3b85UA+VpwDJB1KKEGYixpsrZLBg=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231115014153-5ab050b8a616/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.0 h1:ClYFFeeSj34nKltOpAb9/Z6pzSLWYUpskB4O6hICZ5g=


### PR DESCRIPTION
Use https://github.com/grafana/grafana-openapi-client-go instead of the manually generated client

Requires https://github.com/grafana/grafana-openapi-client-go/pull/30 to be merged and the client ref updated before merging!