### PR TITLE
Check for 404s on deletes

### DIFF
--- a/internal/common/errcheck.go
+++ b/internal/common/errcheck.go
@@ -11,7 +11,7 @@ import (
 
 const NotFoundError = "status: 404"
 
-// CheckReadError checks for common cases on resource read paths:
+// CheckReadError checks for common cases on resource read/delete paths:
 // - If the resource no longer exists and 404s, it should be removed from state and return nil, to stop processing the read.
 // - If there is an error, return the error.
 // - Otherwise, do not return to continue processing the read.

--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -101,9 +101,7 @@ func deleteMessageTemplate(ctx context.Context, data *schema.ResourceData, meta 
 
 	lock.Lock()
 	defer lock.Unlock()
-	if err := client.DeleteMessageTemplate(name); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return diag.Diagnostics{}
+	err := client.DeleteMessageTemplate(name)
+	diag, _ := common.CheckReadError("message template", data, err)
+	return diag
 }

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -162,10 +162,9 @@ func deleteMuteTiming(ctx context.Context, data *schema.ResourceData, meta inter
 
 	lock.Lock()
 	defer lock.Unlock()
-	if err := client.DeleteMuteTiming(name); err != nil {
-		return diag.FromErr(err)
-	}
-	return diag.Diagnostics{}
+	err := client.DeleteMuteTiming(name)
+	diag, _ := common.CheckReadError("mute timing", data, err)
+	return diag
 }
 
 func suppressMonthDiff(k, oldValue, newValue string, d *schema.ResourceData) bool {

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -247,8 +247,9 @@ func deleteAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta i
 	}
 
 	for _, r := range group.Rules {
-		if err := client.DeleteAlertRule(r.UID); err != nil {
-			return diag.FromErr(err)
+		err := client.DeleteAlertRule(r.UID)
+		if diag, shouldReturn := common.CheckReadError("rule group", data, err); shouldReturn {
+			return diag
 		}
 	}
 

--- a/internal/resources/grafana/resource_annotation.go
+++ b/internal/resources/grafana/resource_annotation.go
@@ -167,7 +167,8 @@ func DeleteAnnotation(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	params := annotations.NewDeleteAnnotationByIDParams().WithAnnotationID(idStr)
 	_, err := client.Annotations.DeleteAnnotationByID(params, nil)
-	return diag.FromErr(err)
+	diag, _ := common.CheckReadError("annotation", d, err)
+	return diag
 }
 
 func makeAnnotation(d *schema.ResourceData) (*models.PostAnnotationsCmd, error) {

--- a/internal/resources/grafana/resource_api_key.go
+++ b/internal/resources/grafana/resource_api_key.go
@@ -122,9 +122,6 @@ func resourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	_, err = c.DeleteAPIKey(id)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	diag, _ := common.CheckReadError("API key", d, err)
+	return diag
 }

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -184,7 +184,8 @@ func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 
 func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
-	return diag.FromErr(client.DeleteDashboardByUID(uid))
+	err, _ := common.CheckReadError("dashboard", d, client.DeleteDashboardByUID(uid))
+	return err
 }
 
 func makeDashboard(d *schema.ResourceData) (gapi.Dashboard, error) {

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -221,7 +221,8 @@ func DeleteDataSource(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	params := datasources.NewDeleteDataSourceByIDParams().WithID(idStr)
 	_, err := client.Datasources.DeleteDataSourceByID(params, nil)
-	return diag.FromErr(err)
+	diag, _ := common.CheckReadError("datasource", d, err)
+	return diag
 }
 
 func readDatasource(d *schema.ResourceData, dataSource *models.DataSource) diag.Diagnostics {

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -165,11 +165,9 @@ func DeleteFolder(ctx context.Context, d *schema.ResourceData, meta interface{})
 		deleteParams.WithForceDeleteRules(&force)
 	}
 
-	if _, err := client.Folders.DeleteFolder(deleteParams, nil); err != nil {
-		return diag.Errorf("failed to delete folder: %s", err)
-	}
-
-	return diag.Diagnostics{}
+	_, err := client.Folders.DeleteFolder(deleteParams, nil)
+	diag, _ := common.CheckReadError("folder", d, err)
+	return diag
 }
 
 func ValidateFolderConfigJSON(configI interface{}, k string) ([]string, []error) {

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -206,7 +206,8 @@ func deleteLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interf
 	client, _, uid := OAPIClientFromExistingOrgResource(meta, d.Id())
 	params := library_elements.NewDeleteLibraryElementByUIDParams().WithLibraryElementUID(uid)
 	_, err := client.LibraryElements.DeleteLibraryElementByUID(params, nil)
-	return diag.FromErr(err)
+	diag, _ := common.CheckReadError("library panel", d, err)
+	return diag
 }
 
 func makeLibraryPanel(d *schema.ResourceData) models.CreateLibraryElementCommand {

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -204,7 +204,8 @@ func DeleteOrganization(ctx context.Context, d *schema.ResourceData, meta interf
 	client := OAPIGlobalClient(meta)
 	orgID, _ := strconv.ParseInt(d.Id(), 10, 64)
 	_, err := client.Orgs.DeleteOrgByID(orgs.NewDeleteOrgByIDParams().WithOrgID(orgID), nil)
-	return diag.FromErr(err)
+	diag, _ := common.CheckReadError("organization", d, err)
+	return diag
 }
 
 func ReadUsers(d *schema.ResourceData, meta interface{}) error {

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -139,7 +139,9 @@ func UpdatePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{
 
 func DeletePlaylist(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, _, id := ClientFromExistingOrgResource(meta, d.Id())
-	return diag.FromErr(client.DeletePlaylist(id))
+	err := client.DeletePlaylist(id)
+	diag, _ := common.CheckReadError("playlist", d, err)
+	return diag
 }
 
 func expandPlaylistItems(items []interface{}) []gapi.PlaylistItem {

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -343,10 +343,9 @@ func DeleteReport(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diag.FromErr(err)
 	}
 
-	if err := client.DeleteReport(id); err != nil {
-		return diag.FromErr(err)
-	}
-	return nil
+	err = client.DeleteReport(id)
+	diag, _ := common.CheckReadError("report", d, err)
+	return diag
 }
 
 func schemaToReport(client *gapi.Client, d *schema.ResourceData) (gapi.Report, error) {

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -244,5 +244,7 @@ func UpdateRole(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func DeleteRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
 	g := d.Get("global").(bool)
-	return diag.FromErr(client.DeleteRole(uid, g))
+	err := client.DeleteRole(uid, g)
+	diag, _ := common.CheckReadError("role", d, err)
+	return diag
 }

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -135,5 +135,6 @@ func DeleteServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 
 	params := service_accounts.NewDeleteServiceAccountParams().WithServiceAccountID(id)
 	_, err = client.ServiceAccounts.DeleteServiceAccount(params, nil)
-	return diag.FromErr(err)
+	diag, _ := common.CheckReadError("service account", d, err)
+	return diag
 }

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -270,7 +270,8 @@ func UpdateTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func DeleteTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 	_, err := client.Teams.DeleteTeamByID(teams.NewDeleteTeamByIDParams().WithTeamID(idStr), nil)
-	return diag.FromErr(err)
+	diag, _ := common.CheckReadError("team", d, err)
+	return diag
 }
 
 func updateTeamPreferences(client *goapi.GrafanaHTTPAPI, teamID int64, d *schema.ResourceData) diag.Diagnostics {

--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"context"
 	"strconv"
-	"strings"
 
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -145,11 +144,7 @@ func DeleteUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err = client.DeleteUser(id); err != nil {
-		if !strings.Contains(err.Error(), common.NotFoundError) {
-			return diag.FromErr(err)
-		}
-	}
-
-	return diag.Diagnostics{}
+	err = client.DeleteUser(id)
+	diag, _ := common.CheckReadError("user", d, err)
+	return diag
 }


### PR DESCRIPTION
On all resources, if we 404 when deleting, TF shouldn't fail, it means its job is complete 
This could happen in any case where relation is not set properly between resources (this happens a lot in Terraform) 

Currently, if, for example, a folder and a dashboard are deleted in the same run, if the folder is deleted first, the dashboard will fail to delete, while it is actually deleted