### PR TITLE
Fix `TestAccGrafanaServiceAccountFromCloud`

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -241,14 +241,14 @@ func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
 		stackID, err := client.NewStack(stack)
 		switch {
-		case err != nil && strings.Contains(err.Error(), "409"):
-			// If the API returns a 409, it means that the stack already exists
+		case err != nil && strings.Contains(strings.ToLower(err.Error()), "conflict"):
+			// If the API returns a conflict error, it means that the stack already exists
 			// It may also mean that the stack was recently deleted and is still in the process of being deleted
 			// In that case, we want to retry
 			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
-			return retry.RetryableError(fmt.Errorf("a stack with the name '%s' already exists", stack.Name))
+			return retry.RetryableError(fmt.Errorf("a stack with the name '%s' already exists: %w", stack.Name, err))
 		case err != nil:
-			// If we had an error that isn't a 409 (already exists), try to read the stack
+			// If we had an error that isn't a a conflict error (already exists), try to read the stack
 			// Sometimes, the stack is created but the API returns an error (e.g. 504)
 			readStack, readErr := client.StackBySlug(stack.Slug)
 			if readErr == nil {


### PR DESCRIPTION
This is a weird one. This test was failing but returning: `a stack with the name 'tfserviceaccounttestqnkmr08pvm' already exists` 
See https://github.com/grafana/terraform-provider-grafana/actions/runs/7211112859/job/19645774937

The reason for that error was that the stack name in the test was too long (over 29 chars) and the API returns a 409 Conflict in that case (weird). 
I changed the stack name + I fixed the error management and now the test passes