### PR TITLE
Cloud: Make full use of ID + import generation framework

### DIFF
--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -86,6 +86,5 @@ resource "grafana_cloud_stack" "test" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_cloud_stack.stack_name {{stack_id}} // import by numerical ID
-terraform import grafana_cloud_stack.stack_name {{stack_slug}} // or import by slug
+terraform import grafana_cloud_stack.name "{{ stackSlugOrID }}"
 ```

--- a/docs/resources/cloud_stack_service_account.md
+++ b/docs/resources/cloud_stack_service_account.md
@@ -51,3 +51,11 @@ resource "grafana_cloud_stack_service_account" "cloud_sa" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_cloud_stack_service_account.name "{{ stackSlug }}:{{ serviceAccountID }}"
+```

--- a/examples/resources/grafana_cloud_stack/import.sh
+++ b/examples/resources/grafana_cloud_stack/import.sh
@@ -1,2 +1,1 @@
-terraform import grafana_cloud_stack.stack_name {{stack_id}} // import by numerical ID
-terraform import grafana_cloud_stack.stack_name {{stack_slug}} // or import by slug
+terraform import grafana_cloud_stack.name "{{ stackSlugOrID }}"

--- a/examples/resources/grafana_cloud_stack_service_account/import.sh
+++ b/examples/resources/grafana_cloud_stack_service_account/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_cloud_stack_service_account.name "{{ stackSlug }}:{{ serviceAccountID }}"

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -76,10 +76,11 @@ func stackServiceAccountTokenCreate(ctx context.Context, d *schema.ResourceData,
 	}
 	defer cleanup()
 
-	serviceAccountID, err := strconv.ParseInt(d.Get("service_account_id").(string), 10, 64)
+	split, err := resourceStackServiceAccountID.Split(d.Get("service_account_id").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	serviceAccountID := split[1].(int64)
 
 	name := d.Get("name").(string)
 	ttl := d.Get("seconds_to_live").(int)
@@ -115,10 +116,11 @@ func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, c
 }
 
 func stackServiceAccountTokenReadWithClient(c *goapi.GrafanaHTTPAPI, d *schema.ResourceData) diag.Diagnostics {
-	serviceAccountID, err := strconv.ParseInt(d.Get("service_account_id").(string), 10, 64)
+	split, err := resourceStackServiceAccountID.Split(d.Get("service_account_id").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	serviceAccountID := split[1].(int64)
 
 	response, err := c.ServiceAccounts.ListTokens(serviceAccountID)
 	if err != nil {
@@ -161,10 +163,11 @@ func stackServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData,
 	}
 	defer cleanup()
 
-	serviceAccountID, err := strconv.ParseInt(d.Get("service_account_id").(string), 10, 64)
+	split, err := resourceStackServiceAccountID.Split(d.Get("service_account_id").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	serviceAccountID := split[1].(int64)
 
 	id, err := strconv.ParseInt(d.Id(), 10, 32)
 	if err != nil {


### PR DESCRIPTION
Split from https://github.com/grafana/terraform-provider-grafana/pull/1391 

Convert the `stack` and `stack_service_account` resources to the new ID system that validates the ID format