### PR TITLE
Permission Items: Common code

### DIFF
--- a/docs/resources/folder_permission_item.md
+++ b/docs/resources/folder_permission_item.md
@@ -63,7 +63,7 @@ resource "grafana_folder_permission_item" "on_user" {
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `role` (String) the role onto which the permission is to be assigned
 - `team` (String) the team onto which the permission is to be assigned
-- `user` (String) the user onto which the permission is to be assigned
+- `user` (String) the user or service account onto which the permission is to be assigned
 
 ### Read-Only
 

--- a/internal/resources/grafana/common_resource_permission.go
+++ b/internal/resources/grafana/common_resource_permission.go
@@ -177,7 +177,7 @@ func (r *resourcePermissionBase) writeItem(itemID string, data *resourcePermissi
 				WithBody(&models.SetPermissionCommand{
 					Permission: data.Permission.ValueString(),
 				}).
-				WithResource(foldersPermissionsType).
+				WithResource(r.resourceType).
 				WithResourceID(itemID),
 		)
 		data.ID = types.StringValue(
@@ -195,7 +195,7 @@ func (r *resourcePermissionBase) writeItem(itemID string, data *resourcePermissi
 				WithBody(&models.SetPermissionCommand{
 					Permission: data.Permission.ValueString(),
 				}).
-				WithResource(foldersPermissionsType).
+				WithResource(r.resourceType).
 				WithResourceID(itemID),
 		)
 		data.ID = types.StringValue(
@@ -208,7 +208,7 @@ func (r *resourcePermissionBase) writeItem(itemID string, data *resourcePermissi
 				WithBody(&models.SetPermissionCommand{
 					Permission: data.Permission.ValueString(),
 				}).
-				WithResource(foldersPermissionsType).
+				WithResource(r.resourceType).
 				WithResourceID(itemID),
 		)
 		data.ID = types.StringValue(

--- a/internal/resources/grafana/common_resource_permission.go
+++ b/internal/resources/grafana/common_resource_permission.go
@@ -1,0 +1,216 @@
+// This is common code for the folder/dashboards/datasources/service accounts permissions resources.
+// They all use the same API for setting permissions, so the code is shared.
+
+package grafana
+
+import (
+	"strconv"
+
+	"github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/access_control"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	permissionTargetRole = "role"
+	permissionTargetTeam = "team"
+	permissionTargetUser = "user"
+)
+
+type resourcePermissionItemBaseModel struct {
+	ID         types.String `tfsdk:"id"`
+	OrgID      types.String `tfsdk:"org_id"`
+	Role       types.String `tfsdk:"role"`
+	Team       types.String `tfsdk:"team"`
+	User       types.String `tfsdk:"user"`
+	Permission types.String `tfsdk:"permission"`
+}
+
+type resourcePermissionBase struct {
+	basePluginFrameworkResource
+	resourceType string
+}
+
+func (r *resourcePermissionBase) addInSchemaAttributes(attributes map[string]schema.Attribute) map[string]schema.Attribute {
+	targetOneOf := stringvalidator.ExactlyOneOf(
+		path.MatchRoot(permissionTargetRole),
+		path.MatchRoot(permissionTargetTeam),
+		path.MatchRoot(permissionTargetUser),
+	)
+
+	attributes["id"] = schema.StringAttribute{
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
+	attributes["org_id"] = pluginFrameworkOrgIDAttribute()
+	attributes[permissionTargetRole] = schema.StringAttribute{
+		Optional:    true,
+		Description: "the role onto which the permission is to be assigned",
+		Validators: []validator.String{
+			stringvalidator.OneOf("Editor", "Viewer"),
+			targetOneOf,
+		},
+	}
+	attributes[permissionTargetTeam] = schema.StringAttribute{
+		Optional:    true,
+		Description: "the team onto which the permission is to be assigned",
+		Validators: []validator.String{
+			targetOneOf,
+		},
+		PlanModifiers: []planmodifier.String{
+			&orgScopedAttributePlanModifier{},
+		},
+	}
+	attributes[permissionTargetUser] = schema.StringAttribute{
+		Optional:    true,
+		Description: "the user or service account onto which the permission is to be assigned",
+		Validators: []validator.String{
+			targetOneOf,
+		},
+		PlanModifiers: []planmodifier.String{
+			&orgScopedAttributePlanModifier{},
+		},
+	}
+	attributes["permission"] = schema.StringAttribute{
+		Required:    true,
+		Description: "the permission to be assigned",
+		Validators: []validator.String{
+			stringvalidator.OneOf("View", "Edit", "Admin"),
+		},
+	}
+	return attributes
+}
+
+func (r *resourcePermissionBase) readItem(id string, checkExistsFunc func(client *client.GrafanaHTTPAPI, itemID string) error) (*resourcePermissionItemBaseModel, diag.Diagnostics) {
+	client, orgID, splitID, err := r.clientFromExistingOrgResource(resourceFolderPermissionItemID, id)
+	if err != nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unable to parse resource ID", err.Error())}
+	}
+	itemID := splitID[0].(string)
+	permissionTargetType := splitID[1].(string)
+	permissionTargetID := splitID[2].(string)
+
+	// Check that the resource exists. This depends on the resource type, so a generic function is passed in.
+	if err := checkExistsFunc(client, itemID); err != nil {
+		if common.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Resource does not exist", err.Error())}
+	}
+
+	// GET
+	permissionsResp, err := client.AccessControl.GetResourcePermissions(itemID, r.resourceType)
+	if err != nil {
+		if common.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Failed to read permissions", err.Error())}
+	}
+
+	for _, permission := range permissionsResp.Payload {
+		data := &resourcePermissionItemBaseModel{
+			ID:         types.StringValue(id),
+			OrgID:      types.StringValue(strconv.FormatInt(orgID, 10)),
+			Permission: types.StringValue(permission.Permission),
+		}
+		switch permissionTargetType {
+		case permissionTargetTeam:
+			if v := strconv.FormatInt(permission.TeamID, 10); v == permissionTargetID {
+				data.Team = types.StringValue(v)
+			} else {
+				continue
+			}
+		case permissionTargetUser:
+			if v := strconv.FormatInt(permission.UserID, 10); v == permissionTargetID {
+				data.User = types.StringValue(v)
+			} else {
+				continue
+			}
+		case permissionTargetRole:
+			if permission.BuiltInRole == permissionTargetID {
+				data.Role = types.StringValue(permissionTargetID)
+			} else {
+				continue
+			}
+		default:
+			return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unknown permission target type", permissionTargetType)}
+		}
+
+		return data, nil
+	}
+
+	return nil, nil
+}
+
+func (r *resourcePermissionBase) writeItem(itemID string, data *resourcePermissionItemBaseModel) diag.Diagnostics {
+	client, orgID := r.clientFromNewOrgResource(data.OrgID.ValueString())
+	data.OrgID = types.StringValue(strconv.FormatInt(orgID, 10))
+
+	var err error
+	switch {
+	case !data.User.IsNull():
+		_, userIDStr := SplitOrgResourceID(data.User.ValueString())
+		userID, parseErr := strconv.ParseInt(userIDStr, 10, 64)
+		if parseErr != nil {
+			return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to parse user ID", parseErr.Error())}
+		}
+		_, err = client.AccessControl.SetResourcePermissionsForUser(
+			access_control.NewSetResourcePermissionsForUserParams().
+				WithUserID(userID).
+				WithBody(&models.SetPermissionCommand{
+					Permission: data.Permission.ValueString(),
+				}).
+				WithResource(foldersPermissionsType).
+				WithResourceID(itemID),
+		)
+		data.ID = types.StringValue(
+			resourceFolderPermissionItemID.Make(orgID, itemID, permissionTargetUser, userIDStr),
+		)
+	case !data.Team.IsNull():
+		_, teamIDStr := SplitOrgResourceID(data.Team.ValueString())
+		teamID, parseErr := strconv.ParseInt(teamIDStr, 10, 64)
+		if parseErr != nil {
+			return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to parse user ID", parseErr.Error())}
+		}
+		_, err = client.AccessControl.SetResourcePermissionsForTeam(
+			access_control.NewSetResourcePermissionsForTeamParams().
+				WithTeamID(teamID).
+				WithBody(&models.SetPermissionCommand{
+					Permission: data.Permission.ValueString(),
+				}).
+				WithResource(foldersPermissionsType).
+				WithResourceID(itemID),
+		)
+		data.ID = types.StringValue(
+			resourceFolderPermissionItemID.Make(orgID, itemID, permissionTargetTeam, teamIDStr),
+		)
+	case !data.Role.IsNull():
+		_, err = client.AccessControl.SetResourcePermissionsForBuiltInRole(
+			access_control.NewSetResourcePermissionsForBuiltInRoleParams().
+				WithBuiltInRole(data.Role.ValueString()).
+				WithBody(&models.SetPermissionCommand{
+					Permission: data.Permission.ValueString(),
+				}).
+				WithResource(foldersPermissionsType).
+				WithResourceID(itemID),
+		)
+		data.ID = types.StringValue(
+			resourceFolderPermissionItemID.Make(orgID, itemID, permissionTargetRole, data.Role.ValueString()),
+		)
+	}
+	if err != nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to write permissions", err.Error())}
+	}
+	return nil
+}

--- a/internal/resources/grafana/resource_data_source_permission_item.go
+++ b/internal/resources/grafana/resource_data_source_permission_item.go
@@ -2,19 +2,13 @@ package grafana
 
 import (
 	"context"
-	"strconv"
 
-	"github.com/grafana/grafana-openapi-client-go/client/access_control"
-	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -27,44 +21,29 @@ var (
 )
 
 func makeResourceDatasourcePermissionItem() *common.Resource {
-	return common.NewResource(resourceDatasourcePermissionItemName, resourceDatasourcePermissionItemID, &resourceDatasourcePermissionItem{})
+	resourceStruct := &resourceDatasourcePermissionItem{
+		resourcePermissionBase: resourcePermissionBase{
+			resourceType: datasourcesPermissionsType,
+		},
+	}
+	return common.NewResource(resourceDatasourcePermissionItemName, resourceDatasourcePermissionItemID, resourceStruct)
 }
 
 type resourceDatasourcePermissionItemModel struct {
-	ID            types.String `tfsdk:"id"`
-	OrgID         types.String `tfsdk:"org_id"`
+	resourceFolderPermissionItemModel
 	DatasourceUID types.String `tfsdk:"datasource_uid"`
-	Role          types.String `tfsdk:"role"`
-	Team          types.String `tfsdk:"team"`
-	User          types.String `tfsdk:"user"`
-	Permission    types.String `tfsdk:"permission"`
 }
 
-type resourceDatasourcePermissionItem struct {
-	basePluginFrameworkResource
-}
+type resourceDatasourcePermissionItem struct{ resourcePermissionBase }
 
 func (r *resourceDatasourcePermissionItem) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = resourceDatasourcePermissionItemName
 }
 
 func (r *resourceDatasourcePermissionItem) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	targetOneOf := stringvalidator.ExactlyOneOf(
-		path.MatchRoot(permissionTargetRole),
-		path.MatchRoot(permissionTargetTeam),
-		path.MatchRoot(permissionTargetUser),
-	)
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Manages a single permission item for a datasource. Conflicts with the "grafana_data_source_permission" resource which manages the entire set of permissions for a datasource.`,
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"org_id": pluginFrameworkOrgIDAttribute(),
+		Attributes: r.addInSchemaAttributes(map[string]schema.Attribute{
 			"datasource_uid": schema.StringAttribute{
 				Required:    true,
 				Description: "The UID of the datasource.",
@@ -72,47 +51,12 @@ func (r *resourceDatasourcePermissionItem) Schema(ctx context.Context, req resou
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			permissionTargetRole: schema.StringAttribute{
-				Optional:    true,
-				Description: "the role onto which the permission is to be assigned",
-				Validators: []validator.String{
-					stringvalidator.OneOf("Editor", "Viewer"),
-					targetOneOf,
-				},
-			},
-			permissionTargetTeam: schema.StringAttribute{
-				Optional:    true,
-				Description: "the team onto which the permission is to be assigned",
-				Validators: []validator.String{
-					targetOneOf,
-				},
-				PlanModifiers: []planmodifier.String{
-					&orgScopedAttributePlanModifier{},
-				},
-			},
-			permissionTargetUser: schema.StringAttribute{
-				Optional:    true,
-				Description: "the user or service account onto which the permission is to be assigned",
-				Validators: []validator.String{
-					targetOneOf,
-				},
-				PlanModifiers: []planmodifier.String{
-					&orgScopedAttributePlanModifier{},
-				},
-			},
-			"permission": schema.StringAttribute{
-				Required:    true,
-				Description: "the permission to be assigned",
-				Validators: []validator.String{
-					stringvalidator.OneOf("Query", "Edit", "Admin"),
-				},
-			},
-		},
+		}),
 	}
 }
 
 func (r *resourceDatasourcePermissionItem) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	data, diags := r.read(req.ID)
+	data, diags := r.readItem(req.ID, r.datasourceQuery)
 	if diags != nil {
 		resp.Diagnostics = diags
 		return
@@ -131,7 +75,7 @@ func (r *resourceDatasourcePermissionItem) Create(ctx context.Context, req resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if diags := r.write(&data); diags != nil {
+	if diags := r.writeItem(data.DatasourceUID.ValueString(), &data.resourcePermissionItemBaseModel); diags != nil {
 		resp.Diagnostics = diags
 		return
 	}
@@ -145,7 +89,7 @@ func (r *resourceDatasourcePermissionItem) Read(ctx context.Context, req resourc
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	// Read from API
-	readData, diags := r.read(data.ID.ValueString())
+	readData, diags := r.readItem(data.ID.ValueString(), r.datasourceQuery)
 	if diags != nil {
 		resp.Diagnostics = diags
 		return
@@ -166,7 +110,7 @@ func (r *resourceDatasourcePermissionItem) Update(ctx context.Context, req resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if diags := r.write(&data); diags != nil {
+	if diags := r.writeItem(data.DatasourceUID.ValueString(), &data.resourcePermissionItemBaseModel); diags != nil {
 		resp.Diagnostics = diags
 		return
 	}
@@ -180,133 +124,12 @@ func (r *resourceDatasourcePermissionItem) Delete(ctx context.Context, req resou
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	data.Permission = types.StringValue("")
 
-	if diags := r.write(&data); diags != nil {
+	if diags := r.writeItem(data.DatasourceUID.ValueString(), &data.resourcePermissionItemBaseModel); diags != nil {
 		resp.Diagnostics = diags
 	}
 }
 
-func (r *resourceDatasourcePermissionItem) read(id string) (*resourceDatasourcePermissionItemModel, diag.Diagnostics) {
-	client, orgID, splitID, err := r.clientFromExistingOrgResource(resourceDatasourcePermissionItemID, id)
-	if err != nil {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unable to parse resource ID", err.Error())}
-	}
-	datasourceUID := splitID[0].(string)
-	permissionTargetType := splitID[1].(string)
-	permissionTargetID := splitID[2].(string)
-
-	// Check that the datasource exists
-	_, err = client.Datasources.GetDataSourceByUID(datasourceUID)
-	if err != nil {
-		if common.IsNotFoundError(err) {
-			return nil, nil
-		}
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Failed to read datasource", err.Error())}
-	}
-
-	// GET
-	permissionsResp, err := client.AccessControl.GetResourcePermissions(datasourceUID, datasourcesPermissionsType)
-	if err != nil {
-		if common.IsNotFoundError(err) {
-			return nil, nil
-		}
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Failed to read permissions", err.Error())}
-	}
-
-	for _, permission := range permissionsResp.Payload {
-		data := &resourceDatasourcePermissionItemModel{
-			ID:            types.StringValue(id),
-			OrgID:         types.StringValue(strconv.FormatInt(orgID, 10)),
-			DatasourceUID: types.StringValue(datasourceUID),
-			Permission:    types.StringValue(permission.Permission),
-		}
-		switch permissionTargetType {
-		case permissionTargetTeam:
-			if v := strconv.FormatInt(permission.TeamID, 10); v == permissionTargetID {
-				data.Team = types.StringValue(v)
-			} else {
-				continue
-			}
-		case permissionTargetUser:
-			if v := strconv.FormatInt(permission.UserID, 10); v == permissionTargetID {
-				data.User = types.StringValue(v)
-			} else {
-				continue
-			}
-		case permissionTargetRole:
-			if permission.BuiltInRole == permissionTargetID {
-				data.Role = types.StringValue(permissionTargetID)
-			} else {
-				continue
-			}
-		default:
-			return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unknown permission target type", permissionTargetType)}
-		}
-
-		return data, nil
-	}
-
-	return nil, nil
-}
-
-func (r *resourceDatasourcePermissionItem) write(data *resourceDatasourcePermissionItemModel) diag.Diagnostics {
-	client, orgID := r.clientFromNewOrgResource(data.OrgID.ValueString())
-	datasourceUID := data.DatasourceUID.ValueString()
-	data.OrgID = types.StringValue(strconv.FormatInt(orgID, 10))
-
-	var err error
-	switch {
-	case !data.User.IsNull():
-		_, userIDStr := SplitOrgResourceID(data.User.ValueString())
-		userID, parseErr := strconv.ParseInt(userIDStr, 10, 64)
-		if parseErr != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to parse user ID", parseErr.Error())}
-		}
-		_, err = client.AccessControl.SetResourcePermissionsForUser(
-			access_control.NewSetResourcePermissionsForUserParams().
-				WithUserID(userID).
-				WithBody(&models.SetPermissionCommand{
-					Permission: data.Permission.ValueString(),
-				}).
-				WithResource(datasourcesPermissionsType).
-				WithResourceID(datasourceUID),
-		)
-		data.ID = types.StringValue(
-			resourceDatasourcePermissionItemID.Make(orgID, data.DatasourceUID.ValueString(), permissionTargetUser, userIDStr),
-		)
-	case !data.Team.IsNull():
-		_, teamIDStr := SplitOrgResourceID(data.Team.ValueString())
-		teamID, parseErr := strconv.ParseInt(teamIDStr, 10, 64)
-		if parseErr != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to parse user ID", parseErr.Error())}
-		}
-		_, err = client.AccessControl.SetResourcePermissionsForTeam(
-			access_control.NewSetResourcePermissionsForTeamParams().
-				WithTeamID(teamID).
-				WithBody(&models.SetPermissionCommand{
-					Permission: data.Permission.ValueString(),
-				}).
-				WithResource(datasourcesPermissionsType).
-				WithResourceID(datasourceUID),
-		)
-		data.ID = types.StringValue(
-			resourceDatasourcePermissionItemID.Make(orgID, data.DatasourceUID.ValueString(), permissionTargetTeam, teamIDStr),
-		)
-	case !data.Role.IsNull():
-		_, err = client.AccessControl.SetResourcePermissionsForBuiltInRole(
-			access_control.NewSetResourcePermissionsForBuiltInRoleParams().
-				WithBuiltInRole(data.Role.ValueString()).
-				WithBody(&models.SetPermissionCommand{
-					Permission: data.Permission.ValueString(),
-				}).
-				WithResource(datasourcesPermissionsType).
-				WithResourceID(datasourceUID),
-		)
-		data.ID = types.StringValue(
-			resourceDatasourcePermissionItemID.Make(orgID, data.DatasourceUID.ValueString(), permissionTargetRole, data.Role.ValueString()),
-		)
-	}
-	if err != nil {
-		return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to write permissions", err.Error())}
-	}
-	return nil
+func (r *resourceDatasourcePermissionItem) datasourceQuery(client *client.GrafanaHTTPAPI, datasourceUID string) error {
+	_, err := client.Datasources.GetDataSourceByUID(datasourceUID)
+	return err
 }

--- a/internal/resources/grafana/resource_folder_permission_item.go
+++ b/internal/resources/grafana/resource_folder_permission_item.go
@@ -2,19 +2,13 @@ package grafana
 
 import (
 	"context"
-	"strconv"
 
-	"github.com/grafana/grafana-openapi-client-go/client/access_control"
-	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -26,53 +20,33 @@ var (
 	_ resource.ResourceWithImportState = (*resourceFolderPermissionItem)(nil)
 )
 
-const (
-	permissionTargetRole = "role"
-	permissionTargetTeam = "team"
-	permissionTargetUser = "user"
-)
-
 func makeResourceFolderPermissionItem() *common.Resource {
-	return common.NewResource(resourceFolderPermissionItemName, resourceFolderPermissionItemID, &resourceFolderPermissionItem{})
+	resourceStruct := &resourceFolderPermissionItem{
+		resourcePermissionBase: resourcePermissionBase{
+			resourceType: foldersPermissionsType,
+		},
+	}
+	return common.NewResource(resourceFolderPermissionItemName, resourceFolderPermissionItemID, resourceStruct)
 }
 
 type resourceFolderPermissionItemModel struct {
-	ID         types.String `tfsdk:"id"`
-	OrgID      types.String `tfsdk:"org_id"`
-	FolderUID  types.String `tfsdk:"folder_uid"`
-	Role       types.String `tfsdk:"role"`
-	Team       types.String `tfsdk:"team"`
-	User       types.String `tfsdk:"user"`
-	Permission types.String `tfsdk:"permission"`
+	resourcePermissionItemBaseModel
+	FolderUID types.String `tfsdk:"folder_uid"`
 }
 
-type resourceFolderPermissionItem struct {
-	basePluginFrameworkResource
-}
+type resourceFolderPermissionItem struct{ resourcePermissionBase }
 
 func (r *resourceFolderPermissionItem) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = resourceFolderPermissionItemName
 }
 
 func (r *resourceFolderPermissionItem) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	targetOneOf := stringvalidator.ExactlyOneOf(
-		path.MatchRoot(permissionTargetRole),
-		path.MatchRoot(permissionTargetTeam),
-		path.MatchRoot(permissionTargetUser),
-	)
-
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Manages a single permission item for a folder. Conflicts with the "grafana_folder_permission" resource which manages the entire set of permissions for a folder.
 		* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
 		* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)`,
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"org_id": pluginFrameworkOrgIDAttribute(),
+		Attributes: r.addInSchemaAttributes(map[string]schema.Attribute{
+
 			"folder_uid": schema.StringAttribute{
 				Required:    true,
 				Description: "The UID of the folder.",
@@ -80,47 +54,12 @@ func (r *resourceFolderPermissionItem) Schema(ctx context.Context, req resource.
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			permissionTargetRole: schema.StringAttribute{
-				Optional:    true,
-				Description: "the role onto which the permission is to be assigned",
-				Validators: []validator.String{
-					stringvalidator.OneOf("Editor", "Viewer"),
-					targetOneOf,
-				},
-			},
-			permissionTargetTeam: schema.StringAttribute{
-				Optional:    true,
-				Description: "the team onto which the permission is to be assigned",
-				Validators: []validator.String{
-					targetOneOf,
-				},
-				PlanModifiers: []planmodifier.String{
-					&orgScopedAttributePlanModifier{},
-				},
-			},
-			permissionTargetUser: schema.StringAttribute{
-				Optional:    true,
-				Description: "the user onto which the permission is to be assigned",
-				Validators: []validator.String{
-					targetOneOf,
-				},
-				PlanModifiers: []planmodifier.String{
-					&orgScopedAttributePlanModifier{},
-				},
-			},
-			"permission": schema.StringAttribute{
-				Required:    true,
-				Description: "the permission to be assigned",
-				Validators: []validator.String{
-					stringvalidator.OneOf("View", "Edit", "Admin"),
-				},
-			},
-		},
+		}),
 	}
 }
 
 func (r *resourceFolderPermissionItem) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	data, diags := r.read(req.ID)
+	data, diags := r.readItem(req.ID, r.folderQuery)
 	if diags != nil {
 		resp.Diagnostics = diags
 		return
@@ -139,7 +78,7 @@ func (r *resourceFolderPermissionItem) Create(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if diags := r.write(&data); diags != nil {
+	if diags := r.writeItem(data.FolderUID.ValueString(), &data.resourcePermissionItemBaseModel); diags != nil {
 		resp.Diagnostics = diags
 		return
 	}
@@ -153,7 +92,7 @@ func (r *resourceFolderPermissionItem) Read(ctx context.Context, req resource.Re
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
 	// Read from API
-	readData, diags := r.read(data.ID.ValueString())
+	readData, diags := r.readItem(data.ID.ValueString(), r.folderQuery)
 	if diags != nil {
 		resp.Diagnostics = diags
 		return
@@ -174,7 +113,7 @@ func (r *resourceFolderPermissionItem) Update(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if diags := r.write(&data); diags != nil {
+	if diags := r.writeItem(data.FolderUID.ValueString(), &data.resourcePermissionItemBaseModel); diags != nil {
 		resp.Diagnostics = diags
 		return
 	}
@@ -188,133 +127,12 @@ func (r *resourceFolderPermissionItem) Delete(ctx context.Context, req resource.
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	data.Permission = types.StringValue("")
 
-	if diags := r.write(&data); diags != nil {
+	if diags := r.writeItem(data.FolderUID.ValueString(), &data.resourcePermissionItemBaseModel); diags != nil {
 		resp.Diagnostics = diags
 	}
 }
 
-func (r *resourceFolderPermissionItem) read(id string) (*resourceFolderPermissionItemModel, diag.Diagnostics) {
-	client, orgID, splitID, err := r.clientFromExistingOrgResource(resourceFolderPermissionItemID, id)
-	if err != nil {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unable to parse resource ID", err.Error())}
-	}
-	folderUID := splitID[0].(string)
-	permissionTargetType := splitID[1].(string)
-	permissionTargetID := splitID[2].(string)
-
-	// Check that the folder exists
-	_, err = client.Folders.GetFolderByUID(folderUID)
-	if err != nil {
-		if common.IsNotFoundError(err) {
-			return nil, nil
-		}
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Failed to read folder", err.Error())}
-	}
-
-	// GET
-	permissionsResp, err := client.AccessControl.GetResourcePermissions(folderUID, foldersPermissionsType)
-	if err != nil {
-		if common.IsNotFoundError(err) {
-			return nil, nil
-		}
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Failed to read permissions", err.Error())}
-	}
-
-	for _, permission := range permissionsResp.Payload {
-		data := &resourceFolderPermissionItemModel{
-			ID:         types.StringValue(id),
-			OrgID:      types.StringValue(strconv.FormatInt(orgID, 10)),
-			FolderUID:  types.StringValue(folderUID),
-			Permission: types.StringValue(permission.Permission),
-		}
-		switch permissionTargetType {
-		case permissionTargetTeam:
-			if v := strconv.FormatInt(permission.TeamID, 10); v == permissionTargetID {
-				data.Team = types.StringValue(v)
-			} else {
-				continue
-			}
-		case permissionTargetUser:
-			if v := strconv.FormatInt(permission.UserID, 10); v == permissionTargetID {
-				data.User = types.StringValue(v)
-			} else {
-				continue
-			}
-		case permissionTargetRole:
-			if permission.BuiltInRole == permissionTargetID {
-				data.Role = types.StringValue(permissionTargetID)
-			} else {
-				continue
-			}
-		default:
-			return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unknown permission target type", permissionTargetType)}
-		}
-
-		return data, nil
-	}
-
-	return nil, nil
-}
-
-func (r *resourceFolderPermissionItem) write(data *resourceFolderPermissionItemModel) diag.Diagnostics {
-	client, orgID := r.clientFromNewOrgResource(data.OrgID.ValueString())
-	folderUID := data.FolderUID.ValueString()
-	data.OrgID = types.StringValue(strconv.FormatInt(orgID, 10))
-
-	var err error
-	switch {
-	case !data.User.IsNull():
-		_, userIDStr := SplitOrgResourceID(data.User.ValueString())
-		userID, parseErr := strconv.ParseInt(userIDStr, 10, 64)
-		if parseErr != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to parse user ID", parseErr.Error())}
-		}
-		_, err = client.AccessControl.SetResourcePermissionsForUser(
-			access_control.NewSetResourcePermissionsForUserParams().
-				WithUserID(userID).
-				WithBody(&models.SetPermissionCommand{
-					Permission: data.Permission.ValueString(),
-				}).
-				WithResource(foldersPermissionsType).
-				WithResourceID(folderUID),
-		)
-		data.ID = types.StringValue(
-			resourceFolderPermissionItemID.Make(orgID, data.FolderUID.ValueString(), permissionTargetUser, userIDStr),
-		)
-	case !data.Team.IsNull():
-		_, teamIDStr := SplitOrgResourceID(data.Team.ValueString())
-		teamID, parseErr := strconv.ParseInt(teamIDStr, 10, 64)
-		if parseErr != nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to parse user ID", parseErr.Error())}
-		}
-		_, err = client.AccessControl.SetResourcePermissionsForTeam(
-			access_control.NewSetResourcePermissionsForTeamParams().
-				WithTeamID(teamID).
-				WithBody(&models.SetPermissionCommand{
-					Permission: data.Permission.ValueString(),
-				}).
-				WithResource(foldersPermissionsType).
-				WithResourceID(folderUID),
-		)
-		data.ID = types.StringValue(
-			resourceFolderPermissionItemID.Make(orgID, data.FolderUID.ValueString(), permissionTargetTeam, teamIDStr),
-		)
-	case !data.Role.IsNull():
-		_, err = client.AccessControl.SetResourcePermissionsForBuiltInRole(
-			access_control.NewSetResourcePermissionsForBuiltInRoleParams().
-				WithBuiltInRole(data.Role.ValueString()).
-				WithBody(&models.SetPermissionCommand{
-					Permission: data.Permission.ValueString(),
-				}).
-				WithResource(foldersPermissionsType).
-				WithResourceID(folderUID),
-		)
-		data.ID = types.StringValue(
-			resourceFolderPermissionItemID.Make(orgID, data.FolderUID.ValueString(), permissionTargetRole, data.Role.ValueString()),
-		)
-	}
-	if err != nil {
-		return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to write permissions", err.Error())}
-	}
-	return nil
+func (r *resourceFolderPermissionItem) folderQuery(client *client.GrafanaHTTPAPI, folderUID string) error {
+	_, err := client.Folders.GetFolderByUID(folderUID)
+	return err
 }


### PR DESCRIPTION
Follow-up to https://github.com/grafana/terraform-provider-grafana/pull/1465 and https://github.com/grafana/terraform-provider-grafana/pull/1470 
Lots of the code is exactly the same since it's the same API. This PR puts it in a common struct so that other permissions resources will be easier to add

Some of this code will also be usable for the global permissions resources (the existing not-`_item` ones)