### PR TITLE
Update openapi client to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/grafana/amixr-api-go-client v0.0.11
 	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240322153219-42c6a1d2bcab
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20240306142804-861284d1ba83
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20240325012504-4958bdd139e7
 	github.com/grafana/machine-learning-go-client v0.5.0
 	github.com/grafana/slo-openapi-client/go v0.0.0-20240112175006-de02e75b9d73
 	github.com/grafana/synthetic-monitoring-agent v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/grafana/amixr-api-go-client v0.0.11 h1:jlE+5t0tRuCtjbpM81j70Dr2J4eCyS
 github.com/grafana/amixr-api-go-client v0.0.11/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240322153219-42c6a1d2bcab h1:/5R8NO996/keDkZqKXEkU3/QgFs1wzChKYkakjsBpRk=
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240322153219-42c6a1d2bcab/go.mod h1:6sYY1qgwYfSDNQhKQA0tar8Oc38cIGfyqwejhxoOsPs=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20240306142804-861284d1ba83 h1:n5vecnZOTpRAZu7rIyNmg54k860JPvAuMvnz2AYQD0E=
-github.com/grafana/grafana-openapi-client-go v0.0.0-20240306142804-861284d1ba83/go.mod h1:FiVsMOTtVuo/Ajmt1efuk3/KmDpFQ3qMurQf7e6HwQg=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20240325012504-4958bdd139e7 h1:gn7iZ9YacDvM04w4QzIGvnO4mQ9lhbmtBcWXWjEtR/o=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20240325012504-4958bdd139e7/go.mod h1:hiZnMmXc9KXNUlvkV2BKFsiWuIFF/fF4wGgYWEjBitI=
 github.com/grafana/machine-learning-go-client v0.5.0 h1:Q1K+MPSy8vfMm2jsk3WQ7O77cGr2fM5hxwtPSoPc5NU=
 github.com/grafana/machine-learning-go-client v0.5.0/go.mod h1:QFfZz8NkqVF8++skjkKQXJEZfpCYd8S0yTWJUpsLLTA=
 github.com/grafana/slo-openapi-client/go v0.0.0-20240112175006-de02e75b9d73 h1:E5vAeB5q1H3BVeNhtd1dI8RubucJdPwpx/ElNtKD3ls=


### PR DESCRIPTION
Latest version generated from https://github.com/grafana/grafana-openapi-client-go/pull/90

Had to add querying for the dashboard when it's specified with an ID in the report resource, but that's temporary code since it's deprecated