### PR TITLE
Remove validation in new provider framework config

### DIFF
--- a/internal/provider/configure_clients.go
+++ b/internal/provider/configure_clients.go
@@ -28,7 +28,7 @@ import (
 func createClients(providerConfig frameworkProviderConfig) (*common.Client, error) {
 	var err error
 	c := &common.Client{}
-	if !providerConfig.Auth.IsNull() {
+	if !providerConfig.Auth.IsNull() && !providerConfig.URL.IsNull() {
 		c.GrafanaAPIURL, c.GrafanaAPIConfig, c.DeprecatedGrafanaAPI, err = createGrafanaClient(providerConfig)
 		if err != nil {
 			return nil, err

--- a/internal/provider/framework_provider.go
+++ b/internal/provider/framework_provider.go
@@ -100,14 +100,6 @@ func (c *frameworkProviderConfig) SetDefaults() error {
 		})
 	}
 
-	// Validating here so that it's done for both provider versions (SDK and Plugin Framework)
-	if c.Auth.IsNull() && c.CloudAPIKey.IsNull() && c.SMAccessToken.IsNull() && c.OncallAccessToken.IsNull() {
-		return fmt.Errorf("at least one of the following attributes must be set: auth, cloud_api_key, sm_access_token, oncall_access_token")
-	}
-	if !c.Auth.IsNull() && c.URL.IsNull() || c.Auth.IsNull() && !c.URL.IsNull() {
-		return fmt.Errorf("both auth and url must be set")
-	}
-
 	return nil
 }
 

--- a/internal/provider/legacy_provider_test.go
+++ b/internal/provider/legacy_provider_test.go
@@ -71,11 +71,6 @@ func TestProviderConfigure(t *testing.T) {
 		check       func(t *testing.T, provider *schema.Provider)
 	}{
 		{
-			name:        "no config",
-			env:         map[string]string{},
-			expectedErr: "at least one of the following attributes must be set: auth, cloud_api_key, sm_access_token, oncall_access_token",
-		},
-		{
 			name: "grafana config from env",
 			env: map[string]string{
 				"GRAFANA_AUTH": "admin:admin",


### PR DESCRIPTION
This validation was added here: https://github.com/grafana/terraform-provider-grafana/pull/1206 
However, it's done too early and it prevents the cases where we create a second provider with auth from a dynamically created API key or service account