### PR TITLE
Force recomputation of computed values for Grafana Cloud stacks on slug update

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -226,7 +226,7 @@ available at “https://<stack_slug>.grafana.net".`,
 				Computed: true,
 			},
 		},
-    CustomizeDiff: customdiff.All(
+		CustomizeDiff: customdiff.All(
 			customdiff.ComputedIf("url", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
 				return diff.HasChange("slug")
 			}),
@@ -243,7 +243,7 @@ available at “https://<stack_slug>.grafana.net".`,
 				return diff.HasChange("slug")
 			}),
 		),
-    }
+	}
 }
 
 func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -15,6 +15,7 @@ import (
 	gapi "github.com/grafana/grafana-api-golang-client"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -225,7 +226,24 @@ available at “https://<stack_slug>.grafana.net".`,
 				Computed: true,
 			},
 		},
-	}
+    CustomizeDiff: customdiff.All(
+			customdiff.ComputedIf("url", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("slug")
+			}),
+			customdiff.ComputedIf("alertmanager_name", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("slug")
+			}),
+			customdiff.ComputedIf("logs_name", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("slug")
+			}),
+			customdiff.ComputedIf("traces_name", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("slug")
+			}),
+			customdiff.ComputedIf("prometheus_name", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("slug")
+			}),
+		),
+    }
 }
 
 func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
Names of some attributes of the Grafana Cloud stack depend on the slug of the stack. While the current state of the provider does update these attributes on the resource in the state, if these attributes are referenced in an output clause, the absence of a change in the generated plan renders the change unnoticed and stale information is outputted on a first apply. By using https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff it's possible to mark these values to be computed again if the slug changes, thus being reflected as changes in the plan and generated an up to date output.

Fixes #1191