### PR TITLE
Add `WithoutResource` test helper

### DIFF
--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -290,7 +290,7 @@ func TestAccResourceTeam_InOrg(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, &org),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamInOrganization(name),
@@ -301,6 +301,14 @@ func TestAccResourceTeam_InOrg(t *testing.T) {
 					resource.TestMatchResourceAttr("grafana_team.test", "id", nonDefaultOrgIDRegexp),
 					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_team.test", "grafana_organization.test"),
+				),
+			},
+			// Test destroying team within org. Org keeps existing but team is gone.
+			{
+				Config: testutils.WithoutResource(t, testAccTeamInOrganization(name), "grafana_team.test"),
+				Check: resource.ComposeTestCheckFunc(
+					teamCheckExists.destroyed(&team, &org),
+					orgCheckExists.exists("grafana_organization.test", &org),
 				),
 			},
 		},

--- a/internal/testutils/resources.go
+++ b/internal/testutils/resources.go
@@ -1,0 +1,25 @@
+package testutils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// WithoutResource removes a resource from a Terraform configuration.
+func WithoutResource(t *testing.T, tfCode string, resourceName string) string {
+	tfConfig, err := hclwrite.ParseConfig([]byte(tfCode), "", hcl.Pos{Line: 1, Column: 1})
+	if err != nil {
+		t.Fatalf("failed to parse HCL: %v", err)
+	}
+
+	block := tfConfig.Body().FirstMatchingBlock("resource", strings.Split(resourceName, "."))
+	if block == nil {
+		t.Fatalf("failed to find resource %q", resourceName)
+	}
+	tfConfig.Body().RemoveBlock(block)
+
+	return string(tfConfig.Bytes())
+}

--- a/internal/testutils/resources_test.go
+++ b/internal/testutils/resources_test.go
@@ -1,0 +1,63 @@
+package testutils
+
+import "testing"
+
+func TestWithoutResource(t *testing.T) {
+	t.Parallel()
+
+	input := `resource "grafana_organization" "test" {
+		name = "test"
+	}
+	
+	resource "grafana_folder" "test" {
+		org_id = grafana_organization.test.id
+		title = "test"
+	}
+	
+	resource "grafana_rule_group" "test" {
+		org_id = grafana_organization.test.id
+		name             = "test"
+		folder_uid       = grafana_folder.test.uid
+		interval_seconds = 360
+		rule {
+			name           = "My Alert Rule 1"
+			for            = "2m"
+			condition      = "B"
+			no_data_state  = "NoData"
+			exec_err_state = "Alerting"
+			is_paused = false
+			data {
+				ref_id     = "A"
+				query_type = ""
+				relative_time_range {
+					from = 600
+					to   = 0
+				}
+				datasource_uid = "PD8C576611E62080A"
+				model = jsonencode({
+					hide          = false
+					intervalMs    = 1000
+					maxDataPoints = 43200
+					refId         = "A"
+				})
+			}
+		}
+	}`
+
+	expected := `resource "grafana_organization" "test" {
+  name = "test"
+}
+
+resource "grafana_folder" "test" {
+  org_id = grafana_organization.test.id
+  title  = "test"
+}
+
+`
+
+	actual := WithoutResource(t, input, "grafana_rule_group.test")
+
+	if actual != expected {
+		t.Errorf("expected:\n%q\n\nactual:\n%q", expected, actual)
+	}
+}


### PR DESCRIPTION
We have to test that resources can be destroyed. However, for org tests, since we destroy everything (including the org), the test is bad since destroying the org destroys everything within

To help with this, this new helper will allow to add a step in org tests where we keep the org, but remove the actual resource on which we want to test deletion

To test the behavior, I made the role resource tests use this instead of a `if` and I added a test step for the team resource