### PR TITLE
Cloud: Optimize Cloud SA operations

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_api_key.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/api_keys"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -105,7 +106,7 @@ func resourceStackAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	// Fill the true resource's state after a create by performing a read
-	return resourceStackAPIKeyRead(ctx, d, m)
+	return resourceStackAPIKeyReadWithClient(c, d)
 }
 
 func resourceStackAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -116,6 +117,10 @@ func resourceStackAPIKeyRead(ctx context.Context, d *schema.ResourceData, m inte
 	}
 	defer cleanup()
 
+	return resourceStackAPIKeyReadWithClient(c, d)
+}
+
+func resourceStackAPIKeyReadWithClient(c *goapi.GrafanaHTTPAPI, d *schema.ResourceData) diag.Diagnostics {
 	response, err := c.APIKeys.GetAPIkeys(api_keys.NewGetAPIkeysParams().WithIncludeExpired(common.Ref((true))))
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -84,7 +84,7 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	sa := resp.Payload
 
 	d.SetId(strconv.FormatInt(sa.ID, 10))
-	return readStackServiceAccount(ctx, d, meta)
+	return readStackServiceAccountWithClient(client, d)
 }
 
 func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -95,6 +95,10 @@ func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	defer cleanup()
 
+	return readStackServiceAccountWithClient(client, d)
+}
+
+func readStackServiceAccountWithClient(client *goapi.GrafanaHTTPAPI, d *schema.ResourceData) diag.Diagnostics {
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return diag.FromErr(err)
@@ -152,7 +156,7 @@ func updateStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	return readStackServiceAccount(ctx, d, meta)
+	return readStackServiceAccountWithClient(client, d)
 }
 
 func deleteStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -98,7 +99,7 @@ func stackServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	// Fill the true resource's state by performing a read
-	return stackServiceAccountTokenRead(ctx, d, m)
+	return stackServiceAccountTokenReadWithClient(c, d)
 }
 
 func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -109,6 +110,10 @@ func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	defer cleanup()
 
+	return stackServiceAccountTokenReadWithClient(c, d)
+}
+
+func stackServiceAccountTokenReadWithClient(c *goapi.GrafanaHTTPAPI, d *schema.ResourceData) diag.Diagnostics {
 	serviceAccountID, err := strconv.ParseInt(d.Get("service_account_id").(string), 10, 64)
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Currently, the `cloud_stack_(service_account|api_key)` resources create a temporary service account for all operations (The cloud API doesn't proxy the full CRUD) 

However, for operations like Create and Update, two SAs are created because it's customary to read after write in TF

This PR changes the logic so that we only one temporary key is created