### PR TITLE
Fix `grafana_cloud_stack_service_account` resource to support creating service accounts without a basic role

### DIFF
--- a/docs/resources/cloud_stack_service_account.md
+++ b/docs/resources/cloud_stack_service_account.md
@@ -41,12 +41,12 @@ resource "grafana_cloud_stack_service_account" "cloud_sa" {
 ### Required
 
 - `name` (String) The name of the service account.
+- `role` (String) The basic role of the service account in the organization.
 - `stack_slug` (String)
 
 ### Optional
 
 - `is_disabled` (Boolean) The disabled status for the service account. Defaults to `false`.
-- `role` (String) The basic role of the service account in the organization.
 
 ### Read-Only
 

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -58,8 +58,8 @@ Required access policy scopes:
 			},
 			"role": {
 				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor", "Admin"}, false),
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor", "Admin", "None"}, false),
 				Description:  "The basic role of the service account in the organization.",
 				ForceNew:     true, // The grafana API does not support updating the service account
 			},


### PR DESCRIPTION
Closes #1463 