### PR TITLE
Self-contained `oncall` package

### DIFF
--- a/internal/provider/legacy_provider.go
+++ b/internal/provider/legacy_provider.go
@@ -77,17 +77,6 @@ func Provider(version string) *schema.Provider {
 			"grafana_synthetic_monitoring_probe": syntheticmonitoring.ResourceProbe(),
 		})
 
-		// Resources that require the OnCall client to exist.
-		onCallClientResources = addResourcesMetadataValidation(onCallClientPresent, map[string]*schema.Resource{
-			"grafana_oncall_integration":      oncall.ResourceIntegration(),
-			"grafana_oncall_route":            oncall.ResourceRoute(),
-			"grafana_oncall_escalation_chain": oncall.ResourceEscalationChain(),
-			"grafana_oncall_escalation":       oncall.ResourceEscalation(),
-			"grafana_oncall_on_call_shift":    oncall.ResourceOnCallShift(),
-			"grafana_oncall_schedule":         oncall.ResourceSchedule(),
-			"grafana_oncall_outgoing_webhook": oncall.ResourceOutgoingWebhook(),
-		})
-
 		// Datasources that require the Grafana client to exist.
 		grafanaClientDatasources = addCreateReadResourcesMetadataValidation(
 			readGrafanaClientValidation,
@@ -112,18 +101,6 @@ func Provider(version string) *schema.Provider {
 		smClientDatasources = addResourcesMetadataValidation(smClientPresent, map[string]*schema.Resource{
 			"grafana_synthetic_monitoring_probe":  syntheticmonitoring.DataSourceProbe(),
 			"grafana_synthetic_monitoring_probes": syntheticmonitoring.DataSourceProbes(),
-		})
-
-		// Datasources that require the OnCall client to exist.
-		onCallClientDatasources = addResourcesMetadataValidation(onCallClientPresent, map[string]*schema.Resource{
-			"grafana_oncall_user":             oncall.DataSourceUser(),
-			"grafana_oncall_escalation_chain": oncall.DataSourceEscalationChain(),
-			"grafana_oncall_schedule":         oncall.DataSourceSchedule(),
-			"grafana_oncall_slack_channel":    oncall.DataSourceSlackChannel(),
-			"grafana_oncall_action":           oncall.DataSourceAction(), // deprecated
-			"grafana_oncall_outgoing_webhook": oncall.DataSourceOutgoingWebhook(),
-			"grafana_oncall_user_group":       oncall.DataSourceUserGroup(),
-			"grafana_oncall_team":             oncall.DataSourceTeam(),
 		})
 	)
 
@@ -249,7 +226,7 @@ func Provider(version string) *schema.Provider {
 			machinelearning.ResourcesMap,
 			slo.ResourcesMap,
 			smClientResources,
-			onCallClientResources,
+			oncall.ResourcesMap,
 			cloud.ResourcesMap,
 		),
 
@@ -258,7 +235,7 @@ func Provider(version string) *schema.Provider {
 			machinelearning.DatasourcesMap,
 			slo.DatasourcesMap,
 			smClientDatasources,
-			onCallClientDatasources,
+			oncall.DatasourcesMap,
 			cloud.DatasourcesMap,
 		),
 	}

--- a/internal/provider/legacy_provider_validation.go
+++ b/internal/provider/legacy_provider_validation.go
@@ -42,13 +42,6 @@ func smClientPresent(resourceName string, d *schema.ResourceData, m interface{})
 	return nil
 }
 
-func onCallClientPresent(resourceName string, d *schema.ResourceData, m interface{}) error {
-	if m.(*common.Client).OnCallClient == nil {
-		return fmt.Errorf("the Oncall client is required for `%s`. Set the oncall_access_token provider attribute", resourceName)
-	}
-	return nil
-}
-
 func addResourcesMetadataValidation(validateFunc metadataValidation, resources map[string]*schema.Resource) map[string]*schema.Resource {
 	return addCreateReadResourcesMetadataValidation(validateFunc, validateFunc, resources)
 }

--- a/internal/resources/oncall/data_source_action.go
+++ b/internal/resources/oncall/data_source_action.go
@@ -7,10 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
 
-func DataSourceAction() *schema.Resource {
+func dataSourceAction() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 **Note:** This data source is going to be deprecated, please use outgoing webhook data source instead.
@@ -18,7 +17,7 @@ func DataSourceAction() *schema.Resource {
 
 !> Deprecated: Use the ` + "`grafana_oncall_outgoing_webhook`" + ` data source instead.
 `,
-		ReadContext:        DataSourceActionRead,
+		ReadContext:        withClient[schema.ReadContextFunc](dataSourceActionRead),
 		DeprecationMessage: "This data source is going to be deprecated, please use outgoing webhook data source instead.",
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -30,8 +29,7 @@ func DataSourceAction() *schema.Resource {
 	}
 }
 
-func DataSourceActionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceActionRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListCustomActionOptions{}
 	nameData := d.Get("name").(string)
 

--- a/internal/resources/oncall/data_source_escalation_chain.go
+++ b/internal/resources/oncall/data_source_escalation_chain.go
@@ -4,17 +4,16 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceEscalationChain() *schema.Resource {
+func dataSourceEscalationChain() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_chains/)
 `,
-		ReadContext: dataSourceEscalationChainRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceEscalationChainRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -25,8 +24,7 @@ func DataSourceEscalationChain() *schema.Resource {
 	}
 }
 
-func dataSourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListEscalationChainOptions{}
 	nameData := d.Get("name").(string)
 

--- a/internal/resources/oncall/data_source_outgoing_webhook.go
+++ b/internal/resources/oncall/data_source_outgoing_webhook.go
@@ -7,15 +7,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
 
-func DataSourceOutgoingWebhook() *schema.Resource {
+func dataSourceOutgoingWebhook() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/outgoing_webhooks/)
 `,
-		ReadContext: DataSourceOutgoingWebhookRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceOutgoingWebhookRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -26,8 +25,7 @@ func DataSourceOutgoingWebhook() *schema.Resource {
 	}
 }
 
-func DataSourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListWebhookOptions{}
 	name := d.Get("name").(string)
 

--- a/internal/resources/oncall/data_source_schedule.go
+++ b/internal/resources/oncall/data_source_schedule.go
@@ -4,18 +4,17 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceSchedule() *schema.Resource {
+func dataSourceSchedule() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/oncall/latest/manage/on-call-schedules/)
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/schedules/)
 `,
-		ReadContext: DataSourceScheduleRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceScheduleRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -31,8 +30,7 @@ func DataSourceSchedule() *schema.Resource {
 	}
 }
 
-func DataSourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceScheduleRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListScheduleOptions{}
 	nameData := d.Get("name").(string)
 

--- a/internal/resources/oncall/data_source_slack_channel.go
+++ b/internal/resources/oncall/data_source_slack_channel.go
@@ -4,17 +4,16 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceSlackChannel() *schema.Resource {
+func dataSourceSlackChannel() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/slack_channels/)
 `,
-		ReadContext: DataSourceSlackChannelRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceSlackChannelRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -30,8 +29,7 @@ func DataSourceSlackChannel() *schema.Resource {
 	}
 }
 
-func DataSourceSlackChannelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceSlackChannelRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListSlackChannelOptions{}
 	nameData := d.Get("name").(string)
 

--- a/internal/resources/oncall/data_source_team.go
+++ b/internal/resources/oncall/data_source_team.go
@@ -4,14 +4,13 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceTeam() *schema.Resource {
+func dataSourceTeam() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: DataSourceTeamRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceTeamRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -30,8 +29,7 @@ func DataSourceTeam() *schema.Resource {
 	}
 }
 
-func DataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListTeamOptions{}
 	nameData := d.Get("name").(string)
 

--- a/internal/resources/oncall/data_source_user.go
+++ b/internal/resources/oncall/data_source_user.go
@@ -4,17 +4,16 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceUser() *schema.Resource {
+func dataSourceUser() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/users/)
 `,
-		ReadContext: DataSourceUserRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceUserRead),
 		Schema: map[string]*schema.Schema{
 			"username": {
 				Type:        schema.TypeString,
@@ -35,8 +34,7 @@ func DataSourceUser() *schema.Resource {
 	}
 }
 
-func DataSourceUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListUserOptions{}
 	usernameData := d.Get("username").(string)
 

--- a/internal/resources/oncall/data_source_user_group.go
+++ b/internal/resources/oncall/data_source_user_group.go
@@ -4,17 +4,16 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func DataSourceUserGroup() *schema.Resource {
+func dataSourceUserGroup() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/user_groups/)
 `,
-		ReadContext: DataSourceUserGroupRead,
+		ReadContext: withClient[schema.ReadContextFunc](dataSourceUserGroupRead),
 		Schema: map[string]*schema.Schema{
 			"slack_handle": {
 				Type:     schema.TypeString,
@@ -28,8 +27,7 @@ func DataSourceUserGroup() *schema.Resource {
 	}
 }
 
-func DataSourceUserGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func dataSourceUserGroupRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.ListUserGroupOptions{}
 	slackHandleData := d.Get("slack_handle").(string)
 

--- a/internal/resources/oncall/resource_escalation_chain.go
+++ b/internal/resources/oncall/resource_escalation_chain.go
@@ -6,20 +6,19 @@ import (
 	"net/http"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func ResourceEscalationChain() *schema.Resource {
+func resourceEscalationChain() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_chains/)
 `,
-		CreateContext: ResourceEscalationChainCreate,
-		ReadContext:   ResourceEscalationChainRead,
-		UpdateContext: ResourceEscalationChainUpdate,
-		DeleteContext: ResourceEscalationChainDelete,
+		CreateContext: withClient[schema.CreateContextFunc](resourceEscalationChainCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourceEscalationChainRead),
+		UpdateContext: withClient[schema.UpdateContextFunc](resourceEscalationChainUpdate),
+		DeleteContext: withClient[schema.DeleteContextFunc](resourceEscalationChainDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -39,9 +38,7 @@ func ResourceEscalationChain() *schema.Resource {
 	}
 }
 
-func ResourceEscalationChainCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceEscalationChainCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
 
@@ -57,12 +54,10 @@ func ResourceEscalationChainCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(escalationChain.ID)
 
-	return ResourceEscalationChainRead(ctx, d, m)
+	return resourceEscalationChainRead(ctx, d, client)
 }
 
-func ResourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	escalationChain, r, err := client.EscalationChains.GetEscalationChain(d.Id(), &onCallAPI.GetEscalationChainOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
@@ -79,9 +74,7 @@ func ResourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, m 
 	return nil
 }
 
-func ResourceEscalationChainUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceEscalationChainUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
 
@@ -96,12 +89,10 @@ func ResourceEscalationChainUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	d.SetId(escalationChain.ID)
-	return ResourceEscalationChainRead(ctx, d, m)
+	return resourceEscalationChainRead(ctx, d, client)
 }
 
-func ResourceEscalationChainDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceEscalationChainDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.EscalationChains.DeleteEscalationChain(d.Id(), &onCallAPI.DeleteEscalationChainOptions{})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -46,17 +45,17 @@ var integrationTypes = []string{
 
 var integrationTypesVerbal = strings.Join(integrationTypes, ", ")
 
-func ResourceIntegration() *schema.Resource {
+func resourceIntegration() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/oncall/latest/integrations/)
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/)
 `,
 
-		CreateContext: ResourceIntegrationCreate,
-		ReadContext:   ResourceIntegrationRead,
-		UpdateContext: ResourceIntegrationUpdate,
-		DeleteContext: ResourceIntegrationDelete,
+		CreateContext: withClient[schema.CreateContextFunc](resourceIntegrationCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourceIntegrationRead),
+		UpdateContext: withClient[schema.UpdateContextFunc](resourceIntegrationUpdate),
+		DeleteContext: withClient[schema.DeleteContextFunc](resourceIntegrationDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -274,9 +273,7 @@ func onCallTemplate(description string, hasMessage, hasImage bool) *schema.Schem
 	return &templateSchema
 }
 
-func ResourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	teamIDData := d.Get("team_id").(string)
 	nameData := d.Get("name").(string)
 	typeData := d.Get("type").(string)
@@ -298,12 +295,10 @@ func ResourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	d.SetId(integration.ID)
 
-	return ResourceIntegrationRead(ctx, d, m)
+	return resourceIntegrationRead(ctx, d, client)
 }
 
-func ResourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
 	templateData := d.Get("templates").([]interface{})
@@ -323,11 +318,10 @@ func ResourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	d.SetId(integration.ID)
 
-	return ResourceIntegrationRead(ctx, d, m)
+	return resourceIntegrationRead(ctx, d, client)
 }
 
-func ResourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.GetIntegrationOptions{}
 	integration, r, err := client.Integrations.GetIntegration(d.Id(), options)
 	if err != nil {
@@ -349,8 +343,7 @@ func ResourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m inte
 	return nil
 }
 
-func ResourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.DeleteIntegrationOptions{}
 	_, err := client.Integrations.DeleteIntegration(d.Id(), options)
 	if err != nil {

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -6,20 +6,19 @@ import (
 	"net/http"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func ResourceOutgoingWebhook() *schema.Resource {
+func resourceOutgoingWebhook() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/outgoing_webhooks/)
 `,
-		CreateContext: ResourceOutgoingWebhookCreate,
-		ReadContext:   ResourceOutgoingWebhookRead,
-		UpdateContext: ResourceOutgoingWebhookUpdate,
-		DeleteContext: ResourceOutgoingWebhookDelete,
+		CreateContext: withClient[schema.CreateContextFunc](resourceOutgoingWebhookCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourceOutgoingWebhookRead),
+		UpdateContext: withClient[schema.UpdateContextFunc](resourceOutgoingWebhookUpdate),
+		DeleteContext: withClient[schema.DeleteContextFunc](resourceOutgoingWebhookDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -104,9 +103,7 @@ func ResourceOutgoingWebhook() *schema.Resource {
 	}
 }
 
-func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	name := d.Get("name").(string)
 	teamID := d.Get("team_id").(string)
 	url := d.Get("url").(string)
@@ -182,12 +179,10 @@ func ResourceOutgoingWebhookCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(outgoingWebhook.ID)
 
-	return ResourceOutgoingWebhookRead(ctx, d, m)
+	return resourceOutgoingWebhookRead(ctx, d, client)
 }
 
-func ResourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	outgoingWebhook, r, err := client.Webhooks.GetWebhook(d.Id(), &onCallAPI.GetWebhookOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
@@ -214,9 +209,7 @@ func ResourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, m 
 	return nil
 }
 
-func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	name := d.Get("name").(string)
 	teamID := d.Get("team_id").(string)
 	url := d.Get("url").(string)
@@ -291,12 +284,10 @@ func ResourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	d.SetId(outgoingWebhook.ID)
-	return ResourceOutgoingWebhookRead(ctx, d, m)
+	return resourceOutgoingWebhookRead(ctx, d, client)
 }
 
-func ResourceOutgoingWebhookDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceOutgoingWebhookDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.Webhooks.DeleteWebhook(d.Id(), &onCallAPI.DeleteWebhookOptions{})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/oncall/resource_route.go
+++ b/internal/resources/oncall/resource_route.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -22,15 +21,15 @@ var routeTypeOptions = []string{
 
 var routeTypeOptionsVerbal = strings.Join(routeTypeOptions, ", ")
 
-func ResourceRoute() *schema.Resource {
+func resourceRoute() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/routes/)
 `,
-		CreateContext: ResourceRouteCreate,
-		ReadContext:   ResourceRouteRead,
-		UpdateContext: ResourceRouteUpdate,
-		DeleteContext: ResourceRouteDelete,
+		CreateContext: withClient[schema.CreateContextFunc](resourceRouteCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourceRouteRead),
+		UpdateContext: withClient[schema.UpdateContextFunc](resourceRouteUpdate),
+		DeleteContext: withClient[schema.DeleteContextFunc](resourceRouteDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -131,9 +130,7 @@ func ResourceRoute() *schema.Resource {
 	}
 }
 
-func ResourceRouteCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	integrationID := d.Get("integration_id").(string)
 	escalationChainID := d.Get("escalation_chain_id").(string)
 	routingType := d.Get("routing_type").(string)
@@ -162,12 +159,10 @@ func ResourceRouteCreate(ctx context.Context, d *schema.ResourceData, m interfac
 
 	d.SetId(route.ID)
 
-	return ResourceRouteRead(ctx, d, m)
+	return resourceRouteRead(ctx, d, client)
 }
 
-func ResourceRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceRouteRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	route, r, err := client.Routes.GetRoute(d.Id(), &onCallAPI.GetRouteOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
@@ -201,9 +196,7 @@ func ResourceRouteRead(ctx context.Context, d *schema.ResourceData, m interface{
 	return nil
 }
 
-func ResourceRouteUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	escalationChainID := d.Get("escalation_chain_id").(string)
 	routingType := d.Get("routing_type").(string)
 	routingRegex := d.Get("routing_regex").(string)
@@ -229,12 +222,10 @@ func ResourceRouteUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	d.SetId(route.ID)
-	return ResourceRouteRead(ctx, d, m)
+	return resourceRouteRead(ctx, d, client)
 }
 
-func ResourceRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.Routes.DeleteRoute(d.Id(), &onCallAPI.DeleteRouteOptions{})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -17,15 +17,15 @@ var scheduleTypeOptions = []string{
 	"calendar",
 }
 
-func ResourceSchedule() *schema.Resource {
+func resourceSchedule() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/schedules/)
 `,
-		CreateContext: resourceScheduleCreate,
-		ReadContext:   resourceScheduleRead,
-		UpdateContext: resourceScheduleUpdate,
-		DeleteContext: resourceScheduleDelete,
+		CreateContext: withClient[schema.CreateContextFunc](resourceScheduleCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourceScheduleRead),
+		UpdateContext: withClient[schema.UpdateContextFunc](resourceScheduleUpdate),
+		DeleteContext: withClient[schema.DeleteContextFunc](resourceScheduleDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -101,9 +101,7 @@ func ResourceSchedule() *schema.Resource {
 	}
 }
 
-func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
 	typeData := d.Get("type").(string)
@@ -164,12 +162,10 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	d.SetId(schedule.ID)
 
-	return resourceScheduleRead(ctx, d, m)
+	return resourceScheduleRead(ctx, d, client)
 }
 
-func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
 	slackData := d.Get("slack").([]interface{})
@@ -229,11 +225,10 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	d.SetId(schedule.ID)
 
-	return resourceScheduleRead(ctx, d, m)
+	return resourceScheduleRead(ctx, d, client)
 }
 
-func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.GetScheduleOptions{}
 	schedule, r, err := client.Schedules.GetSchedule(d.Id(), options)
 	if err != nil {
@@ -258,8 +253,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interfa
 	return nil
 }
 
-func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.DeleteScheduleOptions{}
 	_, err := client.Schedules.DeleteSchedule(d.Id(), options)
 	if err != nil {

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -49,15 +49,15 @@ var onCallShiftWeekDayOptionsVerbal = strings.Join(onCallShiftWeekDayOptions, ",
 
 var sourceTerraform = 3
 
-func ResourceOnCallShift() *schema.Resource {
+func resourceOnCallShift() *schema.Resource {
 	return &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/on_call_shifts/)
 `,
-		CreateContext: ResourceOnCallShiftCreate,
-		ReadContext:   ResourceOnCallShiftRead,
-		UpdateContext: ResourceOnCallShiftUpdate,
-		DeleteContext: ResourceOnCallShiftDelete,
+		CreateContext: withClient[schema.CreateContextFunc](resourceOnCallShiftCreate),
+		ReadContext:   withClient[schema.ReadContextFunc](resourceOnCallShiftRead),
+		UpdateContext: withClient[schema.UpdateContextFunc](resourceOnCallShiftUpdate),
+		DeleteContext: withClient[schema.DeleteContextFunc](resourceOnCallShiftDelete),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -183,9 +183,7 @@ func ResourceOnCallShift() *schema.Resource {
 	}
 }
 
-func ResourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	teamIDData := d.Get("team_id").(string)
 	typeData := d.Get("type").(string)
 	nameData := d.Get("name").(string)
@@ -303,12 +301,10 @@ func ResourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	d.SetId(onCallShift.ID)
 
-	return ResourceOnCallShiftRead(ctx, d, m)
+	return resourceOnCallShiftRead(ctx, d, client)
 }
 
-func ResourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
-
+func resourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	typeData := d.Get("type").(string)
 	nameData := d.Get("name").(string)
 	teamIDData := d.Get("team_id").(string)
@@ -426,11 +422,10 @@ func ResourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	d.SetId(onCallShift.ID)
 
-	return ResourceOnCallShiftRead(ctx, d, m)
+	return resourceOnCallShiftRead(ctx, d, client)
 }
 
-func ResourceOnCallShiftRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func resourceOnCallShiftRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.GetOnCallShiftOptions{}
 	onCallShift, r, err := client.OnCallShifts.GetOnCallShift(d.Id(), options)
 	if err != nil {
@@ -462,8 +457,7 @@ func ResourceOnCallShiftRead(ctx context.Context, d *schema.ResourceData, m inte
 	return nil
 }
 
-func ResourceOnCallShiftDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := m.(*common.Client).OnCallClient
+func resourceOnCallShiftDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.DeleteOnCallShiftOptions{}
 	_, err := client.OnCallShifts.DeleteOnCallShift(d.Id(), options)
 	if err != nil {

--- a/internal/resources/oncall/resources.go
+++ b/internal/resources/oncall/resources.go
@@ -1,0 +1,43 @@
+package oncall
+
+import (
+	"context"
+
+	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type crudWithClientFunc func(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics
+
+func withClient[T schema.CreateContextFunc | schema.UpdateContextFunc | schema.ReadContextFunc | schema.DeleteContextFunc](f crudWithClientFunc) T {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		client := meta.(*common.Client).OnCallClient
+		if client == nil {
+			return diag.Errorf("the OnCall client is required for this resource. Set the oncall_access_token provider attribute")
+		}
+		return f(ctx, d, client)
+	}
+}
+
+var DatasourcesMap = map[string]*schema.Resource{
+	"grafana_oncall_user":             dataSourceUser(),
+	"grafana_oncall_escalation_chain": dataSourceEscalationChain(),
+	"grafana_oncall_schedule":         dataSourceSchedule(),
+	"grafana_oncall_slack_channel":    dataSourceSlackChannel(),
+	"grafana_oncall_action":           dataSourceAction(), // deprecated
+	"grafana_oncall_outgoing_webhook": dataSourceOutgoingWebhook(),
+	"grafana_oncall_user_group":       dataSourceUserGroup(),
+	"grafana_oncall_team":             dataSourceTeam(),
+}
+
+var ResourcesMap = map[string]*schema.Resource{
+	"grafana_oncall_integration":      resourceIntegration(),
+	"grafana_oncall_route":            resourceRoute(),
+	"grafana_oncall_escalation_chain": resourceEscalationChain(),
+	"grafana_oncall_escalation":       resourceEscalation(),
+	"grafana_oncall_on_call_shift":    resourceOnCallShift(),
+	"grafana_oncall_schedule":         resourceSchedule(),
+	"grafana_oncall_outgoing_webhook": resourceOutgoingWebhook(),
+}


### PR DESCRIPTION
Just like what was done for `cloud`, `slo` and `ml` packages 
This moves the mapping of resources and client validation to the oncall package. This will make it easier to support TF code generation + upgrade to the new TF plugin framework