### PR TITLE
Fix `service_account_id` reference in `stack_service_account_token` resource

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_service_account_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_test.go
@@ -74,7 +74,7 @@ func TestAccGrafanaServiceAccountFromCloud_MigrateFrom213(t *testing.T) {
 		testAccGrafanaAuthCheckServiceAccounts(&stack, []string{"management-sa"}),
 		resource.TestCheckResourceAttr("grafana_cloud_stack_service_account.management", "name", "management-sa"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack_service_account.management", "role", "Admin"),
-		resource.TestCheckResourceAttr("grafana_cloud_stack_service_account.management", "is_disabled", "true"),
+		resource.TestCheckResourceAttr("grafana_cloud_stack_service_account.management", "is_disabled", "false"),
 		resource.TestCheckResourceAttr("grafana_cloud_stack_service_account_token.management_token", "name", "management-sa-token"),
 		resource.TestCheckNoResourceAttr("grafana_cloud_stack_service_account_token.management_token", "expiration"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack_service_account_token.management_token", "key"),
@@ -88,7 +88,7 @@ func TestAccGrafanaServiceAccountFromCloud_MigrateFrom213(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Apply with 2.13.0 provider
 			{
-				Config: testAccGrafanaServiceAccountFromCloud(slug, slug, true),
+				Config: testAccGrafanaServiceAccountFromCloud(slug, slug, false),
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"grafana": {
 						VersionConstraint: "=2.13.0",
@@ -99,7 +99,7 @@ func TestAccGrafanaServiceAccountFromCloud_MigrateFrom213(t *testing.T) {
 			},
 			// Apply with latest provider
 			{
-				Config:                   testAccGrafanaServiceAccountFromCloud(slug, slug, true),
+				Config:                   testAccGrafanaServiceAccountFromCloud(slug, slug, false),
 				Check:                    check,
 				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 			},
@@ -120,6 +120,17 @@ func testAccGrafanaServiceAccountFromCloud(name, slug string, disabled bool) str
 		stack_slug = grafana_cloud_stack.test.slug
 		service_account_id = grafana_cloud_stack_service_account.management.id
 		name       = "management-sa-token"
+	}
+
+	provider "grafana" {
+		alias = "stack"
+		auth = grafana_cloud_stack_service_account_token.management_token.key
+		url  = grafana_cloud_stack.test.url
+	}
+
+	resource "grafana_folder" "test" {
+		provider = grafana.stack
+		title    = "test"
 	}
 	`, disabled)
 }

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -48,6 +48,12 @@ Required access policy scopes:
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// The service account ID is now possibly a composite ID that includes the stack slug
+					oldID, _ := getStackServiceAccountID(old)
+					newID, _ := getStackServiceAccountID(new)
+					return oldID == newID && oldID != 0 && newID != 0
+				},
 			},
 			"seconds_to_live": {
 				Type:     schema.TypeInt,

--- a/internal/resources/grafana/resources.go
+++ b/internal/resources/grafana/resources.go
@@ -27,14 +27,32 @@ func grafanaOrgIDResourceValidation(d *schema.ResourceData, m interface{}) error
 
 func addValidation(resources map[string]*schema.Resource) map[string]*schema.Resource {
 	for _, r := range resources {
-		readFn := r.ReadContext
 		createFn := r.CreateContext
+		readFn := r.ReadContext
+		updateFn := r.UpdateContext
+		deleteFn := r.DeleteContext
 
 		r.ReadContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			if err := grafanaClientResourceValidation(d, m); err != nil {
 				return diag.FromErr(err)
 			}
 			return readFn(ctx, d, m)
+		}
+		if updateFn != nil {
+			r.UpdateContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+				if err := grafanaClientResourceValidation(d, m); err != nil {
+					return diag.FromErr(err)
+				}
+				return updateFn(ctx, d, m)
+			}
+		}
+		if deleteFn != nil {
+			r.DeleteContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+				if err := grafanaClientResourceValidation(d, m); err != nil {
+					return diag.FromErr(err)
+				}
+				return deleteFn(ctx, d, m)
+			}
 		}
 		if createFn != nil {
 			r.CreateContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION


As mentioned here: https://github.com/grafana/terraform-provider-grafana/issues/1425#issuecomment-2009092975, the plan looks good but the apply of the stack SA causes a recreation of the token

Added a `DiffSuppressFunc` and expanded the test to include a full use case