### PR TITLE
Cloud: Create new OpenAPI client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-api-golang-client v0.27.0
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240126175209-247049a95c63
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240126032018-bd23c00af697
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/slo-openapi-client/go v0.0.0-20240112175006-de02e75b9d73
@@ -17,6 +18,7 @@ require (
 	github.com/grafana/synthetic-monitoring-api-go-client v0.7.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.5
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/terraform-plugin-docs v0.17.0
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
@@ -60,7 +62,6 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.6.2 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-api-golang-client v0.27.0 h1:zIwMXcbCB4n588i3O2N6HfNcQogCNTd/vPkEXTr7zX8=
 github.com/grafana/grafana-api-golang-client v0.27.0/go.mod h1:uNLZEmgKtTjHBtCQMwNn3qsx2mpMb8zU+7T4Xv3NR9Y=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240126175209-247049a95c63 h1:Hvxkgh0MDYUlnyYOMai4kVbjRH6EuzctE1I5AFJRtOI=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240126175209-247049a95c63/go.mod h1:6sYY1qgwYfSDNQhKQA0tar8Oc38cIGfyqwejhxoOsPs=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20240126032018-bd23c00af697 h1:8io6OuKJrhH8SEfwXV1ZpAwgaGhJ25/pjaA3vYmMxxE=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20240126032018-bd23c00af697/go.mod h1:af7rlJw/VtbvAfI5VWzYO4p/pT58FXrN6XqZBnkwBxo=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -8,6 +8,7 @@ import (
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/machine-learning-go-client/mlapi"
 	slo "github.com/grafana/slo-openapi-client/go"
@@ -17,10 +18,11 @@ import (
 )
 
 type Client struct {
-	GrafanaAPIURL       string
-	GrafanaAPIURLParsed *url.URL
-	GrafanaAPIConfig    *goapi.TransportConfig
-	GrafanaCloudAPI     *gapi.Client
+	GrafanaAPIURL          string
+	GrafanaAPIURLParsed    *url.URL
+	GrafanaAPIConfig       *goapi.TransportConfig
+	GrafanaCloudAPI        *gapi.Client
+	GrafanaCloudAPIOpenAPI *gcom.APIClient
 
 	GrafanaOAPI *goapi.GrafanaHTTPAPI
 

--- a/internal/resources/cloud/data_source_cloud_organization.go
+++ b/internal/resources/cloud/data_source_cloud_organization.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -44,25 +45,25 @@ func DataSourceOrganization() *schema.Resource {
 }
 
 func DataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
+	client := meta.(*common.Client).GrafanaCloudAPI
 
 	id := d.Get("id").(string)
 	if id == "" {
 		id = d.Get("slug").(string)
 	}
-	org, _, err := client.OrgsAPI.GetOrg(ctx, id).Execute()
+	org, err := client.GetCloudOrg(id)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	id = strconv.FormatInt(int64(org.Id), 10)
+	id = strconv.FormatInt(org.ID, 10)
 	d.SetId(id)
 	d.Set("id", id)
 	d.Set("name", org.Name)
 	d.Set("slug", org.Slug)
-	d.Set("url", org.Url)
-	d.Set("created_at", org.CreatedAt)
-	d.Set("updated_at", org.UpdatedAt)
+	d.Set("url", org.URL)
+	d.Set("created_at", org.CreatedAt.Format(time.RFC3339))
+	d.Set("updated_at", org.UpdatedAt.Format(time.RFC3339))
 
 	return nil
 }

--- a/internal/resources/cloud/data_source_cloud_organization.go
+++ b/internal/resources/cloud/data_source_cloud_organization.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -45,25 +44,25 @@ func DataSourceOrganization() *schema.Resource {
 }
 
 func DataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
+	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
 
 	id := d.Get("id").(string)
 	if id == "" {
 		id = d.Get("slug").(string)
 	}
-	org, err := client.GetCloudOrg(id)
+	org, _, err := client.OrgsAPI.GetOrg(ctx, id).Execute()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	id = strconv.FormatInt(org.ID, 10)
+	id = strconv.FormatInt(int64(org.Id), 10)
 	d.SetId(id)
 	d.Set("id", id)
 	d.Set("name", org.Name)
 	d.Set("slug", org.Slug)
-	d.Set("url", org.URL)
-	d.Set("created_at", org.CreatedAt.Format(time.RFC3339))
-	d.Set("updated_at", org.UpdatedAt.Format(time.RFC3339))
+	d.Set("url", org.Url)
+	d.Set("created_at", org.CreatedAt)
+	d.Set("updated_at", org.UpdatedAt)
 
 	return nil
 }

--- a/internal/resources/cloud/data_source_cloud_stack.go
+++ b/internal/resources/cloud/data_source_cloud_stack.go
@@ -32,11 +32,12 @@ available at “https://<stack_slug>.grafana.net".`,
 }
 
 func DataSourceStackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
+	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
 
 	slug := d.Get("slug").(string)
 
-	stack, err := client.StackBySlug(slug)
+	req := client.InstancesAPI.GetInstance(ctx, slug)
+	stack, _, err := req.Execute()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/cloud/request_id.go
+++ b/internal/resources/cloud/request_id.go
@@ -1,0 +1,11 @@
+package cloud
+
+import "github.com/hashicorp/go-uuid"
+
+func clientRequestID() string {
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return ""
+	}
+	return "tf-" + uuid
+}

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	gapi "github.com/grafana/grafana-api-golang-client"
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -247,17 +247,18 @@ available at “https://<stack_slug>.grafana.net".`,
 }
 
 func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
+	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
 
-	stack := &gapi.CreateStackInput{
+	stack := gcom.PostInstancesRequest{
 		Name:   d.Get("name").(string),
-		Slug:   d.Get("slug").(string),
-		URL:    d.Get("url").(string),
-		Region: d.Get("region_slug").(string),
+		Slug:   common.Ref(d.Get("slug").(string)),
+		Url:    common.Ref(d.Get("url").(string)),
+		Region: common.Ref(d.Get("region_slug").(string)),
 	}
 
-	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
-		stackID, err := client.NewStack(stack)
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		req := client.InstancesAPI.PostInstances(ctx).PostInstancesRequest(stack).XRequestId(clientRequestID())
+		createdStack, _, err := req.Execute()
 		switch {
 		case err != nil && strings.Contains(strings.ToLower(err.Error()), "conflict"):
 			// If the API returns a conflict error, it means that the stack already exists
@@ -268,15 +269,16 @@ func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		case err != nil:
 			// If we had an error that isn't a a conflict error (already exists), try to read the stack
 			// Sometimes, the stack is created but the API returns an error (e.g. 504)
-			readStack, readErr := client.StackBySlug(stack.Slug)
+			readReq := client.InstancesAPI.GetInstance(ctx, *stack.Slug)
+			readStack, _, readErr := readReq.Execute()
 			if readErr == nil {
-				d.SetId(strconv.FormatInt(readStack.ID, 10))
+				d.SetId(strconv.FormatInt(int64(readStack.Id), 10))
 				return nil
 			}
 			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
 			return retry.RetryableError(fmt.Errorf("failed to create stack: %v", err))
 		default:
-			d.SetId(strconv.FormatInt(stackID, 10))
+			d.SetId(strconv.FormatInt(int64(createdStack.Id), 10))
 		}
 		return nil
 	})
@@ -292,8 +294,7 @@ func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 }
 
 func UpdateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-	stackID, _ := strconv.ParseInt(d.Id(), 10, 64)
+	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
 
 	// The underlying API olnly allows to update the name and description.
 	allowedChanges := []string{"name", "description", "slug"}
@@ -302,12 +303,13 @@ func UpdateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	}
 
 	if d.HasChange("name") || d.HasChange("description") || d.HasChanges("slug") {
-		stack := &gapi.UpdateStackInput{
-			Name:        d.Get("name").(string),
-			Slug:        d.Get("slug").(string),
-			Description: d.Get("description").(string),
+		stack := gcom.PostInstanceRequest{
+			Name:        common.Ref(d.Get("name").(string)),
+			Slug:        common.Ref(d.Get("slug").(string)),
+			Description: common.Ref(d.Get("description").(string)),
 		}
-		err := client.UpdateStack(stackID, stack)
+		req := client.InstancesAPI.PostInstance(ctx, d.Id()).PostInstanceRequest(stack).XRequestId(clientRequestID())
+		_, _, err := req.Execute()
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -321,17 +323,16 @@ func UpdateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 }
 
 func DeleteStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-	if err := client.DeleteStack(d.Id()); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
+	req := client.InstancesAPI.DeleteInstance(ctx, d.Id()).XRequestId(clientRequestID())
+	_, _, err := req.Execute()
+	return diag.FromErr(err)
 }
 
 func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-	stack, err := getStackFromIDOrSlug(client, d.Id())
+	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
+	req := client.InstancesAPI.GetInstance(ctx, d.Id())
+	stack, _, err := req.Execute()
 	if err, shouldReturn := common.CheckReadError("stack", d, err); shouldReturn {
 		return err
 	}
@@ -342,7 +343,7 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return nil
 	}
 
-	if err := FlattenStack(d, *stack); err != nil {
+	if err := FlattenStack(d, stack); err != nil {
 		return diag.FromErr(err)
 	}
 	// Always set the wait attribute to true after creation
@@ -352,75 +353,56 @@ func ReadStack(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	return nil
 }
 
-func FlattenStack(d *schema.ResourceData, stack gapi.Stack) error {
-	id := strconv.FormatInt(stack.ID, 10)
+func FlattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance) error {
+	id := strconv.FormatInt(int64(stack.Id), 10)
 	d.SetId(id)
 	d.Set("name", stack.Name)
 	d.Set("slug", stack.Slug)
-	d.Set("url", stack.URL)
+	d.Set("url", stack.Url)
 	d.Set("status", stack.Status)
 	d.Set("region_slug", stack.RegionSlug)
 	d.Set("description", stack.Description)
 
-	d.Set("org_id", stack.OrgID)
+	d.Set("org_id", stack.OrgId)
 	d.Set("org_slug", stack.OrgSlug)
 	d.Set("org_name", stack.OrgName)
 
-	d.Set("prometheus_user_id", stack.HmInstancePromID)
-	d.Set("prometheus_url", stack.HmInstancePromURL)
+	d.Set("prometheus_user_id", stack.HmInstancePromId)
+	d.Set("prometheus_url", stack.HmInstancePromUrl)
 	d.Set("prometheus_name", stack.HmInstancePromName)
-	reURL, err := appendPath(stack.HmInstancePromURL, "/api/prom")
+	reURL, err := appendPath(stack.HmInstancePromUrl, "/api/prom")
 	if err != nil {
 		return err
 	}
 	d.Set("prometheus_remote_endpoint", reURL)
-	rweURL, err := appendPath(stack.HmInstancePromURL, "/api/prom/push")
+	rweURL, err := appendPath(stack.HmInstancePromUrl, "/api/prom/push")
 	if err != nil {
 		return err
 	}
 	d.Set("prometheus_remote_write_endpoint", rweURL)
 	d.Set("prometheus_status", stack.HmInstancePromStatus)
 
-	d.Set("logs_user_id", stack.HlInstanceID)
-	d.Set("logs_url", stack.HlInstanceURL)
+	d.Set("logs_user_id", stack.HlInstanceId)
+	d.Set("logs_url", stack.HlInstanceUrl)
 	d.Set("logs_name", stack.HlInstanceName)
 	d.Set("logs_status", stack.HlInstanceStatus)
 
-	d.Set("alertmanager_user_id", stack.AmInstanceID)
+	d.Set("alertmanager_user_id", stack.AmInstanceId)
 	d.Set("alertmanager_name", stack.AmInstanceName)
-	d.Set("alertmanager_url", stack.AmInstanceURL)
+	d.Set("alertmanager_url", stack.AmInstanceUrl)
 	d.Set("alertmanager_status", stack.AmInstanceStatus)
 
-	d.Set("traces_user_id", stack.HtInstanceID)
+	d.Set("traces_user_id", stack.HtInstanceId)
 	d.Set("traces_name", stack.HtInstanceName)
-	d.Set("traces_url", stack.HtInstanceURL)
+	d.Set("traces_url", stack.HtInstanceUrl)
 	d.Set("traces_status", stack.HtInstanceStatus)
 
-	d.Set("graphite_user_id", stack.HmInstanceGraphiteID)
+	d.Set("graphite_user_id", stack.HmInstanceGraphiteId)
 	d.Set("graphite_name", stack.HmInstanceGraphiteName)
-	d.Set("graphite_url", stack.HmInstanceGraphiteURL)
+	d.Set("graphite_url", stack.HmInstanceGraphiteUrl)
 	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
 
 	return nil
-}
-
-func getStackFromIDOrSlug(client *gapi.Client, id string) (*gapi.Stack, error) {
-	numericalID, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		// If the ID is not a number, then it may be a slug
-		stack, err := client.StackBySlug(id)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find stack by ID or slug '%s': %w", id, err)
-		}
-		return &stack, nil
-	}
-
-	stack, err := client.StackByID(numericalID)
-	if err != nil {
-		return nil, err
-	}
-
-	return &stack, nil
 }
 
 // Append path to baseurl
@@ -453,7 +435,7 @@ func waitForStackReadiness(ctx context.Context, d *schema.ResourceData) diag.Dia
 		}
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			return retry.NonRetryableError(err)
+			return retry.RetryableError(err)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {


### PR DESCRIPTION
This adds the new openapi client (WIP: https://github.com/grafana/grafana-com-public-clients) and converts a few resources (just to test)
All cloud resources need to be modified to get rid of https://github.com/grafana/grafana-api-golang-client 
