### PR TITLE
Mark old client as deprecated

### DIFF
--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -13,11 +13,11 @@ import (
 )
 
 type Client struct {
-	GrafanaAPIURL       string
-	GrafanaAPIURLParsed *url.URL
-	GrafanaAPIConfig    *gapi.Config
-	GrafanaAPI          *gapi.Client
-	GrafanaCloudAPI     *gapi.Client
+	GrafanaAPIURL        string
+	GrafanaAPIURLParsed  *url.URL
+	GrafanaAPIConfig     *gapi.Config
+	DeprecatedGrafanaAPI *gapi.Client
+	GrafanaCloudAPI      *gapi.Client
 
 	GrafanaOAPI *goapi.GrafanaHTTPAPI
 

--- a/internal/provider/configure_clients.go
+++ b/internal/provider/configure_clients.go
@@ -29,7 +29,7 @@ func createClients(providerConfig frameworkProviderConfig) (*common.Client, erro
 	var err error
 	c := &common.Client{}
 	if !providerConfig.Auth.IsNull() {
-		c.GrafanaAPIURL, c.GrafanaAPIConfig, c.GrafanaAPI, err = createGrafanaClient(providerConfig)
+		c.GrafanaAPIURL, c.GrafanaAPIConfig, c.DeprecatedGrafanaAPI, err = createGrafanaClient(providerConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/provider/legacy_provider_validation.go
+++ b/internal/provider/legacy_provider_validation.go
@@ -17,7 +17,7 @@ import (
 type metadataValidation func(resourceName string, m interface{}) error
 
 func grafanaClientPresent(resourceName string, m interface{}) error {
-	if m.(*common.Client).GrafanaAPI == nil {
+	if m.(*common.Client).GrafanaOAPI == nil {
 		return fmt.Errorf("the Grafana client is required for `%s`. Set the auth and url provider attributes", resourceName)
 	}
 	return nil

--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -40,11 +40,10 @@ func SplitOrgResourceID(id string) (int64, string) {
 	return 0, id
 }
 
-// ClientFromExistingOrgResource creates a client from the ID of an org-scoped resource
-// Those IDs are in the <orgID>:<resourceID> format
-func ClientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, int64, string) {
+// Deprecated: Use OAPIClientFromExistingOrgResource instead
+func DeprecatedClientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, int64, string) {
 	orgID, restOfID := SplitOrgResourceID(id)
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 	if orgID == 0 {
 		orgID = meta.(*common.Client).GrafanaAPIConfig.OrgID // It's configured globally. TODO: Remove this once we drop support for the global org_id
 	} else if orgID > 0 {
@@ -53,11 +52,10 @@ func ClientFromExistingOrgResource(meta interface{}, id string) (*gapi.Client, i
 	return client, orgID, restOfID
 }
 
-// ClientFromNewOrgResource creates a client from the `org_id` attribute of a resource
-// This client is meant to be used in `Create` functions when the ID hasn't already been baked into the resource ID
-func ClientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
+// Deprecated: Use OAPIClientFromNewOrgResource instead
+func DeprecatedClientFromNewOrgResource(meta interface{}, d *schema.ResourceData) (*gapi.Client, int64) {
 	orgID := parseOrgID(d)
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 	if orgID == 0 {
 		orgID = meta.(*common.Client).GrafanaAPIConfig.OrgID // It's configured globally. TODO: Remove this once we drop support for the global org_id
 	} else if orgID > 0 {

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -86,7 +86,7 @@ This resource requires Grafana 9.1.0 or later.
 
 func importContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	name := data.Id()
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	ps, err := client.ContactPointsByName(name)
 	if err != nil {
@@ -107,7 +107,7 @@ func importContactPoint(ctx context.Context, data *schema.ResourceData, meta int
 }
 
 func readContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	uidsToFetch := unpackUIDs(data.Id())
 
@@ -139,7 +139,7 @@ func readContactPoint(ctx context.Context, data *schema.ResourceData, meta inter
 
 func createContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	ps := unpackContactPoints(data)
 	uids := make([]string, 0, len(ps))
@@ -165,7 +165,7 @@ func createContactPoint(ctx context.Context, data *schema.ResourceData, meta int
 
 func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	existingUIDs := unpackUIDs(data.Id())
 	ps := unpackContactPoints(data)
@@ -207,7 +207,7 @@ func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta int
 
 func deleteContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	uids := unpackUIDs(data.Id())
 

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -322,7 +322,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 						}
 						uid := rs.Primary.ID
 
-						client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+						client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 						pt, err := client.ContactPoint(uid)
 						if err != nil {
 							return fmt.Errorf("error getting resource: %w", err)
@@ -431,7 +431,7 @@ func testContactPointCheckExists(rname string, pts *[]gapi.ContactPoint, expCoun
 			return fmt.Errorf("resource name not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		points, err := client.ContactPointsByName(name)
 		if err != nil {
 			return fmt.Errorf("error getting resource: %w", err)
@@ -456,7 +456,7 @@ func testContactPointCheckExists(rname string, pts *[]gapi.ContactPoint, expCoun
 
 func testContactPointCheckDestroy(points []gapi.ContactPoint) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		for _, p := range points {
 			_, err := client.ContactPoint(p.UID)
 			if err == nil {
@@ -470,7 +470,7 @@ func testContactPointCheckDestroy(points []gapi.ContactPoint) resource.TestCheck
 
 func testContactPointCheckAllDestroy(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		points, err := client.ContactPointsByName(name)
 		if err != nil {
 			return fmt.Errorf("error getting resource: %w", err)

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -117,7 +117,7 @@ This resource requires Grafana 9.1.0 or later.
 }
 
 func readMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	name := data.Id()
 	mt, err := client.MuteTiming(name)
@@ -133,7 +133,7 @@ func readMuteTiming(ctx context.Context, data *schema.ResourceData, meta interfa
 
 func createMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	mt := unpackMuteTiming(data)
 
@@ -149,7 +149,7 @@ func createMuteTiming(ctx context.Context, data *schema.ResourceData, meta inter
 
 func updateMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	mt := unpackMuteTiming(data)
 
@@ -163,7 +163,7 @@ func updateMuteTiming(ctx context.Context, data *schema.ResourceData, meta inter
 
 func deleteMuteTiming(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 	name := data.Id()
 
 	lock.Lock()

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -172,7 +172,7 @@ func policySchema(depth uint) *schema.Resource {
 }
 
 func readNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	npt, err := client.NotificationPolicyTree()
 	if err != nil {
@@ -186,7 +186,7 @@ func readNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta
 
 func createNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	npt, err := unpackNotifPolicy(data)
 	if err != nil {
@@ -205,7 +205,7 @@ func createNotificationPolicy(ctx context.Context, data *schema.ResourceData, me
 
 func updateNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	npt, err := unpackNotifPolicy(data)
 	if err != nil {
@@ -223,7 +223,7 @@ func updateNotificationPolicy(ctx context.Context, data *schema.ResourceData, me
 
 func deleteNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock := &meta.(*common.Client).AlertingMutex
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 
 	lock.Lock()
 	defer lock.Unlock()

--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -90,7 +90,7 @@ func TestAccNotificationPolicy_basic(t *testing.T) {
 
 func testNotifPolicyCheckDestroy() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		npt, err := client.NotificationPolicyTree()
 		if err != nil {
 			return fmt.Errorf("failed to get notification policies")
@@ -114,7 +114,7 @@ func testNotifPolicyCheckExists(rname string) resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		npt, err := client.NotificationPolicyTree()
 		if err != nil {
 			return fmt.Errorf("failed to get notification policies")

--- a/internal/resources/grafana/resource_api_key.go
+++ b/internal/resources/grafana/resource_api_key.go
@@ -62,7 +62,7 @@ Manages Grafana API Keys.
 }
 
 func resourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c, orgID := ClientFromNewOrgResource(m, d)
+	c, orgID := DeprecatedClientFromNewOrgResource(m, d)
 
 	request := gapi.CreateAPIKeyRequest{
 		Name:          d.Get("name").(string),
@@ -82,7 +82,7 @@ func resourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c, orgID, idStr := ClientFromExistingOrgResource(m, d.Id())
+	c, orgID, idStr := DeprecatedClientFromExistingOrgResource(m, d.Id())
 
 	response, err := c.GetAPIKeys(true)
 	if err, shouldReturn := common.CheckReadError("API key", d, err); shouldReturn {
@@ -115,7 +115,7 @@ func resourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c, _, idStr := ClientFromExistingOrgResource(m, d.Id())
+	c, _, idStr := DeprecatedClientFromExistingOrgResource(m, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 32)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -94,7 +94,7 @@ Manages Grafana dashboards.
 }
 
 func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 
 	dashboard, err := makeDashboard(d)
 	if err != nil {
@@ -110,7 +110,7 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 
 func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	metaClient := meta.(*common.Client)
-	client, orgID, uid := ClientFromExistingOrgResource(meta, d.Id())
+	client, orgID, uid := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 
 	dashboard, err := client.DashboardByUID(uid)
 	if err, shouldReturn := common.CheckReadError("dashboard", d, err); shouldReturn {
@@ -166,7 +166,7 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 }
 
 func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 
 	dashboard, err := makeDashboard(d)
 	if err != nil {
@@ -183,7 +183,7 @@ func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta interface
 }
 
 func DeleteDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 	err, _ := common.CheckReadError("dashboard", d, client.DeleteDashboardByUID(uid))
 	return err
 }

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -77,7 +77,7 @@ func testAccDashboardPermissionsCheckExistsUID(rn string, dashboardUID *string) 
 		}
 
 		orgID, gotDashboardUID := grafana.SplitOrgResourceID(rs.Primary.ID)
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 
 		_, err := client.DashboardPermissionsByUID(gotDashboardUID)
 		if err != nil {
@@ -102,7 +102,7 @@ func testAccDashboardPermissionsCheckExists(rn string, dashboardID *int64) resou
 		}
 
 		orgID, dashboardIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 
 		gotDashboardID, err := strconv.ParseInt(dashboardIDStr, 10, 64)
 		if err != nil {
@@ -122,7 +122,7 @@ func testAccDashboardPermissionsCheckExists(rn string, dashboardID *int64) resou
 
 func testAccDashboardPermissionsCheckEmptyUID(dashboardUID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		permissions, err := client.DashboardPermissionsByUID(*dashboardUID)
 		if err != nil {
 			return fmt.Errorf("Error getting dashboard permissions %s: %s", *dashboardUID, err)

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -78,7 +78,7 @@ Manages Grafana public dashboards.
 }
 
 func CreatePublicDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 	dashboardUID := d.Get("dashboard_uid").(string)
 
 	publicDashboardPayload := makePublicDashboard(d)
@@ -92,7 +92,7 @@ func CreatePublicDashboard(ctx context.Context, d *schema.ResourceData, meta int
 }
 func UpdatePublicDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	orgID, dashboardUID, publicDashboardUID := SplitPublicDashboardID(d.Id())
-	client := meta.(*common.Client).GrafanaAPI.WithOrgID(orgID)
+	client := meta.(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 
 	publicDashboard := makePublicDashboard(d)
 	pd, err := client.UpdatePublicDashboard(dashboardUID, publicDashboardUID, publicDashboard)
@@ -106,7 +106,7 @@ func UpdatePublicDashboard(ctx context.Context, d *schema.ResourceData, meta int
 
 func DeletePublicDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	orgID, dashboardUID, publicDashboardUID := SplitPublicDashboardID(d.Id())
-	client := meta.(*common.Client).GrafanaAPI.WithOrgID(orgID)
+	client := meta.(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 	return diag.FromErr(client.DeletePublicDashboard(dashboardUID, publicDashboardUID))
 }
 
@@ -123,7 +123,7 @@ func makePublicDashboard(d *schema.ResourceData) gapi.PublicDashboardPayload {
 
 func ReadPublicDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	orgID, dashboardUID, _ := SplitPublicDashboardID(d.Id())
-	client := meta.(*common.Client).GrafanaAPI.WithOrgID(orgID)
+	client := meta.(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 	pd, err := client.PublicDashboardbyUID(dashboardUID)
 	if err, shouldReturn := common.CheckReadError("dashboard", d, err); shouldReturn {
 		return err

--- a/internal/resources/grafana/resource_dashboard_public_test.go
+++ b/internal/resources/grafana/resource_dashboard_public_test.go
@@ -66,7 +66,7 @@ func testAccPublicDashboardCheckExistsUID(rn string) resource.TestCheckFunc {
 
 		orgID, dashboardUID, _ := grafana.SplitPublicDashboardID(rs.Primary.ID)
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 		pd, err := client.PublicDashboardbyUID(dashboardUID)
 		if pd == nil || err != nil {
 			return fmt.Errorf("Error getting public dashboard: %s", err)

--- a/internal/resources/grafana/resource_data_source_permission.go
+++ b/internal/resources/grafana/resource_data_source_permission.go
@@ -82,7 +82,7 @@ Manages the entire set of permissions for a datasource. Permissions that aren't 
 }
 
 func UpdateDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 
 	var list []interface{}
 	if v, ok := d.GetOk("permissions"); ok {
@@ -128,7 +128,7 @@ func UpdateDatasourcePermissions(ctx context.Context, d *schema.ResourceData, me
 }
 
 func ReadDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
@@ -166,7 +166,7 @@ func ReadDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func DeleteDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {

--- a/internal/resources/grafana/resource_data_source_permission_test.go
+++ b/internal/resources/grafana/resource_data_source_permission_test.go
@@ -72,7 +72,7 @@ func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) res
 		}
 
 		orgID, datasourceIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 
 		gotDatasourceID, err := strconv.ParseInt(datasourceIDStr, 10, 64)
 		if err != nil {
@@ -92,7 +92,7 @@ func testAccDatasourcePermissionsCheckExists(rn string, datasourceID *int64) res
 
 func testAccDatasourcePermissionCheckDestroy(datasourceID *int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		response, err := client.DatasourcePermissions(*datasourceID)
 		if err != nil {
 			return fmt.Errorf("error getting datasource permissions %d: %s", *datasourceID, err)

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -70,7 +70,7 @@ func testAccFolderPermissionsCheckExists(rn string, folderUID *string) resource.
 		}
 
 		orgID, gotFolderUID := grafana.SplitOrgResourceID(rs.Primary.ID)
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 
 		_, err := client.FolderPermissions(gotFolderUID)
 		if err != nil {
@@ -85,7 +85,7 @@ func testAccFolderPermissionsCheckExists(rn string, folderUID *string) resource.
 
 func testAccFolderPermissionsCheckEmpty(folderUID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		permissions, err := client.FolderPermissions(*folderUID)
 		if err != nil {
 			return fmt.Errorf("Error getting folder permissions %s: %s", *folderUID, err)

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -73,7 +73,7 @@ func ResourceOrganizationPreferences() *schema.Resource {
 }
 
 func CreateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 
 	_, err := client.UpdateAllOrgPreferences(gapi.Preferences{
 		Theme:            d.Get("theme").(string),
@@ -92,7 +92,7 @@ func CreateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, 
 }
 
 func ReadOrganizationPreferences(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 	if id, _ := strconv.ParseInt(d.Id(), 10, 64); id > 0 {
 		client = client.WithOrgID(id)
 	}
@@ -117,7 +117,7 @@ func UpdateOrganizationPreferences(ctx context.Context, d *schema.ResourceData, 
 }
 
 func DeleteOrganizationPreferences(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaAPI
+	client := meta.(*common.Client).DeprecatedGrafanaAPI
 	if id, _ := strconv.ParseInt(d.Id(), 10, 64); id > 0 {
 		client = client.WithOrgID(id)
 	}

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -240,7 +240,7 @@ func ResourceReport() *schema.Resource {
 }
 
 func CreateReport(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 
 	report, err := schemaToReport(client, d)
 	if err != nil {
@@ -257,7 +257,7 @@ func CreateReport(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func ReadReport(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
@@ -317,7 +317,7 @@ func ReadReport(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 }
 
 func UpdateReport(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
@@ -337,7 +337,7 @@ func UpdateReport(ctx context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func DeleteReport(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -164,7 +164,7 @@ func testAccReportCheckExists(rn string, report *gapi.Report) resource.TestCheck
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		orgID, reportIDStr := grafana.SplitOrgResourceID(rs.Primary.ID)
 		reportID, err := strconv.ParseInt(reportIDStr, 10, 64)
 		if err != nil {
@@ -193,7 +193,7 @@ func testAccReportCheckExists(rn string, report *gapi.Report) resource.TestCheck
 
 func testAccReportCheckDestroy(report *gapi.Report) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		_, err := client.Report(report.ID)
 		if err == nil {
 			return fmt.Errorf("report still exists")

--- a/internal/resources/grafana/resource_role_assignment.go
+++ b/internal/resources/grafana/resource_role_assignment.go
@@ -107,7 +107,7 @@ func UpdateRoleAssignments(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func DeleteRoleAssignments(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, uid := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, uid := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 
 	ra := &gapi.RoleAssignments{
 		RoleUID:         uid,

--- a/internal/resources/grafana/resource_role_assignment_test.go
+++ b/internal/resources/grafana/resource_role_assignment_test.go
@@ -106,7 +106,7 @@ func testRoleAssignmentCheckExists(rn string, ra *gapi.RoleAssignments) resource
 			return fmt.Errorf("resource UID not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		role, err := client.GetRoleAssignments(uid)
 		if err != nil {
 			return fmt.Errorf("error getting role assignments: %s", err)
@@ -120,7 +120,7 @@ func testRoleAssignmentCheckExists(rn string, ra *gapi.RoleAssignments) resource
 
 func testRoleAssignmentCheckDestroy(ra *gapi.RoleAssignments) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		role, err := client.GetRoleAssignments(ra.RoleUID)
 		if err == nil && (len(role.Users) > 0 || len(role.ServiceAccounts) > 0 || len(role.Teams) > 0) {
 			return fmt.Errorf("role is still assigned")

--- a/internal/resources/grafana/resource_service_account_permission.go
+++ b/internal/resources/grafana/resource_service_account_permission.go
@@ -83,7 +83,7 @@ func ReadServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, 
 }
 
 func CreateServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := ClientFromNewOrgResource(meta, d)
+	client, orgID := DeprecatedClientFromNewOrgResource(meta, d)
 	_, idStr := SplitOrgResourceID(d.Get("service_account_id").(string))
 	d.SetId(MakeOrgResourceID(orgID, idStr))
 
@@ -101,7 +101,7 @@ func CreateServiceAccountPermissions(ctx context.Context, d *schema.ResourceData
 }
 
 func UpdateServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 
 	old, new := d.GetChange("permissions")
 	err := updateServiceAccountPermissions(client, idStr, old, new)
@@ -126,12 +126,12 @@ func DeleteServiceAccountPermissions(ctx context.Context, d *schema.ResourceData
 		return diags
 	}
 
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 	return diag.FromErr(updateServiceAccountPermissions(client, idStr, d.Get("permissions"), nil))
 }
 
 func getServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) (interface{}, diag.Diagnostics) {
-	client, _, idStr := ClientFromExistingOrgResource(meta, d.Id())
+	client, _, idStr := DeprecatedClientFromExistingOrgResource(meta, d.Id())
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		return nil, diag.FromErr(err)

--- a/internal/resources/grafana/resource_service_account_permission_test.go
+++ b/internal/resources/grafana/resource_service_account_permission_test.go
@@ -74,7 +74,7 @@ func testServiceAccountPermissionsCheckExists(rn string, saPerm *gapi.ResourcePe
 		if err != nil {
 			return fmt.Errorf("id is malformed: %w", err)
 		}
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.WithOrgID(orgID)
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI.WithOrgID(orgID)
 
 		perms, err := client.ListServiceAccountResourcePermissions(saID)
 		if err != nil {
@@ -91,7 +91,7 @@ func testServiceAccountPermissionsCheckExists(rn string, saPerm *gapi.ResourcePe
 
 func testAccServiceAccountPermissionsCheckDestroy(id int64) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		saPerms, err := client.ListServiceAccountResourcePermissions(id)
 		if err != nil {
 			return err

--- a/internal/resources/grafana/resource_service_account_token_test.go
+++ b/internal/resources/grafana/resource_service_account_token_test.go
@@ -99,7 +99,7 @@ func TestAccServiceAccountToken_inOrg(t *testing.T) {
 }
 
 func testAccServiceAccountTokenCheckDestroy(s *terraform.State) error {
-	c := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+	c := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "grafana_service_account_token" {

--- a/internal/resources/slo/data_source_slo.go
+++ b/internal/resources/slo/data_source_slo.go
@@ -43,7 +43,7 @@ Datasource for retrieving all SLOs.
 func datasourceSloRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	client := m.(*common.Client).GrafanaAPI
+	client := m.(*common.Client).DeprecatedGrafanaAPI
 	apiSlos, _ := client.ListSlos()
 
 	terraformSlos := []interface{}{}

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -240,7 +240,7 @@ func resourceSloCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		return diags
 	}
 
-	client := m.(*common.Client).GrafanaAPI
+	client := m.(*common.Client).DeprecatedGrafanaAPI
 	response, err := client.CreateSlo(slo)
 
 	if err != nil {
@@ -264,7 +264,7 @@ func resourceSloRead(ctx context.Context, d *schema.ResourceData, m interface{})
 
 	sloID := d.Id()
 
-	client := m.(*common.Client).GrafanaAPI
+	client := m.(*common.Client).DeprecatedGrafanaAPI
 	slo, err := client.GetSlo(sloID)
 
 	if err != nil {
@@ -296,7 +296,7 @@ func resourceSloUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 			return diags
 		}
 
-		client := m.(*common.Client).GrafanaAPI
+		client := m.(*common.Client).DeprecatedGrafanaAPI
 
 		err = client.UpdateSlo(sloID, slo)
 		if err != nil {
@@ -315,7 +315,7 @@ func resourceSloUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 func resourceSloDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sloID := d.Id()
 
-	client := m.(*common.Client).GrafanaAPI
+	client := m.(*common.Client).DeprecatedGrafanaAPI
 
 	return diag.FromErr(client.DeleteSlo(sloID))
 }

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -106,7 +106,7 @@ func testAccSloCheckExists(rn string, slo *gapi.Slo) resource.TestCheckFunc {
 			return fmt.Errorf("resource id not set")
 		}
 
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		gotSlo, err := client.GetSlo(rs.Primary.ID)
 
 		if err != nil {
@@ -122,7 +122,7 @@ func testAccSloCheckExists(rn string, slo *gapi.Slo) resource.TestCheckFunc {
 func testAlertingExists(expectation bool, rn string, slo *gapi.Slo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[rn]
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		gotSlo, _ := client.GetSlo(rs.Primary.ID)
 		*slo = gotSlo
 
@@ -140,7 +140,7 @@ func testAlertingExists(expectation bool, rn string, slo *gapi.Slo) resource.Tes
 
 func testAccSloCheckDestroy(slo *gapi.Slo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testutils.Provider.Meta().(*common.Client).GrafanaAPI
+		client := testutils.Provider.Meta().(*common.Client).DeprecatedGrafanaAPI
 		client.DeleteSlo(slo.UUID)
 
 		return nil


### PR DESCRIPTION
Just making it clear so we don't get any reverts like https://github.com/grafana/terraform-provider-grafana/pull/1225 

The client itself will be marked as deprecated once all resources are migrated here and when cloud resources are also migrated off