### PR TITLE
Alerting: Add wrapper function for mutex

### DIFF
--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"sync"
@@ -10,6 +11,8 @@ import (
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	SMAPI "github.com/grafana/synthetic-monitoring-api-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type Client struct {
@@ -27,7 +30,17 @@ type Client struct {
 
 	OnCallClient *onCallAPI.Client
 
-	AlertingMutex sync.Mutex
+	alertingMutex sync.Mutex
+}
+
+// WithAlertingMutex is a helper function that wraps a CRUD Terraform function with a mutex.
+func WithAlertingMutex[T schema.CreateContextFunc | schema.ReadContextFunc | schema.UpdateContextFunc | schema.DeleteContextFunc](f T) T {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		lock := &meta.(*Client).alertingMutex
+		lock.Lock()
+		defer lock.Unlock()
+		return f(ctx, d, meta)
+	}
 }
 
 func (c *Client) GrafanaSubpath(path string) string {

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -47,10 +47,10 @@ Manages Grafana Alerting contact points.
 
 This resource requires Grafana 9.1.0 or later.
 `,
-		CreateContext: updateContactPoint,
+		CreateContext: common.WithAlertingMutex[schema.CreateContextFunc](updateContactPoint),
 		ReadContext:   readContactPoint,
-		UpdateContext: updateContactPoint,
-		DeleteContext: deleteContactPoint,
+		UpdateContext: common.WithAlertingMutex[schema.UpdateContextFunc](updateContactPoint),
+		DeleteContext: common.WithAlertingMutex[schema.DeleteContextFunc](deleteContactPoint),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: importContactPoint,
@@ -146,9 +146,6 @@ func readContactPoint(ctx context.Context, data *schema.ResourceData, meta inter
 }
 
 func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	lock := &meta.(*common.Client).AlertingMutex
-	lock.Lock()
-	defer lock.Unlock()
 	client := OAPIGlobalClient(meta) // TODO: Support org-scoped contact points
 
 	existingUIDs := unpackUIDs(data.Id())
@@ -191,9 +188,6 @@ func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta int
 }
 
 func deleteContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	lock := &meta.(*common.Client).AlertingMutex
-	lock.Lock()
-	defer lock.Unlock()
 	client := OAPIGlobalClient(meta) // TODO: Support org-scoped contact points
 
 	uids := unpackUIDs(data.Id())

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -25,10 +25,10 @@ Sets the global notification policy for Grafana.
 This resource requires Grafana 9.1.0 or later.
 `,
 
-		CreateContext: putNotificationPolicy,
+		CreateContext: common.WithAlertingMutex[schema.CreateContextFunc](putNotificationPolicy),
 		ReadContext:   readNotificationPolicy,
-		UpdateContext: putNotificationPolicy,
-		DeleteContext: deleteNotificationPolicy,
+		UpdateContext: common.WithAlertingMutex[schema.UpdateContextFunc](putNotificationPolicy),
+		DeleteContext: common.WithAlertingMutex[schema.DeleteContextFunc](deleteNotificationPolicy),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -186,9 +186,6 @@ func readNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta
 }
 
 func putNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	lock := &meta.(*common.Client).AlertingMutex
-	lock.Lock()
-	defer lock.Unlock()
 	client := OAPIGlobalClient(meta) // TODO: Support org-scoped policies
 
 	npt, err := unpackNotifPolicy(data)
@@ -206,9 +203,6 @@ func putNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta 
 }
 
 func deleteNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	lock := &meta.(*common.Client).AlertingMutex
-	lock.Lock()
-	defer lock.Unlock()
 	client := OAPIGlobalClient(meta) // TODO: Support org-scoped policies
 
 	if _, err := client.Provisioning.ResetPolicyTree(); err != nil {


### PR DESCRIPTION
The same logic is repeated in all alerting operations. 
This is a tiny refactor to extract that logic and avoid the global "AlertingMutex" variable. Just having a bit of fun with generics 😄 