### PR TITLE
Tests: Replace `ProviderFactories` with `ProtoV5ProviderFactories`

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -4,7 +4,7 @@ page_title: "grafana_contact_point Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting contact points.
-  Official documentation https://grafana.com/docs/grafana/next/alerting/fundamentals/contact-points/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
+  Official documentation https://grafana.com/docs/grafana/next/alerting/fundamentals/notifications/contact-points/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting contact points.
 
-* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/contact-points/)
+* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/notifications/contact-points/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.20.0
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.6.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-mux v0.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/hashicorp/terraform-plugin-docs v0.18.0 h1:2bINhzXc+yDeAcafurshCrIjtd
 github.com/hashicorp/terraform-plugin-docs v0.18.0/go.mod h1:iIUfaJpdUmpi+rI42Kgq+63jAjI8aZVTyxp3Bvk9Hg8=
 github.com/hashicorp/terraform-plugin-framework v1.6.1 h1:hw2XrmUu8d8jVL52ekxim2IqDc+2Kpekn21xZANARLU=
 github.com/hashicorp/terraform-plugin-framework v1.6.1/go.mod h1:aJI+n/hBPhz1J+77GdgNfk5svW12y7fmtxe/5L5IuwI=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.22.1 h1:iTS7WHNVrn7uhe3cojtvWWn83cm2Z6ryIUDTRO0EV7w=
 github.com/hashicorp/terraform-plugin-go v0.22.1/go.mod h1:qrjnqRghvQ6KnDbB12XeZ4FluclYwptntoWCr9QaXTI=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,34 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf6to5server"
+)
+
+func MakeProviderServer(ctx context.Context, version string) (tfprotov5.ProviderServer, error) {
+	// While we still have the SDK2 provider, we have to use the provider v5 protocol
+	// See https://developer.hashicorp.com/terraform/plugin/mux/translating-protocol-version-6-to-5
+	downgradedFrameworkProvider, err := tf6to5server.DowngradeServer(
+		context.Background(),
+		providerserver.NewProtocol6(FrameworkProvider(version)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	providers := []func() tfprotov5.ProviderServer{
+		func() tfprotov5.ProviderServer {
+			return downgradedFrameworkProvider
+		},
+		Provider(version).GRPCProvider,
+	}
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		return nil, err
+	}
+	return muxServer, nil
+}

--- a/internal/resources/cloud/data_source_cloud_ips_test.go
+++ b/internal/resources/cloud/data_source_cloud_ips_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceIPsRead(t *testing.T) {
 	testutils.CheckCloudAPITestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_cloud_ips/data-source.tf"),

--- a/internal/resources/cloud/data_source_cloud_organization_test.go
+++ b/internal/resources/cloud/data_source_cloud_organization_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceOrganization_Basic(t *testing.T) {
 	`, os.Getenv("GRAFANA_CLOUD_ORG"))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/resources/cloud/data_source_cloud_stack_test.go
+++ b/internal/resources/cloud/data_source_cloud_stack_test.go
@@ -20,8 +20,8 @@ func TestAccDataSourceStack_Basic(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccStackCheckDestroy(&stack),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceStackConfig(resourceName),

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -38,7 +38,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCloudAccessPolicyCheckDestroy("us", &policy),
 			testAccCloudAccessPolicyTokenCheckDestroy("us", &policyToken),
@@ -123,7 +123,7 @@ func TestResourceAccessPolicyToken_NoExpiration(t *testing.T) {
 	var policyToken gcom.AuthToken
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudAccessPolicyTokenConfigBasic("initial-no-expiration", "", []string{"metrics:read"}, ""),

--- a/internal/resources/cloud/resource_cloud_api_key_test.go
+++ b/internal/resources/cloud/resource_cloud_api_key_test.go
@@ -36,8 +36,8 @@ func TestAccCloudApiKey_Basic(t *testing.T) {
 			resourceName := prefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 			resource.ParallelTest(t, resource.TestCase{
-				ProviderFactories: testutils.ProviderFactories,
-				CheckDestroy:      testAccCheckCloudAPIKeyDestroy(resourceName),
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             testAccCheckCloudAPIKeyDestroy(resourceName),
 				Steps: []resource.TestStep{
 					{
 						Config: testAccCloudAPIKeyConfig(resourceName, tt.role),

--- a/internal/resources/cloud/resource_cloud_plugin_test.go
+++ b/internal/resources/cloud/resource_cloud_plugin_test.go
@@ -23,8 +23,8 @@ func TestAccResourcePluginInstallation(t *testing.T) {
 	pluginVersion := "1.2.5"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccDeleteExistingStacks(t, stackPrefix) },
-		ProviderFactories: testutils.ProviderFactories,
+		PreCheck:                 func() { testAccDeleteExistingStacks(t, stackPrefix) },
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGrafanaCloudPluginInstallation(stackSlug, pluginSlug, pluginVersion),

--- a/internal/resources/cloud/resource_cloud_stack_api_key_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key_test.go
@@ -26,8 +26,8 @@ func TestAccGrafanaAuthKeyFromCloud(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccStackCheckDestroy(&stack),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGrafanaAuthKeyFromCloud(slug, slug),

--- a/internal/resources/cloud/resource_cloud_stack_service_account_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_test.go
@@ -25,8 +25,8 @@ func TestAccGrafanaServiceAccountFromCloud(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccStackCheckDestroy(&stack),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGrafanaServiceAccountFromCloud(slug, slug, true),

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -57,8 +57,8 @@ func TestResourceStack_Basic(t *testing.T) {
 		PreCheck: func() {
 			testAccDeleteExistingStacks(t, prefix)
 		},
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccStackCheckDestroy(&stack),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			// Create a basic stack
 			{
@@ -130,7 +130,7 @@ func TestResourceStack_Basic(t *testing.T) {
 
 func TestResourceStack_Invalid(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "grafana_cloud_stack" "test" { 

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation_test.go
@@ -27,8 +27,8 @@ func TestAccSyntheticMonitoringInstallation(t *testing.T) {
 			apiKeyName := apiKeyPrefix + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 			resource.ParallelTest(t, resource.TestCase{
-				ProviderFactories: testutils.ProviderFactories,
-				CheckDestroy:      testAccStackCheckDestroy(&stack),
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             testAccStackCheckDestroy(&stack),
 				Steps: []resource.TestStep{
 					{
 						Config: testAccSyntheticMonitoringInstallation(stackSlug, apiKeyName, region),

--- a/internal/resources/examples_test.go
+++ b/internal/resources/examples_test.go
@@ -120,7 +120,7 @@ func TestAccExamples(t *testing.T) {
 				t.Run(filename, func(t *testing.T) {
 					testDef.testCheck(t, filename)
 					resource.Test(t, resource.TestCase{
-						ProviderFactories: testutils.ProviderFactories,
+						ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 						Steps: []resource.TestStep{{
 							Config: testutils.TestAccExample(t, filename),
 						}},

--- a/internal/resources/grafana/data_source_dashboard_test.go
+++ b/internal/resources/grafana/data_source_dashboard_test.go
@@ -42,8 +42,8 @@ func TestAccDatasourceDashboard_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      dashboardCheckExists.destroyed(&dashboard, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             dashboardCheckExists.destroyed(&dashboard, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_dashboard/data-source.tf"),
@@ -58,7 +58,7 @@ func TestAccDatasourceDashboardBadExactlyOneOf(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testutils.TestAccExample(t, "data-sources/grafana_dashboard/bad-ExactlyOneOf.tf"),

--- a/internal/resources/grafana/data_source_dashboards_test.go
+++ b/internal/resources/grafana/data_source_dashboards_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 
 	// Do not use parallel tests here because it tests a listing datasource on the default org
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_dashboards/data-source.tf"),

--- a/internal/resources/grafana/data_source_data_source_test.go
+++ b/internal/resources/grafana/data_source_data_source_test.go
@@ -32,8 +32,8 @@ func TestAccDatasourceDatasource_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_data_source/data-source.tf"),

--- a/internal/resources/grafana/data_source_folder_test.go
+++ b/internal/resources/grafana/data_source_folder_test.go
@@ -25,8 +25,8 @@ func TestAccDatasourceFolder_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      folderCheckExists.destroyed(&folder, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             folderCheckExists.destroyed(&folder, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_folder/data-source.tf"),
@@ -44,7 +44,7 @@ func TestAccDatasourceFolder_nested(t *testing.T) {
 	randomName := acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			folderCheckExists.destroyed(&parent, nil),
 			folderCheckExists.destroyed(&child, nil),

--- a/internal/resources/grafana/data_source_folders_test.go
+++ b/internal/resources/grafana/data_source_folders_test.go
@@ -38,7 +38,7 @@ func TestAccDatasourceFolders_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			folderCheckExists.destroyed(&folderA, nil),
 			folderCheckExists.destroyed(&folderB, nil),

--- a/internal/resources/grafana/data_source_library_panel_test.go
+++ b/internal/resources/grafana/data_source_library_panel_test.go
@@ -32,8 +32,8 @@ func TestAccDatasourceLibraryPanel_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      libraryPanelCheckExists.destroyed(&panel, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),

--- a/internal/resources/grafana/data_source_organization_preferences_test.go
+++ b/internal/resources/grafana/data_source_organization_preferences_test.go
@@ -16,7 +16,7 @@ func TestAccDatasourceOrganizationPreferences_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_organization_preferences/data-source.tf"),

--- a/internal/resources/grafana/data_source_organization_test.go
+++ b/internal/resources/grafana/data_source_organization_test.go
@@ -39,8 +39,8 @@ func TestAccDatasourceOrganization_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_organization/data-source.tf"),

--- a/internal/resources/grafana/data_source_role_test.go
+++ b/internal/resources/grafana/data_source_role_test.go
@@ -29,8 +29,8 @@ func TestAccDatasourceRole_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      roleCheckExists.destroyed(&role, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             roleCheckExists.destroyed(&role, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_role/data-source.tf"),

--- a/internal/resources/grafana/data_source_service_account_test.go
+++ b/internal/resources/grafana/data_source_service_account_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceServiceAccount_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      serviceAccountCheckExists.destroyed(&sa, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             serviceAccountCheckExists.destroyed(&sa, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testServiceAccountDatasourceConfig(name),

--- a/internal/resources/grafana/data_source_team_test.go
+++ b/internal/resources/grafana/data_source_team_test.go
@@ -24,8 +24,8 @@ func TestAccDatasourceTeam_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_team/data-source.tf"),
@@ -54,8 +54,8 @@ func TestAccDatasourceTeam_teamSync(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_team/with-team-sync.tf"),

--- a/internal/resources/grafana/data_source_user_test.go
+++ b/internal/resources/grafana/data_source_user_test.go
@@ -37,8 +37,8 @@ func TestAccDatasourceUser_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      userCheckExists.destroyed(&user, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             userCheckExists.destroyed(&user, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_user/data-source.tf"),

--- a/internal/resources/grafana/data_source_users_test.go
+++ b/internal/resources/grafana/data_source_users_test.go
@@ -25,7 +25,7 @@ func TestAccDatasourceUsers_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_users/data-source.tf"),

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -49,7 +49,7 @@ func resourceContactPoint() *schema.Resource {
 		Description: `
 Manages Grafana Alerting contact points.
 
-* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/contact-points/)
+* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/notifications/contact-points/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -20,7 +20,7 @@ func TestAccContactPoint_basic(t *testing.T) {
 	var points models.ContactPoints
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
@@ -77,7 +77,7 @@ func TestAccContactPoint_compound(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
@@ -158,7 +158,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 	var points models.ContactPoints
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
@@ -347,7 +347,7 @@ func TestAccContactPoint_notifiers10_2(t *testing.T) {
 	var points models.ContactPoints
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
@@ -377,7 +377,7 @@ func TestAccContactPoint_notifiers10_3(t *testing.T) {
 	var points models.ContactPoints
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
@@ -412,8 +412,8 @@ func TestAccContactPoint_sensitiveData(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      alertingContactPointCheckExists.destroyed(&points, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContactPointWithSensitiveData(name, "https://api.eu.opsgenie.com/v2/alerts", "mykey"),
@@ -459,8 +459,8 @@ func TestAccContactPoint_inOrg(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			// Creation
 			{
@@ -495,7 +495,7 @@ func TestAccContactPoint_empty(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
@@ -517,8 +517,8 @@ func TestAccContactPoint_disableProvenance(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      alertingContactPointCheckExists.destroyed(&points, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingContactPointCheckExists.destroyed(&points, nil),
 		Steps: []resource.TestStep{
 			// Create
 			{

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -16,7 +16,7 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 	var tmpl models.NotificationTemplate
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingMessageTemplateCheckExists.destroyed(&tmpl, nil),
 		Steps: []resource.TestStep{
@@ -86,8 +86,8 @@ func TestAccMessageTemplate_inOrg(t *testing.T) {
 	var org models.OrgDetailsDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMessageTemplate_inOrg(name),

--- a/internal/resources/grafana/resource_alerting_mute_timing_test.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing_test.go
@@ -16,7 +16,7 @@ func TestAccMuteTiming_basic(t *testing.T) {
 	var mt models.MuteTimeInterval
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingMuteTimingCheckExists.destroyed(&mt, nil),
 		Steps: []resource.TestStep{
@@ -78,8 +78,8 @@ func TestAccMuteTiming_AllTime(t *testing.T) {
 	name := "My-Mute-Timing"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      alertingMuteTimingCheckExists.destroyed(&mt, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingMuteTimingCheckExists.destroyed(&mt, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -19,7 +19,7 @@ func TestAccNotificationPolicy_basic(t *testing.T) {
 
 	// TODO: Make parallizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingNotificationPolicyCheckExists.destroyed(&policy, nil),
 		Steps: []resource.TestStep{
@@ -97,7 +97,7 @@ func TestAccNotificationPolicy_disableProvenance(t *testing.T) {
 
 	// TODO: Make parallizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingNotificationPolicyCheckExists.destroyed(&policy, nil),
 		Steps: []resource.TestStep{
@@ -145,7 +145,7 @@ func TestAccNotificationPolicy_error(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `resource "grafana_notification_policy" "test" {
@@ -168,8 +168,8 @@ func TestAccNotificationPolicy_inOrg(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNotificationPolicyInOrg(name, "my-key"),

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -18,7 +18,7 @@ func TestAccAlertRule_basic(t *testing.T) {
 	var group models.AlertRuleGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingRuleGroupCheckExists.destroyed(&group, nil),
 		Steps: []resource.TestStep{
@@ -118,7 +118,7 @@ func TestAccAlertRule_model(t *testing.T) {
 	var group models.AlertRuleGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingRuleGroupCheckExists.destroyed(&group, nil),
 		Steps: []resource.TestStep{
@@ -162,7 +162,7 @@ func TestAccAlertRule_compound(t *testing.T) {
 	var group models.AlertRuleGroup
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests deletion.
 		CheckDestroy: alertingRuleGroupCheckExists.destroyed(&group, nil),
 		Steps: []resource.TestStep{
@@ -231,8 +231,8 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			// Test creation.
 			{
@@ -286,7 +286,7 @@ func TestAccAlertRule_disableProvenance(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			orgCheckExists.destroyed(&org, nil),
 			alertingRuleGroupCheckExists.destroyed(&group, &org),
@@ -347,8 +347,8 @@ func TestAccAlertRule_zeroSeconds(t *testing.T) {
 	var name = acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      alertingRuleGroupCheckExists.destroyed(&group, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingRuleGroupCheckExists.destroyed(&group, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAlertRuleZeroSeconds(name),
@@ -371,8 +371,8 @@ func TestAccAlertRule_NotificationSettings(t *testing.T) {
 	var name = acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      alertingRuleGroupCheckExists.destroyed(&group, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingRuleGroupCheckExists.destroyed(&group, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAlertRuleWithNotificationSettings(name, []string{"alertname", "grafana_folder", "test"}),

--- a/internal/resources/grafana/resource_annotation_test.go
+++ b/internal/resources/grafana/resource_annotation_test.go
@@ -22,8 +22,8 @@ func TestAccAnnotation_basic(t *testing.T) {
 	var annotation models.Annotation
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      annotationsCheckExists.destroyed(&annotation, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             annotationsCheckExists.destroyed(&annotation, nil),
 		Steps: []resource.TestStep{
 			{
 				// Test basic resource creation.
@@ -60,8 +60,8 @@ func TestAccAnnotation_inOrg(t *testing.T) {
 	orgName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      annotationsCheckExists.destroyed(&annotation, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             annotationsCheckExists.destroyed(&annotation, &org),
 		Steps: []resource.TestStep{
 			{
 				// Test basic resource creation.
@@ -157,8 +157,8 @@ func TestAccAnnotation_dashboardUID(t *testing.T) {
 	orgName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      annotationsCheckExists.destroyed(&annotation, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             annotationsCheckExists.destroyed(&annotation, &org),
 		Steps: []resource.TestStep{
 			{
 				// Test resource creation with declared dashboard_uid.

--- a/internal/resources/grafana/resource_api_key_test.go
+++ b/internal/resources/grafana/resource_api_key_test.go
@@ -17,8 +17,8 @@ func TestAccGrafanaAuthKey_basic(t *testing.T) {
 	testName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      apiKeyCheckExists.destroyed(&apiKey, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             apiKeyCheckExists.destroyed(&apiKey, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGrafanaAuthKeyConfig(testName, "Admin", 0, false),
@@ -55,8 +55,8 @@ func TestAccGrafanaAuthKey_inOrg(t *testing.T) {
 	testName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGrafanaAuthKeyConfig(testName, "Admin", 0, true),

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -23,7 +23,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDashboardPermissionConfig(true, true),
@@ -90,7 +90,7 @@ func TestAccDashboardPermission_fromDashboardID(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDashboardPermissionConfig(false, true),

--- a/internal/resources/grafana/resource_dashboard_public_test.go
+++ b/internal/resources/grafana/resource_dashboard_public_test.go
@@ -16,7 +16,7 @@ func TestAccPublicDashboard_basic(t *testing.T) {
 	var publicDashboardOrg models.PublicDashboard
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_dashboard_public/resource.tf"),

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -37,8 +37,8 @@ func TestAccDashboard_basic(t *testing.T) {
 
 			// TODO: Make parallelizable
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: testutils.ProviderFactories,
-				CheckDestroy:      dashboardCheckExists.destroyed(&dashboard, nil),
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             dashboardCheckExists.destroyed(&dashboard, nil),
 				Steps: []resource.TestStep{
 					{
 						// Test resource creation.
@@ -100,8 +100,8 @@ func TestAccDashboard_uid_unset(t *testing.T) {
 	var dashboard models.DashboardFullWithMeta
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      dashboardCheckExists.destroyed(&dashboard, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             dashboardCheckExists.destroyed(&dashboard, nil),
 		Steps: []resource.TestStep{
 			{
 				// Create dashboard with no uid set.
@@ -144,8 +144,8 @@ func TestAccDashboard_computed_config(t *testing.T) {
 	var dashboard models.DashboardFullWithMeta
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      dashboardCheckExists.destroyed(&dashboard, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             dashboardCheckExists.destroyed(&dashboard, nil),
 		Steps: []resource.TestStep{
 			{
 				// Test resource creation.
@@ -168,7 +168,7 @@ func TestAccDashboard_folder(t *testing.T) {
 	var folder models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			dashboardCheckExists.destroyed(&dashboard, nil),
 			folderCheckExists.destroyed(&folder, nil),
@@ -210,7 +210,7 @@ func TestAccDashboard_folder_uid(t *testing.T) {
 	var folder models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			dashboardCheckExists.destroyed(&dashboard, nil),
 			folderCheckExists.destroyed(&folder, nil),
@@ -258,7 +258,7 @@ func TestAccDashboard_inOrg(t *testing.T) {
 	orgName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			dashboardCheckExists.destroyed(&dashboard, &org),
 			folderCheckExists.destroyed(&folder, &org),

--- a/internal/resources/grafana/resource_data_source_permission_test.go
+++ b/internal/resources/grafana/resource_data_source_permission_test.go
@@ -17,7 +17,7 @@ func TestAccDatasourcePermission_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatasourcePermission(name, "Edit"),
@@ -42,7 +42,7 @@ func TestAccDatasourcePermission_AdminRole(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatasourcePermission(name, "Admin"),

--- a/internal/resources/grafana/resource_data_source_test.go
+++ b/internal/resources/grafana/resource_data_source_test.go
@@ -81,8 +81,8 @@ func TestAccDataSource_Loki(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -158,8 +158,8 @@ func TestAccDataSource_TestData(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -221,8 +221,8 @@ func TestAccDataSource_Influx(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -238,8 +238,8 @@ func TestAccDataSource_changeUID(t *testing.T) {
 	var dataSource models.DataSource
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -280,8 +280,8 @@ func TestAccDatasource_inOrg(t *testing.T) {
 	orgName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      datasourceCheckExists.destroyed(&dataSource, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatasourceInOrganization(orgName),

--- a/internal/resources/grafana/resource_folder_permission_test.go
+++ b/internal/resources/grafana/resource_folder_permission_test.go
@@ -25,7 +25,7 @@ func TestAccFolderPermission_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFolderPermissionConfig_Basic(randomName),

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -26,7 +26,7 @@ func TestAccFolder_basic(t *testing.T) {
 	var folderWithUID models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			folderCheckExists.destroyed(&folder, nil),
 			folderCheckExists.destroyed(&folderWithUID, nil),
@@ -106,7 +106,7 @@ func TestAccFolder_nested(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			folderCheckExists.destroyed(&parentFolder, nil),
 			folderCheckExists.destroyed(&childFolder1, nil),
@@ -176,7 +176,7 @@ func TestAccFolder_PreventDeletion(t *testing.T) {
 	var folder models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFolderExample_PreventDeletion(name, true), // Create protected folder
@@ -263,8 +263,8 @@ func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 
 			// Do not make parallel, fiddling with auth will break other tests that run in parallel
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: testutils.ProviderFactories,
-				CheckDestroy:      folderCheckExists.destroyed(&folder, nil),
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             folderCheckExists.destroyed(&folder, nil),
 				Steps: []resource.TestStep{
 					{
 						Config:      config,

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -18,8 +18,8 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 	var panel models.LibraryElementResponse
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      libraryPanelCheckExists.destroyed(&panel, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
 		Steps: []resource.TestStep{
 			{
 				// Test resource creation.
@@ -66,7 +66,7 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 	var folder models.Folder
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			libraryPanelCheckExists.destroyed(&panel, nil),
 			folderCheckExists.destroyed(&folder, nil),
@@ -100,8 +100,8 @@ func TestAccLibraryPanel_dashboard(t *testing.T) {
 	var dashboard models.DashboardFullWithMeta
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      libraryPanelCheckExists.destroyed(&panel, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
 		Steps: []resource.TestStep{
 			{
 				// Test library panel is connected to dashboard
@@ -124,8 +124,8 @@ func TestAccLibraryPanel_inOrg(t *testing.T) {
 	orgName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      libraryPanelCheckExists.destroyed(&panel, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLibraryPanelInOrganization(orgName),

--- a/internal/resources/grafana/resource_organization_preferences_test.go
+++ b/internal/resources/grafana/resource_organization_preferences_test.go
@@ -59,8 +59,8 @@ func testAccResourceOrganizationPreferences(t *testing.T, withUID bool) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testOrganizationPreferencesConfig(testRandName, withUID, prefs),

--- a/internal/resources/grafana/resource_organization_test.go
+++ b/internal/resources/grafana/resource_organization_test.go
@@ -18,8 +18,8 @@ func TestAccOrganization_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_basic,
@@ -72,8 +72,8 @@ func TestAccOrganization_users(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_usersCreate,
@@ -148,8 +148,8 @@ func TestAccOrganization_roleNoneUser(t *testing.T) {
 	var org models.OrgDetailsDTO
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_usersCreate,
@@ -207,8 +207,8 @@ func TestAccOrganization_createManyUsers_longtest(t *testing.T) {
 
 	// Don't make this test parallel, it's already creating 1000+ users
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{Config: testAccOrganizationConfig_usersCreateMany_1},
 			{
@@ -234,8 +234,8 @@ func TestAccOrganization_defaultAdmin(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_defaultAdminNormal,
@@ -295,8 +295,8 @@ func TestAccOrganization_externalUser(t *testing.T) {
 	var org models.OrgDetailsDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationConfig_externalUser,

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -21,8 +21,8 @@ func TestAccPlaylist_basic(t *testing.T) {
 	var playlist models.Playlist
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      playlistCheckExists.destroyed(&playlist, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             playlistCheckExists.destroyed(&playlist, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlaylistConfigBasic(rName, "5m"),
@@ -58,8 +58,8 @@ func TestAccPlaylist_update(t *testing.T) {
 	var playlist models.Playlist
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      playlistCheckExists.destroyed(&playlist, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             playlistCheckExists.destroyed(&playlist, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlaylistConfigBasic(rName, "5m"),
@@ -106,8 +106,8 @@ func TestAccPlaylist_disappears(t *testing.T) {
 	var playlist models.Playlist
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      playlistCheckExists.destroyed(&playlist, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             playlistCheckExists.destroyed(&playlist, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlaylistConfigBasic(rName, "5m"),
@@ -129,8 +129,8 @@ func TestAccPlaylist_inOrg(t *testing.T) {
 	var playlist models.Playlist
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      playlistCheckExists.destroyed(&playlist, &org),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             playlistCheckExists.destroyed(&playlist, &org),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPlaylistConfigInOrg(rName, "5m"),

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -20,8 +20,8 @@ func TestAccResourceReport_Multiple_Dashboards(t *testing.T) {
 	var randomUID2 = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      reportCheckExists.destroyed(&report, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             reportCheckExists.destroyed(&report, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_report/multiple-dashboards.tf", map[string]string{
@@ -69,8 +69,8 @@ func TestAccResourceReport_basic(t *testing.T) {
 	var randomUID = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      reportCheckExists.destroyed(&report, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             reportCheckExists.destroyed(&report, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_report/resource.tf", map[string]string{
@@ -169,8 +169,8 @@ func TestAccResourceReport_CreateFromDashboardID(t *testing.T) {
 	var randomUID = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      reportCheckExists.destroyed(&report, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             reportCheckExists.destroyed(&report, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReportCreateFromID(randomUID),
@@ -192,8 +192,8 @@ func TestAccResourceReport_InOrg(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      reportCheckExists.destroyed(&report, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             reportCheckExists.destroyed(&report, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReportCreateInOrg(name),

--- a/internal/resources/grafana/resource_role_assignment_test.go
+++ b/internal/resources/grafana/resource_role_assignment_test.go
@@ -18,8 +18,8 @@ func TestAccRoleAssignments(t *testing.T) {
 	var role models.RoleDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      roleAssignmentCheckExists.destroyed(&role, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             roleAssignmentCheckExists.destroyed(&role, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: roleAssignmentConfig(testName),
@@ -51,8 +51,8 @@ func TestAccRoleAssignments_inOrg(t *testing.T) {
 	var role models.RoleDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: roleAssignmentConfigInOrg(testName),

--- a/internal/resources/grafana/resource_role_test.go
+++ b/internal/resources/grafana/resource_role_test.go
@@ -17,8 +17,8 @@ func TestAccRole_basic(t *testing.T) {
 	var role models.RoleDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      roleCheckExists.destroyed(&role, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             roleCheckExists.destroyed(&role, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: roleConfigBasic,
@@ -63,8 +63,8 @@ func TestAccRoleVersioning(t *testing.T) {
 	name := acctest.RandomWithPrefix("versioning-")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      roleCheckExists.destroyed(&role, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             roleCheckExists.destroyed(&role, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -130,8 +130,8 @@ func TestAccRole_inOrg(t *testing.T) {
 	name := acctest.RandomWithPrefix("role-")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: roleInOrg(name),

--- a/internal/resources/grafana/resource_service_account_permission_test.go
+++ b/internal/resources/grafana/resource_service_account_permission_test.go
@@ -18,8 +18,8 @@ func TestAccServiceAccountPermission_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      serviceAccountPermissionsCheckExists.destroyed(&sa, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             serviceAccountPermissionsCheckExists.destroyed(&sa, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testServiceAccountPermissionsConfig(name),
@@ -41,8 +41,8 @@ func TestAccServiceAccountPermission_inOrg(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testServiceAccountPermissionsConfig_inOrg(name),

--- a/internal/resources/grafana/resource_service_account_test.go
+++ b/internal/resources/grafana/resource_service_account_test.go
@@ -22,8 +22,8 @@ func TestAccServiceAccount_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      serviceAccountCheckExists.destroyed(&updatedSA, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             serviceAccountCheckExists.destroyed(&updatedSA, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testServiceAccountConfig(name, "Editor"),
@@ -65,8 +65,8 @@ func TestAccServiceAccount_NoneRole(t *testing.T) {
 	var sa models.ServiceAccountDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      serviceAccountCheckExists.destroyed(&sa, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             serviceAccountCheckExists.destroyed(&sa, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testServiceAccountConfig(name, "None"),
@@ -102,8 +102,8 @@ func TestAccServiceAccount_many_longtest(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      resource.ComposeAggregateTestCheckFunc(destroyedChecks...),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             resource.ComposeAggregateTestCheckFunc(destroyedChecks...),
 		Steps: []resource.TestStep{
 			{
 				Config: testManyServiceAccountsConfig(name, 60),
@@ -117,7 +117,7 @@ func TestAccServiceAccount_invalid_role(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				ExpectError: regexp.MustCompile(`.*expected role to be one of \[.+\], got InvalidRole`),

--- a/internal/resources/grafana/resource_service_account_token_test.go
+++ b/internal/resources/grafana/resource_service_account_token_test.go
@@ -19,8 +19,8 @@ func TestAccServiceAccountToken_basic(t *testing.T) {
 	var sa models.ServiceAccountDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      serviceAccountCheckExists.destroyed(&sa, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             serviceAccountCheckExists.destroyed(&sa, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceAccountTokenConfig(name, "Editor", 0, false),
@@ -64,8 +64,8 @@ func TestAccServiceAccountToken_inOrg(t *testing.T) {
 	var sa models.ServiceAccountDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceAccountTokenConfig(name, "Editor", 0, true),

--- a/internal/resources/grafana/resource_sso_settings_test.go
+++ b/internal/resources/grafana/resource_sso_settings_test.go
@@ -32,8 +32,8 @@ func TestSSOSettings_basic(t *testing.T) {
 		resourceName := fmt.Sprintf("grafana_sso_settings.%s_sso_settings", provider)
 
 		resource.Test(t, resource.TestCase{
-			ProviderFactories: testutils.ProviderFactories,
-			CheckDestroy:      checkSsoSettingsReset(api, provider, defaultSettings.Payload),
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			CheckDestroy:             checkSsoSettingsReset(api, provider, defaultSettings.Payload),
 			Steps: []resource.TestStep{
 				{
 					Config: testConfigForProvider(provider, "new"),
@@ -79,8 +79,8 @@ func TestSSOSettings_customFields(t *testing.T) {
 	resourceName := "grafana_sso_settings.sso_settings"
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      checkSsoSettingsReset(api, provider, defaultSettings.Payload),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             checkSsoSettingsReset(api, provider, defaultSettings.Payload),
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigWithCustomFields,
@@ -136,7 +136,7 @@ func TestSSOSettings_resourceWithInvalidProvider(t *testing.T) {
 	provider := "invalid_provider"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testConfigForProvider(provider, "new"),
@@ -150,7 +150,7 @@ func TestSSOSettings_resourceWithNoSettings(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testConfigWithNoSettings,
@@ -164,7 +164,7 @@ func TestSSOSettings_resourceWithEmptySettings(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testConfigWithEmptySettings,
@@ -178,7 +178,7 @@ func TestSSOSettings_resourceWithManySettings(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testConfigWithManySettings,
@@ -192,7 +192,7 @@ func TestSSOSettings_resourceWithInvalidCustomField(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testConfigWithInvalidCustomField,
@@ -207,7 +207,7 @@ func TestSSOSettings_resourceWithValidationErrors(t *testing.T) {
 
 	for _, config := range testConfigsWithValidationErrors {
 		resource.Test(t, resource.TestCase{
-			ProviderFactories: testutils.ProviderFactories,
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,

--- a/internal/resources/grafana/resource_team_external_group_test.go
+++ b/internal/resources/grafana/resource_team_external_group_test.go
@@ -20,8 +20,8 @@ func TestAccTeamExternalGroup_basic(t *testing.T) {
 	var team models.TeamDTO
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			// Add groups and test import
 			{

--- a/internal/resources/grafana/resource_team_test.go
+++ b/internal/resources/grafana/resource_team_test.go
@@ -25,8 +25,8 @@ func TestAccTeam_basic(t *testing.T) {
 	teamNameUpdated := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamDefinition(teamName, nil, false, nil),
@@ -66,8 +66,8 @@ func TestAccTeam_preferences(t *testing.T) {
 	teamNameUpdated := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamDefinition(teamName, nil, false, nil),
@@ -114,8 +114,8 @@ func TestAccTeam_teamSync(t *testing.T) {
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			// Test without team sync
 			{
@@ -176,8 +176,8 @@ func TestAccTeam_Members(t *testing.T) {
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamDefinition(teamName, []string{
@@ -245,8 +245,8 @@ func TestAccTeam_RemoveUnexistingMember(t *testing.T) {
 	teamName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      teamCheckExists.destroyed(&team, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             teamCheckExists.destroyed(&team, nil),
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
@@ -295,8 +295,8 @@ func TestAccResourceTeam_InOrg(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      orgCheckExists.destroyed(&org, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             orgCheckExists.destroyed(&org, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTeamInOrganization(name),
@@ -362,7 +362,7 @@ func TestAccTeam_OrgScopedOnAPIKey(t *testing.T) {
 	os.Setenv("GRAFANA_AUTH", saToken.Payload.Key)
 	defer os.Setenv("GRAFANA_AUTH", prevAuth)
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "grafana_team" "test" {

--- a/internal/resources/grafana/resource_user_test.go
+++ b/internal/resources/grafana/resource_user_test.go
@@ -15,8 +15,8 @@ func TestAccUser_basic(t *testing.T) {
 
 	var user models.UserProfileDTO
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      userCheckExists.destroyed(&user, nil),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             userCheckExists.destroyed(&user, nil),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic,

--- a/internal/resources/machinelearning/resource_holiday_test.go
+++ b/internal/resources/machinelearning/resource_holiday_test.go
@@ -21,8 +21,8 @@ func TestAccResourceHoliday(t *testing.T) {
 
 	var holiday mlapi.Holiday
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccMLHolidayCheckDestroy(&holiday),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMLHolidayCheckDestroy(&holiday),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_holiday/ical_holiday.tf", map[string]string{
@@ -115,7 +115,7 @@ func TestAccResourceInvalidMachineLearningHoliday(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      machineLearningHolidayInvalid,

--- a/internal/resources/machinelearning/resource_job_test.go
+++ b/internal/resources/machinelearning/resource_job_test.go
@@ -21,8 +21,8 @@ func TestAccResourceJob(t *testing.T) {
 
 	var job mlapi.Job
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccMLJobCheckDestroy(&job),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMLJobCheckDestroy(&job),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_job/job.tf", map[string]string{
@@ -159,7 +159,7 @@ func TestAccResourceInvalidMachineLearningJob(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      machineLearningJobInvalid,

--- a/internal/resources/machinelearning/resource_outlier_detector_test.go
+++ b/internal/resources/machinelearning/resource_outlier_detector_test.go
@@ -21,8 +21,8 @@ func TestAccResourceOutlierDetector(t *testing.T) {
 
 	var outlier mlapi.OutlierDetector
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccMLOutlierCheckDestroy(&outlier),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccMLOutlierCheckDestroy(&outlier),
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_outlier_detector/mad.tf", map[string]string{
@@ -185,7 +185,7 @@ func TestAccResourceInvalidMachineLearningOutlierDetector(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      machineLearningOutlierDetectorInvalid,

--- a/internal/resources/oncall/data_source_action_test.go
+++ b/internal/resources/oncall/data_source_action_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceAction_Basic(t *testing.T) {
 	actionName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceActionConfig(actionName),

--- a/internal/resources/oncall/data_source_outgoing_webhook_test.go
+++ b/internal/resources/oncall/data_source_outgoing_webhook_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceOutgoingWebhook_Basic(t *testing.T) {
 	outgoingWebhookName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceOutgoingWebhookConfig(outgoingWebhookName),

--- a/internal/resources/oncall/data_source_schedule_test.go
+++ b/internal/resources/oncall/data_source_schedule_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceSchedule_Basic(t *testing.T) {
 	scheduleName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceScheduleConfig(scheduleName),

--- a/internal/resources/oncall/data_source_slack_channel_test.go
+++ b/internal/resources/oncall/data_source_slack_channel_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceSlackChannel_Basic(t *testing.T) {
 	slackChannelName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceSlackChannelConfig(slackChannelName),

--- a/internal/resources/oncall/data_source_team_test.go
+++ b/internal/resources/oncall/data_source_team_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceTeam_Basic(t *testing.T) {
 	teamName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceTeamConfig(teamName),

--- a/internal/resources/oncall/data_source_user_group_test.go
+++ b/internal/resources/oncall/data_source_user_group_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceUserGroup_Basic(t *testing.T) {
 	slackHandle := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceUserGroupConfig(slackHandle),

--- a/internal/resources/oncall/data_source_user_test.go
+++ b/internal/resources/oncall/data_source_user_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceUser_Basic(t *testing.T) {
 	username := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceUserConfig(username),

--- a/internal/resources/oncall/resource_escalation_test.go
+++ b/internal/resources/oncall/resource_escalation_test.go
@@ -20,8 +20,8 @@ func TestAccOnCallEscalation_basic(t *testing.T) {
 	reDuration := 300
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccCheckOnCallEscalationResourceDestroy,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallEscalationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOnCallEscalationConfig(riName, reType, reDuration),

--- a/internal/resources/oncall/resource_integration_test.go
+++ b/internal/resources/oncall/resource_integration_test.go
@@ -19,8 +19,8 @@ func TestAccOnCallIntegration_basic(t *testing.T) {
 	rType := "grafana"
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccCheckOnCallIntegrationResourceDestroy,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallIntegrationResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOnCallIntegrationConfig(rName, rType, ``),

--- a/internal/resources/oncall/resource_outgoing_webhook_test.go
+++ b/internal/resources/oncall/resource_outgoing_webhook_test.go
@@ -18,8 +18,8 @@ func TestAccOnCallOutgoingWebhook_basic(t *testing.T) {
 	webhookName := fmt.Sprintf("name-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccCheckOnCallOutgoingWebhookResourceDestroy,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallOutgoingWebhookResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOnCallOutgoingWebhookConfig(webhookName),

--- a/internal/resources/oncall/resource_route_test.go
+++ b/internal/resources/oncall/resource_route_test.go
@@ -20,8 +20,8 @@ func TestAccOnCallRoute_basic(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccCheckOnCallRouteResourceDestroy,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallRouteResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOnCallRouteConfig(riName, rrRegex),

--- a/internal/resources/oncall/resource_schedule_test.go
+++ b/internal/resources/oncall/resource_schedule_test.go
@@ -18,8 +18,8 @@ func TestAccOnCallSchedule_basic(t *testing.T) {
 	scheduleName := fmt.Sprintf("schedule-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccCheckOnCallScheduleResourceDestroy,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallScheduleResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOnCallScheduleConfig(scheduleName),

--- a/internal/resources/oncall/resource_shift_test.go
+++ b/internal/resources/oncall/resource_shift_test.go
@@ -19,8 +19,8 @@ func TestAccOnCallOnCallShift_basic(t *testing.T) {
 	shiftName := fmt.Sprintf("shift-%s", acctest.RandString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccCheckOnCallOnCallShiftResourceDestroy,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallOnCallShiftResourceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOnCallOnCallShiftConfigWeekly(scheduleName, shiftName),

--- a/internal/resources/slo/data_source_slo_test.go
+++ b/internal/resources/slo/data_source_slo_test.go
@@ -16,8 +16,8 @@ func TestAccDataSourceSlo(t *testing.T) {
 
 	var slo slo.Slo
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		CheckDestroy:      testAccSloCheckDestroy(&slo),
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccSloCheckDestroy(&slo),
 		Steps: []resource.TestStep{
 			{
 				// Creates a SLO Resource

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -21,7 +21,7 @@ func TestAccResourceSlo(t *testing.T) {
 
 	var slo slo.Slo
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests destroy
 		CheckDestroy: testAccSloCheckDestroy(&slo),
 		Steps: []resource.TestStep{
@@ -230,7 +230,7 @@ func TestAccResourceInvalidSlo(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      sloObjectivesInvalid,

--- a/internal/resources/syntheticmonitoring/data_source_probe_test.go
+++ b/internal/resources/syntheticmonitoring/data_source_probe_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceProbe(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probe/data-source.tf"),

--- a/internal/resources/syntheticmonitoring/data_source_probes_test.go
+++ b/internal/resources/syntheticmonitoring/data_source_probes_test.go
@@ -12,7 +12,7 @@ func TestAccDataSourceProbes(t *testing.T) {
 
 	// TODO: Make parallelizable
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/data-source.tf"),

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -25,7 +25,7 @@ func TestAccResourceCheck_dns(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/dns_basic.tf", nameReplaceMap),
@@ -83,7 +83,7 @@ func TestAccResourceCheck_http(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf", nameReplaceMap),
@@ -149,7 +149,7 @@ func TestAccResourceCheck_ping(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/ping_basic.tf", nameReplaceMap),
@@ -192,7 +192,7 @@ func TestAccResourceCheck_tcp(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/tcp_basic.tf", nameReplaceMap),
@@ -245,7 +245,7 @@ func TestAccResourceCheck_traceroute(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/traceroute_basic.tf", nameReplaceMap),
@@ -292,7 +292,7 @@ func TestAccResourceCheck_multihttp(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/multihttp_basic.tf", nameReplaceMap),
@@ -376,7 +376,7 @@ func TestAccResourceCheck_recreate(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_check/http_basic.tf", nameReplaceMap),
@@ -409,7 +409,7 @@ func TestAccResourceCheck_noSettings(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceCheck_noSettings,
@@ -424,7 +424,7 @@ func TestAccResourceCheck_multiple(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceCheck_multiple,

--- a/internal/resources/syntheticmonitoring/resource_probe_test.go
+++ b/internal/resources/syntheticmonitoring/resource_probe_test.go
@@ -20,7 +20,7 @@ func TestAccResourceProbe(t *testing.T) {
 	randomName := acctest.RandomWithPrefix("My Probe")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_probe/resource.tf", map[string]string{
@@ -66,7 +66,7 @@ func TestAccResourceProbe_recreate(t *testing.T) {
 	})
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -101,7 +101,7 @@ func TestAccResourceProbe_recreateProbeUsedInCheck(t *testing.T) {
 	randomName := acctest.RandomWithPrefix("tf")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testSyntheticMonitoringProbeAndCheck(randomName, "test1"),
@@ -158,7 +158,7 @@ func TestAccResourceProbe_Import(t *testing.T) {
 	randomName := acctest.RandomWithPrefix("My Probe")
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_synthetic_monitoring_probe/resource.tf", map[string]string{
@@ -246,8 +246,8 @@ func TestAccResourceProbe_InvalidLabels(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		ProviderFactories: testutils.ProviderFactories,
-		Steps:             steps,
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps:                    steps,
 	})
 }
 


### PR DESCRIPTION
This is needed for the migration to the new Terraform plugin framework 
The `ProviderFactories` attribute directly refers to an old SDKv2 provider, while the `ProtoV5ProviderFactories` attribute allows to reference the full provider setup (muxed from the SDKv2 and Plugin Framework resources)