### PR TITLE
Update OpenAPI client again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.26.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231127132426-27eaf0090f74
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231129154433-006c3acf5e73
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.26.0 h1:Eu2YsfUezYngy8ifvmLybgluIcn/2IS9u1xkzuYstEM=
 github.com/grafana/grafana-api-golang-client v0.26.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231127132426-27eaf0090f74 h1:2o+ZlooKiPAP5iNN19qPak99SbjROLDVf7uArCi3N4I=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231127132426-27eaf0090f74/go.mod h1:nPuLRjbjyil4xL658KpMAjKodgI0pUt/OdaCJ11lJQM=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231129154433-006c3acf5e73 h1:OjE71HRSldBF/6GypUB/6rS3ENHYnxYdKE4PpQ+aCug=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231129154433-006c3acf5e73/go.mod h1:nPuLRjbjyil4xL658KpMAjKodgI0pUt/OdaCJ11lJQM=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.1 h1:ImH6JG8ZJ1h+KP7lJV6nkYyImAXtEthMaoLRpP4Hd0M=

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -5,16 +5,6 @@ import (
 	"strconv"
 
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
-	"github.com/grafana/grafana-openapi-client-go/client/access_control"
-	"github.com/grafana/grafana-openapi-client-go/client/annotations"
-	"github.com/grafana/grafana-openapi-client-go/client/datasources"
-	"github.com/grafana/grafana-openapi-client-go/client/folders"
-	"github.com/grafana/grafana-openapi-client-go/client/library_elements"
-	"github.com/grafana/grafana-openapi-client-go/client/orgs"
-	"github.com/grafana/grafana-openapi-client-go/client/playlists"
-	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
-	"github.com/grafana/grafana-openapi-client-go/client/teams"
-	"github.com/grafana/grafana-openapi-client-go/client/users"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
@@ -29,40 +19,35 @@ var (
 	annotationsCheckExists = newCheckExistsHelper(
 		func(a *models.Annotation) string { return strconv.FormatInt(a.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Annotation, error) {
-			params := annotations.NewGetAnnotationByIDParams().WithAnnotationID(id)
-			resp, err := client.Annotations.GetAnnotationByID(params, nil)
+			resp, err := client.Annotations.GetAnnotationByID(id)
 			return payloadOrError(resp, err)
 		},
 	)
 	datasourceCheckExists = newCheckExistsHelper(
 		func(d *models.DataSource) string { return strconv.FormatInt(d.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.DataSource, error) {
-			params := datasources.NewGetDataSourceByIDParams().WithID(id)
-			resp, err := client.Datasources.GetDataSourceByID(params, nil)
+			resp, err := client.Datasources.GetDataSourceByID(id)
 			return payloadOrError(resp, err)
 		},
 	)
 	folderCheckExists = newCheckExistsHelper(
 		func(f *models.Folder) string { return strconv.FormatInt(f.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Folder, error) {
-			params := folders.NewGetFolderByIDParams().WithFolderID(mustParseInt64(id))
-			resp, err := client.Folders.GetFolderByID(params, nil)
+			resp, err := client.Folders.GetFolderByID(mustParseInt64(id))
 			return payloadOrError(resp, err)
 		},
 	)
 	libraryPanelCheckExists = newCheckExistsHelper(
 		func(t *models.LibraryElementResponse) string { return t.Result.UID },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.LibraryElementResponse, error) {
-			params := library_elements.NewGetLibraryElementByUIDParams().WithLibraryElementUID(id)
-			resp, err := client.LibraryElements.GetLibraryElementByUID(params, nil)
+			resp, err := client.LibraryElements.GetLibraryElementByUID(id)
 			return payloadOrError(resp, err)
 		},
 	)
 	orgCheckExists = newCheckExistsHelper(
 		func(o *models.OrgDetailsDTO) string { return strconv.FormatInt(o.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.OrgDetailsDTO, error) {
-			params := orgs.NewGetOrgByIDParams().WithOrgID(mustParseInt64(id))
-			resp, err := client.Orgs.GetOrgByID(params, nil)
+			resp, err := client.Orgs.GetOrgByID(mustParseInt64(id))
 			return payloadOrError(resp, err)
 		},
 	)
@@ -74,40 +59,35 @@ var (
 			return p.UID
 		},
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Playlist, error) {
-			params := playlists.NewGetPlaylistParams().WithUID(id)
-			resp, err := client.Playlists.GetPlaylist(params, nil)
+			resp, err := client.Playlists.GetPlaylist(id)
 			return payloadOrError(resp, err)
 		},
 	)
 	roleCheckExists = newCheckExistsHelper(
 		func(r *models.RoleDTO) string { return r.UID },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.RoleDTO, error) {
-			params := access_control.NewGetRoleParams().WithRoleUID(id)
-			resp, err := client.AccessControl.GetRole(params, nil)
+			resp, err := client.AccessControl.GetRole(id)
 			return payloadOrError(resp, err)
 		},
 	)
 	serviceAccountCheckExists = newCheckExistsHelper(
 		func(t *models.ServiceAccountDTO) string { return strconv.FormatInt(t.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.ServiceAccountDTO, error) {
-			params := service_accounts.NewRetrieveServiceAccountParams().WithServiceAccountID(mustParseInt64(id))
-			resp, err := client.ServiceAccounts.RetrieveServiceAccount(params, nil)
+			resp, err := client.ServiceAccounts.RetrieveServiceAccount(mustParseInt64(id))
 			return payloadOrError(resp, err)
 		},
 	)
 	teamCheckExists = newCheckExistsHelper(
 		func(t *models.TeamDTO) string { return strconv.FormatInt(t.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.TeamDTO, error) {
-			params := teams.NewGetTeamByIDParams().WithTeamID(id)
-			resp, err := client.Teams.GetTeamByID(params, nil)
+			resp, err := client.Teams.GetTeamByID(id)
 			return payloadOrError(resp, err)
 		},
 	)
 	userCheckExists = newCheckExistsHelper(
 		func(u *models.UserProfileDTO) string { return strconv.FormatInt(u.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.UserProfileDTO, error) {
-			params := users.NewGetUserByIDParams().WithUserID(mustParseInt64(id))
-			resp, err := client.Users.GetUserByID(params, nil)
+			resp, err := client.Users.GetUserByID(mustParseInt64(id))
 			return payloadOrError(resp, err)
 		},
 	)

--- a/internal/resources/grafana/data_source_dashboard.go
+++ b/internal/resources/grafana/data_source_dashboard.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/client/search"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -89,7 +88,7 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 
 		searchType := "dash-db"
 		params := search.NewSearchParams().WithType(&searchType).WithDashboardIds([]int64{int64(id)})
-		resp, err := client.Search.Search(params, nil)
+		resp, err := client.Search.Search(params)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -104,8 +103,7 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	params := dashboards.NewGetDashboardByUIDParams().WithUID(uid)
-	resp, err := client.Dashboards.GetDashboardByUID(params, nil)
+	resp, err := client.Dashboards.GetDashboardByUID(uid)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/grafana/data_source_dashboards.go
+++ b/internal/resources/grafana/data_source_dashboards.go
@@ -88,7 +88,7 @@ func dataSourceReadDashboards(ctx context.Context, d *schema.ResourceData, meta 
 
 	d.SetId(MakeOrgResourceID(orgID, id))
 
-	resp, err := client.Search.Search(params, nil)
+	resp, err := client.Search.Search(params)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/grafana/data_source_data_source.go
+++ b/internal/resources/grafana/data_source_data_source.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"context"
 
-	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -47,15 +46,12 @@ func datasourceDatasourceRead(ctx context.Context, d *schema.ResourceData, meta 
 	var err error
 
 	if name, ok := d.GetOk("name"); ok {
-		params := datasources.NewGetDataSourceByNameParams().WithName(name.(string))
-		resp, err = client.Datasources.GetDataSourceByName(params, nil)
+		resp, err = client.Datasources.GetDataSourceByName(name.(string))
 	} else if id, ok := d.GetOk("id"); ok {
 		_, idStr := SplitOrgResourceID(id.(string))
-		params := datasources.NewGetDataSourceByIDParams().WithID(idStr)
-		resp, err = client.Datasources.GetDataSourceByID(params, nil)
+		resp, err = client.Datasources.GetDataSourceByID(idStr)
 	} else if uid, ok := d.GetOk("uid"); ok {
-		params := datasources.NewGetDataSourceByUIDParams().WithUID(uid.(string))
-		resp, err = client.Datasources.GetDataSourceByUID(params, nil)
+		resp, err = client.Datasources.GetDataSourceByUID(uid.(string))
 	}
 
 	if err != nil {

--- a/internal/resources/grafana/data_source_folder.go
+++ b/internal/resources/grafana/data_source_folder.go
@@ -51,7 +51,7 @@ func findFolderWithTitle(client *goapi.GrafanaHTTPAPI, title string) (*models.Fo
 
 	for {
 		params := folders.NewGetFoldersParams().WithPage(&page)
-		resp, err := client.Folders.GetFolders(params, nil)
+		resp, err := client.Folders.GetFolders(params)
 		if err != nil {
 			return nil, err
 		}
@@ -62,8 +62,7 @@ func findFolderWithTitle(client *goapi.GrafanaHTTPAPI, title string) (*models.Fo
 
 		for _, folder := range resp.Payload {
 			if folder.Title == title {
-				getParams := folders.NewGetFolderByUIDParams().WithFolderUID(folder.UID)
-				resp, err := client.Folders.GetFolderByUID(getParams, nil)
+				resp, err := client.Folders.GetFolderByUID(folder.UID)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/resources/grafana/data_source_folders.go
+++ b/internal/resources/grafana/data_source_folders.go
@@ -66,7 +66,7 @@ func readFolders(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	searchType := "dash-folder"
 	for {
 		params := search.NewSearchParams().WithType(&searchType).WithPage(&page)
-		resp, err := client.Search.Search(params, nil)
+		resp, err := client.Search.Search(params)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/resources/grafana/data_source_library_panel.go
+++ b/internal/resources/grafana/data_source_library_panel.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"context"
 
-	"github.com/grafana/grafana-openapi-client-go/client/library_elements"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -41,8 +40,7 @@ func dataSourceLibraryPanelRead(ctx context.Context, d *schema.ResourceData, met
 			return diag.Errorf("either name or uid must be specified")
 		}
 
-		params := library_elements.NewGetLibraryElementByNameParams().WithLibraryElementName(name)
-		resp, err := client.LibraryElements.GetLibraryElementByName(params, nil)
+		resp, err := client.LibraryElements.GetLibraryElementByName(name)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/resources/grafana/data_source_organization.go
+++ b/internal/resources/grafana/data_source_organization.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/grafana-openapi-client-go/client/orgs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -56,8 +55,7 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, met
 	client := OAPIGlobalClient(meta)
 	name := d.Get("name").(string)
 
-	params := orgs.NewGetOrgByNameParams().WithOrgName(name)
-	org, err := client.Orgs.GetOrgByName(params, nil)
+	org, err := client.Orgs.GetOrgByName(name)
 
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "status: 404") {
@@ -66,8 +64,7 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	orgUsersParams := orgs.NewGetOrgUsersParams().WithOrgID(org.Payload.ID)
-	orgUsers, err := client.Orgs.GetOrgUsers(orgUsersParams, nil)
+	orgUsers, err := client.Orgs.GetOrgUsers(org.Payload.ID)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/grafana/data_source_team.go
+++ b/internal/resources/grafana/data_source_team.go
@@ -39,7 +39,7 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interf
 	name := d.Get("name").(string)
 
 	params := teams.NewSearchTeamsParams().WithName(&name)
-	resp, err := client.Teams.SearchTeams(params, nil)
+	resp, err := client.Teams.SearchTeams(params)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/grafana/data_source_user.go
+++ b/internal/resources/grafana/data_source_user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/grafana-openapi-client-go/client/users"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -65,11 +64,9 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if id := d.Get("user_id").(int); id >= 0 {
-		params := users.NewGetUserByIDParams().WithUserID(int64(id))
-		resp, err = client.Users.GetUserByID(params, nil)
+		resp, err = client.Users.GetUserByID(int64(id))
 	} else if emailOrLogin != "" {
-		params := users.NewGetUserByLoginOrEmailParams().WithLoginOrEmail(emailOrLogin)
-		resp, err = client.Users.GetUserByLoginOrEmail(params, nil)
+		resp, err = client.Users.GetUserByLoginOrEmail(emailOrLogin)
 	} else {
 		err = fmt.Errorf("must specify one of user_id, email, or login")
 	}

--- a/internal/resources/grafana/resource_annotation.go
+++ b/internal/resources/grafana/resource_annotation.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/grafana-openapi-client-go/client/annotations"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -105,8 +104,7 @@ func CreateAnnotation(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.FromErr(err)
 	}
 
-	params := annotations.NewPostAnnotationParams().WithBody(annotation)
-	resp, err := client.Annotations.PostAnnotation(params, nil)
+	resp, err := client.Annotations.PostAnnotation(annotation)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -131,17 +129,14 @@ func UpdateAnnotation(ctx context.Context, d *schema.ResourceData, meta interfac
 		TimeEnd: postAnnotation.TimeEnd,
 	}
 
-	params := annotations.NewUpdateAnnotationParams().WithAnnotationID(idStr).WithBody(&annotation)
-
-	_, err = client.Annotations.UpdateAnnotation(params, nil)
+	_, err = client.Annotations.UpdateAnnotation(idStr, &annotation)
 	return diag.FromErr(err)
 }
 
 func ReadAnnotation(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, orgID, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 
-	params := annotations.NewGetAnnotationByIDParams().WithAnnotationID(idStr)
-	resp, err := client.Annotations.GetAnnotationByID(params, nil)
+	resp, err := client.Annotations.GetAnnotationByID(idStr)
 	if err, shouldReturn := common.CheckReadError("Annotation", d, err); shouldReturn {
 		return err
 	}
@@ -165,8 +160,7 @@ func ReadAnnotation(ctx context.Context, d *schema.ResourceData, meta interface{
 func DeleteAnnotation(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 
-	params := annotations.NewDeleteAnnotationByIDParams().WithAnnotationID(idStr)
-	_, err := client.Annotations.DeleteAnnotationByID(params, nil)
+	_, err := client.Annotations.DeleteAnnotationByID(idStr)
 	diag, _ := common.CheckReadError("annotation", d, err)
 	return diag
 }

--- a/internal/resources/grafana/resource_dashboard_permission.go
+++ b/internal/resources/grafana/resource_dashboard_permission.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
-	"github.com/grafana/grafana-openapi-client-go/client/dashboard_permissions"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
@@ -152,11 +151,9 @@ func ReadDashboardPermissions(ctx context.Context, d *schema.ResourceData, meta 
 
 	if idInt, _ := strconv.ParseInt(idStr, 10, 64); idInt == 0 {
 		// id is not an int, so it must be a uid
-		params := dashboard_permissions.NewGetDashboardPermissionsListByUIDParams().WithUID(idStr)
-		resp, err = client.DashboardPermissions.GetDashboardPermissionsListByUID(params, nil)
+		resp, err = client.DashboardPermissions.GetDashboardPermissionsListByUID(idStr)
 	} else {
-		params := dashboard_permissions.NewGetDashboardPermissionsListByIDParams().WithDashboardID(idInt)
-		resp, err = client.DashboardPermissions.GetDashboardPermissionsListByID(params, nil)
+		resp, err = client.DashboardPermissions.GetDashboardPermissionsListByID(idInt)
 	}
 	if err, shouldReturn := common.CheckReadError("dashboard permissions", d, err); shouldReturn {
 		return err
@@ -199,11 +196,9 @@ func updateDashboardPermissions(client *goapi.GrafanaHTTPAPI, id string, permiss
 	var err error
 	if idInt, _ := strconv.ParseInt(id, 10, 64); idInt == 0 {
 		// id is not an int, so it must be a uid
-		params := dashboard_permissions.NewUpdateDashboardPermissionsByUIDParams().WithUID(id).WithBody(permissions)
-		_, err = client.DashboardPermissions.UpdateDashboardPermissionsByUID(params, nil)
+		_, err = client.DashboardPermissions.UpdateDashboardPermissionsByUID(id, permissions)
 	} else {
-		params := dashboard_permissions.NewUpdateDashboardPermissionsByIDParams().WithDashboardID(idInt).WithBody(permissions)
-		_, err = client.DashboardPermissions.UpdateDashboardPermissionsByID(params, nil)
+		_, err = client.DashboardPermissions.UpdateDashboardPermissionsByID(idInt, permissions)
 	}
 	return err
 }

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/grafana/grafana-openapi-client-go/client/datasources"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
@@ -153,8 +152,7 @@ func CreateDataSource(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.FromErr(err)
 	}
 
-	params := datasources.NewAddDataSourceParams().WithBody(dataSource)
-	resp, err := client.Datasources.AddDataSource(params, nil)
+	resp, err := client.Datasources.AddDataSource(dataSource)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -186,8 +184,7 @@ func UpdateDataSource(ctx context.Context, d *schema.ResourceData, meta interfac
 		User:            dataSource.User,
 		WithCredentials: dataSource.WithCredentials,
 	}
-	params := datasources.NewUpdateDataSourceByIDParams().WithID(idStr).WithBody(&body)
-	_, err = client.Datasources.UpdateDataSourceByID(params, nil)
+	_, err = client.Datasources.UpdateDataSourceByID(idStr, &body)
 
 	return diag.FromErr(err)
 }
@@ -201,11 +198,9 @@ func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 	// Support both numerical and UID IDs, so that we can import an existing datasource with either.
 	// Following the read, it's normalized to a numerical ID.
 	if _, parseErr := strconv.ParseInt(idStr, 10, 64); parseErr == nil {
-		params := datasources.NewGetDataSourceByIDParams().WithID(idStr)
-		resp, err = client.Datasources.GetDataSourceByID(params, nil)
+		resp, err = client.Datasources.GetDataSourceByID(idStr)
 	} else {
-		params := datasources.NewGetDataSourceByUIDParams().WithUID(idStr)
-		resp, err = client.Datasources.GetDataSourceByUID(params, nil)
+		resp, err = client.Datasources.GetDataSourceByUID(idStr)
 	}
 
 	if err, shouldReturn := common.CheckReadError("datasource", d, err); shouldReturn {
@@ -219,8 +214,7 @@ func ReadDataSource(ctx context.Context, d *schema.ResourceData, meta interface{
 func DeleteDataSource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
 
-	params := datasources.NewDeleteDataSourceByIDParams().WithID(idStr)
-	_, err := client.Datasources.DeleteDataSourceByID(params, nil)
+	_, err := client.Datasources.DeleteDataSourceByID(idStr)
 	diag, _ := common.CheckReadError("datasource", d, err)
 	return diag
 }

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/grafana/grafana-openapi-client-go/client/folder_permissions"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
@@ -115,8 +114,7 @@ func UpdateFolderPermissions(ctx context.Context, d *schema.ResourceData, meta i
 
 	folderUID := d.Get("folder_uid").(string)
 
-	params := folder_permissions.NewUpdateFolderPermissionsParams().WithFolderUID(folderUID).WithBody(&permissionList)
-	if _, err := client.FolderPermissions.UpdateFolderPermissions(params, nil); err != nil {
+	if _, err := client.FolderPermissions.UpdateFolderPermissions(folderUID, &permissionList); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -128,8 +126,7 @@ func UpdateFolderPermissions(ctx context.Context, d *schema.ResourceData, meta i
 func ReadFolderPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, orgID, folderUID := OAPIClientFromExistingOrgResource(meta, d.Id())
 
-	params := folder_permissions.NewGetFolderPermissionListParams().WithFolderUID(folderUID)
-	resp, err := client.FolderPermissions.GetFolderPermissionList(params, nil)
+	resp, err := client.FolderPermissions.GetFolderPermissionList(folderUID, nil)
 	if err, shouldReturn := common.CheckReadError("folder permissions", d, err); shouldReturn {
 		return err
 	}
@@ -164,8 +161,7 @@ func DeleteFolderPermissions(ctx context.Context, d *schema.ResourceData, meta i
 	// if for some reason the parent folder doesn't exist, we'll just ignore the error
 	client, _, folderUID := OAPIClientFromExistingOrgResource(meta, d.Id())
 	emptyPermissions := models.UpdateDashboardACLCommand{}
-	params := folder_permissions.NewUpdateFolderPermissionsParams().WithFolderUID(folderUID).WithBody(&emptyPermissions)
-	_, err := client.FolderPermissions.UpdateFolderPermissions(params, nil)
+	_, err := client.FolderPermissions.UpdateFolderPermissions(folderUID, &emptyPermissions)
 	diags, _ := common.CheckReadError("folder permissions", d, err)
 	return diags
 }

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/grafana-openapi-client-go/client/playlists"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
@@ -175,7 +174,7 @@ func testAccPlaylistDisappears() resource.TestCheckFunc {
 		}
 
 		client, _, playlistID := grafana.OAPIClientFromExistingOrgResource(testutils.Provider.Meta(), rs.Primary.ID)
-		_, err := client.Playlists.DeletePlaylist(playlists.NewDeletePlaylistParams().WithUID(playlistID), nil)
+		_, err := client.Playlists.DeletePlaylist(playlistID)
 		return err
 	}
 }

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -130,8 +130,7 @@ func CreateRole(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		Permissions: permissions(d),
 	}
 
-	params := access_control.NewCreateRoleParams().WithBody(&role)
-	resp, err := client.AccessControl.CreateRole(params, nil)
+	resp, err := client.AccessControl.CreateRole(&role)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -164,8 +163,7 @@ func ReadRole(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 }
 
 func readRoleFromUID(client *goapi.GrafanaHTTPAPI, uid string, d *schema.ResourceData) diag.Diagnostics {
-	params := access_control.NewGetRoleParams().WithRoleUID(uid)
-	resp, err := client.AccessControl.GetRole(params, nil)
+	resp, err := client.AccessControl.GetRole(uid)
 	if err, shouldReturn := common.CheckReadError("role", d, err); shouldReturn {
 		return err
 	}
@@ -239,8 +237,7 @@ func UpdateRole(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 			Version:     int64(version),
 			Permissions: permissions(d),
 		}
-		params := access_control.NewUpdateRoleParams().WithRoleUID(uid).WithBody(&r)
-		if _, err := client.AccessControl.UpdateRole(params, nil); err != nil {
+		if _, err := client.AccessControl.UpdateRole(uid, &r); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -67,7 +67,7 @@ func CreateServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	params := service_accounts.NewCreateServiceAccountParams().WithBody(&req)
-	resp, err := client.ServiceAccounts.CreateServiceAccount(params, nil)
+	resp, err := client.ServiceAccounts.CreateServiceAccount(params)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -83,8 +83,7 @@ func ReadServiceAccount(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	params := service_accounts.NewRetrieveServiceAccountParams().WithServiceAccountID(id)
-	resp, err := client.ServiceAccounts.RetrieveServiceAccount(params, nil)
+	resp, err := client.ServiceAccounts.RetrieveServiceAccount(id)
 	if err, shouldReturn := common.CheckReadError("service account", d, err); shouldReturn {
 		return err
 	}
@@ -119,7 +118,7 @@ func UpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 	params := service_accounts.NewUpdateServiceAccountParams().
 		WithBody(&updateRequest).
 		WithServiceAccountID(id)
-	if _, err := client.ServiceAccounts.UpdateServiceAccount(params, nil); err != nil {
+	if _, err := client.ServiceAccounts.UpdateServiceAccount(params); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -133,8 +132,7 @@ func DeleteServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	params := service_accounts.NewDeleteServiceAccountParams().WithServiceAccountID(id)
-	_, err = client.ServiceAccounts.DeleteServiceAccount(params, nil)
+	_, err = client.ServiceAccounts.DeleteServiceAccount(id)
 	diag, _ := common.CheckReadError("service account", d, err)
 	return diag
 }

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -73,7 +73,7 @@ func serviceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m in
 		SecondsToLive: int64(ttl),
 	}
 	params := service_accounts.NewCreateTokenParams().WithServiceAccountID(serviceAccountID).WithBody(&request)
-	response, err := c.ServiceAccounts.CreateToken(params, nil)
+	response, err := c.ServiceAccounts.CreateToken(params)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -97,8 +97,7 @@ func serviceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	params := service_accounts.NewListTokensParams().WithServiceAccountID(serviceAccountID)
-	response, err := c.ServiceAccounts.ListTokens(params, nil)
+	response, err := c.ServiceAccounts.ListTokens(serviceAccountID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,8 +144,7 @@ func serviceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	params := service_accounts.NewDeleteTokenParams().WithServiceAccountID(serviceAccountID).WithTokenID(id)
-	_, err = c.ServiceAccounts.DeleteToken(params, nil)
+	_, err = c.ServiceAccounts.DeleteToken(serviceAccountID, id)
 
 	return diag.FromErr(err)
 }

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -144,7 +144,7 @@ func serviceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	_, err = c.ServiceAccounts.DeleteToken(serviceAccountID, id)
+	_, err = c.ServiceAccounts.DeleteToken(id, serviceAccountID)
 
 	return diag.FromErr(err)
 }


### PR DESCRIPTION
Following https://github.com/grafana/grafana-openapi-client-go/pull/40, we don't need most of the "params" objects