### PR TITLE
Add the OpenAPI-generated SLO client 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/grafana/grafana-api-golang-client v0.27.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240112155719-7845a7890289
 	github.com/grafana/machine-learning-go-client v0.5.0
+	github.com/grafana/slo-openapi-client/go v0.0.0-20240112175006-de02e75b9d73
 	github.com/grafana/synthetic-monitoring-agent v0.19.3
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/grafana/grafana-openapi-client-go v0.0.0-20240112155719-7845a7890289 
 github.com/grafana/grafana-openapi-client-go v0.0.0-20240112155719-7845a7890289/go.mod h1:af7rlJw/VtbvAfI5VWzYO4p/pT58FXrN6XqZBnkwBxo=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
+github.com/grafana/slo-openapi-client/go v0.0.0-20240112175006-de02e75b9d73 h1:E5vAeB5q1H3BVeNhtd1dI8RubucJdPwpx/ElNtKD3ls=
+github.com/grafana/slo-openapi-client/go v0.0.0-20240112175006-de02e75b9d73/go.mod h1:EvM3pcxqS+avXd0G8VMyo/kITr9QsN1CwZTNgYtQ9lI=
 github.com/grafana/synthetic-monitoring-agent v0.19.3 h1:BQ9Tk50YxtGDlwfrgaodTNuW8diSWTvQxFgC3n1jP1E=
 github.com/grafana/synthetic-monitoring-agent v0.19.3/go.mod h1:XdtKpgS1ukINUmAPYfGAAfLF+Ltn7C6ajH6im5kJK1w=
 github.com/grafana/synthetic-monitoring-api-go-client v0.7.0 h1:3ZfQzmXDBPcQTTgMAIIiTw5Dwxm/B4lzf34Sto0d0YY=

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -10,6 +10,7 @@ import (
 	gapi "github.com/grafana/grafana-api-golang-client"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/machine-learning-go-client/mlapi"
+	slo "github.com/grafana/slo-openapi-client/go"
 	SMAPI "github.com/grafana/synthetic-monitoring-api-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -29,6 +30,8 @@ type Client struct {
 	MLAPI *mlapi.Client
 
 	OnCallClient *onCallAPI.Client
+
+	SLOClient *slo.APIClient
 
 	alertingMutex sync.Mutex
 }

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -17,11 +17,10 @@ import (
 )
 
 type Client struct {
-	GrafanaAPIURL        string
-	GrafanaAPIURLParsed  *url.URL
-	GrafanaAPIConfig     *goapi.TransportConfig
-	DeprecatedGrafanaAPI *gapi.Client
-	GrafanaCloudAPI      *gapi.Client
+	GrafanaAPIURL       string
+	GrafanaAPIURLParsed *url.URL
+	GrafanaAPIConfig    *goapi.TransportConfig
+	GrafanaCloudAPI     *gapi.Client
 
 	GrafanaOAPI *goapi.GrafanaHTTPAPI
 

--- a/internal/resources/slo/data_source_slo_test.go
+++ b/internal/resources/slo/data_source_slo_test.go
@@ -3,7 +3,7 @@ package slo_test
 import (
 	"testing"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	slo "github.com/grafana/slo-openapi-client/go"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,7 +14,7 @@ func TestAccDataSourceSlo(t *testing.T) {
 
 	randomName := acctest.RandomWithPrefix("SLO Terraform Testing")
 
-	var slo gapi.Slo
+	var slo slo.Slo
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		CheckDestroy:      testAccSloCheckDestroy(&slo),


### PR DESCRIPTION
Client here: https://github.com/grafana/slo-openapi-client
This replaces the old https://github.com/grafana/grafana-api-golang-client

I was also able to remove the `DeprecatedGrafanaClient` attribute because it was only used by SLO at this point