### PR TITLE
Alerting Message Templates: Add `disable_provenance`

### DIFF
--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -36,6 +36,7 @@ resource "grafana_message_template" "my_template" {
 
 ### Optional
 
+- `disable_provenance` (Boolean) Allow modifying the message template from other sources than Terraform or the Grafana API. Defaults to `false`.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 
 ### Read-Only

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -31,9 +31,10 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 			},
 			// Test import.
 			{
-				ResourceName:      "grafana_message_template.my_template",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "grafana_message_template.my_template",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disable_provenance"},
 			},
 			// Test update with heredoc template doesn't change
 			{
@@ -100,9 +101,10 @@ func TestAccMessageTemplate_inOrg(t *testing.T) {
 			},
 			// Test import.
 			{
-				ResourceName:      "grafana_message_template.my_template",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "grafana_message_template.my_template",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disable_provenance"},
 			},
 			// Test delete template in org.
 			{


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/697

Unfortunately, the API doesn't return the provenance so we have to rely on the last applied value in the state