### PR TITLE
Stack: Remove `Computed` attribute on `url`

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -32,6 +32,7 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestMatchResourceAttr("grafana_cloud_stack.test", "id", common.IDRegexp),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "name", resourceName),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "slug", resourceName),
+		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "url", "https://"+resourceName+".grafana.net"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "description", stackDescription),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "status", "active"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack.test", "labels.tf", "true"),


### PR DESCRIPTION
Since it's computed, it's not available at creation time it seems 
That means that when it's set, it's only applied the second time (on update)

By not setting it as computed, it means that Terraform now defaults it as an empty string, so we need to:
- suppress the diff if we're reverting from the default URL (slug.grafana.net) to an empty string
- write the default URL in the update function, if we're not specifying a custom stack URL. Seems like the create function is fine with getting passed an empty string for a URL (that was already the case, with the Computed setting)

Test run: https://github.com/grafana/terraform-provider-grafana/actions/runs/8074401925/job/22059643287