### PR TITLE
SSO: add validation rules for auth_url, token_url and api_url settings

### DIFF
--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -47,9 +47,7 @@ resource "grafana_sso_settings" "github_sso_settings" {
 
 Required:
 
-- `auth_url` (String) The authorization endpoint of your OAuth2 provider.
 - `client_id` (String) The client Id of your OAuth2 app.
-- `token_url` (String) The token endpoint of your OAuth2 provider.
 
 Optional:
 
@@ -60,6 +58,7 @@ Optional:
 - `allowed_organizations` (String) List of comma- or space-separated organizations. The user should be a member of at least one organization to log in.
 - `api_url` (String) The user information endpoint of your OAuth2 provider.
 - `auth_style` (String) It determines how client_id and client_secret are sent to Oauth2 provider. Possible values are AutoDetect, InParams, InHeader. Default is AutoDetect.
+- `auth_url` (String) The authorization endpoint of your OAuth2 provider. Required for azuread, okta and generic_oauth providers.
 - `auto_login` (Boolean) Log in automatically, skipping the login screen.
 - `client_secret` (String, Sensitive) The client secret of your OAuth2 app.
 - `define_allowed_groups` (Boolean) Define allowed groups.
@@ -85,5 +84,6 @@ Optional:
 - `tls_client_cert` (String) The path to the certificate. Is not applicable on Grafana Cloud.
 - `tls_client_key` (String) The path to the key. Is not applicable on Grafana Cloud.
 - `tls_skip_verify_insecure` (Boolean) If enabled, the client accepts any certificate presented by the server and any host name in that certificate. You should only use this for testing, because this mode leaves SSL/TLS susceptible to man-in-the-middle attacks.
+- `token_url` (String) The token endpoint of your OAuth2 provider. Required for azuread, okta and generic_oauth providers.
 - `use_pkce` (Boolean) If enabled, Grafana will use Proof Key for Code Exchange (PKCE) with the OAuth2 Authorization Code Grant.
 - `use_refresh_token` (Boolean) If enabled, Grafana will fetch a new access token using the refresh token provided by the OAuth2 provider.

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -345,32 +345,32 @@ func DeleteSSOSettings(ctx context.Context, d *schema.ResourceData, meta interfa
 }
 
 func validateOAuth2Settings(provider string, settings map[string]any) error {
-	authUrl := settings["auth_url"].(string)
-	tokenUrl := settings["token_url"].(string)
-	apiUrl := settings["api_url"].(string)
+	authURL := settings["auth_url"].(string)
+	tokenURL := settings["token_url"].(string)
+	apiURL := settings["api_url"].(string)
 
 	switch provider {
 	case "github", "gitlab", "google":
-		if authUrl != "" {
+		if authURL != "" {
 			return fmt.Errorf("auth_url must be empty for the provider %s", provider)
 		}
-		if tokenUrl != "" {
+		if tokenURL != "" {
 			return fmt.Errorf("token_url must be empty for the provider %s", provider)
 		}
-		if apiUrl != "" {
+		if apiURL != "" {
 			return fmt.Errorf("api_url must be empty for the provider %s", provider)
 		}
 	case "azuread", "generic_oauth", "okta":
-		if authUrl == "" {
+		if authURL == "" {
 			return fmt.Errorf("auth_url must be set for the provider %s", provider)
 		}
-		if !isValidUrl(authUrl) {
+		if !isValidUrl(authURL) {
 			return fmt.Errorf("auth_url must be a valid http/https URL")
 		}
-		if tokenUrl == "" {
+		if tokenURL == "" {
 			return fmt.Errorf("token_url must be set for the provider %s", provider)
 		}
-		if !isValidUrl(tokenUrl) {
+		if !isValidUrl(tokenURL) {
 			return fmt.Errorf("token_url must be a valid http/https URL")
 		}
 	}

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -364,13 +364,13 @@ func validateOAuth2Settings(provider string, settings map[string]any) error {
 		if authURL == "" {
 			return fmt.Errorf("auth_url must be set for the provider %s", provider)
 		}
-		if !isValidUrl(authURL) {
+		if !isValidURL(authURL) {
 			return fmt.Errorf("auth_url must be a valid http/https URL")
 		}
 		if tokenURL == "" {
 			return fmt.Errorf("token_url must be set for the provider %s", provider)
 		}
-		if !isValidUrl(tokenURL) {
+		if !isValidURL(tokenURL) {
 			return fmt.Errorf("token_url must be a valid http/https URL")
 		}
 	}
@@ -450,7 +450,7 @@ func isIgnored(provider string, fieldName string) bool {
 	return false
 }
 
-func isValidUrl(actual string) bool {
+func isValidURL(actual string) bool {
 	parsed, err := url.ParseRequestURI(actual)
 	if err != nil {
 		return false


### PR DESCRIPTION
Added custom validation rules for auth_url, token_url and api_url as those settings depend on the provider.