### PR TITLE
Update SM docs with access policy information

### DIFF
--- a/docs/resources/synthetic_monitoring_installation.md
+++ b/docs/resources/synthetic_monitoring_installation.md
@@ -93,7 +93,7 @@ data "grafana_synthetic_monitoring_probes" "main" {
 
 ### Required
 
-- `metrics_publisher_key` (String, Sensitive) The Cloud API Key with the `MetricsPublisher` role used to publish metrics to the SM API
+- `metrics_publisher_key` (String, Sensitive) The [Grafana Cloud access policy](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) with the following scopes: `stacks:read`, `metrics:write`, `logs:write`, `traces:write`. This is used to publish metrics and logs to Grafana Cloud stack.
 - `stack_id` (String) The ID or slug of the stack to install SM on.
 
 ### Optional

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation.go
@@ -43,7 +43,7 @@ This resource cannot be imported but it can be used on an existing Synthetic Mon
 				Sensitive:   true,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The Cloud API Key with the `MetricsPublisher` role used to publish metrics to the SM API",
+				Description: "The [Grafana Cloud access policy](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) with the following scopes: `stacks:read`, `metrics:write`, `logs:write`, `traces:write`. This is used to publish metrics and logs to Grafana Cloud stack.",
 			},
 			"stack_sm_api_url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
API tokens were removed a while ago, so update this documentation to mention access policies, which is what's actually used.