### PR TITLE
SSO: add validation for the provider_name field

### DIFF
--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -3,13 +3,13 @@
 page_title: "grafana_sso_settings Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Manages Grafana SSO Settings for OAuth2, SAML and LDAP.
+  Manages Grafana SSO Settings for OAuth2. SAML support will be added soon.
   Official documentation https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/sso-settings/
 ---
 
 # grafana_sso_settings (Resource)
 
-Manages Grafana SSO Settings for OAuth2, SAML and LDAP.
+Manages Grafana SSO Settings for OAuth2. SAML support will be added soon.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/sso-settings/)
@@ -36,7 +36,7 @@ resource "grafana_sso_settings" "github_sso_settings" {
 ### Required
 
 - `oauth2_settings` (Block Set, Min: 1, Max: 1) The SSO settings set. (see [below for nested schema](#nestedblock--oauth2_settings))
-- `provider_name` (String) The name of the SSO provider.
+- `provider_name` (String) The name of the SSO provider. Supported values: github, gitlab, google, azuread, okta, generic_oauth.
 
 ### Read-Only
 

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 )
@@ -19,7 +20,7 @@ func ResourceSSOSettings() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
-Manages Grafana SSO Settings for OAuth2, SAML and LDAP.
+Manages Grafana SSO Settings for OAuth2. SAML support will be added soon.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/sso-settings/)
@@ -35,9 +36,10 @@ Manages Grafana SSO Settings for OAuth2, SAML and LDAP.
 
 		Schema: map[string]*schema.Schema{
 			providerKey: {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The name of the SSO provider.",
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The name of the SSO provider. Supported values: github, gitlab, google, azuread, okta, generic_oauth.",
+				ValidateFunc: validation.StringInSlice([]string{"github", "gitlab", "google", "azuread", "okta", "generic_oauth"}, false),
 			},
 			oauth2SettingsKey: {
 				Type:        schema.TypeSet,

--- a/internal/resources/grafana/resource_sso_settings_test.go
+++ b/internal/resources/grafana/resource_sso_settings_test.go
@@ -64,6 +64,20 @@ func TestSSOSettings_basic(t *testing.T) {
 	}
 }
 
+func TestSSOSettings_resourceWithInvalidProvider(t *testing.T) {
+	provider := "invalid_provider"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testConfigForProvider(provider, "new"),
+				ExpectError: regexp.MustCompile("expected provider_name to be one of"),
+			},
+		},
+	})
+}
+
 func TestSSOSettings_resourceWithNoSettings(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,


### PR DESCRIPTION
Enforces `provider_name` to be one of github, gitlab, google, azuread, okta, generic_oauth.

Also updated the SSO resource description removing LDAP and mentioning that SAML support will be added soon.