### PR TITLE
SM: Use common resource framework

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -713,5 +713,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_synthetic_monitoring_check.check {{check-id}}
+terraform import grafana_synthetic_monitoring_check.name "{{ id }}"
 ```

--- a/docs/resources/synthetic_monitoring_probe.md
+++ b/docs/resources/synthetic_monitoring_probe.md
@@ -59,6 +59,6 @@ resource "grafana_synthetic_monitoring_probe" "main" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_synthetic_monitoring_probe.probe {{probe-id}}
-terraform import grafana_synthetic_monitoring_probe.probe {{probe-id}}:{{auth_token}}
+terraform import grafana_synthetic_monitoring_probe.name "{{ id }}"
+terraform import grafana_synthetic_monitoring_probe.name "{{ id }}:{{ authToken }}"
 ```

--- a/examples/resources/grafana_synthetic_monitoring_check/import.sh
+++ b/examples/resources/grafana_synthetic_monitoring_check/import.sh
@@ -1,1 +1,1 @@
-terraform import grafana_synthetic_monitoring_check.check {{check-id}}
+terraform import grafana_synthetic_monitoring_check.name "{{ id }}"

--- a/examples/resources/grafana_synthetic_monitoring_probe/import.sh
+++ b/examples/resources/grafana_synthetic_monitoring_probe/import.sh
@@ -1,2 +1,2 @@
-terraform import grafana_synthetic_monitoring_probe.probe {{probe-id}}
-terraform import grafana_synthetic_monitoring_probe.probe {{probe-id}}:{{auth_token}}
+terraform import grafana_synthetic_monitoring_probe.name "{{ id }}"
+terraform import grafana_synthetic_monitoring_probe.name "{{ id }}:{{ authToken }}"

--- a/internal/resources/syntheticmonitoring/data_source_probe.go
+++ b/internal/resources/syntheticmonitoring/data_source_probe.go
@@ -16,7 +16,7 @@ func dataSourceProbe() *schema.Resource {
 	return &schema.Resource{
 		Description: "Data source for retrieving a single probe by name.",
 		ReadContext: withClient[schema.ReadContextFunc](dataSourceProbeRead),
-		Schema: common.CloneResourceSchemaForDatasource(resourceProbe(), map[string]*schema.Schema{
+		Schema: common.CloneResourceSchemaForDatasource(resourceProbe().Schema, map[string]*schema.Schema{
 			"name": {
 				Description: "Name of the probe.",
 				Type:        schema.TypeString,

--- a/internal/resources/syntheticmonitoring/resource_probe.go
+++ b/internal/resources/syntheticmonitoring/resource_probe.go
@@ -17,8 +17,10 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
-func resourceProbe() *schema.Resource {
-	return &schema.Resource{
+var resourceProbeID = common.NewResourceID(common.IntIDField("id"), common.OptionalStringIDField("authToken"))
+
+func resourceProbe() *common.Resource {
+	schema := &schema.Resource{
 
 		Description: `
 Besides the public probes run by Grafana Labs, you can also install your
@@ -102,6 +104,8 @@ Grafana Synthetic Monitoring Agent.
 			},
 		},
 	}
+
+	return common.NewResource("grafana_synthetic_monitoring_probe", resourceProbeID, schema)
 }
 
 func resourceProbeCreate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {
@@ -117,11 +121,11 @@ func resourceProbeCreate(ctx context.Context, d *schema.ResourceData, c *smapi.C
 }
 
 func resourceProbeRead(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {
-	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	id, err := resourceProbeID.Single(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	prb, err := c.GetProbe(ctx, id)
+	prb, err := c.GetProbe(ctx, id.(int64))
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
 			log.Printf("[WARN] removing probe %s from state because it no longer exists", d.Id())

--- a/internal/resources/syntheticmonitoring/resources.go
+++ b/internal/resources/syntheticmonitoring/resources.go
@@ -26,7 +26,7 @@ var DatasourcesMap = map[string]*schema.Resource{
 	"grafana_synthetic_monitoring_probes": dataSourceProbes(),
 }
 
-var ResourcesMap = map[string]*schema.Resource{
-	"grafana_synthetic_monitoring_check": resourceCheck(),
-	"grafana_synthetic_monitoring_probe": resourceProbe(),
+var Resources = []*common.Resource{
+	resourceCheck(),
+	resourceProbe(),
 }

--- a/pkg/provider/resources.go
+++ b/pkg/provider/resources.go
@@ -19,6 +19,7 @@ func Resources() []*common.Resource {
 	resources = append(resources, machinelearning.Resources...)
 	resources = append(resources, oncall.Resources...)
 	resources = append(resources, slo.Resources...)
+	resources = append(resources, syntheticmonitoring.Resources...)
 	return resources
 }
 
@@ -32,7 +33,6 @@ func resourceMap() map[string]*schema.Resource {
 	return mergeResourceMaps(
 		result,
 		grafana.ResourcesMap,
-		syntheticmonitoring.ResourcesMap,
 	)
 }
 


### PR DESCRIPTION
Same as https://github.com/grafana/terraform-provider-grafana/pull/1433 
Paving the way for TF code generation

However, this one was special because it required some modifications to the framework: Adding optional fields to IDs

This was work that I expected I would have to do for Grafana resources anyways, since most Grafana resources have the optional orgID field that can be used in imports