### PR TITLE
SLO: Remove destination datasource type

### DIFF
--- a/docs/data-sources/slos.md
+++ b/docs/data-sources/slos.md
@@ -176,7 +176,6 @@ Read-Only:
 
 Read-Only:
 
-- `type` (String)
 - `uid` (String)
 
 

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -280,7 +280,6 @@ Required:
 
 Optional:
 
-- `type` (String) Type of the Datasource Defaults to `mimir`.
 - `uid` (String) UID for the Mimir Datasource
 
 

--- a/internal/resources/slo/data_source_slo.go
+++ b/internal/resources/slo/data_source_slo.go
@@ -218,11 +218,6 @@ func unpackDestinationDatasource(destinationDatasource *slo.DestinationDatasourc
 	retDestinationDatasource := make(map[string]interface{})
 	retDestinationDatasource["uid"] = destinationDatasource.Uid
 
-	retDestinationDatasource["type"] = defaultDestinationDatasourceType
-	if destinationDatasource.Type != nil {
-		retDestinationDatasource["type"] = *destinationDatasource.Type
-	}
-
 	retDestinationDatasources = append(retDestinationDatasources, retDestinationDatasource)
 
 	return retDestinationDatasources

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -19,7 +19,6 @@ const (
 	QueryTypeRatio     string = "ratio"
 	QueryTypeThreshold string = "threshold"
 )
-const defaultDestinationDatasourceType = "mimir"
 
 func ResourceSlo() *schema.Resource {
 	return &schema.Resource{
@@ -61,12 +60,6 @@ Resource manages Grafana SLOs.
 							Type:        schema.TypeString,
 							Description: `UID for the Mimir Datasource`,
 							Optional:    true,
-						},
-						"type": {
-							Type:        schema.TypeString,
-							Description: `Type of the Datasource`,
-							Optional:    true,
-							Default:     defaultDestinationDatasourceType,
 						},
 					},
 				},
@@ -388,9 +381,7 @@ func packSloResource(d *schema.ResourceData) (slo.Slo, error) {
 }
 
 func packDestinationDatasource(destinationdatasource map[string]interface{}) (slo.DestinationDatasource, error) {
-	packedDestinationDatasource := slo.DestinationDatasource{
-		Type: common.Ref(destinationdatasource["type"].(string)),
-	}
+	packedDestinationDatasource := slo.DestinationDatasource{}
 
 	if destinationdatasource["uid"].(string) != "" {
 		datasourceUID := destinationdatasource["uid"].(string)


### PR DESCRIPTION
Introduced here: https://github.com/grafana/terraform-provider-grafana/pull/1321 
This was a bug in the API