### PR TITLE
Alerting: Add support for location to mute-timings

### DIFF
--- a/docs/resources/mute_timing.md
+++ b/docs/resources/mute_timing.md
@@ -32,6 +32,7 @@ resource "grafana_mute_timing" "my_mute_timing" {
     days_of_month = ["1:7", "-1"]
     months        = ["1:3", "december"]
     years         = ["2030", "2025:2026"]
+    location      = "America/New_York"
   }
 }
 ```
@@ -57,6 +58,7 @@ resource "grafana_mute_timing" "my_mute_timing" {
 Optional:
 
 - `days_of_month` (List of String) An inclusive range of days, 1-31, within a month, e.g. "1" or "14:16". Negative values can be used to represent days counting from the end of a month, e.g. "-1".
+- `location` (String) Provides the time zone for the time interval. Must be a location in the IANA time zone database, e.g "America/New_York"
 - `months` (List of String) An inclusive range of months, either numerical or full calendar month, e.g. "1:3", "december", or "may:august".
 - `times` (Block List) The time ranges, represented in minutes, during which to mute in a given day. (see [below for nested schema](#nestedblock--intervals--times))
 - `weekdays` (List of String) An inclusive range of weekdays, e.g. "monday" or "tuesday:thursday".

--- a/examples/resources/grafana_mute_timing/resource.tf
+++ b/examples/resources/grafana_mute_timing/resource.tf
@@ -10,5 +10,6 @@ resource "grafana_mute_timing" "my_mute_timing" {
     days_of_month = ["1:7", "-1"]
     months        = ["1:3", "december"]
     years         = ["2030", "2025:2026"]
+    location      = "America/New_York"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.8
 	github.com/grafana/amixr-api-go-client v0.0.11
-	github.com/grafana/grafana-api-golang-client v0.26.0
+	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20231208125730-b6492d2ae05f
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.1

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.26.0 h1:Eu2YsfUezYngy8ifvmLybgluIcn/2IS9u1xkzuYstEM=
 github.com/grafana/grafana-api-golang-client v0.26.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
+github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
+github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20231208125730-b6492d2ae05f h1:BYEmWlwwy+f8kI1nB4orGxvFQV1P2zXU+M/Xy8y/D/0=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20231208125730-b6492d2ae05f/go.mod h1:LwkzHzVOQG/fFIZmPvLxU2SrtLyxx+YAkx6ykw5sTfQ=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=

--- a/internal/resources/grafana/resource_alerting_mute_timing_test.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 )
 
 func TestAccMuteTiming_basic(t *testing.T) {
@@ -34,6 +35,7 @@ func TestAccMuteTiming_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_mute_timing.my_mute_timing", "intervals.0.months.1", "12"),
 					resource.TestCheckResourceAttr("grafana_mute_timing.my_mute_timing", "intervals.0.years.0", "2030"),
 					resource.TestCheckResourceAttr("grafana_mute_timing.my_mute_timing", "intervals.0.years.1", "2025:2026"),
+					resource.TestCheckResourceAttr("grafana_mute_timing.my_mute_timing", "intervals.0.location", "America/New_York"),
 				),
 			},
 			// Test import.


### PR DESCRIPTION
This PR adds a missing field `location` to alerting mute-timings. The field is already supported by Grafana (since around 9.3.9, March 2023)

Related to https://github.com/grafana/grafana-api-golang-client/pull/176.