### PR TITLE
Fully support TF plugin framework

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -4,20 +4,31 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type Resource struct {
-	Name   string
-	IDType *ResourceID
-	Schema *schema.Resource
+	Name                  string
+	IDType                *ResourceID
+	Schema                *schema.Resource
+	PluginFrameworkSchema resource.ResourceWithConfigure
 }
 
-func NewResource(name string, idType *ResourceID, schema *schema.Resource) *Resource {
+func NewLegacySDKResource(name string, idType *ResourceID, schema *schema.Resource) *Resource {
 	r := &Resource{
 		Name:   name,
 		IDType: idType,
 		Schema: schema,
+	}
+	return r
+}
+
+func NewResource(name string, idType *ResourceID, schema resource.ResourceWithConfigure) *Resource {
+	r := &Resource{
+		Name:                  name,
+		IDType:                idType,
+		PluginFrameworkSchema: schema,
 	}
 	return r
 }

--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -130,7 +130,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_access_policy",
 		resourceAccessPolicyID,
 		schema,

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -99,7 +99,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_access_policy_token",
 		resourceAccessPolicyTokenID,
 		schema,

--- a/internal/resources/cloud/resource_cloud_api_key.go
+++ b/internal/resources/cloud/resource_cloud_api_key.go
@@ -70,7 +70,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_api_key",
 		resourceAPIKeyID,
 		schema,

--- a/internal/resources/cloud/resource_cloud_plugin.go
+++ b/internal/resources/cloud/resource_cloud_plugin.go
@@ -59,7 +59,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_plugin_installation",
 		resourcePluginInstallationID,
 		schema,

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -199,7 +199,7 @@ Required access policy scopes:
 		),
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_stack",
 		resourceStackID,
 		schema,

--- a/internal/resources/cloud/resource_cloud_stack_api_key.go
+++ b/internal/resources/cloud/resource_cloud_stack_api_key.go
@@ -76,7 +76,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_stack_api_key",
 		nil,
 		schema,

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -73,7 +73,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_stack_service_account",
 		resourceStackServiceAccountID,
 		schema,

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -73,7 +73,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_cloud_stack_service_account_token",
 		nil,
 		schema,

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation.go
@@ -71,7 +71,7 @@ Required access policy scopes:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_synthetic_monitoring_installation",
 		nil,
 		schema,

--- a/internal/resources/examples_test.go
+++ b/internal/resources/examples_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/v2/internal/testutils"
+	"github.com/grafana/terraform-provider-grafana/v2/pkg/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -131,7 +132,11 @@ func TestAccExamples(t *testing.T) {
 	}
 
 	// Sanity check that we have all resources and datasources have been tested
-	for rName := range testutils.Provider.ResourcesMap {
+	resourceNames := map[string]struct{}{}
+	for _, r := range provider.Resources() {
+		resourceNames[r.Name] = struct{}{}
+	}
+	for rName := range resourceNames {
 		if _, ok := testedResources["resources/"+strings.TrimPrefix(rName, "grafana_")]; !ok {
 			t.Errorf("Resource %s was not tested", rName)
 		}
@@ -146,7 +151,7 @@ func TestAccExamples(t *testing.T) {
 	for rName := range testedResources {
 		if strings.HasPrefix(rName, "resources/") {
 			rName = "grafana_" + strings.TrimPrefix(rName, "resources/")
-			if _, ok := testutils.Provider.ResourcesMap[rName]; !ok {
+			if _, ok := resourceNames[rName]; !ok {
 				t.Errorf("Resource %s was tested but is not declared by the provider", rName)
 			}
 		}

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -98,7 +98,7 @@ This resource requires Grafana 9.1.0 or later.
 		}
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_contact_point",
 		orgResourceIDString("name"),
 		resource,

--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -60,7 +60,7 @@ This resource requires Grafana 9.1.0 or later.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_message_template",
 		orgResourceIDString("name"),
 		schema,

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -124,7 +124,7 @@ This resource requires Grafana 9.1.0 or later.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_mute_timing",
 		orgResourceIDString("name"),
 		schema,

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -85,7 +85,7 @@ This resource requires Grafana 9.1.0 or later.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_notification_policy",
 		orgResourceIDString("anyString"),
 		schema,

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -245,7 +245,7 @@ This resource requires Grafana 9.1.0 or later.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_rule_group",
 		resourceRuleGroupID,
 		schema,

--- a/internal/resources/grafana/resource_annotation.go
+++ b/internal/resources/grafana/resource_annotation.go
@@ -95,7 +95,7 @@ func resourceAnnotation() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_annotation",
 		orgResourceIDInt("id"),
 		schema,

--- a/internal/resources/grafana/resource_api_key.go
+++ b/internal/resources/grafana/resource_api_key.go
@@ -61,7 +61,7 @@ Manages Grafana API Keys.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_api_key",
 		nil,
 		schema,

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -92,7 +92,7 @@ Manages Grafana dashboards.
 		SchemaVersion: 1, // The state upgrader was removed in v2. To upgrade, users can first upgrade to the last v1 release, apply, then upgrade to v2.
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_dashboard",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_dashboard_permission.go
+++ b/internal/resources/grafana/resource_dashboard_permission.go
@@ -95,7 +95,7 @@ Manages the entire set of permissions for a dashboard. Permissions that aren't s
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_dashboard_permission",
 		orgResourceIDString("dashboardUID"),
 		schema,

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -83,7 +83,7 @@ Manages Grafana public dashboards.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_dashboard_public",
 		resourcePublicDashboardID,
 		schema,

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -108,7 +108,7 @@ source selected (via the 'type' argument).
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_data_source",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_data_source_config.go
+++ b/internal/resources/grafana/resource_data_source_config.go
@@ -44,7 +44,7 @@ func resourceDataSourceConfig() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_data_source_config",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_data_source_permission.go
+++ b/internal/resources/grafana/resource_data_source_permission.go
@@ -84,7 +84,7 @@ Manages the entire set of permissions for a datasource. Permissions that aren't 
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_data_source_permission",
 		orgResourceIDInt("datasourceID"),
 		schema,

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -67,7 +67,7 @@ func resourceFolder() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_folder",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -85,7 +85,7 @@ Manages the entire set of permissions for a folder. Permissions that aren't spec
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_folder_permission",
 		orgResourceIDString("folderUID"),
 		schema,

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -111,7 +111,7 @@ Manages Grafana library panels.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_library_panel",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -143,7 +143,7 @@ set to true. This feature is only available in Grafana 10.2+.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_organization",
 		common.NewResourceID(common.IntIDField("id")),
 		schema,

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -72,7 +72,7 @@ func resourceOrganizationPreferences() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_organization_preferences",
 		common.NewResourceID(common.IntIDField("orgID")),
 		schema,

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -75,7 +75,7 @@ func resourcePlaylist() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_playlist",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -287,7 +287,7 @@ func resourceReport() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_report",
 		orgResourceIDInt("id"),
 		schema,

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -107,7 +107,7 @@ func resourceRole() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_role",
 		orgResourceIDString("uid"),
 		schema,

--- a/internal/resources/grafana/resource_role_assignment.go
+++ b/internal/resources/grafana/resource_role_assignment.go
@@ -73,7 +73,7 @@ Manages the entire set of assignments for a role. Assignments that aren't specif
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_role_assignment",
 		orgResourceIDString("roleUID"),
 		schema,

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -56,7 +56,7 @@ func resourceServiceAccount() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_service_account",
 		orgResourceIDInt("id"),
 		schema,

--- a/internal/resources/grafana/resource_service_account_permission.go
+++ b/internal/resources/grafana/resource_service_account_permission.go
@@ -79,7 +79,7 @@ Manages the entire set of permissions for a service account. Permissions that ar
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_service_account_permission",
 		orgResourceIDInt("serviceAccountID"),
 		schema,

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -62,7 +62,7 @@ func resourceServiceAccountToken() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_service_account_token",
 		nil,
 		schema,

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -56,7 +56,7 @@ Manages Grafana SSO Settings for OAuth2. SAML support will be added soon.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_sso_settings",
 		orgResourceIDString("provider"),
 		schema,

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -149,7 +149,7 @@ Team Sync can be provisioned using [grafana_team_external_group resource](https:
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_team",
 		orgResourceIDInt("id"),
 		schema,

--- a/internal/resources/grafana/resource_team_external_group.go
+++ b/internal/resources/grafana/resource_team_external_group.go
@@ -49,7 +49,7 @@ func resourceTeamExternalGroup() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_team_external_group",
 		orgResourceIDInt("teamID"),
 		schema,

--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -67,7 +67,7 @@ You must use basic auth.
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_user",
 		resourceUserID,
 		schema,

--- a/internal/resources/machinelearning/resource_holiday.go
+++ b/internal/resources/machinelearning/resource_holiday.go
@@ -104,7 +104,7 @@ resource "grafana_machine_learning_job" "test_job" {
 		},
 	}
 
-	return common.NewResource("grafana_machine_learning_holiday", resourceHolidayID, schema)
+	return common.NewLegacySDKResource("grafana_machine_learning_holiday", resourceHolidayID, schema)
 }
 
 func resourceHolidayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/machinelearning/resource_job.go
+++ b/internal/resources/machinelearning/resource_job.go
@@ -106,7 +106,7 @@ A job defines the queries and model parameters for a machine learning task.
 		},
 	}
 
-	return common.NewResource("grafana_machine_learning_job", resourceJobID, schema)
+	return common.NewLegacySDKResource("grafana_machine_learning_job", resourceJobID, schema)
 }
 
 func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/machinelearning/resource_outlier_detector.go
+++ b/internal/resources/machinelearning/resource_outlier_detector.go
@@ -124,7 +124,7 @@ Visit https://grafana.com/docs/grafana-cloud/machine-learning/outlier-detection/
 		},
 	}
 
-	return common.NewResource("grafana_machine_learning_outlier_detector", resourceOutlierDetectorID, schema)
+	return common.NewLegacySDKResource("grafana_machine_learning_outlier_detector", resourceOutlierDetectorID, schema)
 }
 
 func resourceOutlierCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/oncall/resource_escalation.go
+++ b/internal/resources/oncall/resource_escalation.go
@@ -198,7 +198,7 @@ func resourceEscalation() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_escalation",
 		resourceID,
 		schema,

--- a/internal/resources/oncall/resource_escalation_chain.go
+++ b/internal/resources/oncall/resource_escalation_chain.go
@@ -38,7 +38,7 @@ func resourceEscalationChain() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_escalation_chain",
 		resourceID,
 		schema,

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -235,7 +235,7 @@ func resourceIntegration() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_integration",
 		resourceID,
 		schema,

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -103,7 +103,7 @@ func resourceOutgoingWebhook() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_outgoing_webhook",
 		resourceID,
 		schema,

--- a/internal/resources/oncall/resource_route.go
+++ b/internal/resources/oncall/resource_route.go
@@ -130,7 +130,7 @@ func resourceRoute() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_route",
 		resourceID,
 		schema,

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -100,7 +100,7 @@ func resourceSchedule() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_schedule",
 		resourceID,
 		schema,

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -182,7 +182,7 @@ func resourceOnCallShift() *common.Resource {
 		},
 	}
 
-	return common.NewResource(
+	return common.NewLegacySDKResource(
 		"grafana_oncall_on_call_shift",
 		resourceID,
 		schema,

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -222,7 +222,7 @@ Resource manages Grafana SLOs.
 		},
 	}
 
-	return common.NewResource("grafana_slo", resourceSloID, schema)
+	return common.NewLegacySDKResource("grafana_slo", resourceSloID, schema)
 }
 
 var keyvalueSchema = &schema.Resource{

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -744,7 +744,7 @@ multiple checks for a single endpoint to check different capabilities.
 		},
 	}
 
-	return common.NewResource("grafana_synthetic_monitoring_check", resourceCheckID, schema)
+	return common.NewLegacySDKResource("grafana_synthetic_monitoring_check", resourceCheckID, schema)
 }
 
 func resourceCheckCreate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {

--- a/internal/resources/syntheticmonitoring/resource_probe.go
+++ b/internal/resources/syntheticmonitoring/resource_probe.go
@@ -105,7 +105,7 @@ Grafana Synthetic Monitoring Agent.
 		},
 	}
 
-	return common.NewResource("grafana_synthetic_monitoring_probe", resourceProbeID, schema)
+	return common.NewLegacySDKResource("grafana_synthetic_monitoring_probe", resourceProbeID, schema)
 }
 
 func resourceProbeCreate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -240,14 +240,12 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 
 // DataSources defines the data sources implemented in the provider.
 func (p *frameworkProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	// TODO: Implement same thing as legacy_provider_validation.go when adding datasources
 	return nil
 }
 
 // Resources defines the resources implemented in the provider.
 func (p *frameworkProvider) Resources(_ context.Context) []func() resource.Resource {
-	// TODO: Implement same thing as legacy_provider_validation.go when adding resources
-	return nil
+	return pluginFrameworkResources()
 }
 
 // FrameworkProvider returns a terraform-plugin-framework Provider.

--- a/pkg/provider/resources.go
+++ b/pkg/provider/resources.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v2/internal/resources/oncall"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/resources/slo"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/resources/syntheticmonitoring"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -27,7 +28,11 @@ func Resources() []*common.Resource {
 func resourceMap() map[string]*schema.Resource {
 	result := make(map[string]*schema.Resource)
 	for _, r := range Resources() {
-		result[r.Name] = r.Schema
+		schema := r.Schema
+		if schema == nil {
+			continue
+		}
+		result[r.Name] = schema
 	}
 	return result
 }
@@ -40,4 +45,16 @@ func mergeResourceMaps(maps ...map[string]*schema.Resource) map[string]*schema.R
 		}
 	}
 	return result
+}
+
+func pluginFrameworkResources() []func() resource.Resource {
+	var resources []func() resource.Resource
+	for _, r := range Resources() {
+		resourceSchema := r.PluginFrameworkSchema
+		if resourceSchema == nil {
+			continue
+		}
+		resources = append(resources, func() resource.Resource { return resourceSchema })
+	}
+	return resources
 }


### PR DESCRIPTION
Now that all resources are under the new `common.Resource` struct, we can easily support the new Terraform plugin framework 

This PR switches the `NewResource` function to use the Terraform plugin framework and makes all current resource use a `NewLegacySDKResource` helper instead