### PR TITLE
Update oncall shift interval param docs

### DIFF
--- a/docs/resources/oncall_on_call_shift.md
+++ b/docs/resources/oncall_on_call_shift.md
@@ -104,7 +104,7 @@ output "emea_weekday__rolling_users" {
 - `by_month` (Set of Number) This parameter takes a list of months. Valid values are 1 to 12
 - `by_monthday` (Set of Number) This parameter takes a list of days of the month.  Valid values are 1 to 31 or -31 to -1
 - `frequency` (String) The frequency of the event. Can be hourly, daily, weekly, monthly
-- `interval` (Number) The positive integer representing at which intervals the recurrence rule repeats. Required if a frequency is set (fallback to 1 if omitted but it will later be detected as a change).
+- `interval` (Number) The positive integer representing at which intervals the recurrence rule repeats.
 - `level` (Number) The priority level. The higher the value, the higher the priority.
 - `rolling_users` (List of Set of String) The list of lists with on-call users (for rolling_users event type)
 - `start_rotation_from_user_index` (Number) The index of the list of users in rolling_users, from which on-call rotation starts.

--- a/docs/resources/oncall_on_call_shift.md
+++ b/docs/resources/oncall_on_call_shift.md
@@ -73,6 +73,7 @@ resource "grafana_oncall_on_call_shift" "emea_weekday_shift" {
   start      = "2022-02-28T03:00:00"
   duration   = 60 * 60 * 12 // 12 hours
   frequency  = "weekly"
+  interval   = 1
   by_day     = ["MO", "TU", "WE", "TH", "FR"]
   week_start = "MO"
   // Run `terraform refresh` and `terraform output` to see the flattened list of users in the rotation
@@ -103,7 +104,7 @@ output "emea_weekday__rolling_users" {
 - `by_month` (Set of Number) This parameter takes a list of months. Valid values are 1 to 12
 - `by_monthday` (Set of Number) This parameter takes a list of days of the month.  Valid values are 1 to 31 or -31 to -1
 - `frequency` (String) The frequency of the event. Can be hourly, daily, weekly, monthly
-- `interval` (Number) The positive integer representing at which intervals the recurrence rule repeats.
+- `interval` (Number) The positive integer representing at which intervals the recurrence rule repeats. Required if a frequency is set (fallback to 1 if omitted but it will later be detected as a change).
 - `level` (Number) The priority level. The higher the value, the higher the priority.
 - `rolling_users` (List of Set of String) The list of lists with on-call users (for rolling_users event type)
 - `start_rotation_from_user_index` (Number) The index of the list of users in rolling_users, from which on-call rotation starts.

--- a/examples/resources/grafana_oncall_on_call_shift/resource.tf
+++ b/examples/resources/grafana_oncall_on_call_shift/resource.tf
@@ -58,6 +58,7 @@ resource "grafana_oncall_on_call_shift" "emea_weekday_shift" {
   start      = "2022-02-28T03:00:00"
   duration   = 60 * 60 * 12 // 12 hours
   frequency  = "weekly"
+  interval   = 1
   by_day     = ["MO", "TU", "WE", "TH", "FR"]
   week_start = "MO"
   // Run `terraform refresh` and `terraform output` to see the flattened list of users in the rotation

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -102,6 +102,9 @@ func ResourceOnCallShift() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(onCallShiftFrequencyOptions, false),
 				Description:  fmt.Sprintf("The frequency of the event. Can be %s", onCallShiftFrequencyOptionsVerbal),
+				RequiredWith: []string{
+					"interval",
+				},
 			},
 			"users": {
 				Type: schema.TypeSet,
@@ -126,7 +129,10 @@ func ResourceOnCallShift() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(1),
-				Description:  "The positive integer representing at which intervals the recurrence rule repeats. Required if a frequency is set (fallback to 1 if omitted but it will later be detected as a change).",
+				Description:  "The positive integer representing at which intervals the recurrence rule repeats.",
+				RequiredWith: []string{
+					"frequency",
+				},
 			},
 			"week_start": {
 				Type:         schema.TypeString,

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -126,7 +126,7 @@ func ResourceOnCallShift() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(1),
-				Description:  "The positive integer representing at which intervals the recurrence rule repeats.",
+				Description:  "The positive integer representing at which intervals the recurrence rule repeats. Required if a frequency is set (fallback to 1 if omitted but it will later be detected as a change).",
 			},
 			"week_start": {
 				Type:         schema.TypeString,

--- a/internal/resources/oncall/resource_shift_test.go
+++ b/internal/resources/oncall/resource_shift_test.go
@@ -46,6 +46,13 @@ func TestAccOnCallOnCallShift_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "frequency", "hourly"),
 				),
 			},
+			{
+				Config: testAccOnCallOnCallShiftConfigSingle(scheduleName, shiftName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallOnCallShiftResourceExists("grafana_oncall_on_call_shift.test-acc-on_call_shift"),
+					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "name", shiftName),
+				),
+			},
 		},
 	})
 }
@@ -102,6 +109,23 @@ resource "grafana_oncall_on_call_shift" "test-acc-on_call_shift" {
 	level = 1
 	frequency = "hourly"
 	interval = 2
+}
+`, scheduleName, shiftName)
+}
+
+func testAccOnCallOnCallShiftConfigSingle(scheduleName, shiftName string) string {
+	return fmt.Sprintf(`
+resource "grafana_oncall_schedule" "test-acc-schedule" {
+	type = "calendar"
+	name = "%s"
+	time_zone = "UTC"
+}
+
+resource "grafana_oncall_on_call_shift" "test-acc-on_call_shift" {
+	name = "%s"
+	type = "single_event"
+	start = "2020-09-04T16:00:00"
+	duration = 60
 }
 `, scheduleName, shiftName)
 }


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/9142

Double-checked about `time_zone` parameter, couldn't reproduce the issue (it worked as optional in my tests, and reviewing the logic, it seems that should be always the case).