### PR TITLE
Permission resources: Common code

### DIFF
--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -74,7 +74,7 @@ Required:
 
 Optional:
 
-- `role` (String) Manage permissions for `Viewer` or `Editor` roles.
+- `role` (String) Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`.
 - `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
 - `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.
 

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -90,7 +90,7 @@ Required:
 
 Optional:
 
-- `built_in_role` (String) Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`. Can only be set from Grafana v9.2.3+. Defaults to ``.
+- `built_in_role` (String) Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`.
 - `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
 - `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.
 

--- a/docs/resources/folder_permission.md
+++ b/docs/resources/folder_permission.md
@@ -73,7 +73,7 @@ Required:
 
 Optional:
 
-- `role` (String) Manage permissions for `Viewer` or `Editor` roles.
+- `role` (String) Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`.
 - `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
 - `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.
 

--- a/docs/resources/service_account_permission.md
+++ b/docs/resources/service_account_permission.md
@@ -70,12 +70,12 @@ resource "grafana_service_account_permission" "test_permissions" {
 
 Required:
 
-- `permission` (String) Permission to associate with item. Must be `Edit` or `Admin`.
+- `permission` (String) Permission to associate with item. Must be one of `View`, `Edit`, or `Admin`.
 
 Optional:
 
-- `team_id` (String) ID of the team to manage permissions for. Specify either this or `user_id`. Defaults to `0`.
-- `user_id` (String) ID of the user or service account to manage permissions for. Specify either this or `team_id`. Defaults to `0`.
+- `team_id` (String) ID of the team to manage permissions for. Defaults to `0`.
+- `user_id` (String) ID of the user or service account to manage permissions for. Defaults to `0`.
 
 ## Import
 

--- a/internal/resources/grafana/common_resource_permission_sdk2.go
+++ b/internal/resources/grafana/common_resource_permission_sdk2.go
@@ -1,0 +1,239 @@
+// Warning: The following are still in SDK2 format. They will eventually be converted to Plugin Framework format.
+
+package grafana
+
+import (
+	"context"
+	"strconv"
+
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/access_control"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type resourcePermissionsHelper struct {
+	resourceType  string
+	roleAttribute string // Not all resources have the same name for this attribute
+
+	// Given the resource data, check the resource exists and return the correct ID for permissions.
+	// Ex: We support ID and UID for dashboards but the permissions are managed by UID.
+	getResource func(d *schema.ResourceData, meta interface{}) (string, error)
+}
+
+func (h *resourcePermissionsHelper) addCommonSchemaAttributes(s map[string]*schema.Schema) {
+	permissionSchema := map[string]*schema.Schema{
+		"team_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "0",
+			Description: "ID of the team to manage permissions for.",
+		},
+		"user_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "0",
+			Description: "ID of the user or service account to manage permissions for.",
+		},
+		"permission": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice([]string{"View", "Edit", "Admin"}, false),
+			Description:  "Permission to associate with item. Must be one of `View`, `Edit`, or `Admin`.",
+		},
+	}
+	if h.resourceType == datasourcesPermissionsType {
+		permissionSchema["permission"] = &schema.Schema{
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice([]string{"Query", "Edit", "Admin"}, false),
+			Description:  "Permission to associate with item. Options: `Query`, `Edit` or `Admin` (`Admin` can only be used with Grafana v10.3.0+).",
+		}
+	}
+	if h.roleAttribute != "" {
+		permissionSchema[h.roleAttribute] = &schema.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor", "Admin"}, false),
+			Description:  "Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`.",
+		}
+	}
+
+	commonSchema := map[string]*schema.Schema{
+		"org_id": orgIDAttribute(),
+		"permissions": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			DefaultFunc: func() (interface{}, error) {
+				return []interface{}{}, nil
+			},
+			Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
+			// Ignore the org ID of the team/SA when hashing. It works with or without it.
+			Set: func(i interface{}) int {
+				m := i.(map[string]interface{})
+				_, teamID := SplitOrgResourceID(m["team_id"].(string))
+				_, userID := SplitOrgResourceID((m["user_id"].(string)))
+				role := ""
+				if h.roleAttribute != "" {
+					role = m[h.roleAttribute].(string)
+				}
+				return schema.HashString(role + teamID + userID + m["permission"].(string))
+			},
+			Elem: &schema.Resource{
+				Schema: permissionSchema,
+			},
+		},
+	}
+
+	for k, v := range commonSchema {
+		s[k] = v
+	}
+}
+
+func (h *resourcePermissionsHelper) updatePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, orgID := OAPIClientFromNewOrgResource(meta, d)
+
+	resourceID, err := h.getResource(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var list []interface{}
+	if v, ok := d.GetOk("permissions"); ok {
+		list = v.(*schema.Set).List()
+	}
+	var permissionList []*models.SetResourcePermissionCommand
+	for _, permission := range list {
+		permission := permission.(map[string]interface{})
+		permissionItem := models.SetResourcePermissionCommand{}
+		if h.roleAttribute != "" && permission[h.roleAttribute].(string) != "" {
+			permissionItem.BuiltInRole = permission[h.roleAttribute].(string)
+		}
+		_, teamIDStr := SplitOrgResourceID(permission["team_id"].(string))
+		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
+		if teamID > 0 {
+			permissionItem.TeamID = teamID
+		}
+		_, userIDStr := SplitOrgResourceID(permission["user_id"].(string))
+		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
+		if userID > 0 {
+			permissionItem.UserID = userID
+		}
+		permissionItem.Permission = permission["permission"].(string)
+		permissionList = append(permissionList, &permissionItem)
+	}
+
+	if err := h.updateResourcePermissions(client, resourceID, permissionList); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(MakeOrgResourceID(orgID, resourceID))
+
+	return h.readPermissions(ctx, d, meta)
+}
+
+func (h *resourcePermissionsHelper) readPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, orgID, resourceID := OAPIClientFromExistingOrgResource(meta, d.Id())
+
+	// Check if the resource still exists
+	_, err := h.getResource(d, meta)
+	if err, shouldReturn := common.CheckReadError("resource", d, err); shouldReturn {
+		return err
+	}
+
+	resp, err := client.AccessControl.GetResourcePermissions(resourceID, h.resourceType)
+	if err, shouldReturn := common.CheckReadError("permissions", d, err); shouldReturn {
+		return err
+	}
+
+	resourcePermissions := resp.Payload
+	var permissionItems []interface{}
+	for _, permission := range resourcePermissions {
+		// Only managed permissions can be provisioned through this resource, so we disregard the permissions obtained through custom and fixed roles here
+		if !permission.IsManaged || permission.IsInherited {
+			continue
+		}
+		permissionItem := make(map[string]interface{})
+		if h.roleAttribute != "" {
+			permissionItem[h.roleAttribute] = permission.BuiltInRole
+		}
+		permissionItem["team_id"] = strconv.FormatInt(permission.TeamID, 10)
+		permissionItem["user_id"] = strconv.FormatInt(permission.UserID, 10)
+		permissionItem["permission"] = permission.Permission
+
+		permissionItems = append(permissionItems, permissionItem)
+	}
+
+	d.SetId(MakeOrgResourceID(orgID, resourceID))
+	d.Set("org_id", strconv.FormatInt(orgID, 10))
+	d.Set("permissions", permissionItems)
+
+	return nil
+}
+
+func (h *resourcePermissionsHelper) deletePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// since permissions are tied to the resource, we can't really delete the permissions.
+	// we will simply remove all permissions, leaving a resource that only an admin can access.
+	// if for some reason the resource doesn't exist, we'll just ignore the error
+	client, _, resourceID := OAPIClientFromExistingOrgResource(meta, d.Id())
+	err := h.updateResourcePermissions(client, resourceID, []*models.SetResourcePermissionCommand{})
+	diags, _ := common.CheckReadError("permissions", d, err)
+	return diags
+}
+
+func (h *resourcePermissionsHelper) updateResourcePermissions(client *goapi.GrafanaHTTPAPI, uid string, permissions []*models.SetResourcePermissionCommand) error {
+	areEqual := func(a *models.ResourcePermissionDTO, b *models.SetResourcePermissionCommand) bool {
+		return a.Permission == b.Permission && a.TeamID == b.TeamID && a.UserID == b.UserID && a.BuiltInRole == b.BuiltInRole
+	}
+
+	listResp, err := client.AccessControl.GetResourcePermissions(uid, h.resourceType)
+	if err != nil {
+		return err
+	}
+
+	var permissionList []*models.SetResourcePermissionCommand
+deleteLoop:
+	for _, current := range listResp.Payload {
+		// Only managed and non-inherited permissions can be provisioned through this resource, so we disregard the permissions obtained through custom and fixed roles here
+		if !current.IsManaged || current.IsInherited {
+			continue
+		}
+		for _, new := range permissions {
+			if areEqual(current, new) {
+				continue deleteLoop
+			}
+		}
+
+		permToRemove := models.SetResourcePermissionCommand{
+			TeamID:      current.TeamID,
+			UserID:      current.UserID,
+			BuiltInRole: current.BuiltInRole,
+			Permission:  "",
+		}
+
+		permissionList = append(permissionList, &permToRemove)
+	}
+
+addLoop:
+	for _, new := range permissions {
+		for _, current := range listResp.Payload {
+			if areEqual(current, new) {
+				continue addLoop
+			}
+		}
+
+		permissionList = append(permissionList, new)
+	}
+
+	body := models.SetPermissionsCommand{Permissions: permissionList}
+	params := access_control.NewSetResourcePermissionsParams().
+		WithResource(h.resourceType).
+		WithResourceID(uid).
+		WithBody(&body)
+	_, err = client.AccessControl.SetResourcePermissions(params)
+
+	return err
+}

--- a/internal/resources/grafana/resource_dashboard_permission.go
+++ b/internal/resources/grafana/resource_dashboard_permission.go
@@ -1,37 +1,34 @@
 package grafana
 
 import (
-	"context"
-	"strconv"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	goapi "github.com/grafana/grafana-openapi-client-go/client"
-	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
 func resourceDashboardPermission() *common.Resource {
-	schema := &schema.Resource{
+	crudHelper := &resourcePermissionsHelper{
+		resourceType:  dashboardsPermissionsType,
+		roleAttribute: "role",
+		getResource:   resourceDashboardPermissionGet,
+	}
 
+	schema := &schema.Resource{
 		Description: `
 Manages the entire set of permissions for a dashboard. Permissions that aren't specified when applying this resource will be removed.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/)
 `,
 
-		CreateContext: UpdateDashboardPermissions,
-		ReadContext:   ReadDashboardPermissions,
-		UpdateContext: UpdateDashboardPermissions,
-		DeleteContext: DeleteDashboardPermissions,
+		CreateContext: crudHelper.updatePermissions,
+		ReadContext:   crudHelper.readPermissions,
+		UpdateContext: crudHelper.updatePermissions,
+		DeleteContext: crudHelper.deletePermissions,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"org_id": orgIDAttribute(),
 			"dashboard_id": {
 				Type:         schema.TypeInt,
 				ForceNew:     true,
@@ -49,51 +46,9 @@ Manages the entire set of permissions for a dashboard. Permissions that aren't s
 				ExactlyOneOf: []string{"dashboard_id", "dashboard_uid"},
 				Description:  "UID of the dashboard to apply permissions to.",
 			},
-			"permissions": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{}, nil
-				},
-				Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
-				// Ignore the org ID of the team/SA when hashing. It works with or without it.
-				Set: func(i interface{}) int {
-					m := i.(map[string]interface{})
-					_, teamID := SplitOrgResourceID(m["team_id"].(string))
-					_, userID := SplitOrgResourceID((m["user_id"].(string)))
-					return schema.HashString(m["role"].(string) + teamID + userID + m["permission"].(string))
-				},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"role": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor"}, false),
-							Description:  "Manage permissions for `Viewer` or `Editor` roles.",
-						},
-						"team_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the team to manage permissions for.",
-						},
-						"user_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the user or service account to manage permissions for.",
-						},
-						"permission": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"View", "Edit", "Admin"}, false),
-							Description:  "Permission to associate with item. Must be one of `View`, `Edit`, or `Admin`.",
-						},
-					},
-				},
-			},
 		},
 	}
+	crudHelper.addCommonSchemaAttributes(schema.Schema)
 
 	return common.NewLegacySDKResource(
 		"grafana_dashboard_permission",
@@ -102,109 +57,26 @@ Manages the entire set of permissions for a dashboard. Permissions that aren't s
 	)
 }
 
-func UpdateDashboardPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
-
-	var list []interface{}
-	if v, ok := d.GetOk("permissions"); ok {
-		list = v.(*schema.Set).List()
+func resourceDashboardPermissionGet(d *schema.ResourceData, meta interface{}) (string, error) {
+	client, _ := OAPIClientFromNewOrgResource(meta, d)
+	uid := d.Get("dashboard_uid").(string)
+	if d.Id() != "" {
+		client, _, uid = OAPIClientFromExistingOrgResource(meta, d.Id())
 	}
 
-	permissionList := models.UpdateDashboardACLCommand{}
-	for _, permission := range list {
-		permission := permission.(map[string]interface{})
-		permissionItem := models.DashboardACLUpdateItem{}
-		if permission["role"].(string) != "" {
-			permissionItem.Role = permission["role"].(string)
+	if uid != "" {
+		_, err := client.Dashboards.GetDashboardByUID(uid)
+		if err != nil {
+			return "", err
 		}
-		_, teamIDStr := SplitOrgResourceID(permission["team_id"].(string))
-		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
-		if teamID > 0 {
-			permissionItem.TeamID = teamID
-		}
-		_, userIDStr := SplitOrgResourceID(permission["user_id"].(string))
-		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
-		if userID > 0 {
-			permissionItem.UserID = userID
-		}
-		permissionItem.Permission = parsePermissionType(permission["permission"].(string))
-		permissionList.Items = append(permissionList.Items, &permissionItem)
+		d.Set("dashboard_uid", uid)
+		return uid, nil
 	}
-
-	var id string
-	if dashboardID, ok := d.GetOk("dashboard_id"); ok {
-		id = strconv.FormatInt(int64(dashboardID.(int)), 10)
-	} else {
-		id = d.Get("dashboard_uid").(string)
-	}
-
-	err := updateDashboardPermissions(client, id, &permissionList)
+	id := int64(d.Get("dashboard_id").(int))
+	dashboard, err := getDashboardByID(client, id)
 	if err != nil {
-		return diag.FromErr(err)
+		return "", err
 	}
-
-	d.SetId(MakeOrgResourceID(orgID, id))
-
-	return ReadDashboardPermissions(ctx, d, meta)
-}
-
-func ReadDashboardPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-	var resp interface {
-		GetPayload() []*models.DashboardACLInfoDTO
-	}
-	var err error
-
-	if idInt, _ := strconv.ParseInt(idStr, 10, 64); idInt == 0 {
-		// id is not an int, so it must be a uid
-		resp, err = client.DashboardPermissions.GetDashboardPermissionsListByUID(idStr)
-	} else {
-		resp, err = client.DashboardPermissions.GetDashboardPermissionsListByID(idInt)
-	}
-	if err, shouldReturn := common.CheckReadError("dashboard permissions", d, err); shouldReturn {
-		return err
-	}
-
-	dashboardPermissions := resp.GetPayload()
-	permissionItems := make([]interface{}, len(dashboardPermissions))
-	count := 0
-	for _, permission := range dashboardPermissions {
-		if permission.DashboardID != -1 {
-			permissionItem := make(map[string]interface{})
-			permissionItem["role"] = permission.Role
-			permissionItem["team_id"] = strconv.FormatInt(permission.TeamID, 10)
-			permissionItem["user_id"] = strconv.FormatInt(permission.UserID, 10)
-			permissionItem["permission"] = permission.PermissionName
-
-			permissionItems[count] = permissionItem
-			count++
-			d.Set("dashboard_id", permission.DashboardID)
-			d.Set("dashboard_uid", permission.UID)
-		}
-	}
-
-	d.Set("permissions", permissionItems)
-
-	return nil
-}
-
-func DeleteDashboardPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// since permissions are tied to dashboards, we can't really delete the permissions.
-	// we will simply remove all permissions, leaving a dashboard that only an admin can access.
-	// if for some reason the parent dashboard doesn't exist, we'll just ignore the error
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-	err := updateDashboardPermissions(client, idStr, &models.UpdateDashboardACLCommand{})
-	diags, _ := common.CheckReadError("dashboard permissions", d, err)
-	return diags
-}
-
-func updateDashboardPermissions(client *goapi.GrafanaHTTPAPI, id string, permissions *models.UpdateDashboardACLCommand) error {
-	var err error
-	if idInt, _ := strconv.ParseInt(id, 10, 64); idInt == 0 {
-		// id is not an int, so it must be a uid
-		_, err = client.DashboardPermissions.UpdateDashboardPermissionsByUID(id, permissions)
-	} else {
-		_, err = client.DashboardPermissions.UpdateDashboardPermissionsByID(idInt, permissions)
-	}
-	return err
+	d.Set("dashboard_uid", dashboard.UID)
+	return dashboard.UID, nil
 }

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -13,6 +14,7 @@ import (
 func TestAccDashboardPermission_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
+	randomName := acctest.RandString(6)
 	var (
 		dashboard models.DashboardFullWithMeta
 		team      models.TeamDTO
@@ -20,12 +22,11 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 		sa        models.ServiceAccountDTO
 	)
 
-	// TODO: Make parallelizable
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDashboardPermissionConfig(true, true),
+				Config: testAccDashboardPermissionConfig(randomName, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					dashboardCheckExists.exists("grafana_dashboard.testDashboard", &dashboard),
 					teamCheckExists.exists("grafana_team.testTeam", &team),
@@ -43,7 +44,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 			},
 			// Test remove permissions by not setting any permissions
 			{
-				Config: testAccDashboardPermissionConfig(true, false),
+				Config: testAccDashboardPermissionConfig(randomName, true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					dashboardCheckExists.exists("grafana_dashboard.testDashboard", &dashboard),
 					resource.TestCheckResourceAttr("grafana_dashboard_permission.testPermission", "permissions.#", "0"),
@@ -52,7 +53,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 			},
 			// Reapply permissions
 			{
-				Config: testAccDashboardPermissionConfig(true, true),
+				Config: testAccDashboardPermissionConfig(randomName, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					dashboardCheckExists.exists("grafana_dashboard.testDashboard", &dashboard),
 					teamCheckExists.exists("grafana_team.testTeam", &team),
@@ -65,7 +66,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 			},
 			// Test remove permissions by removing the resource
 			{
-				Config: testutils.WithoutResource(t, testAccDashboardPermissionConfig(true, true), "grafana_dashboard_permission.testPermission"),
+				Config: testutils.WithoutResource(t, testAccDashboardPermissionConfig(randomName, true, true), "grafana_dashboard_permission.testPermission"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					dashboardCheckExists.exists("grafana_dashboard.testDashboard", &dashboard),
 					checkDashboardPermissionsEmpty(&dashboard, false),
@@ -80,6 +81,7 @@ func TestAccDashboardPermission_basic(t *testing.T) {
 func TestAccDashboardPermission_fromDashboardID(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 
+	randomName := acctest.RandString(6)
 	var (
 		dashboard models.DashboardFullWithMeta
 		team      models.TeamDTO
@@ -87,12 +89,11 @@ func TestAccDashboardPermission_fromDashboardID(t *testing.T) {
 		sa        models.ServiceAccountDTO
 	)
 
-	// TODO: Make parallelizable
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDashboardPermissionConfig(false, true),
+				Config: testAccDashboardPermissionConfig(randomName, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					dashboardCheckExists.exists("grafana_dashboard.testDashboard", &dashboard),
 					teamCheckExists.exists("grafana_team.testTeam", &team),
@@ -102,11 +103,6 @@ func TestAccDashboardPermission_fromDashboardID(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_dashboard_permission.testPermission", "permissions.#", "5"),
 					checkDashboardPermissionsSet(&dashboard, &team, &user, &sa, false),
 				),
-			},
-			{
-				ImportState:       true,
-				ResourceName:      "grafana_dashboard_permission.testPermission",
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -186,7 +182,7 @@ func checkDashboardPermissions(dashboard *models.DashboardFullWithMeta, expected
 	return nil
 }
 
-func testAccDashboardPermissionConfig(refDashboardByUID bool, hasPermissions bool) string {
+func testAccDashboardPermissionConfig(name string, refDashboardByUID bool, hasPermissions bool) string {
 	ref := "dashboard_id = grafana_dashboard.testDashboard.dashboard_id"
 	if refDashboardByUID {
 		ref = "dashboard_uid = grafana_dashboard.testDashboard.uid"
@@ -220,33 +216,33 @@ func testAccDashboardPermissionConfig(refDashboardByUID bool, hasPermissions boo
 resource "grafana_dashboard" "testDashboard" {
     config_json = <<EOT
 {
-    "title": "Terraform Dashboard Permission Test Dashboard",
+    "title": "%[1]s",
     "id": 14,
     "version": "43",
-    "uid": "someuid"
+    "uid": "%[1]s"
 }
 EOT
 }
 
 resource "grafana_team" "testTeam" {
-  name = "terraform-test-team-permissions"
+  name = "%[1]s"
 }
 
 resource "grafana_user" "testAdminUser" {
-  email    = "terraform-test-dashboard-permissions@localhost"
-  name     = "Terraform Test Dashboard Permissions"
-  login    = "ttdp"
+  email    = "%[1]s@localhost"
+  name     = "%[1]s"
+  login    = "%[1]s"
   password = "zyx987"
 }
 
 resource "grafana_service_account" "test" {
-	name        = "terraform-test-service-account-dashboard-perms"
+	name        = "%[1]s"
 	role 	    = "Editor"
 }
 
 resource "grafana_dashboard_permission" "testPermission" {
-  %s
-  %s
+  %[2]s
+  %[3]s
 }
-`, ref, perms)
+`, name, ref, perms)
 }

--- a/internal/resources/grafana/resource_data_source_permission.go
+++ b/internal/resources/grafana/resource_data_source_permission.go
@@ -1,38 +1,38 @@
 package grafana
 
 import (
-	"context"
-	"strconv"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	goapi "github.com/grafana/grafana-openapi-client-go/client"
-	"github.com/grafana/grafana-openapi-client-go/client/access_control"
-	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
 func resourceDatasourcePermission() *common.Resource {
-	schema := &schema.Resource{
+	crudHelper := &resourcePermissionsHelper{
+		resourceType:  datasourcesPermissionsType,
+		roleAttribute: "built_in_role",
+		getResource:   resourceDatasourcePermissionGet,
+	}
 
+	schema := &schema.Resource{
 		Description: `
 Manages the entire set of permissions for a datasource. Permissions that aren't specified when applying this resource will be removed.
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/)
 `,
 
-		CreateContext: UpdateDatasourcePermissions,
-		ReadContext:   ReadDatasourcePermissions,
-		UpdateContext: UpdateDatasourcePermissions,
-		DeleteContext: DeleteDatasourcePermissions,
+		CreateContext: crudHelper.updatePermissions,
+		ReadContext:   crudHelper.readPermissions,
+		UpdateContext: crudHelper.updatePermissions,
+		DeleteContext: crudHelper.deletePermissions,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"org_id": orgIDAttribute(),
 			"datasource_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				Deprecated:   "Use `datasource_uid` instead",
 				Description:  "Deprecated: Use `datasource_uid` instead.",
 				AtLeastOneOf: []string{"datasource_id", "datasource_uid"},
@@ -41,55 +41,13 @@ Manages the entire set of permissions for a datasource. Permissions that aren't 
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				Description:  "UID of the datasource to apply permissions to.",
 				AtLeastOneOf: []string{"datasource_id", "datasource_uid"},
 			},
-			"permissions": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{}, nil
-				},
-				Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
-				// Ignore the org ID of the team/SA when hashing. It works with or without it.
-				Set: func(i interface{}) int {
-					m := i.(map[string]interface{})
-					_, teamID := SplitOrgResourceID(m["team_id"].(string))
-					_, userID := SplitOrgResourceID((m["user_id"].(string)))
-					return schema.HashString(m["built_in_role"].(string) + teamID + userID + m["permission"].(string))
-				},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"team_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the team to manage permissions for.",
-						},
-						"user_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the user or service account to manage permissions for.",
-						},
-						"built_in_role": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "",
-							ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor", "Admin"}, false),
-							Description:  "Name of the basic role to manage permissions for. Options: `Viewer`, `Editor` or `Admin`. Can only be set from Grafana v9.2.3+.",
-						},
-						"permission": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Query", "Edit", "Admin"}, false),
-							Description:  "Permission to associate with item. Options: `Query`, `Edit` or `Admin` (`Admin` can only be used with Grafana v10.3.0+).",
-						},
-					},
-				},
-			},
 		},
 	}
+	crudHelper.addCommonSchemaAttributes(schema.Schema)
 
 	return common.NewLegacySDKResource(
 		"grafana_data_source_permission",
@@ -98,152 +56,19 @@ Manages the entire set of permissions for a datasource. Permissions that aren't 
 	)
 }
 
-func UpdateDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
-
-	var list []interface{}
-	if v, ok := d.GetOk("permissions"); ok {
-		list = v.(*schema.Set).List()
+func resourceDatasourcePermissionGet(d *schema.ResourceData, meta interface{}) (string, error) {
+	client, _ := OAPIClientFromNewOrgResource(meta, d)
+	_, id := SplitOrgResourceID(d.Get("datasource_uid").(string))
+	if d.Id() != "" {
+		client, _, id = OAPIClientFromExistingOrgResource(meta, d.Id())
 	}
-
-	// TODO: Switch to UID, but support both until next major release
-	id := d.Get("datasource_uid").(string)
 	if id == "" {
-		id = d.Get("datasource_id").(string)
+		_, id = SplitOrgResourceID(d.Get("datasource_id").(string))
 	}
-	_, id = SplitOrgResourceID(id)
 	datasource, err := getDatasourceByUIDOrID(client, id)
 	if err != nil {
-		return diag.FromErr(err)
+		return "", err
 	}
-
-	var configuredPermissions []*models.SetResourcePermissionCommand
-	for _, permission := range list {
-		permission := permission.(map[string]interface{})
-		var permissionItem models.SetResourcePermissionCommand
-		_, teamIDStr := SplitOrgResourceID(permission["team_id"].(string))
-		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
-		if teamID > 0 {
-			permissionItem.TeamID = teamID
-		}
-		_, userIDStr := SplitOrgResourceID(permission["user_id"].(string))
-		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
-		if userID > 0 {
-			permissionItem.UserID = userID
-		}
-		if permission["built_in_role"].(string) != "" {
-			permissionItem.BuiltInRole = permission["built_in_role"].(string)
-		}
-		permissionItem.Permission = permission["permission"].(string)
-		configuredPermissions = append(configuredPermissions, &permissionItem)
-	}
-
-	if err := updateResourcePermissions(client, datasource.UID, datasourcesPermissionsType, configuredPermissions); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(MakeOrgResourceID(orgID, datasource.UID))
-
-	return ReadDatasourcePermissions(ctx, d, meta)
-}
-
-func ReadDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, id := OAPIClientFromExistingOrgResource(meta, d.Id())
-
-	datasource, err := getDatasourceByUIDOrID(client, id)
-	if diag, shouldReturn := common.CheckReadError("data source permissions", d, err); shouldReturn {
-		return diag
-	}
-
-	listResp, err := client.AccessControl.GetResourcePermissions(datasource.UID, datasourcesPermissionsType)
-	if err, shouldReturn := common.CheckReadError("datasource permissions", d, err); shouldReturn {
-		return err
-	}
-
-	var permissionItems []interface{}
-	for _, permission := range listResp.Payload {
-		// Only managed permissions can be provisioned through this resource, so we disregard the permissions obtained through custom and fixed roles here
-		if !permission.IsManaged {
-			continue
-		}
-		permissionItem := make(map[string]interface{})
-		permissionItem["built_in_role"] = permission.BuiltInRole
-		permissionItem["team_id"] = strconv.FormatInt(permission.TeamID, 10)
-		permissionItem["user_id"] = strconv.FormatInt(permission.UserID, 10)
-		permissionItem["permission"] = permission.Permission
-
-		permissionItems = append(permissionItems, permissionItem)
-	}
-
-	d.SetId(MakeOrgResourceID(datasource.OrgID, datasource.UID))
-	d.Set("permissions", permissionItems)
-
-	return nil
-}
-
-func DeleteDatasourcePermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, id := OAPIClientFromExistingOrgResource(meta, d.Id())
-
-	datasource, err := getDatasourceByUIDOrID(client, id)
-	if diags, shouldReturn := common.CheckReadError("data source permissions", d, err); shouldReturn {
-		return diags
-	}
-
-	err = updateResourcePermissions(client, datasource.UID, datasourcesPermissionsType, []*models.SetResourcePermissionCommand{})
-	diags, _ := common.CheckReadError("datasource permissions", d, err)
-	return diags
-}
-
-func updateResourcePermissions(client *goapi.GrafanaHTTPAPI, uid, resourceType string, permissions []*models.SetResourcePermissionCommand) error {
-	areEqual := func(a *models.ResourcePermissionDTO, b *models.SetResourcePermissionCommand) bool {
-		return a.Permission == b.Permission && a.TeamID == b.TeamID && a.UserID == b.UserID && a.BuiltInRole == b.BuiltInRole
-	}
-
-	listResp, err := client.AccessControl.GetResourcePermissions(uid, resourceType)
-	if err != nil {
-		return err
-	}
-
-	var permissionList []*models.SetResourcePermissionCommand
-deleteLoop:
-	for _, current := range listResp.Payload {
-		// Only managed and non-inherited permissions can be provisioned through this resource, so we disregard the permissions obtained through custom and fixed roles here
-		if !current.IsManaged || current.IsInherited {
-			continue
-		}
-		for _, new := range permissions {
-			if areEqual(current, new) {
-				continue deleteLoop
-			}
-		}
-
-		permToRemove := models.SetResourcePermissionCommand{
-			TeamID:      current.TeamID,
-			UserID:      current.UserID,
-			BuiltInRole: current.BuiltInRole,
-			Permission:  "",
-		}
-
-		permissionList = append(permissionList, &permToRemove)
-	}
-
-addLoop:
-	for _, new := range permissions {
-		for _, current := range listResp.Payload {
-			if areEqual(current, new) {
-				continue addLoop
-			}
-		}
-
-		permissionList = append(permissionList, new)
-	}
-
-	body := models.SetPermissionsCommand{Permissions: permissionList}
-	params := access_control.NewSetResourcePermissionsParams().
-		WithResource(resourceType).
-		WithResourceID(uid).
-		WithBody(&body)
-	_, err = client.AccessControl.SetResourcePermissions(params)
-
-	return err
+	d.Set("datasource_uid", datasource.UID)
+	return datasource.UID, nil
 }

--- a/internal/resources/grafana/resource_data_source_permission_test.go
+++ b/internal/resources/grafana/resource_data_source_permission_test.go
@@ -80,7 +80,6 @@ func TestAccDatasourcePermission_WithID(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					datasourcePermissionsCheckExists.exists("grafana_data_source_permission.fooPermissions", &ds),
 					resource.TestCheckResourceAttrSet("grafana_data_source_permission.fooPermissions", "datasource_id"),
-					resource.TestCheckNoResourceAttr("grafana_data_source_permission.fooPermissions", "datasource_uid"),
 					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.#", "4"),
 					resource.TestCheckResourceAttr("grafana_data_source_permission.fooPermissions", "permissions.0.permission", "Edit"),
 				),

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -1,87 +1,43 @@
 package grafana
 
 import (
-	"context"
-	"strconv"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
 func resourceFolderPermission() *common.Resource {
-	schema := &schema.Resource{
+	crudHelper := &resourcePermissionsHelper{
+		resourceType:  foldersPermissionsType,
+		roleAttribute: "role",
+		getResource:   resourceFolderPermissionGet,
+	}
 
+	schema := &schema.Resource{
 		Description: `
 Manages the entire set of permissions for a folder. Permissions that aren't specified when applying this resource will be removed.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)
 `,
 
-		CreateContext: UpdateFolderPermissions,
-		ReadContext:   ReadFolderPermissions,
-		UpdateContext: UpdateFolderPermissions,
-		DeleteContext: DeleteFolderPermissions,
+		CreateContext: crudHelper.updatePermissions,
+		ReadContext:   crudHelper.readPermissions,
+		UpdateContext: crudHelper.updatePermissions,
+		DeleteContext: crudHelper.deletePermissions,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"org_id": orgIDAttribute(),
 			"folder_uid": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The UID of the folder.",
 			},
-			"permissions": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{}, nil
-				},
-				Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
-				// Ignore the org ID of the team/SA when hashing. It works with or without it.
-				Set: func(i interface{}) int {
-					m := i.(map[string]interface{})
-					_, teamID := SplitOrgResourceID(m["team_id"].(string))
-					_, userID := SplitOrgResourceID(m["user_id"].(string))
-					return schema.HashString(m["role"].(string) + teamID + userID + m["permission"].(string))
-				},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"role": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor"}, false),
-							Description:  "Manage permissions for `Viewer` or `Editor` roles.",
-						},
-						"team_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the team to manage permissions for.",
-						},
-						"user_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the user or service account to manage permissions for.",
-						},
-						"permission": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"View", "Edit", "Admin"}, false),
-							Description:  "Permission to associate with item. Must be one of `View`, `Edit`, or `Admin`.",
-						},
-					},
-				},
-			},
 		},
 	}
+	crudHelper.addCommonSchemaAttributes(schema.Schema)
 
 	return common.NewLegacySDKResource(
 		"grafana_folder_permission",
@@ -90,102 +46,17 @@ Manages the entire set of permissions for a folder. Permissions that aren't spec
 	)
 }
 
-func UpdateFolderPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
-
-	var list []interface{}
-	if v, ok := d.GetOk("permissions"); ok {
-		list = v.(*schema.Set).List()
+func resourceFolderPermissionGet(d *schema.ResourceData, meta interface{}) (string, error) {
+	client, _ := OAPIClientFromNewOrgResource(meta, d)
+	uid := d.Get("folder_uid").(string)
+	if d.Id() != "" {
+		client, _, uid = OAPIClientFromExistingOrgResource(meta, d.Id())
 	}
-	var permissionList []*models.SetResourcePermissionCommand
-	for _, permission := range list {
-		permission := permission.(map[string]interface{})
-		permissionItem := models.SetResourcePermissionCommand{}
-		if permission["role"].(string) != "" {
-			permissionItem.BuiltInRole = permission["role"].(string)
-		}
-		_, teamIDStr := SplitOrgResourceID(permission["team_id"].(string))
-		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
-		if teamID > 0 {
-			permissionItem.TeamID = teamID
-		}
-		_, userIDStr := SplitOrgResourceID(permission["user_id"].(string))
-		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
-		if userID > 0 {
-			permissionItem.UserID = userID
-		}
-		permissionItem.Permission = permission["permission"].(string)
-		permissionList = append(permissionList, &permissionItem)
+	resp, err := client.Folders.GetFolderByUID(uid)
+	if err != nil {
+		return "", err
 	}
-
-	folderUID := d.Get("folder_uid").(string)
-
-	if err := updateResourcePermissions(client, folderUID, foldersPermissionsType, permissionList); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(MakeOrgResourceID(orgID, folderUID))
-
-	return ReadFolderPermissions(ctx, d, meta)
-}
-
-func ReadFolderPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID, folderUID := OAPIClientFromExistingOrgResource(meta, d.Id())
-
-	// Check if the folder still exists
-	_, err := client.Folders.GetFolderByUID(folderUID)
-	if err, shouldReturn := common.CheckReadError("folder", d, err); shouldReturn {
-		return err
-	}
-
-	resp, err := client.AccessControl.GetResourcePermissions(folderUID, foldersPermissionsType)
-	if err, shouldReturn := common.CheckReadError("folder permissions", d, err); shouldReturn {
-		return err
-	}
-
-	folderPermissions := resp.Payload
-	var permissionItems []interface{}
-	for _, permission := range folderPermissions {
-		// Only managed permissions can be provisioned through this resource, so we disregard the permissions obtained through custom and fixed roles here
-		if !permission.IsManaged || permission.IsInherited {
-			continue
-		}
-		permissionItem := make(map[string]interface{})
-		permissionItem["role"] = permission.BuiltInRole
-		permissionItem["team_id"] = strconv.FormatInt(permission.TeamID, 10)
-		permissionItem["user_id"] = strconv.FormatInt(permission.UserID, 10)
-		permissionItem["permission"] = permission.Permission
-
-		permissionItems = append(permissionItems, permissionItem)
-	}
-
-	d.SetId(MakeOrgResourceID(orgID, folderUID))
-	d.Set("org_id", strconv.FormatInt(orgID, 10))
-	d.Set("folder_uid", folderUID)
-	d.Set("permissions", permissionItems)
-
-	return nil
-}
-
-func DeleteFolderPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// since permissions are tied to folders, we can't really delete the permissions.
-	// we will simply remove all permissions, leaving a folder that only an admin can access.
-	// if for some reason the parent folder doesn't exist, we'll just ignore the error
-	client, _, folderUID := OAPIClientFromExistingOrgResource(meta, d.Id())
-	err := updateResourcePermissions(client, folderUID, foldersPermissionsType, []*models.SetResourcePermissionCommand{})
-	diags, _ := common.CheckReadError("folder permissions", d, err)
-	return diags
-}
-
-func parsePermissionType(permission string) models.PermissionType {
-	permissionInt := models.PermissionType(-1)
-	switch permission {
-	case "View":
-		permissionInt = models.PermissionType(1)
-	case "Edit":
-		permissionInt = models.PermissionType(2)
-	case "Admin":
-		permissionInt = models.PermissionType(4)
-	}
-	return permissionInt
+	folder := resp.Payload
+	d.Set("folder_uid", folder.UID)
+	return folder.UID, nil
 }

--- a/internal/resources/grafana/resource_service_account_permission.go
+++ b/internal/resources/grafana/resource_service_account_permission.go
@@ -1,19 +1,18 @@
 package grafana
 
 import (
-	"context"
 	"strconv"
 
-	goapi "github.com/grafana/grafana-openapi-client-go/client"
-	"github.com/grafana/grafana-openapi-client-go/client/access_control"
-	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceServiceAccountPermission() *common.Resource {
+	crudHelper := &resourcePermissionsHelper{
+		resourceType: serviceAccountsPermissionsType,
+		getResource:  resourceServiceAccountPermissionGet,
+	}
+
 	schema := &schema.Resource{
 		Description: `
 Manages the entire set of permissions for a service account. Permissions that aren't specified when applying this resource will be removed.
@@ -22,60 +21,29 @@ Manages the entire set of permissions for a service account. Permissions that ar
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/#manage-users-and-teams-permissions-for-a-service-account-in-grafana)`,
 
-		CreateContext: CreateServiceAccountPermissions,
-		ReadContext:   ReadServiceAccountPermissions,
-		UpdateContext: UpdateServiceAccountPermissions,
-		DeleteContext: DeleteServiceAccountPermissions,
+		CreateContext: crudHelper.updatePermissions,
+		ReadContext:   crudHelper.readPermissions,
+		UpdateContext: crudHelper.updatePermissions,
+		DeleteContext: crudHelper.deletePermissions,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		Schema: map[string]*schema.Schema{
-			"org_id": orgIDAttribute(),
 			"service_account_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The id of the service account.",
-			},
-			"permissions": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{}, nil
-				},
-				Description: "The permission items to add/update. Items that are omitted from the list will be removed.",
-				// Ignore the org ID of the team when hashing. It works with or without it.
-				Set: func(i interface{}) int {
-					m := i.(map[string]interface{})
-					_, teamID := SplitOrgResourceID(m["team_id"].(string))
-					_, userID := SplitOrgResourceID((m["user_id"].(string)))
-					return schema.HashString(teamID + userID + m["permission"].(string))
-				},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"team_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the team to manage permissions for. Specify either this or `user_id`.",
-						},
-						"user_id": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "0",
-							Description: "ID of the user or service account to manage permissions for. Specify either this or `team_id`.",
-						},
-						"permission": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Edit", "Admin"}, false),
-							Description:  "Permission to associate with item. Must be `Edit` or `Admin`.",
-						},
-					},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, old = SplitOrgResourceID(old)
+					_, new = SplitOrgResourceID(new)
+					return old == new
 				},
 			},
 		},
 	}
+	crudHelper.addCommonSchemaAttributes(schema.Schema)
 
 	return common.NewLegacySDKResource(
 		"grafana_service_account_permission",
@@ -84,163 +52,22 @@ Manages the entire set of permissions for a service account. Permissions that ar
 	)
 }
 
-func ReadServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	saPerms, diags := getServiceAccountPermissions(ctx, d, meta)
-	d.Set("permissions", saPerms)
-	return diags
-}
-
-func CreateServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
-	_, idStr := SplitOrgResourceID(d.Get("service_account_id").(string))
-	d.SetId(MakeOrgResourceID(orgID, idStr))
-
-	// On creation, the service account permissions are unknown, we need to start by reading them.
-	currentPerms, diags := getServiceAccountPermissions(ctx, d, meta)
-	if diags.HasError() {
-		return diags
+func resourceServiceAccountPermissionGet(d *schema.ResourceData, meta interface{}) (string, error) {
+	client, _ := OAPIClientFromNewOrgResource(meta, d)
+	_, id := SplitOrgResourceID(d.Get("service_account_id").(string))
+	if d.Id() != "" {
+		client, _, id = OAPIClientFromExistingOrgResource(meta, d.Id())
 	}
-	err := updateServiceAccountPermissions(client, idStr, currentPerms, d.Get("permissions"))
+	idInt, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
-		return diag.FromErr(err)
+		return "", err
 	}
-
-	return ReadServiceAccountPermissions(ctx, d, meta)
-}
-
-func UpdateServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-
-	old, new := d.GetChange("permissions")
-	err := updateServiceAccountPermissions(client, idStr, old, new)
+	resp, err := client.ServiceAccounts.RetrieveServiceAccount(idInt)
 	if err != nil {
-		return diag.FromErr(err)
+		return "", err
 	}
-
-	return ReadServiceAccountPermissions(ctx, d, meta)
-}
-
-func DeleteServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-
-	_, serviceAccountID := SplitOrgResourceID(d.Get("service_account_id").(string))
-	id, err := strconv.ParseInt(serviceAccountID, 10, 64)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	_, err = client.ServiceAccounts.RetrieveServiceAccount(id)
-	if diags, shouldReturn := common.CheckReadError("service account permissions", d, err); shouldReturn {
-		return diags
-	}
-
-	return diag.FromErr(updateServiceAccountPermissions(client, idStr, d.Get("permissions"), nil))
-}
-
-func getServiceAccountPermissions(ctx context.Context, d *schema.ResourceData, meta interface{}) (interface{}, diag.Diagnostics) {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-
-	resp, err := client.AccessControl.GetResourcePermissions(idStr, serviceAccountsPermissionsType)
-	if err, shouldReturn := common.CheckReadError("service account permissions", d, err); shouldReturn {
-		return nil, err
-	}
-
-	saPerms := make([]interface{}, 0)
-	for _, p := range resp.Payload {
-		// Only managed service account permissions can be provisioned through this resource.
-		if !p.IsManaged {
-			continue
-		}
-		permMap := map[string]interface{}{
-			"team_id":    strconv.FormatInt(p.TeamID, 10),
-			"user_id":    strconv.FormatInt(p.UserID, 10),
-			"permission": p.Permission,
-		}
-		saPerms = append(saPerms, permMap)
-	}
-
-	return saPerms, nil
-}
-
-func updateServiceAccountPermissions(client *goapi.GrafanaHTTPAPI, idStr string, from, to interface{}) error {
-	oldTeamPerms := make(map[int64]string, 0)
-	oldUserPerms := make(map[int64]string, 0)
-	for _, p := range listOrSet(from) {
-		perm := p.(map[string]interface{})
-		_, teamIDStr := SplitOrgResourceID(perm["team_id"].(string))
-		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
-		_, userIDStr := SplitOrgResourceID(perm["user_id"].(string))
-		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
-		if teamID > 0 {
-			oldTeamPerms[teamID] = perm["permission"].(string)
-		}
-		if userID > 0 {
-			oldUserPerms[userID] = perm["permission"].(string)
-		}
-	}
-
-	var permissionList []*models.SetResourcePermissionCommand
-
-	// Iterate over permissions from the configuration (the desired permission setup)
-	for _, p := range listOrSet(to) {
-		permission := p.(map[string]interface{})
-		permissionItem := models.SetResourcePermissionCommand{}
-		_, teamIDStr := SplitOrgResourceID(permission["team_id"].(string))
-		teamID, _ := strconv.ParseInt(teamIDStr, 10, 64)
-		_, userIDStr := SplitOrgResourceID(permission["user_id"].(string))
-		userID, _ := strconv.ParseInt(userIDStr, 10, 64)
-		if teamID > 0 {
-			perm, has := oldTeamPerms[teamID]
-			if has {
-				delete(oldTeamPerms, teamID)
-				// Skip permissions that have not been changed
-				if perm == permission["permission"].(string) {
-					continue
-				}
-			}
-			permissionItem.TeamID = teamID
-		} else if userID > 0 {
-			perm, has := oldUserPerms[userID]
-			if has {
-				delete(oldUserPerms, userID)
-				if perm == permission["permission"].(string) {
-					continue
-				}
-			}
-			permissionItem.UserID = userID
-		}
-		permissionItem.Permission = permission["permission"].(string)
-		permissionList = append(permissionList, &permissionItem)
-	}
-
-	// Remove the permissions that are in the state but not in the config
-	for teamID := range oldTeamPerms {
-		permissionList = append(permissionList, &models.SetResourcePermissionCommand{
-			TeamID:     teamID,
-			Permission: "",
-		})
-	}
-	for userID := range oldUserPerms {
-		permissionList = append(permissionList, &models.SetResourcePermissionCommand{
-			UserID:     userID,
-			Permission: "",
-		})
-	}
-
-	params := access_control.NewSetResourcePermissionsParams().
-		WithResource(serviceAccountsPermissionsType).
-		WithResourceID(idStr).
-		WithBody(&models.SetPermissionsCommand{Permissions: permissionList})
-	_, err := client.AccessControl.SetResourcePermissions(params)
-	return err
-}
-
-func listOrSet(v interface{}) []interface{} {
-	if v == nil {
-		return make([]interface{}, 0)
-	}
-	if v, ok := v.(*schema.Set); ok {
-		return v.List()
-	}
-	return v.([]interface{})
+	sa := resp.Payload
+	id = strconv.FormatInt(sa.ID, 10)
+	d.Set("service_account_id", id)
+	return id, nil
 }

--- a/internal/resources/grafana/resource_service_account_permission_test.go
+++ b/internal/resources/grafana/resource_service_account_permission_test.go
@@ -25,9 +25,13 @@ func TestAccServiceAccountPermission_basic(t *testing.T) {
 				Config: testServiceAccountPermissionsConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					serviceAccountPermissionsCheckExists.exists("grafana_service_account_permission.test_permissions", &sa),
-					resource.TestMatchResourceAttr("grafana_service_account_permission.test_permissions", "service_account_id", defaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_service_account_permission.test_permissions", "permissions.#", "3"),
 				),
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "grafana_service_account_permission.test_permissions",
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -49,11 +53,15 @@ func TestAccServiceAccountPermission_inOrg(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkResourceIsInOrg("grafana_service_account_permission.test", "grafana_organization.test"),
 					serviceAccountPermissionsCheckExists.exists("grafana_service_account_permission.test", &sa),
-					resource.TestMatchResourceAttr("grafana_service_account_permission.test", "service_account_id", nonDefaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_service_account_permission.test", "permissions.#", "1"),
 					resource.TestMatchResourceAttr("grafana_service_account_permission.test", "permissions.0.team_id", nonDefaultOrgIDRegexp),
 					resource.TestCheckResourceAttr("grafana_service_account_permission.test", "permissions.0.permission", "Edit"),
 				),
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "grafana_service_account_permission.test",
+				ImportStateVerify: true,
 			},
 			// Test destroy
 			{
@@ -111,13 +119,13 @@ func testServiceAccountPermissionsConfig_inOrg(name string) string {
 
 	resource "grafana_team" "test" {
 		org_id  = grafana_organization.test.id
-		name    = "test"
+		name    = "%[1]s"
 		members = []
 	}
 	
 	resource "grafana_service_account" "test" {
 		org_id = grafana_organization.test.id
-		name   = "test"
+		name   = "%[1]s"
 		role   = "Viewer"
 	}
 	


### PR DESCRIPTION
Current situation:
- Folder and datasource permissions have copy pasted code and same API
- Service account permissions has the same API as the previous two resources, but different code
- Dashboard permissions use a deprecated API

This PR brings all of the resource's code into a common helper