### PR TITLE
Reports: Add report_variables to dashboards

### DIFF
--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -91,7 +91,7 @@ Required:
 
 Optional:
 
-- `report_variables` (Map of String) Add report variables to the dashboard. Values should be a string separated by commas.
+- `report_variables` (Map of String) Add report variables to the dashboard. Values should be separated by commas.
 - `time_range` (Block List, Max: 1) Time range of the report. (see [below for nested schema](#nestedblock--dashboards--time_range))
 
 <a id="nestedblock--dashboards--time_range"></a>

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -91,6 +91,7 @@ Required:
 
 Optional:
 
+- `report_variables` (Map of String) Add report variables to the dashboard. Values should be a string separated by commas.
 - `time_range` (Block List, Max: 1) Time range of the report. (see [below for nested schema](#nestedblock--dashboards--time_range))
 
 <a id="nestedblock--dashboards--time_range"></a>

--- a/examples/resources/grafana_report/multiple-dashboards.tf
+++ b/examples/resources/grafana_report/multiple-dashboards.tf
@@ -32,6 +32,10 @@ resource "grafana_report" "test" {
       from = "now-1h"
       to   = "now"
     }
+    report_variables = { 
+      query0 = "a,b"
+      query1 = "c,d"
+    }
   }
 
   dashboards {

--- a/examples/resources/grafana_report/multiple-dashboards.tf
+++ b/examples/resources/grafana_report/multiple-dashboards.tf
@@ -32,7 +32,7 @@ resource "grafana_report" "test" {
       from = "now-1h"
       to   = "now"
     }
-    report_variables = { 
+    report_variables = {
       query0 = "a,b"
       query1 = "c,d"
     }

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -584,7 +584,7 @@ func parseCustomReportInterval(i interface{}) (int, string, error) {
 func validateReportVariables(i interface{}, path cty.Path) diag.Diagnostics {
 	m, ok := i.(map[string]interface{})
 	if !ok {
-		return diag.FromErr(errors.New("report_variables schema should be a map of strings seperated by commas"))
+		return diag.FromErr(errors.New("report_variables schema should be a map of strings separated by commas"))
 	}
 
 	for _, v := range m {

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -50,6 +50,8 @@ func TestAccResourceReport_Multiple_Dashboards(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.uid", randomUID),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.time_range.0.from", "now-1h"),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.time_range.0.to", "now"),
+					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.report_variables.query0", "a,b"),
+					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.report_variables.query1", "c,d"),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.time_range.0.from", ""),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.time_range.0.to", ""),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.uid", randomUID2),


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1008

It adds `report_variables` under `dashboards` using the new way to do it.

Reports expect a map of a list of string for this field, but for a SDK limitation/bug it doesn't work even if we specify the type of the map. 

The workaround of this was to expect a map of strings only and parse the values send the correct values.

So:
```tf
report_values = {
  query0 = "val1,val2"
  query1 = "val3,val4"
}
```
will send:
```json
"report_values" {
    "query0": ["val1", "val2"]
    "query1": ["val3", "val4"]
}
```

I was tested it locally and I checked that deprecated message isn't prompted.