### PR TITLE
Alert Rule Group: Migrate away from legacy ID format

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -194,6 +194,6 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import grafana_rule_group.name "{{ folderUID }}:{{ name }}"
-terraform import grafana_rule_group.name "{{ orgID }}:{{ folderUID }}:{{ name }}"
+terraform import grafana_rule_group.name "{{ folderUID }}:{{ title }}"
+terraform import grafana_rule_group.name "{{ orgID }}:{{ folderUID }}:{{ title }}"
 ```

--- a/examples/resources/grafana_rule_group/import.sh
+++ b/examples/resources/grafana_rule_group/import.sh
@@ -1,2 +1,2 @@
-terraform import grafana_rule_group.name "{{ folderUID }}:{{ name }}"
-terraform import grafana_rule_group.name "{{ orgID }}:{{ folderUID }}:{{ name }}"
+terraform import grafana_rule_group.name "{{ folderUID }}:{{ title }}"
+terraform import grafana_rule_group.name "{{ orgID }}:{{ folderUID }}:{{ title }}"

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -63,9 +63,9 @@ var (
 		},
 	)
 	alertingRuleGroupCheckExists = newCheckExistsHelper(
-		func(g *models.AlertRuleGroup) string { return g.FolderUID + ";" + g.Title },
+		func(g *models.AlertRuleGroup) string { return g.FolderUID + ":" + g.Title },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.AlertRuleGroup, error) {
-			folder, title, _ := strings.Cut(id, ";")
+			folder, title, _ := strings.Cut(id, ":")
 			resp, err := client.Provisioning.GetAlertRuleGroup(title, folder)
 			return payloadOrError(resp, err)
 		},

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -19,10 +19,10 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
-var resourceRuleGroupID = common.NewResourceID(
+var resourceRuleGroupID = common.NewResourceIDWithLegacySeparator(";",
 	common.OptionalIntIDField("orgID"),
 	common.StringIDField("folderUID"),
-	common.StringIDField("name"),
+	common.StringIDField("title"),
 )
 
 func resourceRuleGroup() *common.Resource {
@@ -253,11 +253,15 @@ This resource requires Grafana 9.1.0 or later.
 }
 
 func readAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID, idStr := OAPIClientFromExistingOrgResource(meta, data.Id())
+	client, orgID, idWithoutOrg := OAPIClientFromExistingOrgResource(meta, data.Id())
 
-	key := UnpackGroupID(idStr)
+	split, err := resourceRuleGroupID.Split(idWithoutOrg)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	folderUID, title := split[0].(string), split[1].(string)
 
-	resp, err := client.Provisioning.GetAlertRuleGroup(key.Name, key.FolderUID)
+	resp, err := client.Provisioning.GetAlertRuleGroup(title, folderUID)
 	if err, shouldReturn := common.CheckReadError("rule group", data, err); shouldReturn {
 		return err
 	}
@@ -286,7 +290,7 @@ func readAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta int
 	}
 	data.Set("disable_provenance", disableProvenance)
 	data.Set("rule", rules)
-	data.SetId(MakeOrgResourceID(orgID, packGroupID(key)))
+	data.SetId(resourceRuleGroupID.Make(orgID, folderUID, title))
 
 	return nil
 }
@@ -326,17 +330,20 @@ func putAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	key := packGroupID(AlertRuleGroupKey{resp.Payload.FolderUID, resp.Payload.Title})
-	data.SetId(MakeOrgResourceID(orgID, key))
+	data.SetId(resourceRuleGroupID.Make(orgID, resp.Payload.FolderUID, resp.Payload.Title))
 	return readAlertRuleGroup(ctx, data, meta)
 }
 
 func deleteAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, data.Id())
+	client, _, idWithoutOrg := OAPIClientFromExistingOrgResource(meta, data.Id())
 
-	key := UnpackGroupID(idStr)
+	split, err := resourceRuleGroupID.Split(idWithoutOrg)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	folderUID, title := split[0].(string), split[1].(string)
 	// TODO use DeleteAlertRuleGroup method instead (available since Grafana 11)
-	resp, err := client.Provisioning.GetAlertRuleGroup(key.Name, key.FolderUID)
+	resp, err := client.Provisioning.GetAlertRuleGroup(title, folderUID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -540,28 +547,6 @@ func unpackMap(raw interface{}) map[string]string {
 		result[k] = v.(string)
 	}
 	return result
-}
-
-type AlertRuleGroupKey struct {
-	FolderUID string
-	Name      string
-}
-
-const groupIDSeparator = ";"
-
-func packGroupID(key AlertRuleGroupKey) string {
-	return key.FolderUID + ";" + key.Name
-}
-
-func UnpackGroupID(tfID string) AlertRuleGroupKey {
-	vals := strings.SplitN(tfID, groupIDSeparator, 2)
-	if len(vals) != 2 {
-		return AlertRuleGroupKey{}
-	}
-	return AlertRuleGroupKey{
-		FolderUID: vals[0],
-		Name:      vals[1],
-	}
 }
 
 func packNotificationSettings(settings *models.AlertRuleNotificationSettings) (interface{}, error) {

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
+//nolint:staticcheck
 var resourceRuleGroupID = common.NewResourceIDWithLegacySeparator(";",
 	common.OptionalIntIDField("orgID"),
 	common.StringIDField("folderUID"),

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/grafana/terraform-provider-grafana/v2/internal/testutils"
 )
@@ -51,6 +52,19 @@ func TestAccAlertRule_basic(t *testing.T) {
 				ResourceName:      "grafana_rule_group.my_alert_rule",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			// Test import with legacy ID (split by ;). TODO: Remove this on next major release.
+			{
+				ResourceName:      "grafana_rule_group.my_alert_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["grafana_rule_group.my_alert_rule"]
+					if rs == nil {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s;%s", rs.Primary.Attributes["folder_uid"], rs.Primary.Attributes["name"]), nil
+				},
 			},
 			// Test update content.
 			{


### PR DESCRIPTION
For the next major version, I am standardizing all resource IDs on a `:` separator 
The alert rule group has a `;` so we have to migrate it. This is done with the resource ID helper 

On the next major version, the legacy separator support will be removed