### PR TITLE
Datasource User[s]: Use OpenAPI client

### DIFF
--- a/internal/resources/grafana/data_source_user.go
+++ b/internal/resources/grafana/data_source_user.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/client/users"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -55,7 +54,7 @@ does not currently work with API Tokens. You must use basic auth.
 }
 
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaOAPI.Clone().WithOrgID(0) // Users are global/org-agnostic
+	client := OAPIGlobalClient(meta) // Users are global/org-agnostic
 
 	var resp interface{ GetPayload() *models.UserProfileDTO }
 	var err error

--- a/internal/resources/grafana/data_source_users.go
+++ b/internal/resources/grafana/data_source_users.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/client/users"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -65,7 +64,7 @@ does not currently work with API Tokens. You must use basic auth.
 }
 
 func readUsers(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaOAPI.Clone().WithOrgID(0) // Users are global/org-agnostic
+	client := OAPIGlobalClient(meta) // Users are global/org-agnostic
 
 	allUsers := []*models.UserSearchHitDTO{}
 	var page int64 = 1

--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -92,6 +92,10 @@ func OAPIClientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*go
 	return client, orgID
 }
 
+func OAPIGlobalClient(meta interface{}) *goapi.GrafanaHTTPAPI {
+	return meta.(*common.Client).GrafanaOAPI.Clone().WithOrgID(0)
+}
+
 func parseOrgID(d *schema.ResourceData) int64 {
 	orgID, _ := strconv.ParseInt(d.Get("org_id").(string), 10, 64)
 	return orgID


### PR DESCRIPTION
Use https://github.com/grafana/grafana-openapi-client-go instead of the manually generated client