### PR TITLE
Folder Permissions: Reconcile if the folder was deleted

### DIFF
--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -128,6 +128,12 @@ func UpdateFolderPermissions(ctx context.Context, d *schema.ResourceData, meta i
 func ReadFolderPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, orgID, folderUID := OAPIClientFromExistingOrgResource(meta, d.Id())
 
+	// Check if the folder still exists
+	_, err := client.Folders.GetFolderByUID(folderUID)
+	if err, shouldReturn := common.CheckReadError("folder", d, err); shouldReturn {
+		return err
+	}
+
 	resp, err := client.AccessControl.GetResourcePermissions(folderUID, foldersPermissionsType)
 	if err, shouldReturn := common.CheckReadError("folder permissions", d, err); shouldReturn {
 		return err

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -15,17 +17,18 @@ func TestAccFolderPermission_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Folder permissions only work for service accounts in Grafana 9+, so we're just not testing versions before 9.
 
 	var (
-		folder models.Folder
-		team   models.TeamDTO
-		user   models.UserProfileDTO
-		sa     models.ServiceAccountDTO
+		folder     models.Folder
+		team       models.TeamDTO
+		user       models.UserProfileDTO
+		sa         models.ServiceAccountDTO
+		randomName = acctest.RandString(6)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testutils.ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFolderPermissionConfig_Basic,
+				Config: testAccFolderPermissionConfig_Basic(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					folderCheckExists.exists("grafana_folder.testFolder", &folder),
 					teamCheckExists.exists("grafana_team.testTeam", &team),
@@ -40,9 +43,30 @@ func TestAccFolderPermission_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test delete the folder and check that TF sees a difference
+			{
+				PreConfig: func() {
+					client := grafana.OAPIGlobalClient(testutils.Provider.Meta())
+					params := folders.NewDeleteFolderParams().WithFolderUID(folder.UID)
+					_, err := client.Folders.DeleteFolder(params)
+					if err != nil {
+						t.Fatalf("error deleting folder: %s", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Write back the folder to check that TF can reconcile
+			{
+				Config: testAccFolderPermissionConfig_Basic(randomName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					folderCheckExists.exists("grafana_folder.testFolder", &folder),
+					resource.TestCheckResourceAttr("grafana_folder_permission.testPermission", "permissions.#", "5"),
+				),
+			},
 			// Test remove permissions by not setting any permissions
 			{
-				Config: testAccFolderPermissionConfig_NoPermissions,
+				Config: testAccFolderPermissionConfig_NoPermissions(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					folderCheckExists.exists("grafana_folder.testFolder", &folder),
 					resource.TestCheckResourceAttr("grafana_folder_permission.testPermission", "permissions.#", "0"),
@@ -51,7 +75,7 @@ func TestAccFolderPermission_basic(t *testing.T) {
 			},
 			// Reapply permissions
 			{
-				Config: testAccFolderPermissionConfig_Basic,
+				Config: testAccFolderPermissionConfig_Basic(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					folderCheckExists.exists("grafana_folder.testFolder", &folder),
 					teamCheckExists.exists("grafana_team.testTeam", &team),
@@ -63,7 +87,7 @@ func TestAccFolderPermission_basic(t *testing.T) {
 			},
 			// Test remove permissions by removing the resource
 			{
-				Config: testutils.WithoutResource(t, testAccFolderPermissionConfig_Basic, "grafana_folder_permission.testPermission"),
+				Config: testutils.WithoutResource(t, testAccFolderPermissionConfig_Basic(randomName), "grafana_folder_permission.testPermission"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					folderCheckExists.exists("grafana_folder.testFolder", &folder),
 					checkFolderPermissionsEmpty(&folder),
@@ -139,30 +163,33 @@ func checkFolderPermissions(folder *models.Folder, expectedPerms []*models.Dashb
 	return nil
 }
 
-const testAccFolderPermissionConfig_Common = `
+func testAccFolderPermissionConfig_Common(name string) string {
+	return fmt.Sprintf(`
 resource "grafana_folder" "testFolder" {
-	title = "terraform-test-folder-permissions"
+	title = "%[1]s"
   }
   
   resource "grafana_team" "testTeam" {
-	name = "terraform-test-team-permissions"
+	name = "%[1]s"
   }
   
   resource "grafana_user" "testAdminUser" {
-	email    = "terraform-test-permissions@localhost"
-	name     = "Terraform Test Permissions"
-	login    = "ttp"
+	email    = "%[1]s@localhost"
+	name     = "%[1]s"
+	login    = "%[1]s"
 	password = "zyx987"
   }
   
   resource "grafana_service_account" "test" {
-	  name        = "terraform-test-service-account-folder-perms"
+	  name        = "%[1]s"
 	  role        = "Editor"
 	  is_disabled = false
   }
-`
+`, name)
+}
 
-const testAccFolderPermissionConfig_Basic = testAccFolderPermissionConfig_Common + `
+func testAccFolderPermissionConfig_Basic(name string) string {
+	return testAccFolderPermissionConfig_Common(name) + `
 resource "grafana_folder_permission" "testPermission" {
   folder_uid = grafana_folder.testFolder.uid
   permissions {
@@ -187,9 +214,12 @@ resource "grafana_folder_permission" "testPermission" {
   }
 }
 `
-
-const testAccFolderPermissionConfig_NoPermissions = testAccFolderPermissionConfig_Common + `
-resource "grafana_folder_permission" "testPermission" {
-  folder_uid = grafana_folder.testFolder.uid
 }
-`
+
+func testAccFolderPermissionConfig_NoPermissions(name string) string {
+	return testAccFolderPermissionConfig_Common(name) + `
+	resource "grafana_folder_permission" "testPermission" {
+	  folder_uid = grafana_folder.testFolder.uid
+	}
+	`
+}


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1339 

Currently, the provider will try to fetch the permissions but it crashes because the folder is gone 
Also, I gave random names to the test resources because I had a bit of trouble with conflicts locally