### PR TITLE
Ignore CSS rule failures in linkchecker

### DIFF
--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -4,8 +4,5 @@ ignore=
   # https://regex101.com/r/Pl0jCn/1
   \/\*\!sc\*\/
 
-[output]
-verbose=1
-
 [MarkdownCheck]
 filename_re=.*\.md

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,5 +1,11 @@
 [filtering]
 checkextern=1
+ignore=
+  # https://regex101.com/r/Pl0jCn/1
+  \/\*\!sc\*\/
+
+[output]
+verbose=1
 
 [MarkdownCheck]
 filename_re=.*\.md


### PR DESCRIPTION
The link checking tool works rather well but for some reason, it sometimes 404s trying to query CSS rules
It's always rules ending with `/*!sc*/`, so this should fix the issue
See https://github.com/grafana/terraform-provider-grafana/actions/runs/8456346680/job/23165928130 for an example of a failure