### PR TITLE
Remove global resources var

### DIFF
--- a/docs/resources/machine_learning_holiday.md
+++ b/docs/resources/machine_learning_holiday.md
@@ -60,3 +60,11 @@ Required:
 Optional:
 
 - `name` (String) The name of the custom period.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_machine_learning_holiday.name "{{ id }}"
+```

--- a/docs/resources/machine_learning_job.md
+++ b/docs/resources/machine_learning_job.md
@@ -36,3 +36,11 @@ A job defines the queries and model parameters for a machine learning task.
 ### Read-Only
 
 - `id` (String) The ID of the job.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_machine_learning_job.name "{{ id }}"
+```

--- a/docs/resources/machine_learning_outlier_detector.md
+++ b/docs/resources/machine_learning_outlier_detector.md
@@ -58,3 +58,11 @@ Optional:
 Required:
 
 - `epsilon` (Number) Specify the epsilon parameter (positive float)
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_machine_learning_outlier_detector.name "{{ id }}"
+```

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -290,3 +290,11 @@ Required:
 
 - `key` (String)
 - `value` (String)
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import grafana_slo.name "{{ uuid }}"
+```

--- a/examples/resources/grafana_machine_learning_holiday/import.sh
+++ b/examples/resources/grafana_machine_learning_holiday/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_machine_learning_holiday.name "{{ id }}"

--- a/examples/resources/grafana_machine_learning_job/import.sh
+++ b/examples/resources/grafana_machine_learning_job/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_machine_learning_job.name "{{ id }}"

--- a/examples/resources/grafana_machine_learning_outlier_detector/import.sh
+++ b/examples/resources/grafana_machine_learning_outlier_detector/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_machine_learning_outlier_detector.name "{{ id }}"

--- a/examples/resources/grafana_slo/import.sh
+++ b/examples/resources/grafana_slo/import.sh
@@ -1,0 +1,1 @@
+terraform import grafana_slo.name "{{ uuid }}"

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -2,15 +2,10 @@ package common
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-var allResources = []*Resource{}
 
 type Resource struct {
 	Name   string
@@ -24,7 +19,6 @@ func NewResource(name string, idType *ResourceID, schema *schema.Resource) *Reso
 		IDType: idType,
 		Schema: schema,
 	}
-	allResources = append(allResources, r)
 	return r
 }
 
@@ -36,25 +30,4 @@ func (r *Resource) ImportExample() string {
 	}
 	return fmt.Sprintf(`terraform import %s.name %q
 `, r.Name, strings.Join(fields, defaultSeparator))
-}
-
-// GenerateImportFiles generates import files for all resources that use a helper defined in this package
-func GenerateImportFiles(path string) error {
-	for _, r := range allResources {
-		resourcePath := filepath.Join(path, "resources", r.Name, "import.sh")
-		if err := os.RemoveAll(resourcePath); err != nil { // Remove the file if it exists
-			return err
-		}
-
-		if r.IDType == nil {
-			log.Printf("Skipping import file generation for %s because it does not have an ID type\n", r.Name)
-			continue
-		}
-
-		log.Printf("Generating import file for %s (writing to %s)\n", r.Name, resourcePath)
-		if err := os.WriteFile(resourcePath, []byte(r.ImportExample()), 0600); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/resources/cloud/resources.go
+++ b/internal/resources/cloud/resources.go
@@ -22,11 +22,3 @@ var Resources = []*common.Resource{
 	resourceStackServiceAccountToken(),
 	resourceSyntheticMonitoringInstallation(),
 }
-
-func ResourcesMap() map[string]*schema.Resource {
-	m := make(map[string]*schema.Resource)
-	for _, r := range Resources {
-		m[r.Name] = r.Schema
-	}
-	return m
-}

--- a/internal/resources/machinelearning/resource_holiday.go
+++ b/internal/resources/machinelearning/resource_holiday.go
@@ -13,8 +13,10 @@ import (
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
 
-func resourceHoliday() *schema.Resource {
-	return &schema.Resource{
+var resourceHolidayID = common.NewResourceID(common.StringIDField("id"))
+
+func resourceHoliday() *common.Resource {
+	schema := &schema.Resource{
 
 		Description: `
 A holiday describes time periods where a time series is expected to behave differently to normal.
@@ -101,6 +103,8 @@ resource "grafana_machine_learning_job" "test_job" {
 			},
 		},
 	}
+
+	return common.NewResource("grafana_machine_learning_holiday", resourceHolidayID, schema)
 }
 
 func resourceHolidayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/machinelearning/resource_job.go
+++ b/internal/resources/machinelearning/resource_job.go
@@ -12,8 +12,10 @@ import (
 	"github.com/grafana/terraform-provider-grafana/internal/common"
 )
 
-func resourceJob() *schema.Resource {
-	return &schema.Resource{
+var resourceJobID = common.NewResourceID(common.StringIDField("id"))
+
+func resourceJob() *common.Resource {
+	schema := &schema.Resource{
 
 		Description: `
 A job defines the queries and model parameters for a machine learning task.
@@ -102,6 +104,8 @@ A job defines the queries and model parameters for a machine learning task.
 			},
 		},
 	}
+
+	return common.NewResource("grafana_machine_learning_job", resourceJobID, schema)
 }
 
 func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/machinelearning/resource_outlier_detector.go
+++ b/internal/resources/machinelearning/resource_outlier_detector.go
@@ -12,8 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func resourceOutlierDetector() *schema.Resource {
-	return &schema.Resource{
+var resourceOutlierDetectorID = common.NewResourceID(common.StringIDField("id"))
+
+func resourceOutlierDetector() *common.Resource {
+	schema := &schema.Resource{
 
 		Description: `
 An outlier detector monitors the results of a query and reports when its values are outside normal bands.
@@ -120,6 +122,8 @@ Visit https://grafana.com/docs/grafana-cloud/machine-learning/outlier-detection/
 			},
 		},
 	}
+
+	return common.NewResource("grafana_machine_learning_outlier_detector", resourceOutlierDetectorID, schema)
 }
 
 func resourceOutlierCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/machinelearning/resources.go
+++ b/internal/resources/machinelearning/resources.go
@@ -20,8 +20,8 @@ func checkClient(f func(ctx context.Context, d *schema.ResourceData, meta interf
 
 var DatasourcesMap = map[string]*schema.Resource{}
 
-var ResourcesMap = map[string]*schema.Resource{
-	"grafana_machine_learning_job":              resourceJob(),
-	"grafana_machine_learning_holiday":          resourceHoliday(),
-	"grafana_machine_learning_outlier_detector": resourceOutlierDetector(),
+var Resources = []*common.Resource{
+	resourceJob(),
+	resourceHoliday(),
+	resourceOutlierDetector(),
 }

--- a/internal/resources/slo/data_source_slo.go
+++ b/internal/resources/slo/data_source_slo.go
@@ -25,7 +25,7 @@ Datasource for retrieving all SLOs.
 				Computed:    true,
 				Description: `Returns a list of all SLOs"`,
 				Elem: &schema.Resource{
-					Schema: common.CloneResourceSchemaForDatasource(resourceSlo(), map[string]*schema.Schema{
+					Schema: common.CloneResourceSchemaForDatasource(resourceSlo().Schema, map[string]*schema.Schema{
 						"uuid": {
 							Type:        schema.TypeString,
 							Description: `A unique, random identifier. This value will also be the name of the resource stored in the API server. This value is read-only.`,

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -20,8 +20,10 @@ const (
 	QueryTypeThreshold string = "threshold"
 )
 
-func resourceSlo() *schema.Resource {
-	return &schema.Resource{
+var resourceSloID = common.NewResourceID(common.StringIDField("uuid"))
+
+func resourceSlo() *common.Resource {
+	schema := &schema.Resource{
 		Description: `
 Resource manages Grafana SLOs. 
 
@@ -219,6 +221,8 @@ Resource manages Grafana SLOs.
 			},
 		},
 	}
+
+	return common.NewResource("grafana_slo", resourceSloID, schema)
 }
 
 var keyvalueSchema = &schema.Resource{

--- a/internal/resources/slo/resources.go
+++ b/internal/resources/slo/resources.go
@@ -25,6 +25,6 @@ var DatasourcesMap = map[string]*schema.Resource{
 	"grafana_slos": datasourceSlo(),
 }
 
-var ResourcesMap = map[string]*schema.Resource{
-	"grafana_slo": resourceSlo(),
+var Resources = []*common.Resource{
+	resourceSlo(),
 }

--- a/pkg/provider/legacy_provider.go
+++ b/pkg/provider/legacy_provider.go
@@ -151,14 +151,7 @@ func Provider(version string) *schema.Provider {
 			},
 		},
 
-		ResourcesMap: mergeResourceMaps(
-			grafana.ResourcesMap,
-			machinelearning.ResourcesMap,
-			slo.ResourcesMap,
-			syntheticmonitoring.ResourcesMap,
-			oncall.ResourcesMap,
-			cloud.ResourcesMap(),
-		),
+		ResourcesMap: resourceMap(),
 
 		DataSourcesMap: mergeResourceMaps(
 			grafana.DatasourcesMap,
@@ -248,14 +241,4 @@ func int64ValueOrNull(d *schema.ResourceData, key string) types.Int64 {
 		return types.Int64Value(int64(v.(int)))
 	}
 	return types.Int64Null()
-}
-
-func mergeResourceMaps(maps ...map[string]*schema.Resource) map[string]*schema.Resource {
-	result := make(map[string]*schema.Resource)
-	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
-	}
-	return result
 }

--- a/pkg/provider/resources.go
+++ b/pkg/provider/resources.go
@@ -1,0 +1,47 @@
+// This file contains
+
+package provider
+
+import (
+	"github.com/grafana/terraform-provider-grafana/internal/common"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/cloud"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/grafana"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/machinelearning"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/oncall"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/slo"
+	"github.com/grafana/terraform-provider-grafana/internal/resources/syntheticmonitoring"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func Resources() []*common.Resource {
+	var resources []*common.Resource
+	resources = append(resources, cloud.Resources...)
+	return resources
+}
+
+func resourceMap() map[string]*schema.Resource {
+	result := make(map[string]*schema.Resource)
+	for _, r := range Resources() {
+		result[r.Name] = r.Schema
+	}
+
+	// TODO: Migrate to common.Resource instances (in Resources function)
+	return mergeResourceMaps(
+		result,
+		grafana.ResourcesMap,
+		machinelearning.ResourcesMap,
+		slo.ResourcesMap,
+		syntheticmonitoring.ResourcesMap,
+		oncall.ResourcesMap,
+	)
+}
+
+func mergeResourceMaps(maps ...map[string]*schema.Resource) map[string]*schema.Resource {
+	result := make(map[string]*schema.Resource)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/pkg/provider/resources.go
+++ b/pkg/provider/resources.go
@@ -16,6 +16,8 @@ import (
 func Resources() []*common.Resource {
 	var resources []*common.Resource
 	resources = append(resources, cloud.Resources...)
+	resources = append(resources, machinelearning.Resources...)
+	resources = append(resources, slo.Resources...)
 	return resources
 }
 
@@ -29,8 +31,6 @@ func resourceMap() map[string]*schema.Resource {
 	return mergeResourceMaps(
 		result,
 		grafana.ResourcesMap,
-		machinelearning.ResourcesMap,
-		slo.ResourcesMap,
 		syntheticmonitoring.ResourcesMap,
 		oncall.ResourcesMap,
 	)

--- a/templates/resources/slo.md.tmpl
+++ b/templates/resources/slo.md.tmpl
@@ -21,3 +21,9 @@ description: |-
 {{ tffile "examples/resources/grafana_slo/resource_complex.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+Import is supported using the following syntax:
+
+{{ codefile "shell" "examples/resources/grafana_slo/import.sh" }}

--- a/tools/genimports/main.go
+++ b/tools/genimports/main.go
@@ -1,19 +1,39 @@
 package main
 
 import (
+	"log"
 	"os"
+	"path/filepath"
 
-	"github.com/grafana/terraform-provider-grafana/internal/common"
 	"github.com/grafana/terraform-provider-grafana/pkg/provider"
 )
-
-// TODO: Move to cmd, and remove global var in common
 
 func main() {
 	p := provider.Provider("genimports") // Instantiate the provider so that all resources are registered
 	_ = p
 
-	if err := common.GenerateImportFiles(os.Args[1]); err != nil {
+	if err := generateImportFiles(os.Args[1]); err != nil {
 		panic(err)
 	}
+}
+
+// GenerateImportFiles generates import files for all resources that use a helper defined in this package
+func generateImportFiles(path string) error {
+	for _, r := range provider.Resources() {
+		resourcePath := filepath.Join(path, "resources", r.Name, "import.sh")
+		if err := os.RemoveAll(resourcePath); err != nil { // Remove the file if it exists
+			return err
+		}
+
+		if r.IDType == nil {
+			log.Printf("Skipping import file generation for %s because it does not have an ID type\n", r.Name)
+			continue
+		}
+
+		log.Printf("Generating import file for %s (writing to %s)\n", r.Name, resourcePath)
+		if err := os.WriteFile(resourcePath, []byte(r.ImportExample()), 0600); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
The `provider` package now has a function that will expose all the resources from all subcategories of the provider 

This list is used to:
- Used in the import docs generation command
- Sent to both provider servers
- Used in the tf code generation command


***Review only the first commit, I merged https://github.com/grafana/terraform-provider-grafana/pull/1433, forgetting that it depended on this PR here 🤦***