### PR TITLE
Update OpenAPI client following error management changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.26.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231123130316-d81910df4f15
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231123143558-91f2985bb3ef
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.26.0 h1:Eu2YsfUezYngy8ifvmLybgluIcn/2IS9u1xkzuYstEM=
 github.com/grafana/grafana-api-golang-client v0.26.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231123130316-d81910df4f15 h1:a0dCB1kISO6nEBBWDcNBu01MxCiShRIjOrxgnd02bbE=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231123130316-d81910df4f15/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231123143558-91f2985bb3ef h1:wPNbC5nrNXSGIPctfmFhJNoBAhnCOe1aZm5ymiFzlKM=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231123143558-91f2985bb3ef/go.mod h1:2vJ8YEgriYoHaNg5eijRU/q7eJTxT078VrGRSTTLeRk=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.0 h1:ClYFFeeSj34nKltOpAb9/Z6pzSLWYUpskB4O6hICZ5g=

--- a/internal/common/errcheck.go
+++ b/internal/common/errcheck.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/go-openapi/runtime"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -36,5 +37,8 @@ func CheckReadError(resourceType string, d *schema.ResourceData, err error) (ret
 }
 
 func IsNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), NotFoundError)
+	if err, ok := err.(runtime.ClientResponseStatus); ok {
+		return err.IsCode(404)
+	}
+	return strings.Contains(err.Error(), NotFoundError) // TODO: Remove when the old client is removed
 }


### PR DESCRIPTION
Error management was modified and we should now match errors differently. The errors are now typed and provide a `IsCode()` function we can use rather than matching on a string