### PR TITLE
Add system theme for org and team preferences

### DIFF
--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -29,6 +29,6 @@ data "grafana_organization_preferences" "test" {}
 - `home_dashboard_id` (Number) The Organization home dashboard ID.
 - `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `id` (String) The ID of this resource.
-- `theme` (String) The Organization theme. Available values are `light`, `dark`, or an empty string for the default.
+- `theme` (String) The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.
 - `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.
 - `week_start` (String) The Organization week start.

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -29,7 +29,7 @@ resource "grafana_organization_preferences" "test" {
 - `home_dashboard_id` (Number) The Organization home dashboard ID.
 - `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
-- `theme` (String) The Organization theme. Available values are `light`, `dark`, or an empty string for the default.
+- `theme` (String) The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.
 - `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.
 - `week_start` (String) The Organization week start.
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -55,7 +55,7 @@ to the team. Note: users specified here must already exist in Grafana.
 Optional:
 
 - `home_dashboard_uid` (String) The UID of the dashboard to display when a team member logs in. Defaults to ``.
-- `theme` (String) The default theme for this team. Available themes are `light`, `dark`, or an empty string for the default theme. Defaults to ``.
+- `theme` (String) The default theme for this team. Available themes are `light`, `dark`, `system`, or an empty string for the default theme. Defaults to ``.
 - `timezone` (String) The default timezone for this team. Available values are `utc`, `browser`, or an empty string for the default. Defaults to ``.
 
 

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -32,8 +32,8 @@ func ResourceOrganizationPreferences() *schema.Resource {
 			"theme": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "The Organization theme. Available values are `light`, `dark`, or an empty string for the default.",
-				ValidateFunc: validation.StringInSlice([]string{"light", "dark", ""}, false),
+				Description:  "The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.",
+				ValidateFunc: validation.StringInSlice([]string{"light", "dark", "system", ""}, false),
 			},
 			"home_dashboard_id": {
 				Type:          schema.TypeInt,

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -101,8 +101,8 @@ Team Sync can be provisioned using [grafana_team_external_group resource](https:
 						"theme": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"light", "dark", ""}, false),
-							Description:  "The default theme for this team. Available themes are `light`, `dark`, or an empty string for the default theme.",
+							ValidateFunc: validation.StringInSlice([]string{"light", "dark", "system", ""}, false),
+							Description:  "The default theme for this team. Available themes are `light`, `dark`, `system`, or an empty string for the default theme.",
 							Default:      "",
 						},
 						"home_dashboard_uid": {


### PR DESCRIPTION
Added `system` theme for resources, `grafana_organization_preferences` and `grafana_team`.

Official documentation:
- https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#default_theme