### PR TITLE
Alerting Rule Group: Parse duration with strfmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.20.0
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/prometheus/common v0.46.0
 	golang.org/x/text v0.14.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/prometheus/common v0.46.0 h1:doXzt5ybi1HBKpsZOL0sSkaNHJJqkyfEWZGGqqScV0Y=
-github.com/prometheus/common v0.46.0/go.mod h1:Tp0qkxpb9Jsg54QMe+EAmqXkSV7Evdy1BTn+g2pa/hQ=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/common/schema.go
+++ b/internal/common/schema.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	promModel "github.com/prometheus/common/model"
 )
 
 // SchemaDiffFloat32 is a SchemaDiffSuppressFunc for diffing float32 values.
@@ -68,7 +68,7 @@ func ValidateDuration(i interface{}, p cty.Path) diag.Diagnostics {
 
 func ValidateDurationWithDays(i interface{}, p cty.Path) diag.Diagnostics {
 	v := i.(string)
-	_, err := promModel.ParseDuration(v)
+	_, err := strfmt.ParseDuration(v)
 	if err != nil {
 		return diag.Errorf("%q is not a valid duration: %s", v, err)
 	}

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	promModel "github.com/prometheus/common/model"
 )
 
 func ResourceRuleGroup() *schema.Resource {
@@ -87,8 +86,8 @@ This resource requires Grafana 9.1.0 or later.
 							Description:      "The amount of time for which the rule must be breached for the rule to be considered to be Firing. Before this time has elapsed, the rule is only considered to be Pending.",
 							ValidateDiagFunc: common.ValidateDurationWithDays,
 							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-								oldDuration, _ := promModel.ParseDuration(oldValue)
-								newDuration, _ := promModel.ParseDuration(newValue)
+								oldDuration, _ := strfmt.ParseDuration(oldValue)
+								newDuration, _ := strfmt.ParseDuration(newValue)
 								return oldDuration == newDuration
 							},
 						},

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -32,6 +32,18 @@ func TestAccAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.data.0.model", "{\"hide\":false,\"refId\":\"A\"}"),
 				),
 			},
+			// Test "for: 0s"
+			{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{
+					"2m": "0s",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_alert_rule", &group),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "name", "My Rule Group"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_alert_rule", "rule.0.for", "0s"),
+				),
+			},
 			// Test import.
 			{
 				ResourceName:      "grafana_rule_group.my_alert_rule",


### PR DESCRIPTION
Attempting to test https://github.com/grafana/terraform-provider-grafana/issues/1273, I found that an extra lib is used to parse durations 
With this PR, we use the same lib as go-openapi to parse durations