### PR TITLE
Alerting Notification Policy: Support org-specific provisioning

### DIFF
--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -109,6 +109,7 @@ resource "grafana_notification_policy" "my_notification_policy" {
 - `disable_provenance` (Boolean) Allow modifying the notification policy from other sources than Terraform or the Grafana API. Defaults to `false`.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
 - `group_wait` (String) Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.
+- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `policy` (Block List) Routing rules for specific label sets. (see [below for nested schema](#nestedblock--policy))
 - `repeat_interval` (String) Minimum time interval for re-sending a notification if an alert is still firing. Default is 4 hours.
 

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -213,9 +213,12 @@ func putNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta 
 
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		_, err := client.Provisioning.PutPolicyTree(putParams)
-		if orgID > 1 && err != nil && err.(*runtime.APIError).IsCode(500) {
-			return retry.RetryableError(err)
-		} else if err != nil {
+		if orgID > 1 && err != nil {
+			if apiError, ok := err.(*runtime.APIError); ok && (apiError.IsCode(500) || apiError.IsCode(404)) {
+				return retry.RetryableError(err)
+			}
+		}
+		if err != nil {
 			return retry.NonRetryableError(err)
 		}
 		return nil

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -187,8 +187,8 @@ func readNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta
 	client, orgID, _ := OAPIClientFromExistingOrgResource(meta, data.Id())
 
 	resp, err := client.Provisioning.GetPolicyTree()
-	if err, shouldReturn := common.CheckReadError("notification policy", data, err); shouldReturn {
-		return err
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	packNotifPolicy(resp.Payload, data)

--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -188,7 +188,6 @@ func TestAccNotificationPolicy_inOrg(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccNotificationPolicyInOrg(name string) string {

--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -164,6 +165,8 @@ func TestAccNotificationPolicy_inOrg(t *testing.T) {
 	var policy models.Route
 	var org models.OrgDetailsDTO
 
+	name := acctest.RandString(10)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -172,10 +175,9 @@ func TestAccNotificationPolicy_inOrg(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNotificationPolicyInOrg(),
+				Config: testAccNotificationPolicyInOrg(name),
 				Check: resource.ComposeTestCheckFunc(
 					orgCheckExists.exists("grafana_organization.test", &org),
-					alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
 					checkResourceIsInOrg("grafana_notification_policy.test", "grafana_organization.test"),
 				),
 			},
@@ -184,10 +186,10 @@ func TestAccNotificationPolicy_inOrg(t *testing.T) {
 
 }
 
-func testAccNotificationPolicyInOrg() string {
+func testAccNotificationPolicyInOrg(name string) string {
 	return fmt.Sprintf(`
 	resource "grafana_organization" "test" {
-		name = "test"
+		name = "%[1]s"
 	}
 
 	resource "grafana_notification_policy" "test" {
@@ -206,7 +208,7 @@ func testAccNotificationPolicyInOrg() string {
 
 		org_id = grafana_organization.test.id
 	}
-	`)
+	`, name)
 }
 
 func testAccNotificationPolicyDisableProvenance(disableProvenance bool) string {


### PR DESCRIPTION
Adds the `org_id` attribute to be consistent with other org-specific resources