### PR TITLE
Self-contained cloud package

### DIFF
--- a/internal/provider/legacy_provider.go
+++ b/internal/provider/legacy_provider.go
@@ -80,19 +80,6 @@ func Provider(version string) *schema.Provider {
 			"grafana_synthetic_monitoring_probe": syntheticmonitoring.ResourceProbe(),
 		})
 
-		// Resources that require the Cloud client to exist.
-		cloudClientResources = addResourcesMetadataValidation(cloudClientPresent, map[string]*schema.Resource{
-			"grafana_cloud_access_policy":               cloud.ResourceAccessPolicy(),
-			"grafana_cloud_access_policy_token":         cloud.ResourceAccessPolicyToken(),
-			"grafana_cloud_api_key":                     cloud.ResourceAPIKey(),
-			"grafana_cloud_plugin_installation":         cloud.ResourcePluginInstallation(),
-			"grafana_cloud_stack":                       cloud.ResourceStack(),
-			"grafana_cloud_stack_api_key":               cloud.ResourceStackAPIKey(),
-			"grafana_cloud_stack_service_account":       cloud.ResourceStackServiceAccount(),
-			"grafana_cloud_stack_service_account_token": cloud.ResourceStackServiceAccountToken(),
-			"grafana_synthetic_monitoring_installation": cloud.ResourceInstallation(),
-		})
-
 		// Resources that require the OnCall client to exist.
 		onCallClientResources = addResourcesMetadataValidation(onCallClientPresent, map[string]*schema.Resource{
 			"grafana_oncall_integration":      oncall.ResourceIntegration(),
@@ -131,13 +118,6 @@ func Provider(version string) *schema.Provider {
 		smClientDatasources = addResourcesMetadataValidation(smClientPresent, map[string]*schema.Resource{
 			"grafana_synthetic_monitoring_probe":  syntheticmonitoring.DataSourceProbe(),
 			"grafana_synthetic_monitoring_probes": syntheticmonitoring.DataSourceProbes(),
-		})
-
-		// Datasources that require the Cloud client to exist.
-		cloudClientDatasources = addResourcesMetadataValidation(cloudClientPresent, map[string]*schema.Resource{
-			"grafana_cloud_ips":          cloud.DataSourceIPs(),
-			"grafana_cloud_organization": cloud.DataSourceOrganization(),
-			"grafana_cloud_stack":        cloud.DataSourceStack(),
 		})
 
 		// Datasources that require the OnCall client to exist.
@@ -275,7 +255,7 @@ func Provider(version string) *schema.Provider {
 			machinelearning.ResourcesMap,
 			smClientResources,
 			onCallClientResources,
-			cloudClientResources,
+			cloud.ResourcesMap,
 		),
 
 		DataSourcesMap: mergeResourceMaps(
@@ -283,7 +263,7 @@ func Provider(version string) *schema.Provider {
 			machinelearning.DatasourcesMap,
 			smClientDatasources,
 			onCallClientDatasources,
-			cloudClientDatasources,
+			cloud.DatasourcesMap,
 		),
 	}
 

--- a/internal/provider/legacy_provider_validation.go
+++ b/internal/provider/legacy_provider_validation.go
@@ -42,13 +42,6 @@ func smClientPresent(resourceName string, d *schema.ResourceData, m interface{})
 	return nil
 }
 
-func cloudClientPresent(resourceName string, d *schema.ResourceData, m interface{}) error {
-	if m.(*common.Client).GrafanaCloudAPI == nil {
-		return fmt.Errorf("the Cloud API client is required for `%s`. Set the cloud_api_key provider attribute", resourceName)
-	}
-	return nil
-}
-
 func onCallClientPresent(resourceName string, d *schema.ResourceData, m interface{}) error {
 	if m.(*common.Client).OnCallClient == nil {
 		return fmt.Errorf("the Oncall client is required for `%s`. Set the oncall_access_token provider attribute", resourceName)

--- a/internal/resources/cloud/data_source_cloud_ips.go
+++ b/internal/resources/cloud/data_source_cloud_ips.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceIPs() *schema.Resource {
+func datasourceIPs() *schema.Resource {
 	return &schema.Resource{
 		Description: "Data source for retrieving sets of cloud IPs. See https://grafana.com/docs/grafana-cloud/reference/allow-list/ for more info",
-		ReadContext: DataSourceIPsRead,
+		ReadContext: datasourceIPsRead,
 		Schema: map[string]*schema.Schema{
 			"hosted_alerts": {
 				Description: "Set of IP addresses that are used for hosted alerts.",
@@ -59,7 +59,7 @@ func DataSourceIPs() *schema.Resource {
 	}
 }
 
-func DataSourceIPsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceIPsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	d.SetId("cloud_ips")
 	for attr, dataURL := range map[string]string{
 		"hosted_alerts":  "https://grafana.com/api/hosted-alerts/source-ips.txt",

--- a/internal/resources/cloud/data_source_cloud_organization.go
+++ b/internal/resources/cloud/data_source_cloud_organization.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceOrganization() *schema.Resource {
+func datasourceOrganization() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: DataSourceOrganizationRead,
+		ReadContext: withClient[schema.ReadContextFunc](datasourceOrganizationRead),
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:     schema.TypeString,
@@ -43,9 +43,7 @@ func DataSourceOrganization() *schema.Resource {
 	}
 }
 
-func DataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func datasourceOrganizationRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	id := d.Get("id").(string)
 	if id == "" {
 		id = d.Get("slug").(string)

--- a/internal/resources/cloud/data_source_cloud_stack.go
+++ b/internal/resources/cloud/data_source_cloud_stack.go
@@ -3,16 +3,17 @@ package cloud
 import (
 	"context"
 
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceStack() *schema.Resource {
+func datasourceStack() *schema.Resource {
 	return &schema.Resource{
 		Description: "Data source for Grafana Stack",
-		ReadContext: DataSourceStackRead,
-		Schema: common.CloneResourceSchemaForDatasource(ResourceStack(), map[string]*schema.Schema{
+		ReadContext: withClient[schema.ReadContextFunc](datasourceStackRead),
+		Schema: common.CloneResourceSchemaForDatasource(resourceStack(), map[string]*schema.Schema{
 			"slug": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -31,7 +32,7 @@ available at “https://<stack_slug>.grafana.net".`,
 	}
 }
 
-func DataSourceStackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceStackRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	d.SetId(d.Get("slug").(string))
-	return ReadStack(ctx, d, meta)
+	return readStack(ctx, d, client)
 }

--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -15,7 +15,7 @@ import (
 
 var ResourceAccessPolicyID = common.NewResourceIDWithLegacySeparator("grafana_cloud_access_policy", "/", "region", "policyId") //nolint:staticcheck
 
-func ResourceAccessPolicy() *schema.Resource {
+func resourceAccessPolicy() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
@@ -29,10 +29,10 @@ Required access policy scopes:
 * accesspolicies:delete
 `,
 
-		CreateContext: CreateCloudAccessPolicy,
-		UpdateContext: UpdateCloudAccessPolicy,
-		DeleteContext: DeleteCloudAccessPolicy,
-		ReadContext:   ReadCloudAccessPolicy,
+		CreateContext: withClient[schema.CreateContextFunc](createCloudAccessPolicy),
+		UpdateContext: withClient[schema.UpdateContextFunc](updateCloudAccessPolicy),
+		DeleteContext: withClient[schema.DeleteContextFunc](deleteCloudAccessPolicy),
+		ReadContext:   withClient[schema.ReadContextFunc](readCloudAccessPolicy),
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -126,8 +126,7 @@ var cloudAccessPolicyRealmSchema = &schema.Resource{
 	},
 }
 
-func CreateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
+func createCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	region := d.Get("region").(string)
 
 	displayName := d.Get("display_name").(string)
@@ -149,12 +148,10 @@ func CreateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta i
 
 	d.SetId(ResourceAccessPolicyID.Make(region, result.Id))
 
-	return ReadCloudAccessPolicy(ctx, d, meta)
+	return readCloudAccessPolicy(ctx, d, client)
 }
 
-func UpdateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func updateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	split, err := ResourceAccessPolicyID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -176,12 +173,10 @@ func UpdateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta i
 		return apiError(err)
 	}
 
-	return ReadCloudAccessPolicy(ctx, d, meta)
+	return readCloudAccessPolicy(ctx, d, client)
 }
 
-func ReadCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func readCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	split, err := ResourceAccessPolicyID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -208,9 +203,7 @@ func ReadCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta int
 	return nil
 }
 
-func DeleteCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func deleteCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	split, err := ResourceAccessPolicyID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_plugin.go
+++ b/internal/resources/cloud/resource_cloud_plugin.go
@@ -11,7 +11,7 @@ import (
 
 var ResourcePluginInstallationID = common.NewResourceIDWithLegacySeparator("grafana_cloud_plugin_installation", "_", "stackSlug", "pluginSlug") //nolint:staticcheck
 
-func ResourcePluginInstallation() *schema.Resource {
+func resourcePluginInstallation() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 Manages Grafana Cloud Plugin Installations.
@@ -44,19 +44,17 @@ Required access policy scopes:
 				ForceNew:    true,
 			},
 		},
-		CreateContext: ResourcePluginInstallationCreate,
-		ReadContext:   ResourcePluginInstallationRead,
+		CreateContext: withClient[schema.CreateContextFunc](resourcePluginInstallationCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourcePluginInstallationRead),
 		UpdateContext: nil,
-		DeleteContext: ResourcePluginInstallationDelete,
+		DeleteContext: withClient[schema.DeleteContextFunc](resourcePluginInstallationDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
 
-func ResourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func resourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	stackSlug := d.Get("stack_slug").(string)
 	pluginSlug := d.Get("slug").(string)
 
@@ -76,9 +74,7 @@ func ResourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func ResourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func resourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	split, err := ResourcePluginInstallationID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -98,9 +94,7 @@ func ResourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func ResourcePluginInstallationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*common.Client).GrafanaCloudAPI
-
+func resourcePluginInstallationDelete(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
 	split, err := ResourcePluginInstallationID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_api_key.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/api_keys"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -16,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func ResourceStackAPIKey() *schema.Resource {
+func resourceStackAPIKey() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 Manages API keys of a Grafana Cloud stack using the Cloud API
@@ -31,9 +32,9 @@ Required access policy scopes:
 !> Deprecated: please use ` + "`grafana_cloud_stack_service_account`" + ` and ` + "`grafana_cloud_stack_service_account_token`" + ` instead, see https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-terraform.
 `,
 
-		CreateContext:      resourceStackAPIKeyCreate,
-		ReadContext:        resourceStackAPIKeyRead,
-		DeleteContext:      resourceStackAPIKeyDelete,
+		CreateContext:      withClient[schema.CreateContextFunc](resourceStackAPIKeyCreate),
+		ReadContext:        withClient[schema.ReadContextFunc](resourceStackAPIKeyRead),
+		DeleteContext:      withClient[schema.DeleteContextFunc](resourceStackAPIKeyDelete),
 		DeprecationMessage: "Use `grafana_cloud_stack_service_account` together with `grafana_cloud_stack_service_account_token` resources instead see https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-terraform",
 
 		Schema: map[string]*schema.Schema{
@@ -76,12 +77,11 @@ Required access policy scopes:
 	}
 }
 
-func resourceStackAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceStackAPIKeyCreate(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	name := d.Get("name").(string)
 	role := d.Get("role").(string)
 	ttl := d.Get("seconds_to_live").(int)
 
-	cloudClient := m.(*common.Client).GrafanaCloudAPI
 	c, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -113,8 +113,7 @@ func resourceStackAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m in
 	return resourceStackAPIKeyReadWithClient(c, d)
 }
 
-func resourceStackAPIKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	cloudClient := m.(*common.Client).GrafanaCloudAPI
+func resourceStackAPIKeyRead(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	c, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -154,13 +153,12 @@ func resourceStackAPIKeyReadWithClient(c *goapi.GrafanaHTTPAPI, d *schema.Resour
 	return nil
 }
 
-func resourceStackAPIKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceStackAPIKeyDelete(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	id, err := strconv.ParseInt(d.Id(), 10, 32)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	cloudClient := m.(*common.Client).GrafanaCloudAPI
 	c, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func ResourceStackServiceAccount() *schema.Resource {
+func resourceStackServiceAccount() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
@@ -32,10 +32,10 @@ Required access policy scopes:
 * stack-service-accounts:write
 `,
 
-		CreateContext: createStackServiceAccount,
-		ReadContext:   readStackServiceAccount,
-		UpdateContext: updateStackServiceAccount,
-		DeleteContext: deleteStackServiceAccount,
+		CreateContext: withClient[schema.CreateContextFunc](createStackServiceAccount),
+		ReadContext:   withClient[schema.ReadContextFunc](readStackServiceAccount),
+		UpdateContext: withClient[schema.UpdateContextFunc](updateStackServiceAccount),
+		DeleteContext: withClient[schema.DeleteContextFunc](deleteStackServiceAccount),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -68,8 +68,7 @@ Required access policy scopes:
 	}
 }
 
-func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cloudClient := meta.(*common.Client).GrafanaCloudAPI
+func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	client, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -91,8 +90,7 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	return readStackServiceAccountWithClient(client, d)
 }
 
-func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cloudClient := meta.(*common.Client).GrafanaCloudAPI
+func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	client, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -130,8 +128,7 @@ func readStackServiceAccountWithClient(client *goapi.GrafanaHTTPAPI, d *schema.R
 	return nil
 }
 
-func updateStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cloudClient := meta.(*common.Client).GrafanaCloudAPI
+func updateStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	client, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -158,8 +155,7 @@ func updateStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta
 	return readStackServiceAccountWithClient(client, d)
 }
 
-func deleteStackServiceAccount(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cloudClient := meta.(*common.Client).GrafanaCloudAPI
+func deleteStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	client, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -5,15 +5,15 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func ResourceStackServiceAccountToken() *schema.Resource {
+func resourceStackServiceAccountToken() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 Manages service account tokens of a Grafana Cloud stack using the Cloud API
@@ -27,9 +27,9 @@ Required access policy scopes:
 * stack-service-accounts:write
 `,
 
-		CreateContext: stackServiceAccountTokenCreate,
-		ReadContext:   stackServiceAccountTokenRead,
-		DeleteContext: stackServiceAccountTokenDelete,
+		CreateContext: withClient[schema.CreateContextFunc](stackServiceAccountTokenCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](stackServiceAccountTokenRead),
+		DeleteContext: withClient[schema.DeleteContextFunc](stackServiceAccountTokenDelete),
 
 		Schema: map[string]*schema.Schema{
 			"stack_slug": {
@@ -69,8 +69,7 @@ Required access policy scopes:
 	}
 }
 
-func stackServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	cloudClient := m.(*common.Client).GrafanaCloudAPI
+func stackServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	c, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -105,8 +104,7 @@ func stackServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData,
 	return stackServiceAccountTokenReadWithClient(c, d)
 }
 
-func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	cloudClient := m.(*common.Client).GrafanaCloudAPI
+func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	c, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)
@@ -156,8 +154,7 @@ func stackServiceAccountTokenReadWithClient(c *goapi.GrafanaHTTPAPI, d *schema.R
 	return nil
 }
 
-func stackServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	cloudClient := m.(*common.Client).GrafanaCloudAPI
+func stackServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
 	c, cleanup, err := CreateTemporaryStackGrafanaClient(ctx, cloudClient, d.Get("stack_slug").(string), "terraform-temp-")
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resources.go
+++ b/internal/resources/cloud/resources.go
@@ -1,0 +1,23 @@
+package cloud
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var DatasourcesMap = map[string]*schema.Resource{
+	"grafana_cloud_ips":          datasourceIPs(),
+	"grafana_cloud_organization": datasourceOrganization(),
+	"grafana_cloud_stack":        datasourceStack(),
+}
+
+var ResourcesMap = map[string]*schema.Resource{
+	"grafana_cloud_access_policy":               resourceAccessPolicy(),
+	"grafana_cloud_access_policy_token":         resourceAccessPolicyToken(),
+	"grafana_cloud_api_key":                     resourceAPIKey(),
+	"grafana_cloud_plugin_installation":         resourcePluginInstallation(),
+	"grafana_cloud_stack":                       resourceStack(),
+	"grafana_cloud_stack_api_key":               resourceStackAPIKey(),
+	"grafana_cloud_stack_service_account":       resourceStackServiceAccount(),
+	"grafana_cloud_stack_service_account_token": resourceStackServiceAccountToken(),
+	"grafana_synthetic_monitoring_installation": resourceSyntheticMonitoringInstallation(),
+}


### PR DESCRIPTION
Split from https://github.com/grafana/terraform-provider-grafana/pull/1391
- Makes the resource functions private (exposed via a single map attribute) rather than each resource individually
- Puts the client validation in the cloud package