### PR TITLE
fix(contact points): panic when post contact points request fails

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -165,11 +165,11 @@ func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta int
 			if common.IsNotFoundError(err) {
 				params := provisioning.NewPostContactpointsParams().WithBody(p)
 				resp, err := client.Provisioning.PostContactpoints(params)
-				ps[i].tfState["uid"] = resp.Payload.UID
-				newUIDs = append(newUIDs, resp.Payload.UID)
 				if err != nil {
 					return diag.FromErr(err)
 				}
+				ps[i].tfState["uid"] = resp.Payload.UID
+				newUIDs = append(newUIDs, resp.Payload.UID)
 				continue
 			}
 			return diag.FromErr(err)


### PR DESCRIPTION
When I tried to create a contact point the provider paniced when I get a 401 back from Grafana. It was due to not checking the error before accessing the response struct. 