### PR TITLE
Fix alerting resources' error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.27.0
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20240112155719-7845a7890289
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20240118162741-b884e1a072bf
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/synthetic-monitoring-agent v0.19.3
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
 github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20240112155719-7845a7890289 h1:HGaFaEpOKc/6pRTSiCgnfh2Px1WywHUQ/p9srfS1zvA=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20240112155719-7845a7890289/go.mod h1:af7rlJw/VtbvAfI5VWzYO4p/pT58FXrN6XqZBnkwBxo=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20240118162741-b884e1a072bf h1:bi08tzZ4QEEe4KBDXfJlcO9QwUdvM/ndzrmV3mozzkU=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20240118162741-b884e1a072bf/go.mod h1:af7rlJw/VtbvAfI5VWzYO4p/pT58FXrN6XqZBnkwBxo=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/synthetic-monitoring-agent v0.19.3 h1:BQ9Tk50YxtGDlwfrgaodTNuW8diSWTvQxFgC3n1jP1E=

--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -2,6 +2,7 @@ package grafana_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -134,6 +135,24 @@ func TestAccNotificationPolicy_disableProvenance(t *testing.T) {
 					alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
 					resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccNotificationPolicy_error(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "grafana_notification_policy" "test" {
+					group_by      = ["..."]
+					contact_point = "invalid"
+				  }`,
+				// This tests that the API error message is propagated to the user.
+				ExpectError: regexp.MustCompile("400.+invalid object specification: receiver 'invalid' does not exist"),
 			},
 		},
 	})


### PR DESCRIPTION
Currently, the API error messages aren't being propagated to the TF user because the field is wrong: https://github.com/grafana/grafana-openapi-client-go/pull/65