### PR TITLE
Folder: Use UID instead of numerical ID

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -42,13 +42,3 @@ text = "deprecatedComment: the proper format is `Deprecated: <text>`"
 [[issues.exclude-rules]]
 linters = ["gosec"]
 text = "G402: TLS MinVersion too low."
-
-# TODO: Use Folder UID instead where possible
-[[issues.exclude-rules]]
-linters = ["staticcheck"]
-text = "use FolderUID instead"
-
-# TODO: Use Folder UID instead where possible
-[[issues.exclude-rules]]
-linters = ["staticcheck"]
-text = "use UID instead"

--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -52,7 +52,8 @@ data "grafana_dashboard" "from_uid" {
 ### Read-Only
 
 - `config_json` (String) The complete dashboard model JSON.
-- `folder` (Number) The numerical ID of the folder where the Grafana dashboard is found.
+- `folder` (Number, Deprecated) Deprecated. Use `folder_uid` instead
+- `folder_uid` (String) The UID of the folder where the Grafana dashboard is found.
 - `id` (String) The ID of this resource.
 - `is_starred` (Boolean) Whether or not the Grafana dashboard is starred. Starred Dashboards will show up on your own Home Dashboard by default, and are a convenient way to mark Dashboards that you’re interested in.
 - `slug` (String) URL slug of the dashboard (deprecated).

--- a/docs/data-sources/dashboards.md
+++ b/docs/data-sources/dashboards.md
@@ -54,15 +54,15 @@ data "grafana_dashboards" "tags" {
   tags   = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
 }
 
-data "grafana_dashboards" "folder_ids" {
-  org_id     = grafana_organization.test.id
-  folder_ids = [grafana_dashboard.data_source_dashboards1.folder]
+data "grafana_dashboards" "folder_uids" {
+  org_id      = grafana_organization.test.id
+  folder_uids = [grafana_dashboard.data_source_dashboards1.folder]
 }
 
-data "grafana_dashboards" "folder_ids_tags" {
-  org_id     = grafana_organization.test.id
-  folder_ids = [grafana_dashboard.data_source_dashboards1.folder]
-  tags       = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
+data "grafana_dashboards" "folder_uids_tags" {
+  org_id      = grafana_organization.test.id
+  folder_uids = [grafana_dashboard.data_source_dashboards1.folder]
+  tags        = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
 }
 
 // use depends_on to wait for dashboard resource to be created before searching
@@ -98,7 +98,8 @@ data "grafana_dashboards" "wrong_org" {
 
 ### Optional
 
-- `folder_ids` (List of Number) Numerical IDs of Grafana folders containing dashboards. Specify to filter for dashboards by folder (eg. `[0]` for General folder), or leave blank to get all dashboards in all folders.
+- `folder_ids` (List of Number, Deprecated) Deprecated, use `folder_uids` instead.
+- `folder_uids` (List of String) UIDs of Grafana folders containing dashboards. Specify to filter for dashboards by folder (eg. `["General"]` for General folder), or leave blank to get all dashboards in all folders.
 - `limit` (Number) Maximum number of dashboard search results to return. Defaults to `5000`.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `tags` (List of String) List of string Grafana dashboard tags to search for, eg. `["prod"]`. Used only as search input, i.e., attribute value will remain unchanged.

--- a/docs/data-sources/library_panel.md
+++ b/docs/data-sources/library_panel.md
@@ -97,7 +97,7 @@ data "grafana_dashboard" "from_library_panel_connection" {
 - `created` (String) Timestamp when the library panel was created.
 - `dashboard_ids` (List of Number) Numerical IDs of Grafana dashboards containing the library panel.
 - `description` (String) Description of the library panel.
-- `folder_id` (String) ID of the folder where the library panel is stored.
+- `folder_id` (String, Deprecated) Deprecated. Use `folder_uid` instead
 - `folder_name` (String) Name of the folder containing the library panel.
 - `folder_uid` (String) Unique ID (UID) of the folder containing the library panel.
 - `id` (String) The ID of this resource.

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -43,7 +43,8 @@ resource "grafana_library_panel" "test" {
 
 ### Optional
 
-- `folder_id` (String) ID of the folder where the library panel is stored.
+- `folder_id` (String, Deprecated) Deprecated. Use `folder_uid` instead
+- `folder_uid` (String) Unique ID (UID) of the folder containing the library panel.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `uid` (String) The unique identifier (UID) of a library panel uniquely identifies library panels between multiple Grafana installs. It’s automatically generated unless you specify it during library panel creation.The UID provides consistent URLs for accessing library panels and when syncing library panels between multiple Grafana installs.
 
@@ -53,7 +54,6 @@ resource "grafana_library_panel" "test" {
 - `dashboard_ids` (List of Number) Numerical IDs of Grafana dashboards containing the library panel.
 - `description` (String) Description of the library panel.
 - `folder_name` (String) Name of the folder containing the library panel.
-- `folder_uid` (String) Unique ID (UID) of the folder containing the library panel.
 - `id` (String) The ID of this resource.
 - `panel_id` (Number) The numeric ID of the library panel computed by Grafana.
 - `type` (String) Type of the library panel (eg. text).

--- a/examples/data-sources/grafana_dashboards/data-source.tf
+++ b/examples/data-sources/grafana_dashboards/data-source.tf
@@ -34,15 +34,15 @@ data "grafana_dashboards" "tags" {
   tags   = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
 }
 
-data "grafana_dashboards" "folder_ids" {
-  org_id     = grafana_organization.test.id
-  folder_ids = [grafana_dashboard.data_source_dashboards1.folder]
+data "grafana_dashboards" "folder_uids" {
+  org_id      = grafana_organization.test.id
+  folder_uids = [grafana_dashboard.data_source_dashboards1.folder]
 }
 
-data "grafana_dashboards" "folder_ids_tags" {
-  org_id     = grafana_organization.test.id
-  folder_ids = [grafana_dashboard.data_source_dashboards1.folder]
-  tags       = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
+data "grafana_dashboards" "folder_uids_tags" {
+  org_id      = grafana_organization.test.id
+  folder_uids = [grafana_dashboard.data_source_dashboards1.folder]
+  tags        = jsondecode(grafana_dashboard.data_source_dashboards1.config_json)["tags"]
 }
 
 // use depends_on to wait for dashboard resource to be created before searching

--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -144,9 +144,9 @@ var (
 		},
 	)
 	folderCheckExists = newCheckExistsHelper(
-		func(f *models.Folder) string { return strconv.FormatInt(f.ID, 10) },
-		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Folder, error) {
-			resp, err := client.Folders.GetFolderByID(mustParseInt64(id))
+		func(f *models.Folder) string { return f.UID },
+		func(client *goapi.GrafanaHTTPAPI, uid string) (*models.Folder, error) {
+			resp, err := client.Folders.GetFolderByUID(uid)
 			return payloadOrError(resp, err)
 		},
 	)

--- a/internal/resources/grafana/data_source_dashboard.go
+++ b/internal/resources/grafana/data_source_dashboard.go
@@ -53,7 +53,13 @@ func datasourceDashboard() *schema.Resource {
 			"folder": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The numerical ID of the folder where the Grafana dashboard is found.",
+				Description: "Deprecated. Use `folder_uid` instead",
+				Deprecated:  "Use `folder_uid` instead",
+			},
+			"folder_uid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The UID of the folder where the Grafana dashboard is found.",
 			},
 			"is_starred": {
 				Type:        schema.TypeBool,
@@ -120,7 +126,9 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("config_json", string(configJSONBytes))
 	d.Set("version", int64(model["version"].(float64)))
 	d.Set("title", model["title"].(string))
+	// nolint:staticcheck
 	d.Set("folder", dashboard.Meta.FolderID)
+	d.Set("folder_uid", dashboard.Meta.FolderUID)
 	d.Set("is_starred", dashboard.Meta.IsStarred)
 	d.Set("slug", dashboard.Meta.Slug)
 	d.Set("url", metaClient.GrafanaSubpath(dashboard.Meta.URL))

--- a/internal/resources/grafana/data_source_dashboards.go
+++ b/internal/resources/grafana/data_source_dashboards.go
@@ -26,8 +26,15 @@ Datasource for retrieving all dashboards. Specify list of folder IDs to search i
 			"folder_ids": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Numerical IDs of Grafana folders containing dashboards. Specify to filter for dashboards by folder (eg. `[0]` for General folder), or leave blank to get all dashboards in all folders.",
+				Description: "Deprecated, use `folder_uids` instead.",
 				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Deprecated:  "Use `folder_uids` instead.",
+			},
+			"folder_uids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "UIDs of Grafana folders containing dashboards. Specify to filter for dashboards by folder (eg. `[\"General\"]` for General folder), or leave blank to get all dashboards in all folders.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"limit": {
 				Type:        schema.TypeInt,
@@ -79,6 +86,11 @@ func dataSourceReadDashboards(ctx context.Context, d *schema.ResourceData, meta 
 	if list, ok := d.GetOk("folder_ids"); ok {
 		params.FolderIds = common.ListToIntSlice[int64](list.([]interface{}))
 		id.Write([]byte(fmt.Sprintf("%v", params.FolderIds)))
+	}
+
+	if list, ok := d.GetOk("folder_uids"); ok {
+		params.FolderUIDs = common.ListToStringSlice(list.([]interface{}))
+		id.Write([]byte(fmt.Sprintf("%v", params.FolderUIDs)))
 	}
 
 	if list, ok := d.GetOk("tags"); ok {

--- a/internal/resources/grafana/data_source_dashboards_test.go
+++ b/internal/resources/grafana/data_source_dashboards_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+func TestAccDataSourceDashboardsAllAndByFolderUID(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=10.0.0")
 
 	// Do not use parallel tests here because it tests a listing datasource on the default org
 	resource.Test(t, resource.TestCase{
@@ -22,15 +22,15 @@ func TestAccDataSourceDashboardsAllAndByFolderID(t *testing.T) {
 					resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.0.title", "data_source_dashboards 1"),
 					resource.TestCheckResourceAttr("data.grafana_dashboards.tags", "dashboards.0.folder_title", "test folder data_source_dashboards"),
 
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.#", "1"),
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.0.uid", "data-source-dashboards-1"),
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.0.title", "data_source_dashboards 1"),
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids", "dashboards.#", "1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids", "dashboards.0.folder_title", "test folder data_source_dashboards"),
 
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.#", "1"),
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.0.uid", "data-source-dashboards-1"),
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.0.title", "data_source_dashboards 1"),
-					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_ids_tags", "dashboards.0.folder_title", "test folder data_source_dashboards"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids_tags", "dashboards.#", "1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids_tags", "dashboards.0.uid", "data-source-dashboards-1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids_tags", "dashboards.0.title", "data_source_dashboards 1"),
+					resource.TestCheckResourceAttr("data.grafana_dashboards.folder_uids_tags", "dashboards.0.folder_title", "test folder data_source_dashboards"),
 
 					resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.#", "1"),
 					resource.TestCheckResourceAttr("data.grafana_dashboards.limit_one", "dashboards.0.uid", "data-source-dashboards-1"),

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -135,7 +135,10 @@ func ReadDashboard(ctx context.Context, d *schema.ResourceData, meta interface{}
 	// If the folder was originally set to a numeric ID, we read the folder ID
 	// Othwerwise, we read the folder UID
 	_, folderID := SplitOrgResourceID(d.Get("folder").(string))
+	// nolint:staticcheck
 	if common.IDRegexp.MatchString(folderID) && dashboard.Meta.FolderID > 0 {
+		// TODO: Remove on next major release
+		// nolint:staticcheck
 		d.Set("folder", strconv.FormatInt(dashboard.Meta.FolderID, 10))
 	} else {
 		d.Set("folder", dashboard.Meta.FolderUID)
@@ -205,6 +208,8 @@ func makeDashboard(d *schema.ResourceData) (models.SaveDashboardCommand, error) 
 
 	_, folderID := SplitOrgResourceID(d.Get("folder").(string))
 	if folderInt, err := strconv.ParseInt(folderID, 10, 64); err == nil {
+		// TODO: Remove on next major release
+		// nolint:staticcheck
 		dashboard.FolderID = folderInt
 	} else {
 		dashboard.FolderUID = folderID

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -60,13 +60,13 @@ func TestAccFolder_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"prevent_destroy_if_not_empty"},
 			},
-			// Change the title of a folder. This shouldn't change the ID (the folder doesn't have to be recreated)
+			// Change the title of a folder. This shouldn't recreate the folder
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_folder/resource.tf", map[string]string{
 					"Terraform Test Folder": "Terraform Test Folder Updated",
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderIDDidntChange("grafana_folder.test_folder", &folder),
+					testAccFolderWasntRecreated("grafana_folder.test_folder", &folder),
 					resource.TestMatchResourceAttr("grafana_folder.test_folder", "id", defaultOrgIDRegexp),
 					resource.TestMatchResourceAttr("grafana_folder.test_folder", "uid", common.UIDRegexp),
 					resource.TestCheckResourceAttr("grafana_folder.test_folder", "title", "Terraform Test Folder Updated"),
@@ -194,7 +194,6 @@ func TestAccFolder_PreventDeletion(t *testing.T) {
 						client := grafanaTestClient()
 						_, err := client.Dashboards.PostDashboard(&models.SaveDashboardCommand{
 							FolderUID: folder.UID,
-							FolderID:  folder.ID,
 							Dashboard: map[string]interface{}{
 								"uid":   name + "-dashboard",
 								"title": name + "-dashboard",
@@ -282,7 +281,7 @@ func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 	}
 }
 
-func testAccFolderIDDidntChange(rn string, oldFolder *models.Folder) resource.TestCheckFunc {
+func testAccFolderWasntRecreated(rn string, oldFolder *models.Folder) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		newFolderResource, ok := s.RootModule().Resources[rn]
 		if !ok {
@@ -294,8 +293,8 @@ func testAccFolderIDDidntChange(rn string, oldFolder *models.Folder) resource.Te
 		if err != nil {
 			return fmt.Errorf("error getting folder: %s", err)
 		}
-		if newFolder.ID != oldFolder.ID {
-			return fmt.Errorf("folder id has changed: %d -> %d", oldFolder.ID, newFolder.ID)
+		if newFolder.Created != oldFolder.Created {
+			return fmt.Errorf("folder creation date has changed: %s -> %s", oldFolder.Created, newFolder.Created)
 		}
 		return nil
 	}

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -48,11 +48,30 @@ Manages Grafana library panels.
 			"folder_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "ID of the folder where the library panel is stored.",
+				Description: "Deprecated. Use `folder_uid` instead",
+				Deprecated:  "Use `folder_uid` instead",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("folder_uid") != "" && new == "" {
+						return true
+					}
 					_, old = SplitOrgResourceID(old)
 					_, new = SplitOrgResourceID(new)
 					return old == "0" && new == "" || old == "" && new == "0" || old == new
+				},
+				ConflictsWith: []string{"folder_uid"},
+			},
+			"folder_uid": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Unique ID (UID) of the folder containing the library panel.",
+				ConflictsWith: []string{"folder_id"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("folder_id") != "" && new == "" {
+						return true
+					}
+					_, old = SplitOrgResourceID(old)
+					_, new = SplitOrgResourceID(new)
+					return old == new
 				},
 			},
 			"name": {
@@ -86,11 +105,6 @@ Manages Grafana library panels.
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Name of the folder containing the library panel.",
-			},
-			"folder_uid": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Unique ID (UID) of the folder containing the library panel.",
 			},
 			"created": {
 				Type:        schema.TypeString,
@@ -154,14 +168,15 @@ func readLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("uid", panel.UID)
 	d.Set("panel_id", panel.ID)
 	d.Set("org_id", strconv.FormatInt(panel.OrgID, 10))
+	// nolint:staticcheck
 	d.Set("folder_id", MakeOrgResourceID(orgID, panel.FolderID))
+	d.Set("folder_uid", panel.Meta.FolderUID)
 	d.Set("description", panel.Description)
 	d.Set("type", panel.Type)
 	d.Set("name", panel.Name)
 	d.Set("model_json", modelJSON)
 	d.Set("version", panel.Version)
 	d.Set("folder_name", panel.Meta.FolderName)
-	d.Set("folder_uid", panel.Meta.FolderUID)
 	d.Set("created", panel.Meta.Created.String())
 	d.Set("updated", panel.Meta.Updated.String())
 
@@ -186,15 +201,22 @@ func updateLibraryPanel(ctx context.Context, d *schema.ResourceData, meta interf
 	modelJSON := d.Get("model_json").(string)
 	panelJSON, _ := unmarshalLibraryPanelModelJSON(modelJSON)
 
-	_, folderIDStr := SplitOrgResourceID(d.Get("folder_id").(string))
-	folderID, _ := strconv.ParseInt(folderIDStr, 10, 64)
 	body := models.PatchLibraryElementCommand{
-		Name:     d.Get("name").(string),
-		FolderID: folderID,
-		Model:    panelJSON,
-		Kind:     1,
-		Version:  int64(d.Get("version").(int)),
+		Name:    d.Get("name").(string),
+		Model:   panelJSON,
+		Kind:    1,
+		Version: int64(d.Get("version").(int)),
 	}
+
+	if folderUID, ok := d.GetOk("folder_uid"); ok {
+		_, body.FolderUID = SplitOrgResourceID(folderUID.(string))
+	} else if folderIDStr, ok := d.GetOk("folder_id"); ok {
+		_, folderIDStr = SplitOrgResourceID(folderIDStr.(string))
+		folderID, _ := strconv.ParseInt(folderIDStr.(string), 10, 64)
+		// nolint:staticcheck
+		body.FolderID = folderID
+	}
+
 	resp, err := client.LibraryElements.UpdateLibraryElement(uid, &body)
 	if err != nil {
 		return diag.FromErr(err)
@@ -215,14 +237,20 @@ func makeLibraryPanel(d *schema.ResourceData) models.CreateLibraryElementCommand
 	modelJSON := d.Get("model_json").(string)
 	panelJSON, _ := unmarshalLibraryPanelModelJSON(modelJSON)
 
-	_, folderIDStr := SplitOrgResourceID(d.Get("folder_id").(string))
-	folderID, _ := strconv.ParseInt(folderIDStr, 10, 64)
 	panel := models.CreateLibraryElementCommand{
-		UID:      d.Get("uid").(string),
-		Name:     d.Get("name").(string),
-		FolderID: folderID,
-		Model:    panelJSON,
-		Kind:     1,
+		UID:   d.Get("uid").(string),
+		Name:  d.Get("name").(string),
+		Model: panelJSON,
+		Kind:  1,
+	}
+
+	if folderUID, ok := d.GetOk("folder_uid"); ok {
+		_, panel.FolderUID = SplitOrgResourceID(folderUID.(string))
+	} else if folderIDStr, ok := d.GetOk("folder_id"); ok {
+		_, folderIDStr = SplitOrgResourceID(folderIDStr.(string))
+		folderID, _ := strconv.ParseInt(folderIDStr.(string), 10, 64)
+		// nolint:staticcheck
+		panel.FolderID = folderID
 	}
 
 	return panel

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -59,7 +59,7 @@ func TestAccLibraryPanel_basic(t *testing.T) {
 }
 
 func TestAccLibraryPanel_folder(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
 	name := acctest.RandString(10)
 	var panel models.LibraryElementResponse
@@ -158,7 +158,7 @@ resource "grafana_folder" "test_folder" {
 
 resource "grafana_library_panel" "test_folder" {
 	name      = "%[1]s"
-	folder_id = grafana_folder.test_folder.id
+	folder_uid = grafana_folder.test_folder.uid
 	model_json = jsonencode({
 		title   = "%[1]s",
 		id      = 12,


### PR DESCRIPTION
The numerical ID is deprecated since v9. Let's remove it on next major version