### PR TITLE
FIx Grafana 10.3 TODOs

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -372,7 +372,7 @@ func TestAccContactPoint_notifiers10_2(t *testing.T) {
 }
 
 func TestAccContactPoint_notifiers10_3(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t) // TODO: Switch to `testutils.CheckOSSTestsEnabled(t, ">=10.3.0")` once 10.3 is released.
+	testutils.CheckOSSTestsEnabled(t, ">=10.3.0")
 
 	var points models.ContactPoints
 

--- a/internal/resources/grafana/resource_data_source_permission_test.go
+++ b/internal/resources/grafana/resource_data_source_permission_test.go
@@ -1,10 +1,12 @@
 package grafana_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -12,22 +14,21 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t)
 
 	var ds models.DataSource
-
-	// TODO: Admin role can only be set from Grafana 10.3.0 onwards. Test this!
-	config := testutils.TestAccExample(t, "resources/grafana_data_source_permission/resource.tf")
+	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccDatasourcePermission(name, "Edit"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					datasourcePermissionsCheckExists.exists("grafana_data_source_permission.fooPermissions", &ds),
 					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "4"),
+					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.0.permission", "Edit"),
 				),
 			},
 			{
-				Config: testutils.WithoutResource(t, config, "grafana_data_source_permission.fooPermissions"),
+				Config: testutils.WithoutResource(t, testAccDatasourcePermission(name, "Edit"), "grafana_data_source_permission.fooPermissions"),
 				Check:  datasourcePermissionsCheckExists.destroyed(&ds, nil),
 			},
 		},
@@ -38,23 +39,77 @@ func TestAccDatasourcePermission_AdminRole(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t, ">=10.3.0")
 
 	var ds models.DataSource
-
-	config := testutils.TestAccExample(t, "resources/grafana_data_source_permission/resource.tf")
+	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccDatasourcePermission(name, "Admin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					datasourcePermissionsCheckExists.exists("grafana_data_source_permission.fooPermissions", &ds),
 					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "4"),
+					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.0.permission", "Admin"),
 				),
 			},
 			{
-				Config: testutils.WithoutResource(t, config, "grafana_data_source_permission.fooPermissions"),
+				Config: testutils.WithoutResource(t, testAccDatasourcePermission(name, "Admin"), "grafana_data_source_permission.fooPermissions"),
 				Check:  datasourcePermissionsCheckExists.destroyed(&ds, nil),
 			},
 		},
 	})
+}
+
+func testAccDatasourcePermission(name string, teamPermission string) string {
+	return fmt.Sprintf(`
+resource "grafana_team" "team" {
+	name = "%[1]s"
+}
+
+resource "grafana_data_source" "foo" {
+	name = "%[1]s"
+	type = "cloudwatch"
+
+	json_data_encoded = jsonencode({
+		defaultRegion = "us-east-1"
+		authType      = "keys"
+	})
+
+	secure_json_data_encoded = jsonencode({
+		accessKey = "123"
+		secretKey = "456"
+	})
+}
+
+resource "grafana_user" "user" {
+	name     = "%[1]s"
+	email    = "%[1]s@example.com"
+	login    = "%[1]s"
+	password = "hunter2"
+}
+
+resource "grafana_service_account" "sa" {
+	name = "%[1]s"
+	role = "Viewer"
+}
+
+resource "grafana_data_source_permission" "fooPermissions" {
+	datasource_id = grafana_data_source.foo.id
+	permissions {
+		team_id    = grafana_team.team.id
+		permission = "%[2]s"
+	}
+	permissions {
+		user_id    = grafana_user.user.id
+		permission = "Edit"
+	}
+	permissions {
+		built_in_role = "Viewer"
+		permission    = "Query"
+	}
+	permissions {
+		user_id    = grafana_service_account.sa.id
+		permission = "Query"
+	}
+}`, name, teamPermission)
 }


### PR DESCRIPTION
- Datasource permissions: Test the `Admin` permission which was added in 10.3
- Move the `opsgenie` contact point notifier test from the cloud instance to the OSS instance