### PR TITLE
Preferences: Deprecate `home_dashboard_id`

### DIFF
--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -26,7 +26,7 @@ data "grafana_organization_preferences" "test" {}
 
 ### Read-Only
 
-- `home_dashboard_id` (Number) The Organization home dashboard ID.
+- `home_dashboard_id` (Number, Deprecated) The Organization home dashboard ID. Deprecated: Use `home_dashboard_uid` instead.
 - `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `id` (String) The ID of this resource.
 - `theme` (String) The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -26,7 +26,7 @@ resource "grafana_organization_preferences" "test" {
 
 ### Optional
 
-- `home_dashboard_id` (Number) The Organization home dashboard ID.
+- `home_dashboard_id` (Number, Deprecated) The Organization home dashboard ID. Deprecated: Use `home_dashboard_uid` instead.
 - `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `theme` (String) The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.

--- a/examples/resources/grafana_team_preferences/resource.tf
+++ b/examples/resources/grafana_team_preferences/resource.tf
@@ -7,8 +7,8 @@ resource "grafana_team" "team" {
 }
 
 resource "grafana_team_preferences" "team_preferences" {
-  team_id           = grafana_team.team.id
-  theme             = "dark"
-  timezone          = "browser"
-  home_dashboard_id = grafana_dashboard.metrics.dashboard_id
+  team_id            = grafana_team.team.id
+  theme              = "dark"
+  timezone           = "browser"
+  home_dashboard_uid = grafana_dashboard.metrics.uid
 }

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -38,8 +38,9 @@ func ResourceOrganizationPreferences() *schema.Resource {
 			"home_dashboard_id": {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Description:   "The Organization home dashboard ID.",
+				Description:   "The Organization home dashboard ID. Deprecated: Use `home_dashboard_uid` instead.",
 				ConflictsWith: []string{"home_dashboard_uid"},
+				Deprecated:    "Use `home_dashboard_uid` instead.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					_, uidSet := d.GetOk("home_dashboard_uid")
 					return uidSet


### PR DESCRIPTION
It's not returned by the API in Grafana 10+