### PR TITLE
POC: Standardize and verify ID formats

### DIFF
--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -89,5 +89,5 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_cloud_access_policy.policyname {{region}}/{{policy_id}}
+terraform import grafana_cloud_access_policy.name "{{ region }}:{{ policyId }}"
 ```

--- a/docs/resources/cloud_access_policy_token.md
+++ b/docs/resources/cloud_access_policy_token.md
@@ -64,3 +64,11 @@ resource "grafana_cloud_access_policy_token" "test" {
 - `id` (String) The ID of this resource.
 - `token` (String, Sensitive)
 - `updated_at` (String) Last update date of the access policy token.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_cloud_access_policy_token.name "{{ region }}:{{ tokenId }}"
+```

--- a/docs/resources/cloud_api_key.md
+++ b/docs/resources/cloud_api_key.md
@@ -44,5 +44,5 @@ resource "grafana_cloud_api_key" "test" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_cloud_api_key.resource_name "{{org-name}}-{{api_key_name}}"
+terraform import grafana_cloud_api_key.name "{{ orgSlug }}:{{ apiKeyName }}"
 ```

--- a/docs/resources/cloud_plugin_installation.md
+++ b/docs/resources/cloud_plugin_installation.md
@@ -41,5 +41,5 @@ resource "grafana_cloud_plugin_installation" "test" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_cloud_plugin_installation.plugin_name {{stack_slug}}_{{plugin_slug}}
+terraform import grafana_cloud_plugin_installation.name "{{ stackSlug }}:{{ pluginSlug }}"
 ```

--- a/examples/resources/grafana_cloud_access_policy/import.sh
+++ b/examples/resources/grafana_cloud_access_policy/import.sh
@@ -1,1 +1,1 @@
-terraform import grafana_cloud_access_policy.policyname {{region}}/{{policy_id}}
+terraform import grafana_cloud_access_policy.name "{{ region }}:{{ policyId }}"

--- a/examples/resources/grafana_cloud_access_policy_token/import.sh
+++ b/examples/resources/grafana_cloud_access_policy_token/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_cloud_access_policy_token.name "{{ region }}:{{ tokenId }}"

--- a/examples/resources/grafana_cloud_api_key/import.sh
+++ b/examples/resources/grafana_cloud_api_key/import.sh
@@ -1,1 +1,1 @@
-terraform import grafana_cloud_api_key.resource_name "{{org-name}}-{{api_key_name}}"
+terraform import grafana_cloud_api_key.name "{{ orgSlug }}:{{ apiKeyName }}"

--- a/examples/resources/grafana_cloud_plugin_installation/import.sh
+++ b/examples/resources/grafana_cloud_plugin_installation/import.sh
@@ -1,1 +1,1 @@
-terraform import grafana_cloud_plugin_installation.plugin_name {{stack_slug}}_{{plugin_slug}}
+terraform import grafana_cloud_plugin_installation.name "{{ stackSlug }}:{{ pluginSlug }}"

--- a/internal/common/id.go
+++ b/internal/common/id.go
@@ -1,0 +1,84 @@
+package common
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	defaultSeparator = ":"
+	allIDs           = []*TFID{}
+)
+
+type TFID struct {
+	resourceName   string
+	separators     []string
+	expectedFields []string
+}
+
+func NewTFID(resourceName string, expectedFields ...string) *TFID {
+	return newTFIDWithSeparators(resourceName, []string{defaultSeparator}, expectedFields...)
+}
+
+// Deprecated: Use NewTFID instead
+// We should standardize on a single separator, so that function should only be used for old resources
+// On major versions, switch to NewTFID and remove uses of this function
+func NewTFIDWithLegacySeparator(resourceName, legacySeparator string, expectedFields ...string) *TFID {
+	return newTFIDWithSeparators(resourceName, []string{defaultSeparator, legacySeparator}, expectedFields...)
+}
+
+func newTFIDWithSeparators(resourceName string, separators []string, expectedFields ...string) *TFID {
+	tfID := &TFID{
+		resourceName:   resourceName,
+		separators:     separators,
+		expectedFields: expectedFields,
+	}
+	allIDs = append(allIDs, tfID)
+	return tfID
+}
+
+func (id *TFID) Example() string {
+	fields := make([]string, len(id.expectedFields))
+	for i := range fields {
+		fields[i] = fmt.Sprintf("{{ %s }}", id.expectedFields[i])
+	}
+	return fmt.Sprintf(`terraform import %s.name %q
+`, id.resourceName, strings.Join(fields, defaultSeparator))
+}
+
+func (id *TFID) Make(parts ...any) string {
+	if len(parts) != len(id.expectedFields) {
+		panic(fmt.Sprintf("expected %d fields, got %d", len(id.expectedFields), len(parts))) // This is a coding error, so panic is appropriate
+	}
+	stringParts := make([]string, len(parts))
+	for i, part := range parts {
+		stringParts[i] = fmt.Sprintf("%v", part)
+	}
+	return strings.Join(stringParts, defaultSeparator)
+}
+
+func (s *TFID) Split(id string) ([]string, error) {
+	for _, sep := range s.separators {
+		parts := strings.Split(id, sep)
+		if len(parts) == len(s.expectedFields) {
+			return parts, nil
+		}
+	}
+	return nil, fmt.Errorf("id %q does not match expected format. Should be in the format: %s", id, strings.Join(s.expectedFields, defaultSeparator))
+}
+
+// GenerateImportFiles generates import files for all resources that use a helper defined in this package
+func GenerateImportFiles(path string) error {
+	for _, id := range allIDs {
+		resourcePath := filepath.Join(path, "resources", id.resourceName, "import.sh")
+		log.Printf("Generating import file for %s (writing to %s)\n", id.resourceName, resourcePath)
+		err := os.WriteFile(resourcePath, []byte(id.Example()), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/common/id.go
+++ b/internal/common/id.go
@@ -60,14 +60,14 @@ func (id *TFID) Make(parts ...any) string {
 	return strings.Join(stringParts, defaultSeparator)
 }
 
-func (s *TFID) Split(id string) ([]string, error) {
-	for _, sep := range s.separators {
-		parts := strings.Split(id, sep)
-		if len(parts) == len(s.expectedFields) {
+func (id *TFID) Split(resourceID string) ([]string, error) {
+	for _, sep := range id.separators {
+		parts := strings.Split(resourceID, sep)
+		if len(parts) == len(id.expectedFields) {
 			return parts, nil
 		}
 	}
-	return nil, fmt.Errorf("id %q does not match expected format. Should be in the format: %s", id, strings.Join(s.expectedFields, defaultSeparator))
+	return nil, fmt.Errorf("id %q does not match expected format. Should be in the format: %s", resourceID, strings.Join(id.expectedFields, defaultSeparator))
 }
 
 // GenerateImportFiles generates import files for all resources that use a helper defined in this package
@@ -75,7 +75,7 @@ func GenerateImportFiles(path string) error {
 	for _, id := range allIDs {
 		resourcePath := filepath.Join(path, "resources", id.resourceName, "import.sh")
 		log.Printf("Generating import file for %s (writing to %s)\n", id.resourceName, resourcePath)
-		err := os.WriteFile(resourcePath, []byte(id.Example()), 0644)
+		err := os.WriteFile(resourcePath, []byte(id.Example()), 0600)
 		if err != nil {
 			return err
 		}

--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var ResourceAccessPolicyID = common.NewTFIDWithLegacySeparator("grafana_cloud_access_policy", "/", "region", "policyId")
+var ResourceAccessPolicyID = common.NewTFIDWithLegacySeparator("grafana_cloud_access_policy", "/", "region", "policyId") //nolint:staticcheck
 
 func ResourceAccessPolicy() *schema.Resource {
 	return &schema.Resource{

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var ResourceAccessPolicyTokenID = common.NewTFIDWithLegacySeparator("grafana_cloud_access_policy_token", "/", "region", "tokenId")
+var ResourceAccessPolicyTokenID = common.NewTFIDWithLegacySeparator("grafana_cloud_access_policy_token", "/", "region", "tokenId") //nolint:staticcheck
 
 func ResourceAccessPolicyToken() *schema.Resource {
 	return &schema.Resource{

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -2,8 +2,6 @@ package cloud
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -12,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+var ResourceAccessPolicyTokenID = common.NewTFIDWithLegacySeparator("grafana_cloud_access_policy_token", "/", "region", "tokenId")
 
 func ResourceAccessPolicyToken() *schema.Resource {
 	return &schema.Resource{
@@ -112,7 +112,7 @@ func CreateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, m
 		return apiError(err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", region, *result.Id))
+	d.SetId(ResourceAccessPolicyTokenID.Make(region, result.Id))
 	d.Set("token", result.Token)
 
 	return ReadCloudAccessPolicyToken(ctx, d, meta)
@@ -120,7 +120,12 @@ func CreateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, m
 
 func UpdateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*common.Client).GrafanaCloudAPI
-	region, id, _ := strings.Cut(d.Id(), "/")
+
+	split, err := ResourceAccessPolicyTokenID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	region, id := split[0], split[1]
 
 	displayName := d.Get("display_name").(string)
 	if displayName == "" {
@@ -140,7 +145,11 @@ func UpdateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, m
 func ReadCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*common.Client).GrafanaCloudAPI
 
-	region, id, _ := strings.Cut(d.Id(), "/")
+	split, err := ResourceAccessPolicyTokenID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	region, id := split[0], split[1]
 
 	result, _, err := client.TokensAPI.GetToken(ctx, id).Region(region).Execute()
 	if err, shouldReturn := common.CheckReadError("policy token", d, err); shouldReturn {
@@ -158,14 +167,20 @@ func ReadCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, met
 	if result.UpdatedAt != nil {
 		d.Set("updated_at", result.UpdatedAt.Format(time.RFC3339))
 	}
+	d.SetId(ResourceAccessPolicyTokenID.Make(region, result.Id))
 
 	return nil
 }
 
 func DeleteCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*common.Client).GrafanaCloudAPI
-	region, id, _ := strings.Cut(d.Id(), "/")
 
-	_, _, err := client.TokensAPI.DeleteToken(ctx, id).Region(region).XRequestId(ClientRequestID()).Execute()
+	split, err := ResourceAccessPolicyTokenID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	region, id := split[0], split[1]
+
+	_, _, err = client.TokensAPI.DeleteToken(ctx, id).Region(region).XRequestId(ClientRequestID()).Execute()
 	return apiError(err)
 }

--- a/internal/resources/cloud/resource_cloud_api_key.go
+++ b/internal/resources/cloud/resource_cloud_api_key.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var ResourceAPIKeyID = common.NewTFIDWithLegacySeparator("grafana_cloud_api_key", "-", "orgSlug", "apiKeyName")
+var ResourceAPIKeyID = common.NewTFIDWithLegacySeparator("grafana_cloud_api_key", "-", "orgSlug", "apiKeyName") //nolint:staticcheck
 var cloudAPIKeyRoles = []string{"Viewer", "Editor", "Admin", "MetricsPublisher", "PluginPublisher"}
 
 func ResourceAPIKey() *schema.Resource {

--- a/internal/resources/cloud/resource_cloud_api_key.go
+++ b/internal/resources/cloud/resource_cloud_api_key.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+var ResourceAPIKeyID = common.NewTFIDWithLegacySeparator("grafana_cloud_api_key", "-", "orgSlug", "apiKeyName")
 var cloudAPIKeyRoles = []string{"Viewer", "Editor", "Admin", "MetricsPublisher", "PluginPublisher"}
 
 func ResourceAPIKey() *schema.Resource {
@@ -77,7 +77,7 @@ func ResourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	d.Set("key", *resp.Token)
-	d.SetId(org + "-" + resp.Name)
+	d.SetId(ResourceAPIKeyID.Make(org, resp.Name))
 
 	return ResourceAPIKeyRead(ctx, d, meta)
 }
@@ -85,8 +85,11 @@ func ResourceAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func ResourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).GrafanaCloudAPI
 
-	splitID := strings.SplitN(d.Id(), "-", 2)
-	org, name := splitID[0], splitID[1]
+	split, err := ResourceAPIKeyID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	org, name := split[0], split[1]
 
 	resp, _, err := c.OrgsAPI.GetApiKey(ctx, name, org).Execute()
 	if err != nil {
@@ -96,6 +99,7 @@ func ResourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("name", resp.Name)
 	d.Set("role", resp.Role)
 	d.Set("cloud_org_slug", org)
+	d.SetId(ResourceAPIKeyID.Make(org, resp.Name))
 
 	return nil
 }
@@ -103,7 +107,13 @@ func ResourceAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta interf
 func ResourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).GrafanaCloudAPI
 
-	_, err := c.OrgsAPI.DelApiKey(ctx, d.Get("name").(string), d.Get("cloud_org_slug").(string)).XRequestId(ClientRequestID()).Execute()
+	split, err := ResourceAPIKeyID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	org, name := split[0], split[1]
+
+	_, err = c.OrgsAPI.DelApiKey(ctx, name, org).XRequestId(ClientRequestID()).Execute()
 	d.SetId("")
 	return apiError(err)
 }

--- a/internal/resources/cloud/resource_cloud_plugin.go
+++ b/internal/resources/cloud/resource_cloud_plugin.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ResourcePluginInstallationID = common.NewTFIDWithLegacySeparator("grafana_cloud_plugin_installation", "_", "stackSlug", "pluginSlug")
+var ResourcePluginInstallationID = common.NewTFIDWithLegacySeparator("grafana_cloud_plugin_installation", "_", "stackSlug", "pluginSlug") //nolint:staticcheck
 
 func ResourcePluginInstallation() *schema.Resource {
 	return &schema.Resource{

--- a/internal/resources/cloud/resource_cloud_plugin.go
+++ b/internal/resources/cloud/resource_cloud_plugin.go
@@ -2,13 +2,14 @@ package cloud
 
 import (
 	"context"
-	"strings"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+var ResourcePluginInstallationID = common.NewTFIDWithLegacySeparator("grafana_cloud_plugin_installation", "_", "stackSlug", "pluginSlug")
 
 func ResourcePluginInstallation() *schema.Resource {
 	return &schema.Resource{
@@ -64,7 +65,7 @@ func ResourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceDat
 		return apiError(err)
 	}
 
-	d.SetId(stackSlug + "_" + pluginSlug)
+	d.SetId(ResourcePluginInstallationID.Make(stackSlug, pluginSlug))
 
 	return nil
 }
@@ -72,8 +73,11 @@ func ResourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceDat
 func ResourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*common.Client).GrafanaCloudAPI
 
-	splitID := strings.SplitN(d.Id(), "_", 2)
-	stackSlug, pluginSlug := splitID[0], splitID[1]
+	split, err := ResourcePluginInstallationID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	stackSlug, pluginSlug := split[0], split[1]
 
 	installation, _, err := client.InstancesAPI.GetInstancePlugin(ctx, stackSlug, pluginSlug).Execute()
 	if err, shouldReturn := common.CheckReadError("plugin", d, err); shouldReturn {
@@ -83,6 +87,7 @@ func ResourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("stack_slug", installation.InstanceSlug)
 	d.Set("slug", installation.PluginSlug)
 	d.Set("version", installation.Version)
+	d.SetId(ResourcePluginInstallationID.Make(stackSlug, pluginSlug))
 
 	return nil
 }
@@ -90,9 +95,12 @@ func ResourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData,
 func ResourcePluginInstallationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*common.Client).GrafanaCloudAPI
 
-	splitID := strings.SplitN(d.Id(), "_", 2)
-	stackSlug, pluginSlug := splitID[0], splitID[1]
+	split, err := ResourcePluginInstallationID.Split(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	stackSlug, pluginSlug := split[0], split[1]
 
-	_, _, err := client.InstancesAPI.DeleteInstancePlugin(ctx, stackSlug, pluginSlug).XRequestId(ClientRequestID()).Execute()
+	_, _, err = client.InstancesAPI.DeleteInstancePlugin(ctx, stackSlug, pluginSlug).XRequestId(ClientRequestID()).Execute()
 	return apiError(err)
 }

--- a/internal/resources/cloud/resource_cloud_plugin_test.go
+++ b/internal/resources/cloud/resource_cloud_plugin_test.go
@@ -3,6 +3,7 @@ package cloud_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -39,6 +40,27 @@ func TestAccResourcePluginInstallation(t *testing.T) {
 				ResourceName:      "grafana_cloud_plugin_installation.test-installation",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Import with different ID formats (Legacy and current)
+			{
+				ResourceName:      "grafana_cloud_plugin_installation.test-installation",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s_%s", stackSlug, pluginSlug),
+			},
+			{
+				ResourceName:      "grafana_cloud_plugin_installation.test-installation",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s:%s", stackSlug, pluginSlug),
+			},
+			// Test import with invalid ID
+			{
+				ResourceName:      "grafana_cloud_plugin_installation.test-installation",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "noseparator",
+				ExpectError:       regexp.MustCompile("Error: id \"noseparator\" does not match expected format. Should be in the format: stackSlug:pluginSlug"),
 			},
 			// Test deletion (stack must keep existing to really test deletion)
 			{

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
 )
 
+//go:generate go run ./tools/genimports examples
 //go:generate ./tools/generate-docs.sh
 
 var (

--- a/tools/genimports/main.go
+++ b/tools/genimports/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+
+	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/provider"
+)
+
+func main() {
+	p := provider.Provider("genimports") // Instantiate the provider so that all resources are registered
+	_ = p
+
+	if err := common.GenerateImportFiles(os.Args[1]); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Currently, resource ID formats are all over the place. The separator is mostly `:`, but sometimes it's `_`, `/` or `;`

In this PR, I create a helper struct to manage IDs:
- It defines a default separator with retrocompatibility with the old formats. The old separators should be deprecated on the next major version
- It provides validation for the number of fields provided. Currently, it panics in most resources if you provide not enough fields
- It does auto-generation of the `import.sh` files

If this looks good, I can expand this to all resources and then validate that the ID is set this way for all resources. Providing consistent import and ID management for all resources!