### PR TITLE
Team External Group: Use OpenAPI for tests + Fix delete

### DIFF
--- a/internal/resources/grafana/resource_team_external_group_test.go
+++ b/internal/resources/grafana/resource_team_external_group_test.go
@@ -2,12 +2,13 @@ package grafana_test
 
 import (
 	"fmt"
-	"strconv"
+	"strings"
 	"testing"
 
-	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -15,31 +16,22 @@ import (
 func TestAccTeamExternalGroup_basic(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t)
 
-	teamID := int64(-1)
+	name := acctest.RandString(10)
+	var team models.TeamDTO
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccTeamExternalGroupCheckDestroy(),
+		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
+			// Add groups and test import
 			{
-				Config: testAccTeamConfig_groupAdd,
+				Config: testAccTeamExternalGroupConfig(name, []string{"test-group1", "test-group2"}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccTeamExternalGroupCheckExists("grafana_team_external_group.test", &teamID),
-					resource.TestCheckResourceAttr(
-						"grafana_team_external_group.test", "groups.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"grafana_team_external_group.test", "groups.0", "test-group",
-					),
-				),
-			},
-			{
-				Config: testAccTeamConfig_groupRemove,
-				Check: resource.ComposeTestCheckFunc(
-					testAccTeamExternalGroupCheckExists("grafana_team_external_group.test", &teamID),
-					resource.TestCheckResourceAttr(
-						"grafana_team_external_group.test", "groups.#", "0",
-					),
+					teamCheckExists.exists("grafana_team.test", &team),
+					testAccTeamExternalGroupCheck(&team, []string{"test-group1", "test-group2"}),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.#", "2"),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.0", "test-group1"),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.1", "test-group2"),
 				),
 			},
 			{
@@ -47,66 +39,79 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Remove groups
+			{
+				Config: testAccTeamExternalGroupConfig(name, nil),
+				Check: resource.ComposeTestCheckFunc(
+					teamCheckExists.exists("grafana_team.test", &team),
+					testAccTeamExternalGroupCheck(&team, nil),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.#", "0"),
+				),
+			},
+			// Add groups again
+			{
+				Config: testAccTeamExternalGroupConfig(name, []string{"test-group3", "test-group4"}),
+				Check: resource.ComposeTestCheckFunc(
+					teamCheckExists.exists("grafana_team.test", &team),
+					testAccTeamExternalGroupCheck(&team, []string{"test-group3", "test-group4"}),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.#", "2"),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.0", "test-group3"),
+					resource.TestCheckResourceAttr("grafana_team_external_group.test", "groups.1", "test-group4"),
+				),
+			},
+			// Delete resource and check groups are removed
+			{
+				Config: testutils.WithoutResource(t, testAccTeamExternalGroupConfig(name, []string{"test-group3", "test-group4"}), "grafana_team_external_group.test"),
+				Check: resource.ComposeTestCheckFunc(
+					teamCheckExists.exists("grafana_team.test", &team),
+					testAccTeamExternalGroupCheck(&team, nil),
+				),
+			},
 		},
 	})
 }
 
-func testAccTeamExternalGroupCheckExists(rn string, teamID *int64) resource.TestCheckFunc {
+func testAccTeamExternalGroupCheck(team *models.TeamDTO, expectedGroups []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("Resource not found: %s\n %#v", rn, s.RootModule().Resources)
-		}
+		client := grafana.OAPIGlobalClient(testutils.Provider.Meta())
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource id not set")
-		}
-
-		orgID, teamIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
-
-		gotTeamID, err := strconv.ParseInt(teamIDStr, 10, 64)
-		if err != nil {
-			return fmt.Errorf("team id is malformed")
-		}
-
-		_, err = client.TeamGroups(gotTeamID)
+		resp, err := client.SyncTeamGroups.GetTeamGroupsAPI(team.ID)
 		if err != nil {
 			return fmt.Errorf("Error getting team external groups: %s", err)
 		}
 
-		*teamID = gotTeamID
+		expectedGroupsMap := map[string]struct{}{}
+		for _, group := range expectedGroups {
+			expectedGroupsMap[group] = struct{}{}
+		}
+
+		if len(resp.Payload) != len(expectedGroups) {
+			return fmt.Errorf("Expected %d groups, got %d", len(expectedGroups), len(resp.Payload))
+		}
+
+		for _, group := range resp.Payload {
+			if _, ok := expectedGroupsMap[group.GroupID]; !ok {
+				return fmt.Errorf("Unexpected group %s", group.GroupID)
+			}
+		}
 
 		return nil
 	}
 }
 
-func testAccTeamExternalGroupCheckDestroy() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// you can't really destroy dashboard permissions so nothing to check for
-		return nil
+func testAccTeamExternalGroupConfig(name string, groups []string) string {
+	groupsString := ""
+	if len(groups) > 0 {
+		groupsString = fmt.Sprintf(`"%s"`, strings.Join(groups, `", "`))
 	}
-}
 
-const testAccTeamConfig_groupAdd = `
-resource "grafana_team" "testTeam" {
-  name  = "terraform-test-team-external-group"
+	return fmt.Sprintf(`
+	resource "grafana_team" "test" {
+		name  = "%s"
+	}
+	
+	resource "grafana_team_external_group" "test" {
+		team_id    = grafana_team.test.id
+		groups = [ %s ]
+	}`, name, groupsString)
 }
-
-resource "grafana_team_external_group" "test" {
-  team_id    = grafana_team.testTeam.id
-  groups = [
-    "test-group",
-  ]
-}
-`
-const testAccTeamConfig_groupRemove = `
-resource "grafana_team" "testTeam" {
-  name  = "terraform-test-team-external-group"
-}
-
-resource "grafana_team_external_group" "test" {
-  team_id    = grafana_team.testTeam.id
-  groups = [ ]
-}
-`


### PR DESCRIPTION
In this PR:
- Use OpenAPI to test that groups are properly applied
- Add tests to check that all features work: import, removing groups, deleting the resource
- Fix the delete function. It didn't delete anything. Now, it will remove all group from the configured team