### PR TITLE
Cloud Stacks: Add `labels`

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -45,6 +45,7 @@ available at “https://<stack_slug>.grafana.net".
 - `graphite_url` (String)
 - `graphite_user_id` (Number)
 - `id` (String) The stack id assigned to this stack by Grafana.
+- `labels` (Map of String) A map of labels to assign to the stack.
 - `logs_name` (String)
 - `logs_status` (String)
 - `logs_url` (String)

--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -45,7 +45,7 @@ available at “https://<stack_slug>.grafana.net".
 - `graphite_url` (String)
 - `graphite_user_id` (Number)
 - `id` (String) The stack id assigned to this stack by Grafana.
-- `labels` (Map of String) A map of labels to assign to the stack.
+- `labels` (Map of String) A map of labels to assign to the stack. Label keys and values must match the following regexp: "^[a-zA-Z0-9/\\-.]+$" and stacks cannot have more than 10 labels.
 - `logs_name` (String)
 - `logs_status` (String)
 - `logs_url` (String)

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -33,6 +33,7 @@ available at “https://<stack_slug>.grafana.net".
 ### Optional
 
 - `description` (String) Description of stack.
+- `labels` (Map of String) A map of labels to assign to the stack.
 - `region_slug` (String) Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -33,7 +33,7 @@ available at “https://<stack_slug>.grafana.net".
 ### Optional
 
 - `description` (String) Description of stack.
-- `labels` (Map of String) A map of labels to assign to the stack.
+- `labels` (Map of String) A map of labels to assign to the stack. Label keys and values must match the following regexp: "^[a-zA-Z0-9/\\-.]+$" and stacks cannot have more than 10 labels.
 - `region_slug` (String) Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.

--- a/internal/common/adapters.go
+++ b/internal/common/adapters.go
@@ -68,6 +68,14 @@ func ListOfSetsToStringSlice(listSet []interface{}) [][]string {
 	return ret
 }
 
+func UnpackMap[T any](m interface{}) map[string]T {
+	ret := make(map[string]T)
+	for k, v := range m.(map[string]interface{}) {
+		ret[k] = v.(T)
+	}
+	return ret
+}
+
 func Ref[T any](v T) *T {
 	return &v
 }

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -225,10 +225,9 @@ func CreateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 func UpdateStack(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*common.Client).GrafanaCloudAPI
 
-	// The underlying API only allows to update the name, slug, url and description.
-	allowedChanges := []string{"name", "description", "slug", "url"}
+	allowedChanges := []string{"name", "description", "slug", "url", "labels"}
 	if d.HasChangesExcept(allowedChanges...) {
-		return diag.Errorf("Error: Only name, slug, url and description can be updated.")
+		return diag.Errorf("Error: Only %s and description can be updated.", strings.Join(allowedChanges, ", "))
 	}
 
 	if d.HasChange("name") || d.HasChange("description") || d.HasChanges("slug") || d.HasChanges("url") {

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -34,6 +34,9 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.source", "terraform"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.#", "2"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_write_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "prometheus_user_id"),
@@ -187,6 +190,10 @@ func testAccStackConfigBasicWithCustomResourceName(name, slug, region, resourceN
 		slug  = "%s"
 		region_slug = "%s"
 		description = "%s"
+		labels = {
+			tf     = "true"
+			source = "terraform"
+		}
 	  }
 	`, resourceName, name, slug, region, description)
 }

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -37,7 +37,7 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.source", "terraform"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.to_delete", "true"),
-		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.#", "3"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.%", "3"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_write_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "prometheus_user_id"),
@@ -107,7 +107,7 @@ func TestResourceStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.source", "terraform-updated"),
-					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.#", "2"),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.%", "2"),
 				),
 			},
 			// Test import from ID

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -36,7 +36,7 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.source", "terraform"),
-		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.to_delete", "true"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.todelete", "true"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.%", "3"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_write_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"),
@@ -252,7 +252,7 @@ func testAccStackConfigBasicWithCustomResourceName(name, slug, region, resourceN
 		labels = {
 			tf        = "true"
 			source    = "terraform"
-			to_delete = "true"
+			todelete = "true"
 		}
 	  }
 	`, resourceName, name, slug, region, description)

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -36,7 +36,8 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.source", "terraform"),
-		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.#", "2"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.to_delete", "true"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.#", "3"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "prometheus_remote_write_endpoint", "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "prometheus_user_id"),
@@ -104,6 +105,9 @@ func TestResourceStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
 					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.source", "terraform-updated"),
+					resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.#", "2"),
 				),
 			},
 			// Test import from ID
@@ -191,8 +195,9 @@ func testAccStackConfigBasicWithCustomResourceName(name, slug, region, resourceN
 		region_slug = "%s"
 		description = "%s"
 		labels = {
-			tf     = "true"
-			source = "terraform"
+			tf        = "true"
+			source    = "terraform"
+			to_delete = "true"
 		}
 	  }
 	`, resourceName, name, slug, region, description)
@@ -205,6 +210,10 @@ func testAccStackConfigUpdate(name string, slug string, description string) stri
 		slug  = "%s"
 		region_slug = "eu"
 		description = "%s"
+		labels = {
+			tf     = "true"
+			source = "terraform-updated"
+		}
 	  }
 	`, name, slug, description)
 }


### PR DESCRIPTION
Allows labelling cloud stacks with a map of arbitrary labels