### PR TITLE
Alerting Template: Use OpenAPI client + support `org_id`

### DIFF
--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -34,6 +34,10 @@ resource "grafana_message_template" "my_template" {
 - `name` (String) The name of the message template.
 - `template` (String) The content of the message template.
 
+### Optional
+
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -109,7 +109,7 @@ func TestAccMessageTemplate_inOrg(t *testing.T) {
 				Config: testutils.WithoutResource(t, testAccMessageTemplate_inOrg(name), "grafana_message_template.my_template"),
 				Check: resource.ComposeTestCheckFunc(
 					orgCheckExists.exists("grafana_organization.test", &org),
-					alertingMessageTemplateCheckExists.destroyed(&tmpl, nil),
+					alertingMessageTemplateCheckExists.destroyed(&tmpl, &org),
 				),
 			},
 		},


### PR DESCRIPTION
Uses the new OpenAPI client: https://github.com/grafana/grafana-openapi-client-go 
Also, adds the `org_id` attribute and supports org-specific templates. Each Grafana org has its own alertmanager config