### PR TITLE
Add full integration test

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -11,6 +11,18 @@ permissions:
   id-token: write
 
 jobs:
+  # Tests that Terraform can actually install and use the provider
+  # Ex: https://github.com/grafana/terraform-provider-grafana/issues/1372
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: 
+          go-version: '1.21'
+      - uses: hashicorp/setup-terraform@v3
+      - run: make integration-test
+
   cloudinstance:
     concurrency: cloud-instance
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ website/vendor
 
 testdata/*.crt
 testdata/*.key
+testdata/integration/*
+!testdata/integration/main.tf
+!testdata/integration/test.sh
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,6 +51,9 @@ testacc-subpath-docker:
 	make testacc-oss && \
 	docker compose --profile proxy down
 
+integration-test:
+	DOCKER_COMPOSE_ARGS="$(DOCKER_COMPOSE_ARGS)" GRAFANA_VERSION=$(GRAFANA_VERSION) ./testdata/integration/test.sh
+
 release:
 	@test $${RELEASE_VERSION?Please set environment variable RELEASE_VERSION}
 	@git tag $$RELEASE_VERSION

--- a/internal/provider/framework_provider.go
+++ b/internal/provider/framework_provider.go
@@ -32,6 +32,7 @@ type frameworkProviderConfig struct {
 
 	StoreDashboardSha256 types.Bool `tfsdk:"store_dashboard_sha256"`
 
+	CloudAPIKey            types.String `tfsdk:"cloud_api_key"` // Deprecated
 	CloudAccessPolicyToken types.String `tfsdk:"cloud_access_policy_token"`
 	CloudAPIURL            types.String `tfsdk:"cloud_api_url"`
 
@@ -53,7 +54,10 @@ func (c *frameworkProviderConfig) SetDefaults() error {
 	c.TLSCert = envDefaultFuncString(c.TLSCert, "GRAFANA_TLS_CERT")
 	c.CACert = envDefaultFuncString(c.CACert, "GRAFANA_CA_CERT")
 	c.CloudAccessPolicyToken = envDefaultFuncString(c.CloudAccessPolicyToken, "GRAFANA_CLOUD_ACCESS_POLICY_TOKEN")
-	c.CloudAccessPolicyToken = envDefaultFuncString(c.CloudAccessPolicyToken, "GRAFANA_CLOUD_API_KEY") // Backwards compatibility. TODO: Remove once cloud_api_key is removed
+	c.CloudAPIKey = envDefaultFuncString(c.CloudAPIKey, "GRAFANA_CLOUD_API_KEY") // Backwards compatibility. TODO: Remove once cloud_api_key is removed
+	if c.CloudAccessPolicyToken.IsNull() && !c.CloudAPIKey.IsNull() {
+		c.CloudAccessPolicyToken = c.CloudAPIKey
+	}
 	c.CloudAPIURL = envDefaultFuncString(c.CloudAPIURL, "GRAFANA_CLOUD_API_URL", "https://grafana.com")
 	c.SMAccessToken = envDefaultFuncString(c.SMAccessToken, "GRAFANA_SM_ACCESS_TOKEN")
 	c.SMURL = envDefaultFuncString(c.SMURL, "GRAFANA_SM_URL", "https://synthetic-monitoring-api.grafana.net")

--- a/internal/provider/framework_provider.go
+++ b/internal/provider/framework_provider.go
@@ -32,7 +32,6 @@ type frameworkProviderConfig struct {
 
 	StoreDashboardSha256 types.Bool `tfsdk:"store_dashboard_sha256"`
 
-	CloudAPIKey            types.String `tfsdk:"cloud_api_key"` // Deprecated
 	CloudAccessPolicyToken types.String `tfsdk:"cloud_access_policy_token"`
 	CloudAPIURL            types.String `tfsdk:"cloud_api_url"`
 
@@ -54,10 +53,7 @@ func (c *frameworkProviderConfig) SetDefaults() error {
 	c.TLSCert = envDefaultFuncString(c.TLSCert, "GRAFANA_TLS_CERT")
 	c.CACert = envDefaultFuncString(c.CACert, "GRAFANA_CA_CERT")
 	c.CloudAccessPolicyToken = envDefaultFuncString(c.CloudAccessPolicyToken, "GRAFANA_CLOUD_ACCESS_POLICY_TOKEN")
-	c.CloudAPIKey = envDefaultFuncString(c.CloudAPIKey, "GRAFANA_CLOUD_API_KEY") // Backwards compatibility. TODO: Remove once cloud_api_key is removed
-	if c.CloudAccessPolicyToken.IsNull() && !c.CloudAPIKey.IsNull() {
-		c.CloudAccessPolicyToken = c.CloudAPIKey
-	}
+	c.CloudAccessPolicyToken = envDefaultFuncString(c.CloudAccessPolicyToken, "GRAFANA_CLOUD_API_KEY") // Backwards compatibility. TODO: Remove once cloud_api_key is removed
 	c.CloudAPIURL = envDefaultFuncString(c.CloudAPIURL, "GRAFANA_CLOUD_API_URL", "https://grafana.com")
 	c.SMAccessToken = envDefaultFuncString(c.SMAccessToken, "GRAFANA_SM_ACCESS_TOKEN")
 	c.SMURL = envDefaultFuncString(c.SMURL, "GRAFANA_SM_URL", "https://synthetic-monitoring-api.grafana.net")

--- a/testdata/integration/main.tf
+++ b/testdata/integration/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    grafana = {
+      version = "999.999.999"
+      source  = "grafana/grafana"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}
+
+resource "grafana_folder" "my_folder" {
+  title = "My Folder"
+}

--- a/testdata/integration/test.sh
+++ b/testdata/integration/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# DOCKER_COMPOSE_ARGS and GRAFANA_VERSION need to be set
+if [ -z "${DOCKER_COMPOSE_ARGS}" ]; then
+  echo "DOCKER_COMPOSE_ARGS is not set"
+  exit 1
+fi
+
+if [ -z "${GRAFANA_VERSION}" ]; then
+  echo "GRAFANA_VERSION is not set"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Build the provider
+cd ${SCRIPT_DIR}/../..
+REPO_ROOT=$(pwd)
+go build
+
+# Write the Terraform configuration (points to the locally built provider)
+cd ${SCRIPT_DIR}
+rm -rf .terraform* terraform.state && \
+cat <<EOF > config.tfrc
+provider_installation {
+   dev_overrides {
+     "grafana/grafana" = "${REPO_ROOT}"
+  }
+}
+EOF
+
+# Run Terraform
+export TF_CLI_CONFIG_FILE=${SCRIPT_DIR}/config.tfrc
+export GRAFANA_URL=http://0.0.0.0:3000
+export GRAFANA_VERSION=${GRAFANA_VERSION}
+
+trap "docker compose down" EXIT
+docker compose up ${DOCKER_COMPOSE_ARGS}
+terraform apply -auto-approve
+terraform destroy -auto-approve


### PR DESCRIPTION
During last release, the provider was unusable due to a provider config error. None of the tests caught it. 

This adds an integration test make target which actually installs the provider and tries to use it. This test fails on v2.12.0 but succeeds on v2.12.1 and main, as expected

_Note: See the commit history for a failing test example. I reverted the v2.12.1 fix_