### PR TITLE
Plugin Framework: Fix `Configure` function

### DIFF
--- a/internal/resources/cloud/common.go
+++ b/internal/resources/cloud/common.go
@@ -54,12 +54,8 @@ type basePluginFrameworkResource struct {
 }
 
 func (r *basePluginFrameworkResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		resp.Diagnostics.AddError(
-			"Unconfigured Cloud API client",
-			"the Cloud API client is required for this resource. Set the cloud_access_policy_token provider attribute",
-		)
-
+	// Configure is called multiple times (sometimes when ProviderData is not yet available), we only want to configure once
+	if req.ProviderData == nil || r.client != nil {
 		return
 	}
 

--- a/internal/resources/cloud/resource_cloud_org_member.go
+++ b/internal/resources/cloud/resource_cloud_org_member.go
@@ -103,6 +103,11 @@ func (r *orgMemberResource) ImportState(ctx context.Context, req resource.Import
 }
 
 func (r *orgMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("client not configured", "client not configured")
+		return
+	}
+
 	// Read Terraform plan data into the model
 	var data resourceOrgMemberModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -159,6 +164,11 @@ func (r *orgMemberResource) Read(ctx context.Context, req resource.ReadRequest, 
 }
 
 func (r *orgMemberResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("client not configured", "client not configured")
+		return
+	}
+
 	// Read Terraform plan data into the model
 	var data resourceOrgMemberModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -194,6 +204,11 @@ func (r *orgMemberResource) Update(ctx context.Context, req resource.UpdateReque
 }
 
 func (r *orgMemberResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	if r.client == nil {
+		resp.Diagnostics.AddError("client not configured", "client not configured")
+		return
+	}
+
 	// Read Terraform prior state data into the model
 	var data resourceOrgMemberModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -212,6 +227,10 @@ func (r *orgMemberResource) Delete(ctx context.Context, req resource.DeleteReque
 }
 
 func (r *orgMemberResource) readFromID(ctx context.Context, id string) (*resourceOrgMemberModel, diag.Diagnostics) {
+	if r.client == nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("client not configured", "client not configured")}
+	}
+
 	split, err := resourceOrgMemberID.Split(id)
 	if err != nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unable to split ID", err.Error())}

--- a/internal/resources/grafana/common_resource_permission.go
+++ b/internal/resources/grafana/common_resource_permission.go
@@ -164,12 +164,15 @@ func (r *resourcePermissionBase) readItem(id string, checkExistsFunc func(client
 }
 
 func (r *resourcePermissionBase) writeItem(itemID string, data *resourcePermissionItemBaseModel) diag.Diagnostics {
-	client, orgID := r.clientFromNewOrgResource(data.OrgID.ValueString())
+	client, orgID, err := r.clientFromNewOrgResource(data.OrgID.ValueString())
+	if err != nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Failed to get client", err.Error())}
+	}
+
 	data.OrgID = types.StringValue(strconv.FormatInt(orgID, 10))
 	_, itemID = SplitOrgResourceID(itemID)
 	data.ResourceID = types.StringValue(itemID)
 
-	var err error
 	switch {
 	case !data.User.IsNull():
 		_, userIDStr := SplitOrgResourceID(data.User.ValueString())

--- a/internal/resources/grafana/resource_role_assignment_item.go
+++ b/internal/resources/grafana/resource_role_assignment_item.go
@@ -132,7 +132,11 @@ func (r *resourceRoleAssignmentItem) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	client, orgID := r.clientFromNewOrgResource(data.OrgID.ValueString())
+	client, orgID, err := r.clientFromNewOrgResource(data.OrgID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to get client", err.Error())
+		return
+	}
 
 	// Get existing role assignments
 	resourceRoleAssignmentMutex.Lock()

--- a/testdata/integration/main.tf
+++ b/testdata/integration/main.tf
@@ -12,6 +12,18 @@ provider "grafana" {
   auth = "admin:admin"
 }
 
+resource "grafana_team" "my_team" {
+  name = "My Team"
+}
+
 resource "grafana_folder" "my_folder" {
   title = "My Folder"
+}
+
+// This resource is implemented by the Terraform Plugin Framework
+// We're testing that both the legacy SDK (folder resource) and the new SDK/Plugin Framework work correctly
+resource "grafana_folder_permission_item" "my_folder_permission" {
+  folder_uid = grafana_folder.my_folder.uid
+  team       = grafana_team.my_team.id
+  permission = "Edit"
 }


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1485 
I was using the `Configure` function of resources to extract the grafana client 
Turns out that this function is called before ProviderData is even initialized in real world scenarios 

I moved the client exist check down to where the client is actually used and now the resources work as shown in the modified integration test which used to fail before the fix