### PR TITLE
Fix alerting contact point issues

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -230,6 +230,8 @@ func unpackContactPoints(data *schema.ResourceData) []statePair {
 		}
 		processedUIDs := map[string]bool{}
 		for _, p := range newPointsList {
+			// Checking if the point/receiver should be deleted
+			// If all fields are zeroed out, except UID, then the receiver should be deleted
 			deleted := false
 			pointMap := p.(map[string]interface{})
 			if uid, ok := pointMap["uid"]; ok && uid != "" {
@@ -243,12 +245,16 @@ func unpackContactPoints(data *schema.ResourceData) []statePair {
 				}
 			}
 
+			// Add the point/receiver to the result
+			// If it's not deleted, it will either be created or updated
 			result = append(result, statePair{
 				tfState: pointMap,
 				gfState: unpackPointConfig(n, p, name),
 				deleted: deleted,
 			})
 		}
+		// Checking if the point/receiver should be deleted
+		// If the point is not present in the "new" part of the diff, but is present in the "old" part, then the receiver should be deleted
 		for _, p := range oldPointsList {
 			pointMap := p.(map[string]interface{})
 			if uid, ok := pointMap["uid"]; ok && uid != "" && !processedUIDs[uid.(string)] {


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1277

Terraform state management is extremely weird and the updates didn't work correctly for contact points. Updates would be pushed with invalid payloads (all fields zeroed out except UID) 
In this PR, rather than using an extra GET call when updating, we use the state read during the refresh step to build up what receivers need to be updated/added/deleted

I also added a test with the failing case posted in the issue