### PR TITLE
Cloud Stack: Fix description on stack create

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -255,10 +255,11 @@ func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	client := meta.(*common.Client).GrafanaCloudAPIOpenAPI
 
 	stack := gcom.PostInstancesRequest{
-		Name:   d.Get("name").(string),
-		Slug:   common.Ref(d.Get("slug").(string)),
-		Url:    common.Ref(d.Get("url").(string)),
-		Region: common.Ref(d.Get("region_slug").(string)),
+		Name:        d.Get("name").(string),
+		Slug:        common.Ref(d.Get("slug").(string)),
+		Url:         common.Ref(d.Get("url").(string)),
+		Region:      common.Ref(d.Get("region_slug").(string)),
+		Description: common.Ref(d.Get("description").(string)),
 	}
 
 	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {

--- a/internal/resources/cloud/resource_cloud_stack_api_key_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key_test.go
@@ -39,7 +39,7 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStackConfigBasic(slug, slug),
+				Config: testAccStackConfigBasic(slug, slug, "description"),
 				Check:  testAccGrafanaAuthKeyCheckDestroyCloud,
 			},
 		},
@@ -47,7 +47,7 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 }
 
 func testAccGrafanaAuthKeyFromCloud(name, slug string) string {
-	return testAccStackConfigBasic(name, slug) + `
+	return testAccStackConfigBasic(name, slug, "description") + `
 	resource "grafana_cloud_stack_api_key" "management" {
 		stack_slug = grafana_cloud_stack.test.slug
 		name       = "management-key"

--- a/internal/resources/cloud/resource_cloud_stack_service_account_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_test.go
@@ -41,7 +41,7 @@ func TestAccGrafanaServiceAccountFromCloud(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccStackConfigBasic(slug, slug),
+				Config: testAccStackConfigBasic(slug, slug, "description"),
 				Check:  testAccGrafanaServiceAccountCheckDestroyCloud,
 			},
 		},
@@ -49,7 +49,7 @@ func TestAccGrafanaServiceAccountFromCloud(t *testing.T) {
 }
 
 func testAccGrafanaServiceAccountFromCloud(name, slug string) string {
-	return testAccStackConfigBasic(name, slug) + `
+	return testAccStackConfigBasic(name, slug, "description") + `
 	resource "grafana_cloud_stack_service_account" "management" {
 		stack_slug = grafana_cloud_stack.test.slug
 		name       = "management-sa"

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -31,6 +31,7 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestMatchResourceAttr("grafana_cloud_stack.test", "id", common.IDRegexp),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "name", resourceName),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_write_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"),

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -51,21 +51,21 @@ func TestResourceStack_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a basic stack
 			{
-				Config: testAccStackConfigBasic(resourceName, resourceName),
+				Config: testAccStackConfigBasic(resourceName, resourceName, stackDescription),
 				Check:  firstStepChecks,
 			},
 			// Check that we can't takeover a stack without importing it
 			// The retrying logic for creation is very permissive,
 			// but it shouldn't allow to apply an already existing stack on a new resource
 			{
-				Config: testAccStackConfigBasic(resourceName, resourceName) +
-					testAccStackConfigBasicWithCustomResourceName(resourceName, resourceName, "eu", "test2"), // new stack with same name/slug
+				Config: testAccStackConfigBasic(resourceName, resourceName, stackDescription) +
+					testAccStackConfigBasicWithCustomResourceName(resourceName, resourceName, "eu", "test2", stackDescription), // new stack with same name/slug
 				ExpectError: regexp.MustCompile(fmt.Sprintf(".*a stack with the name '%s' already exists.*", resourceName)),
 			},
 			// Test that the stack is correctly recreated if it's tainted and reapplied
 			// This is a special case because stack deletion is asynchronous
 			{
-				Config: testAccStackConfigBasic(resourceName, resourceName),
+				Config: testAccStackConfigBasic(resourceName, resourceName, stackDescription),
 				Check:  firstStepChecks,
 				Taint:  []string{"grafana_cloud_stack.test"},
 			},
@@ -76,7 +76,7 @@ func TestResourceStack_Basic(t *testing.T) {
 					testAccDeleteExistingStacks(t, prefix)
 					time.Sleep(10 * time.Second)
 				},
-				Config: testAccStackConfigBasic(resourceName, resourceName),
+				Config: testAccStackConfigBasic(resourceName, resourceName, stackDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
 					resource.TestMatchResourceAttr("grafana_cloud_stack.test", "id", common.IDRegexp),
@@ -170,18 +170,19 @@ func testAccStackCheckDestroy(a *gapi.Stack) resource.TestCheckFunc {
 	}
 }
 
-func testAccStackConfigBasic(name string, slug string) string {
-	return testAccStackConfigBasicWithCustomResourceName(name, slug, "eu", "test")
+func testAccStackConfigBasic(name string, slug string, description string) string {
+	return testAccStackConfigBasicWithCustomResourceName(name, slug, "eu", "test", description)
 }
 
-func testAccStackConfigBasicWithCustomResourceName(name, slug, region, resourceName string) string {
+func testAccStackConfigBasicWithCustomResourceName(name, slug, region, resourceName, description string) string {
 	return fmt.Sprintf(`
 	resource "grafana_cloud_stack" "%s" {
 		name  = "%s"
 		slug  = "%s"
 		region_slug = "%s"
+		description = "%s"
 	  }
-	`, resourceName, name, slug, region)
+	`, resourceName, name, slug, region, description)
 }
 
 func testAccStackConfigUpdate(name string, slug string, description string) string {

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
@@ -49,7 +49,7 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 }
 
 func testAccSyntheticMonitoringInstallation_Base(stackSlug, apiKeyName, region string) string {
-	return testAccStackConfigBasicWithCustomResourceName(stackSlug, stackSlug, region, "test") +
+	return testAccStackConfigBasicWithCustomResourceName(stackSlug, stackSlug, region, "test", "description") +
 		testAccCloudAPIKeyConfig(apiKeyName, "MetricsPublisher")
 }
 


### PR DESCRIPTION
This pull request should fix the issue with grafana_cloud_stack resources being created with an empty description. See issue #1324 