### PR TITLE
Fix flaky `data_source_dashboards` test

### DIFF
--- a/internal/resources/grafana/data_source_dashboards_test.go
+++ b/internal/resources/grafana/data_source_dashboards_test.go
@@ -10,7 +10,8 @@ import (
 func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	resource.ParallelTest(t, resource.TestCase{
+	// Do not use parallel tests here because it tests a listing datasource on the default org
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
By using `ParallelTest`, it sometimes conflicts with other tests