### PR TITLE
Flaky tests: Use random UID for report tests

### DIFF
--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -166,7 +166,7 @@ func TestAccResourceReport_CreateFromDashboardID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					reportCheckExists.exists("grafana_report.test", &report),
 					resource.TestCheckResourceAttrSet("grafana_report.test", "dashboard_id"),
-					resource.TestCheckResourceAttr("grafana_report.test", "dashboard_uid", "report-from-uid"),
+					resource.TestCheckResourceAttr("grafana_report.test", "dashboard_uid", randomUID),
 				),
 			},
 		},


### PR DESCRIPTION
Some tests fail with `version-mismatch` when updating dashboards. Should be better by using a random ID