### PR TITLE
Alert Rule: Fix `0s` issue

### DIFF
--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -334,7 +334,11 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 		return nil, err
 	}
 
-	forDuration, err := strfmt.ParseDuration(json["for"].(string))
+	forStr := json["for"].(string)
+	if forStr == "" {
+		forStr = "0"
+	}
+	forDuration, err := strfmt.ParseDuration(forStr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1273
Turns out Terraform is giving us an empty string there. In that case, it should be zero, so it's parseable