### PR TITLE
Update Grafana versions in tests

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -42,26 +42,26 @@ jobs:
       fail-fast: false # Let all versions run, even if one fails
       matrix:
         # OSS tests, run on all versions
-        version: ['10.2.3', '10.1.6', '9.5.15', '8.5.27']
+        version: ['10.3.1', '10.2.3', '9.5.15', '8.5.27']
         type: ['oss']
         subset: ['basic', 'other', 'long']
         include:
-          - version: '10.2.3'
+          - version: '10.3.1'
             type: 'oss'
             subset: examples
           # TLS proxy tests, run only on latest version
-          - version: '10.2.3'
+          - version: '10.3.1'
             type: 'tls'
             subset: 'basic'
           # Sub-path tests. Runs tests on localhost:3000/grafana/
-          - version: '10.2.3'
+          - version: '10.3.1'
             type: 'subpath'
             subset: 'basic'
-          - version: '10.2.3'
+          - version: '10.3.1'
             type: 'subpath'
             subset: 'other'
           # Enterprise tests, run only on latest version
-          - version: '10.2.3'
+          - version: '10.3.1'
             type: 'enterprise'
             subset: 'all'
     name: ${{ matrix.version }} - ${{ matrix.type }} - ${{ matrix.subset }}

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -42,26 +42,26 @@ jobs:
       fail-fast: false # Let all versions run, even if one fails
       matrix:
         # OSS tests, run on all versions
-        version: ['10.2.0', '10.1.5', '9.5.13', '8.5.27']
+        version: ['10.2.3', '10.1.6', '9.5.15', '8.5.27']
         type: ['oss']
         subset: ['basic', 'other', 'long']
         include:
-          - version: '10.2.0'
+          - version: '10.2.3'
             type: 'oss'
             subset: examples
           # TLS proxy tests, run only on latest version
-          - version: '10.2.0'
+          - version: '10.2.3'
             type: 'tls'
             subset: 'basic'
           # Sub-path tests. Runs tests on localhost:3000/grafana/
-          - version: '10.2.0'
+          - version: '10.2.3'
             type: 'subpath'
             subset: 'basic'
-          - version: '10.2.0'
+          - version: '10.2.3'
             type: 'subpath'
             subset: 'other'
           # Enterprise tests, run only on latest version
-          - version: '10.2.0'
+          - version: '10.2.3'
             type: 'enterprise'
             subset: 'all'
     name: ${{ matrix.version }} - ${{ matrix.type }} - ${{ matrix.subset }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= 10.1.5
+GRAFANA_VERSION ?= 10.2.3
 DOCKER_COMPOSE_ARGS ?= --force-recreate --detach --remove-orphans --wait
 
 testacc:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= 10.2.3
+GRAFANA_VERSION ?= 10.3.1
 DOCKER_COMPOSE_ARGS ?= --force-recreate --detach --remove-orphans --wait
 
 testacc:

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -161,6 +161,9 @@ var (
 		func(o *models.OrgDetailsDTO) string { return strconv.FormatInt(o.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.OrgDetailsDTO, error) {
 			resp, err := client.Orgs.GetOrgByID(mustParseInt64(id))
+			if err, ok := err.(runtime.ClientResponseStatus); ok && err.IsCode(403) {
+				return nil, &runtime.APIError{Code: 404, Response: "forbidden. The org either does not exist or the user does not have access to it"}
+			}
 			return payloadOrError(resp, err)
 		},
 	)

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -230,11 +230,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
-		// Implicitly tests deletion.
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			orgCheckExists.destroyed(&org, nil),
-			alertingRuleGroupCheckExists.destroyed(&group, &org),
-		),
+		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			// Test creation.
 			{

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -94,6 +94,10 @@ source selected (via the 'type' argument).
 				Optional:    true,
 				Default:     false,
 				Description: "Whether to set the data source as default. This should only be `true` to a single data source.",
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					// You can't unset the default data source, because you need one, you have to set another as default instead.
+					return oldValue == "true" && newValue == "false" || oldValue == newValue
+				},
 			},
 			"url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
All the latest versions!

There was one small issue with the `is_default` attribute where it seems to default to true if you have the only datasource on the instance. It does make sense though. I don't think setting `is_default` from true to false ever worked so it's good to ignore it