### PR TITLE
Alerting Rule Groups: Support editing from UI

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -120,7 +120,7 @@ EOT
 
 ### Optional
 
-- `allow_editing_from_ui` (Boolean) Whether to allow editing of the rule group from the Grafana UI. Defaults to `false`.
+- `disable_provenance` (Boolean) Allow modifying the rule group from other sources than Terraform or the Grafana API. Defaults to `false`.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -120,6 +120,7 @@ EOT
 
 ### Optional
 
+- `allow_editing_from_ui` (Boolean) Whether to allow editing of the rule group from the Grafana UI. Defaults to `false`.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.9
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.27.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231208205908-c7a6574ca01d
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231215124113-30c79ed880b9
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.9
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.27.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20231208125730-b6492d2ae05f
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20231208205908-c7a6574ca01d
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
 github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231208205908-c7a6574ca01d h1:VifO6GJ27kwQhlOtiig0TW43q7n8PYFYy/TRmg42Ysw=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231208205908-c7a6574ca01d/go.mod h1:LwkzHzVOQG/fFIZmPvLxU2SrtLyxx+YAkx6ykw5sTfQ=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231215124113-30c79ed880b9 h1:yRvxeTz934brAilk3YaRK0f43Q079rBMU6t81ereQkI=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231215124113-30c79ed880b9/go.mod h1:wc6Hbh3K2TgCUSfBC/BOzabItujtHMESZeFk5ZhdxhQ=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.1 h1:ImH6JG8ZJ1h+KP7lJV6nkYyImAXtEthMaoLRpP4Hd0M=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
 github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231208125730-b6492d2ae05f h1:BYEmWlwwy+f8kI1nB4orGxvFQV1P2zXU+M/Xy8y/D/0=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20231208125730-b6492d2ae05f/go.mod h1:LwkzHzVOQG/fFIZmPvLxU2SrtLyxx+YAkx6ykw5sTfQ=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231208205908-c7a6574ca01d h1:VifO6GJ27kwQhlOtiig0TW43q7n8PYFYy/TRmg42Ysw=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20231208205908-c7a6574ca01d/go.mod h1:LwkzHzVOQG/fFIZmPvLxU2SrtLyxx+YAkx6ykw5sTfQ=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.1 h1:ImH6JG8ZJ1h+KP7lJV6nkYyImAXtEthMaoLRpP4Hd0M=

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -269,22 +269,6 @@ func putAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	// getResp, err := client.Provisioning.GetAlertRuleGroup(group.Group, group.FolderUID)
-	// if err != nil {
-	// 	return diag.FromErr(err)
-	// }
-	// for _, r := range getResp.Payload.Rules {
-	// 	// Need to do a separate API call to PUT each rule in order to set the provenance.
-	// 	params := provisioning.NewPutAlertRuleParams().WithUID(r.UID).WithBody(r)
-	// 	if data.Get("allow_editing_from_ui").(bool) {
-	// 		disableProvenance := "disabled" // This can be any non-empty string.
-	// 		params.SetXDisableProvenance(&disableProvenance)
-	// 	}
-	// 	if _, err := client.Provisioning.PutAlertRule(params); err != nil {
-	// 		return diag.FromErr(err)
-	// 	}
-	// }
-
 	key := packGroupID(AlertRuleGroupKey{resp.Payload.FolderUID, resp.Payload.Title})
 	data.SetId(MakeOrgResourceID(orgID, key))
 	return readAlertRuleGroup(ctx, data, meta)

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -286,7 +286,8 @@ func deleteAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta i
 	group := resp.Payload
 
 	for _, r := range group.Rules {
-		_, err := client.Provisioning.DeleteAlertRule(r.UID)
+		params := provisioning.NewDeleteAlertRuleParams().WithUID(r.UID)
+		_, err := client.Provisioning.DeleteAlertRule(params)
 		if diag, shouldReturn := common.CheckReadError("rule group", data, err); shouldReturn {
 			return diag
 		}

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -268,7 +268,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 	})
 }
 
-func TestAccAlertRule_editFromUI(t *testing.T) {
+func TestAccAlertRule_disableProvenance(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	var group models.AlertRuleGroup
@@ -289,7 +289,7 @@ func TestAccAlertRule_editFromUI(t *testing.T) {
 					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_rule_group.test", "grafana_organization.test"),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_rule_group.test", "allow_editing_from_ui", "false"),
+					resource.TestCheckResourceAttr("grafana_rule_group.test", "disable_provenance", "false"),
 				),
 			},
 			// Test import.
@@ -306,7 +306,7 @@ func TestAccAlertRule_editFromUI(t *testing.T) {
 					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_rule_group.test", "grafana_organization.test"),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_rule_group.test", "allow_editing_from_ui", "true"),
+					resource.TestCheckResourceAttr("grafana_rule_group.test", "disable_provenance", "true"),
 				),
 			},
 			// Test import.
@@ -323,14 +323,14 @@ func TestAccAlertRule_editFromUI(t *testing.T) {
 					orgCheckExists.exists("grafana_organization.test", &org),
 					checkResourceIsInOrg("grafana_rule_group.test", "grafana_organization.test"),
 					resource.TestCheckResourceAttr("grafana_rule_group.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_rule_group.test", "allow_editing_from_ui", "false"),
+					resource.TestCheckResourceAttr("grafana_rule_group.test", "disable_provenance", "false"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAlertRuleGroupInOrgConfig(name string, interval int, enableEditingInUI bool) string {
+func testAccAlertRuleGroupInOrgConfig(name string, interval int, disableProvenance bool) string {
 	return fmt.Sprintf(`
 resource "grafana_organization" "test" {
 	name = "%[1]s"
@@ -346,7 +346,7 @@ resource "grafana_rule_group" "test" {
 	name             = "%[1]s"
 	folder_uid       = grafana_folder.test.uid
 	interval_seconds = %[2]d
-	allow_editing_from_ui = %[3]t
+	disable_provenance = %[3]t
 	rule {
 		name           = "My Alert Rule 1"
 		for            = "2m"
@@ -371,5 +371,5 @@ resource "grafana_rule_group" "test" {
 		}
 	}
 }
-`, name, interval, enableEditingInUI)
+`, name, interval, disableProvenance)
 }


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/697 
Requires https://github.com/grafana/grafana-openapi-client-go/pull/45 

There has been informal support through setting the `X-Disable-Provenance` header manually but it doesn't work that well and the current way it's done is really hard to test. Notably, it currently fails on updates for contact points (see issue) and it isn't easily discoverable

This adds a field on the rule group to allow editing from UI

Note: The provenance is actually a rule attribute (not group). Because we manage the rule group as a whole and the setting has to set through a header, I chose to add the setting as a group-scoped attribute because it's easier to manage 
Otherwise, we'd have to do POSTs, PUTs and DELETEs for each rule within the group

Also, I added tests to make sure that the provenance is correctly synced from Terraform to the alerting service and that it can be read back