### PR TITLE
Nil check on oncall integration templates

### DIFF
--- a/docs/resources/oncall_integration.md
+++ b/docs/resources/oncall_integration.md
@@ -56,7 +56,7 @@ resource "grafana_oncall_integration" "integration_with_templates" {
 ### Optional
 
 - `team_id` (String) The ID of the OnCall team. To get one, create a team in Grafana, and navigate to the OnCall plugin (to sync the team with OnCall). You can then get the ID using the `grafana_oncall_team` datasource.
-- `templates` (Block List, Max: 1) Jinja2 templates for Alert payload. (see [below for nested schema](#nestedblock--templates))
+- `templates` (Block List, Max: 1) Jinja2 templates for Alert payload. An empty templates block will be ignored. (see [below for nested schema](#nestedblock--templates))
 
 ### Read-Only
 

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -202,7 +202,7 @@ func ResourceIntegration() *schema.Resource {
 					},
 				},
 				MaxItems:    1,
-				Description: "Jinja2 templates for Alert payload.",
+				Description: "Jinja2 templates for Alert payload. An empty templates block will be ignored.",
 			},
 		},
 	}
@@ -575,6 +575,10 @@ func expandTemplates(input []interface{}) *onCallAPI.Templates {
 	templates := onCallAPI.Templates{}
 
 	for _, r := range input {
+		if r == nil {
+			continue
+		}
+
 		inputMap := r.(map[string]interface{})
 		if inputMap["grouping_key"] != "" {
 			gk := inputMap["grouping_key"].(string)

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -203,6 +203,27 @@ func ResourceIntegration() *schema.Resource {
 				},
 				MaxItems:    1,
 				Description: "Jinja2 templates for Alert payload. An empty templates block will be ignored.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldTemplate, newTemplate := d.GetChange("templates")
+
+					getTemplatesOrEmpty := func(template interface{}) map[string]interface{} {
+						list := template.([]interface{})
+						if len(list) > 0 && list[0] != nil {
+							return list[0].(map[string]interface{})
+						}
+						return map[string]interface{}{}
+					}
+					oldTemplateMap, newTemplateMap := getTemplatesOrEmpty(oldTemplate), getTemplatesOrEmpty(newTemplate)
+					if len(oldTemplateMap) != len(newTemplateMap) {
+						return false
+					}
+					for k, v := range oldTemplateMap {
+						if newTemplateMap[k] != v {
+							return false
+						}
+					}
+					return true
+				},
 			},
 		},
 	}

--- a/internal/resources/oncall/resource_integration_test.go
+++ b/internal/resources/oncall/resource_integration_test.go
@@ -23,12 +23,33 @@ func TestAccOnCallIntegration_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckOnCallIntegrationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOnCallIntegrationConfig(rName, rType),
+				Config: testAccOnCallIntegrationConfig(rName, rType, ``),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOnCallIntegrationResourceExists("grafana_oncall_integration.test-acc-integration"),
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "name", rName),
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "type", rType),
 					resource.TestCheckResourceAttrSet("grafana_oncall_integration.test-acc-integration", "link"),
+				),
+			},
+			{
+				Config: testAccOnCallIntegrationConfig(rName, rType, `templates {}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallIntegrationResourceExists("grafana_oncall_integration.test-acc-integration"),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "name", rName),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "type", rType),
+					resource.TestCheckResourceAttrSet("grafana_oncall_integration.test-acc-integration", "link"),
+				),
+			},
+			{
+				Config: testAccOnCallIntegrationConfig(rName, rType, `templates {
+					grouping_key = "test"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallIntegrationResourceExists("grafana_oncall_integration.test-acc-integration"),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "name", rName),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "type", rType),
+					resource.TestCheckResourceAttrSet("grafana_oncall_integration.test-acc-integration", "link"),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "templates.0.grouping_key", "test"),
 				),
 			},
 		},
@@ -49,7 +70,7 @@ func testAccCheckOnCallIntegrationResourceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccOnCallIntegrationConfig(rName, rType string) string {
+func testAccOnCallIntegrationConfig(rName, rType, additionalConfigs string) string {
 	return fmt.Sprintf(`
 resource "grafana_oncall_integration" "test-acc-integration" {
 	name = "%s"
@@ -63,9 +84,9 @@ resource "grafana_oncall_integration" "test-acc-integration" {
 	    }
 	}
 
-	templates {}
+	%s
 }
-`, rName, rType)
+`, rName, rType, additionalConfigs)
 }
 
 func testAccCheckOnCallIntegrationResourceExists(name string) resource.TestCheckFunc {

--- a/internal/resources/oncall/resource_integration_test.go
+++ b/internal/resources/oncall/resource_integration_test.go
@@ -49,7 +49,7 @@ func testAccCheckOnCallIntegrationResourceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccOnCallIntegrationConfig(rName, rType, templates string) string {
+func testAccOnCallIntegrationConfig(rName, rType string) string {
 	return fmt.Sprintf(`
 resource "grafana_oncall_integration" "test-acc-integration" {
 	name = "%s"

--- a/internal/resources/oncall/resource_integration_test.go
+++ b/internal/resources/oncall/resource_integration_test.go
@@ -49,7 +49,7 @@ func testAccCheckOnCallIntegrationResourceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccOnCallIntegrationConfig(rName, rType string) string {
+func testAccOnCallIntegrationConfig(rName, rType, templates string) string {
 	return fmt.Sprintf(`
 resource "grafana_oncall_integration" "test-acc-integration" {
 	name = "%s"
@@ -62,6 +62,8 @@ resource "grafana_oncall_integration" "test-acc-integration" {
 	        enabled = false
 	    }
 	}
+
+	templates {}
 }
 `, rName, rType)
 }


### PR DESCRIPTION
If a user defines an empty templates block, it currently panics 
An empty block should be functionally equivalent to not defining the block at all