### PR TITLE
Typed resource ID helper

### DIFF
--- a/internal/common/resource_id.go
+++ b/internal/common/resource_id.go
@@ -5,32 +5,58 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
 )
 
+type ResourceIDFieldType string
+
 var (
-	defaultSeparator = ":"
-	allIDs           = []*ResourceID{}
+	defaultSeparator          = ":"
+	ResourceIDFieldTypeInt    = ResourceIDFieldType("int")
+	ResourceIDFieldTypeString = ResourceIDFieldType("string")
+	allIDs                    = []*ResourceID{}
 )
+
+type ResourceIDField struct {
+	Name string
+	Type ResourceIDFieldType
+	// Optional bool // Unimplemented. Will be used for org ID
+}
+
+func StringIDField(name string) ResourceIDField {
+	return ResourceIDField{
+		Name: name,
+		Type: ResourceIDFieldTypeString,
+	}
+}
+
+func IntIDField(name string) ResourceIDField {
+	return ResourceIDField{
+		Name: name,
+		Type: ResourceIDFieldTypeInt,
+	}
+}
 
 type ResourceID struct {
 	resourceName   string
 	separators     []string
-	expectedFields []string
+	expectedFields []ResourceIDField
 }
 
-func NewResourceID(resourceName string, expectedFields ...string) *ResourceID {
+func NewResourceID(resourceName string, expectedFields ...ResourceIDField) *ResourceID {
 	return newResourceIDWithSeparators(resourceName, []string{defaultSeparator}, expectedFields...)
 }
 
 // Deprecated: Use NewResourceID instead
 // We should standardize on a single separator, so that function should only be used for old resources
 // On major versions, switch to NewResourceID and remove uses of this function
-func NewResourceIDWithLegacySeparator(resourceName, legacySeparator string, expectedFields ...string) *ResourceID {
+func NewResourceIDWithLegacySeparator(resourceName, legacySeparator string, expectedFields ...ResourceIDField) *ResourceID {
 	return newResourceIDWithSeparators(resourceName, []string{defaultSeparator, legacySeparator}, expectedFields...)
 }
 
-func newResourceIDWithSeparators(resourceName string, separators []string, expectedFields ...string) *ResourceID {
+func newResourceIDWithSeparators(resourceName string, separators []string, expectedFields ...ResourceIDField) *ResourceID {
 	tfID := &ResourceID{
 		resourceName:   resourceName,
 		separators:     separators,
@@ -43,31 +69,83 @@ func newResourceIDWithSeparators(resourceName string, separators []string, expec
 func (id *ResourceID) Example() string {
 	fields := make([]string, len(id.expectedFields))
 	for i := range fields {
-		fields[i] = fmt.Sprintf("{{ %s }}", id.expectedFields[i])
+		fields[i] = fmt.Sprintf("{{ %s }}", id.expectedFields[i].Name)
 	}
 	return fmt.Sprintf(`terraform import %s.name %q
 `, id.resourceName, strings.Join(fields, defaultSeparator))
 }
 
+// Make creates a resource ID from the given parts
+// The parts must have the correct number of fields and types
 func (id *ResourceID) Make(parts ...any) string {
 	if len(parts) != len(id.expectedFields) {
 		panic(fmt.Sprintf("expected %d fields, got %d", len(id.expectedFields), len(parts))) // This is a coding error, so panic is appropriate
 	}
 	stringParts := make([]string, len(parts))
 	for i, part := range parts {
-		stringParts[i] = fmt.Sprintf("%v", part)
+		// Unwrap pointers
+		if reflect.ValueOf(part).Kind() == reflect.Ptr {
+			part = reflect.ValueOf(part).Elem().Interface()
+		}
+		expectedField := id.expectedFields[i]
+		switch expectedField.Type {
+		case ResourceIDFieldTypeInt:
+			asInt, ok := part.(int64)
+			if !ok {
+				panic(fmt.Sprintf("expected int64 for field %q, got %T", expectedField.Name, part)) // This is a coding error, so panic is appropriate
+			}
+			stringParts[i] = strconv.FormatInt(asInt, 10)
+		case ResourceIDFieldTypeString:
+			asString, ok := part.(string)
+			if !ok {
+				panic(fmt.Sprintf("expected string for field %q, got %T", expectedField.Name, part)) // This is a coding error, so panic is appropriate
+			}
+			stringParts[i] = asString
+		}
 	}
+
 	return strings.Join(stringParts, defaultSeparator)
 }
 
-func (id *ResourceID) Split(resourceID string) ([]string, error) {
+// Single parses a resource ID into a single value
+func (id *ResourceID) Single(resourceID string) (any, error) {
+	parts, err := id.Split(resourceID)
+	if err != nil {
+		return nil, err
+	}
+	return parts[0], nil
+}
+
+// Split parses a resource ID into its parts
+// The parts will be cast to the expected types
+func (id *ResourceID) Split(resourceID string) ([]any, error) {
 	for _, sep := range id.separators {
 		parts := strings.Split(resourceID, sep)
 		if len(parts) == len(id.expectedFields) {
-			return parts, nil
+			partsAsAny := make([]any, len(parts))
+			for i, part := range parts {
+				expectedField := id.expectedFields[i]
+				switch expectedField.Type {
+				case ResourceIDFieldTypeInt:
+					asInt, err := strconv.ParseInt(part, 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("expected int for field %q, got %q", expectedField.Name, part)
+					}
+					partsAsAny[i] = asInt
+				case ResourceIDFieldTypeString:
+					partsAsAny[i] = part
+				}
+			}
+
+			return partsAsAny, nil
 		}
 	}
-	return nil, fmt.Errorf("id %q does not match expected format. Should be in the format: %s", resourceID, strings.Join(id.expectedFields, defaultSeparator))
+
+	expectedFieldNames := make([]string, len(id.expectedFields))
+	for i, f := range id.expectedFields {
+		expectedFieldNames[i] = f.Name
+	}
+	return nil, fmt.Errorf("id %q does not match expected format. Should be in the format: %s", resourceID, strings.Join(expectedFieldNames, defaultSeparator))
 }
 
 // GenerateImportFiles generates import files for all resources that use a helper defined in this package

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -154,7 +154,7 @@ func testAccCloudAccessPolicyCheckExists(rn string, a *gcom.AuthAccessPolicy) re
 			return fmt.Errorf("resource id not set")
 		}
 
-		region, id, _ := strings.Cut(rs.Primary.ID, "/")
+		region, id, _ := strings.Cut(rs.Primary.ID, ":")
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		policy, _, err := client.AccesspoliciesAPI.GetAccessPolicy(context.Background(), id).Region(region).Execute()
@@ -179,7 +179,7 @@ func testAccCloudAccessPolicyTokenCheckExists(rn string, a *gcom.AuthToken) reso
 			return fmt.Errorf("resource id not set")
 		}
 
-		region, id, _ := strings.Cut(rs.Primary.ID, "/")
+		region, id, _ := strings.Cut(rs.Primary.ID, ":")
 
 		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		token, _, err := client.TokensAPI.GetToken(context.Background(), id).Region(region).Execute()
@@ -195,6 +195,9 @@ func testAccCloudAccessPolicyTokenCheckExists(rn string, a *gcom.AuthToken) reso
 
 func testAccCloudAccessPolicyCheckDestroy(region string, a *gcom.AuthAccessPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		if a == nil {
+			return nil
+		}
 		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		policy, _, err := client.AccesspoliciesAPI.GetAccessPolicy(context.Background(), *a.Id).Region(region).Execute()
 		if err == nil && policy.Name != "" {
@@ -207,6 +210,9 @@ func testAccCloudAccessPolicyCheckDestroy(region string, a *gcom.AuthAccessPolic
 
 func testAccCloudAccessPolicyTokenCheckDestroy(region string, a *gcom.AuthToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		if a == nil {
+			return nil
+		}
 		client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 		token, _, err := client.TokensAPI.GetToken(context.Background(), *a.Id).Region(region).Execute()
 		if err == nil && token.Name != "" {

--- a/internal/resources/cloud/resource_cloud_plugin.go
+++ b/internal/resources/cloud/resource_cloud_plugin.go
@@ -9,7 +9,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ResourcePluginInstallationID = common.NewResourceIDWithLegacySeparator("grafana_cloud_plugin_installation", "_", "stackSlug", "pluginSlug") //nolint:staticcheck
+var (
+	//nolint:staticcheck
+	resourcePluginInstallationID = common.NewResourceIDWithLegacySeparator(
+		"grafana_cloud_plugin_installation",
+		"_",
+		common.StringIDField("stackSlug"),
+		common.StringIDField("pluginSlug"),
+	)
+)
 
 func resourcePluginInstallation() *schema.Resource {
 	return &schema.Resource{
@@ -69,19 +77,19 @@ func resourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceDat
 		return apiError(err)
 	}
 
-	d.SetId(ResourcePluginInstallationID.Make(stackSlug, pluginSlug))
+	d.SetId(resourcePluginInstallationID.Make(stackSlug, pluginSlug))
 
 	return nil
 }
 
 func resourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	split, err := ResourcePluginInstallationID.Split(d.Id())
+	split, err := resourcePluginInstallationID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	stackSlug, pluginSlug := split[0], split[1]
 
-	installation, _, err := client.InstancesAPI.GetInstancePlugin(ctx, stackSlug, pluginSlug).Execute()
+	installation, _, err := client.InstancesAPI.GetInstancePlugin(ctx, stackSlug.(string), pluginSlug.(string)).Execute()
 	if err, shouldReturn := common.CheckReadError("plugin", d, err); shouldReturn {
 		return err
 	}
@@ -89,18 +97,18 @@ func resourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("stack_slug", installation.InstanceSlug)
 	d.Set("slug", installation.PluginSlug)
 	d.Set("version", installation.Version)
-	d.SetId(ResourcePluginInstallationID.Make(stackSlug, pluginSlug))
+	d.SetId(resourcePluginInstallationID.Make(stackSlug, pluginSlug))
 
 	return nil
 }
 
 func resourcePluginInstallationDelete(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	split, err := ResourcePluginInstallationID.Split(d.Id())
+	split, err := resourcePluginInstallationID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	stackSlug, pluginSlug := split[0], split[1]
 
-	_, _, err = client.InstancesAPI.DeleteInstancePlugin(ctx, stackSlug, pluginSlug).XRequestId(ClientRequestID()).Execute()
+	_, _, err = client.InstancesAPI.DeleteInstancePlugin(ctx, stackSlug.(string), pluginSlug.(string)).XRequestId(ClientRequestID()).Execute()
 	return apiError(err)
 }

--- a/internal/resources/cloud/resource_cloud_stack_service_account_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_test.go
@@ -3,7 +3,6 @@ package cloud_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -87,24 +86,14 @@ func testAccGrafanaAuthCheckServiceAccounts(stack *gcom.FormattedApiInstance, ex
 			return fmt.Errorf("failed to get service accounts: %w", err)
 		}
 
-		var foundSAs []string
-		for _, sa := range response.Payload.ServiceAccounts {
-			if !strings.HasPrefix(sa.Name, "test-api-key-") {
-				foundSAs = append(foundSAs, sa.Name)
-				if sa.Tokens == 0 {
-					return fmt.Errorf("expected to find at least one token for service account %s", sa.Name)
-				}
-			}
-		}
-
-		if len(foundSAs) != len(expectedSAs) {
-			return fmt.Errorf("expected %d keys, got %d", len(expectedSAs), len(foundSAs))
-		}
 		for _, expectedSA := range expectedSAs {
 			found := false
-			for _, foundSA := range foundSAs {
-				if expectedSA == foundSA {
+			for _, sa := range response.Payload.ServiceAccounts {
+				if sa.Name == expectedSA {
 					found = true
+					if sa.Tokens == 0 {
+						return fmt.Errorf("expected to find at least one token for service account %s", sa.Name)
+					}
 					break
 				}
 			}


### PR DESCRIPTION
Each resource's ID is composed of n (>=1) string or integer elements 
We can generalize this behavior and do the parsing/formatting in the helper function 
This is extracted from https://github.com/grafana/terraform-provider-grafana/pull/1391 and is part of a push to have standardized IDs for all resources, allowing for easier generation of TF code!