### PR TITLE
Folder datasource fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - GF_SERVER_ROOT_URL=${GRAFANA_URL}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
       - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
+      - GF_FEATURE_TOGGLES_ENABLE=nestedFolders
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s

--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -29,7 +29,7 @@ data "grafana_folder" "from_title" {
 
 ### Required
 
-- `title` (String) The name of the Grafana folder.
+- `title` (String) The title of the folder.
 
 ### Optional
 
@@ -37,6 +37,7 @@ data "grafana_folder" "from_title" {
 
 ### Read-Only
 
-- `id` (Number) The numerical ID of the Grafana folder.
-- `uid` (String) The uid of the Grafana folder.
+- `id` (String) The ID of this resource.
+- `parent_folder_uid` (String) The uid of the parent folder. If set, the folder will be nested. If not set, the folder will be created in the root folder. Note: This requires the nestedFolders feature flag to be enabled on your Grafana instance.
+- `uid` (String) Unique identifier.
 - `url` (String) The full URL of the folder.

--- a/internal/resources/grafana/data_source_folder_test.go
+++ b/internal/resources/grafana/data_source_folder_test.go
@@ -1,13 +1,14 @@
 package grafana_test
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -17,18 +18,10 @@ func TestAccDatasourceFolder_basic(t *testing.T) {
 	var folder models.Folder
 	checks := []resource.TestCheckFunc{
 		folderCheckExists.exists("grafana_folder.test", &folder),
-		resource.TestCheckResourceAttr(
-			"data.grafana_folder.from_title", "title", "test-folder",
-		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_folder.from_title", "id", common.IDRegexp,
-		),
-		resource.TestCheckResourceAttr(
-			"data.grafana_folder.from_title", "uid", "test-ds-folder-uid",
-		),
-		resource.TestCheckResourceAttr(
-			"data.grafana_folder.from_title", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/dashboards/f/test-ds-folder-uid/test-folder",
-		),
+		resource.TestCheckResourceAttr("data.grafana_folder.from_title", "title", "test-folder"),
+		resource.TestMatchResourceAttr("data.grafana_folder.from_title", "id", defaultOrgIDRegexp),
+		resource.TestCheckResourceAttr("data.grafana_folder.from_title", "uid", "test-ds-folder-uid"),
+		resource.TestCheckResourceAttr("data.grafana_folder.from_title", "url", strings.TrimRight(os.Getenv("GRAFANA_URL"), "/")+"/dashboards/f/test-ds-folder-uid/test-folder"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -41,4 +34,61 @@ func TestAccDatasourceFolder_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccDatasourceFolder_nested(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=10.3.0")
+
+	var parent models.Folder
+	var child models.Folder
+	randomName := acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: testutils.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			folderCheckExists.destroyed(&parent, nil),
+			folderCheckExists.destroyed(&child, nil),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testNestedFolderData(randomName),
+				Check: resource.ComposeTestCheckFunc(
+					folderCheckExists.exists("grafana_folder.parent", &parent),
+					folderCheckExists.exists("grafana_folder.child", &child),
+					resource.TestCheckResourceAttr("data.grafana_folder.parent", "title", randomName),
+					resource.TestCheckResourceAttr("data.grafana_folder.parent", "uid", randomName),
+					resource.TestMatchResourceAttr("data.grafana_folder.parent", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("data.grafana_folder.parent", "parent_folder_uid", ""),
+
+					resource.TestCheckResourceAttr("data.grafana_folder.child", "title", randomName+"-child"),
+					resource.TestCheckResourceAttr("data.grafana_folder.child", "uid", randomName+"-child"),
+					resource.TestMatchResourceAttr("data.grafana_folder.child", "id", defaultOrgIDRegexp),
+					resource.TestCheckResourceAttr("data.grafana_folder.child", "parent_folder_uid", randomName),
+				),
+			},
+		},
+	})
+}
+
+func testNestedFolderData(name string) string {
+	return fmt.Sprintf(`
+resource "grafana_folder" "parent" {
+	title = "%[1]s"
+	uid   = "%[1]s"
+}
+	
+resource "grafana_folder" "child" {
+	title = "%[1]s-child"
+	uid   = "%[1]s-child"
+	parent_folder_uid = grafana_folder.parent.uid
+}
+	
+data "grafana_folder" "parent" {
+	title = grafana_folder.parent.title
+}
+	
+data "grafana_folder" "child" {
+	title = grafana_folder.child.title
+}
+`, name)
 }

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -98,7 +98,7 @@ func TestAccFolder_basic(t *testing.T) {
 }
 
 func TestAccFolder_nested(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t) // TODO: Switch to OSS once nested folders are enabled by default
+	testutils.CheckOSSTestsEnabled(t, ">=10.3.0")
 
 	var parentFolder models.Folder
 	var childFolder1 models.Folder


### PR DESCRIPTION
- Make the nested folders tests run in OSS, not in the cloud instance
- Build the folder datasource from the folder resource's schema, rather than duplicating things
- (bugfix) Use the search API rather than the get folders API, it seems that the latter does not return nested folders