### PR TITLE
Self-contained ML package

### DIFF
--- a/internal/provider/legacy_provider.go
+++ b/internal/provider/legacy_provider.go
@@ -70,11 +70,6 @@ func Provider(version string) *schema.Provider {
 				"grafana_sso_settings":               grafana.ResourceSSOSettings(),
 				"grafana_user":                       grafana.ResourceUser(),
 
-				// Machine Learning
-				"grafana_machine_learning_job":              machinelearning.ResourceJob(),
-				"grafana_machine_learning_holiday":          machinelearning.ResourceHoliday(),
-				"grafana_machine_learning_outlier_detector": machinelearning.ResourceOutlierDetector(),
-
 				// SLO
 				"grafana_slo": slo.ResourceSlo(),
 			})
@@ -277,6 +272,7 @@ func Provider(version string) *schema.Provider {
 
 		ResourcesMap: mergeResourceMaps(
 			grafanaClientResources,
+			machinelearning.ResourcesMap,
 			smClientResources,
 			onCallClientResources,
 			cloudClientResources,
@@ -284,6 +280,7 @@ func Provider(version string) *schema.Provider {
 
 		DataSourcesMap: mergeResourceMaps(
 			grafanaClientDatasources,
+			machinelearning.DatasourcesMap,
 			smClientDatasources,
 			onCallClientDatasources,
 			cloudClientDatasources,

--- a/internal/resources/machinelearning/resource_holiday.go
+++ b/internal/resources/machinelearning/resource_holiday.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
 
-func ResourceHoliday() *schema.Resource {
+func resourceHoliday() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
@@ -30,10 +30,10 @@ resource "grafana_machine_learning_job" "test_job" {
 }
 ` + "```",
 
-		CreateContext: ResourceHolidayCreate,
-		ReadContext:   ResourceHolidayRead,
-		UpdateContext: ResourceHolidayUpdate,
-		DeleteContext: ResourceHolidayDelete,
+		CreateContext: checkClient(resourceHolidayCreate),
+		ReadContext:   checkClient(resourceHolidayRead),
+		UpdateContext: checkClient(resourceHolidayUpdate),
+		DeleteContext: checkClient(resourceHolidayDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -103,7 +103,7 @@ resource "grafana_machine_learning_job" "test_job" {
 	}
 }
 
-func ResourceHolidayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHolidayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	holiday, err := makeMLHoliday(d)
 	if err != nil {
@@ -114,10 +114,10 @@ func ResourceHolidayCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 	d.SetId(holiday.ID)
-	return ResourceHolidayRead(ctx, d, meta)
+	return resourceHolidayRead(ctx, d, meta)
 }
 
-func ResourceHolidayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHolidayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	holiday, err := c.Holiday(ctx, d.Id())
 	if err, shouldReturn := common.CheckReadError("holiday", d, err); shouldReturn {
@@ -143,7 +143,7 @@ func ResourceHolidayRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
-func ResourceHolidayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHolidayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	job, err := makeMLHoliday(d)
 	if err != nil {
@@ -153,10 +153,10 @@ func ResourceHolidayUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return ResourceHolidayRead(ctx, d, meta)
+	return resourceHolidayRead(ctx, d, meta)
 }
 
-func ResourceHolidayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHolidayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	err := c.DeleteHoliday(ctx, d.Id())
 	if err != nil {

--- a/internal/resources/machinelearning/resource_job.go
+++ b/internal/resources/machinelearning/resource_job.go
@@ -12,17 +12,17 @@ import (
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
 
-func ResourceJob() *schema.Resource {
+func resourceJob() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
 A job defines the queries and model parameters for a machine learning task.
 `,
 
-		CreateContext: ResourceJobCreate,
-		ReadContext:   ResourceJobRead,
-		UpdateContext: ResourceJobUpdate,
-		DeleteContext: ResourceJobDelete,
+		CreateContext: checkClient(resourceJobCreate),
+		ReadContext:   checkClient(resourceJobRead),
+		UpdateContext: checkClient(resourceJobUpdate),
+		DeleteContext: checkClient(resourceJobDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -104,7 +104,7 @@ A job defines the queries and model parameters for a machine learning task.
 	}
 }
 
-func ResourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	job, err := makeMLJob(d, meta)
 	if err != nil {
@@ -115,10 +115,10 @@ func ResourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 	d.SetId(job.ID)
-	return ResourceJobRead(ctx, d, meta)
+	return resourceJobRead(ctx, d, meta)
 }
 
-func ResourceJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	job, err := c.Job(ctx, d.Id())
 	if err, shouldReturn := common.CheckReadError("job", d, err); shouldReturn {
@@ -149,7 +149,7 @@ func ResourceJobRead(ctx context.Context, d *schema.ResourceData, meta interface
 	return nil
 }
 
-func ResourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	job, err := makeMLJob(d, meta)
 	if err != nil {
@@ -159,10 +159,10 @@ func ResourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return ResourceJobRead(ctx, d, meta)
+	return resourceJobRead(ctx, d, meta)
 }
 
-func ResourceJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	err := c.DeleteJob(ctx, d.Id())
 	if err != nil {

--- a/internal/resources/machinelearning/resource_outlier_detector.go
+++ b/internal/resources/machinelearning/resource_outlier_detector.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func ResourceOutlierDetector() *schema.Resource {
+func resourceOutlierDetector() *schema.Resource {
 	return &schema.Resource{
 
 		Description: `
@@ -23,10 +23,10 @@ The normal band is configured by choice of algorithm, its sensitivity and other 
 Visit https://grafana.com/docs/grafana-cloud/machine-learning/outlier-detection/ for more details.
 `,
 
-		CreateContext: ResourceOutlierCreate,
-		ReadContext:   ResourceOutlierRead,
-		UpdateContext: ResourceOutlierUpdate,
-		DeleteContext: ResourceOutlierDelete,
+		CreateContext: checkClient(resourceOutlierCreate),
+		ReadContext:   checkClient(resourceOutlierRead),
+		UpdateContext: checkClient(resourceOutlierUpdate),
+		DeleteContext: checkClient(resourceOutlierDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -122,7 +122,7 @@ Visit https://grafana.com/docs/grafana-cloud/machine-learning/outlier-detection/
 	}
 }
 
-func ResourceOutlierCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOutlierCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	outlier, err := makeMLOutlier(d, meta)
 	if err != nil {
@@ -133,10 +133,10 @@ func ResourceOutlierCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 	d.SetId(outlier.ID)
-	return ResourceOutlierRead(ctx, d, meta)
+	return resourceOutlierRead(ctx, d, meta)
 }
 
-func ResourceOutlierRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOutlierRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	outlier, err := c.OutlierDetector(ctx, d.Id())
 	if err, shouldReturn := common.CheckReadError("outlier detector", d, err); shouldReturn {
@@ -164,7 +164,7 @@ func ResourceOutlierRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
-func ResourceOutlierUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOutlierUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	outlier, err := makeMLOutlier(d, meta)
 	if err != nil {
@@ -174,10 +174,10 @@ func ResourceOutlierUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return ResourceOutlierRead(ctx, d, meta)
+	return resourceOutlierRead(ctx, d, meta)
 }
 
-func ResourceOutlierDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOutlierDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	err := c.DeleteOutlierDetector(ctx, d.Id())
 	if err != nil {

--- a/internal/resources/machinelearning/resources.go
+++ b/internal/resources/machinelearning/resources.go
@@ -1,0 +1,27 @@
+package machinelearning
+
+import (
+	"context"
+
+	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func checkClient(f func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		client := meta.(*common.Client).MLAPI
+		if client == nil {
+			return diag.Errorf("the ML API client is required for this resource. Set the url and auth provider attributes")
+		}
+		return f(ctx, d, meta)
+	}
+}
+
+var DatasourcesMap = map[string]*schema.Resource{}
+
+var ResourcesMap = map[string]*schema.Resource{
+	"grafana_machine_learning_job":              resourceJob(),
+	"grafana_machine_learning_holiday":          resourceHoliday(),
+	"grafana_machine_learning_outlier_detector": resourceOutlierDetector(),
+}


### PR DESCRIPTION
Just like #1393 and #1396

- Makes the resource functions private (exposed via a single map attribute) rather than each resource individually
- Puts the client validation in the ML package