### PR TITLE
SM Installation: Determine API URL from stack's region slug

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -58,7 +58,7 @@ func TestResourceStack_Basic(t *testing.T) {
 			// but it shouldn't allow to apply an already existing stack on a new resource
 			{
 				Config: testAccStackConfigBasic(resourceName, resourceName) +
-					testAccStackConfigBasicWithCustomResourceName(resourceName, resourceName, "test2"), // new stack with same name/slug
+					testAccStackConfigBasicWithCustomResourceName(resourceName, resourceName, "eu", "test2"), // new stack with same name/slug
 				ExpectError: regexp.MustCompile(fmt.Sprintf(".*a stack with the name '%s' already exists.*", resourceName)),
 			},
 			// Test that the stack is correctly recreated if it's tainted and reapplied
@@ -170,17 +170,17 @@ func testAccStackCheckDestroy(a *gapi.Stack) resource.TestCheckFunc {
 }
 
 func testAccStackConfigBasic(name string, slug string) string {
-	return testAccStackConfigBasicWithCustomResourceName(name, slug, "test")
+	return testAccStackConfigBasicWithCustomResourceName(name, slug, "eu", "test")
 }
 
-func testAccStackConfigBasicWithCustomResourceName(name string, slug string, resourceName string) string {
+func testAccStackConfigBasicWithCustomResourceName(name, slug, region, resourceName string) string {
 	return fmt.Sprintf(`
 	resource "grafana_cloud_stack" "%s" {
 		name  = "%s"
 		slug  = "%s"
-		region_slug = "eu"
+		region_slug = "%s"
 	  }
-	`, resourceName, name, slug)
+	`, resourceName, name, slug, region)
 }
 
 func testAccStackConfigUpdate(name string, slug string, description string) string {

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
@@ -46,7 +46,6 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 			})
 		})
 	}
-
 }
 
 func testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName, region string) string {

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
@@ -17,7 +17,6 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 		"eu":             "https://synthetic-monitoring-api-eu-west.grafana.net",
 	} {
 		t.Run(region, func(t *testing.T) {
-
 			var stack gapi.Stack
 			stackPrefix := "tfsminstalltest"
 			testAccDeleteExistingStacks(t, stackPrefix)

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
@@ -12,42 +12,51 @@ import (
 func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 	testutils.CheckCloudAPITestsEnabled(t)
 
-	var stack gapi.Stack
-	stackPrefix := "tfsminstalltest"
-	testAccDeleteExistingStacks(t, stackPrefix)
-	stackSlug := GetRandomStackName(stackPrefix)
+	for region, expectedURL := range map[string]string{
+		"prod-ca-east-0": "https://synthetic-monitoring-api-ca-east-0.grafana.net",
+		"eu":             "https://synthetic-monitoring-api-eu-west.grafana.net",
+	} {
+		t.Run(region, func(t *testing.T) {
 
-	apiKeyPrefix := "testsminstall-"
-	testAccDeleteExistingCloudAPIKeys(t, apiKeyPrefix)
-	apiKeyName := apiKeyPrefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+			var stack gapi.Stack
+			stackPrefix := "tfsminstalltest"
+			testAccDeleteExistingStacks(t, stackPrefix)
+			stackSlug := GetRandomStackName(stackPrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccStackCheckDestroy(&stack),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
-					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_installation.test", "sm_access_token"),
-					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_installation.test", "stack_sm_api_url"),
-				),
-			},
-			// Test deletion
-			{
-				Config: testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName),
-			},
-		},
-	})
+			apiKeyPrefix := "testsminstall-"
+			testAccDeleteExistingCloudAPIKeys(t, apiKeyPrefix)
+			apiKeyName := apiKeyPrefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProviderFactories: testutils.ProviderFactories,
+				CheckDestroy:      testAccStackCheckDestroy(&stack),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName, region),
+						Check: resource.ComposeTestCheckFunc(
+							testAccStackCheckExists("grafana_cloud_stack.test", &stack),
+							resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_installation.test", "sm_access_token"),
+							resource.TestCheckResourceAttr("grafana_synthetic_monitoring_installation.test", "stack_sm_api_url", expectedURL),
+						),
+					},
+					// Test deletion
+					{
+						Config: testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName, region),
+					},
+				},
+			})
+		})
+	}
+
 }
 
-func testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName string) string {
-	return testAccStackConfigBasic(stackSlug, stackSlug) +
+func testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName, region string) string {
+	return testAccStackConfigBasicWithCustomResourceName(stackSlug, stackSlug, region, "test") +
 		testAccCloudAPIKeyConfig(apiKeyName, "MetricsPublisher")
 }
 
-func testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName string) string {
-	return testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName) +
+func testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName, region string) string {
+	return testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName, region) +
 		`
 	resource "grafana_synthetic_monitoring_installation" "test" {
 		stack_id              = grafana_cloud_stack.test.id


### PR DESCRIPTION
Most APIs (other than some exceptions) have determinate API URLs based on the stack's region slug 
For the exceptions which are the older regions, we can keep a map