### PR TITLE
Alerting Notification Policy: Allow inheriting contact point

### DIFF
--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -65,7 +65,7 @@ resource "grafana_notification_policy" "my_notification_policy" {
       match = "=~"
       value = "host.*|host-b.*"
     }
-    contact_point = grafana_contact_point.a_contact_point.name
+    contact_point = grafana_contact_point.a_contact_point.name // This can be omitted to inherit from the parent
     continue      = true
     mute_timings  = [grafana_mute_timing.a_mute_timing.name]
 
@@ -79,7 +79,7 @@ resource "grafana_notification_policy" "my_notification_policy" {
         match = "="
         value = "subvalue"
       }
-      contact_point = grafana_contact_point.a_contact_point.name
+      contact_point = grafana_contact_point.a_contact_point.name // This can also be omitted to inherit from the parent's parent
       group_by      = ["..."]
     }
   }
@@ -120,12 +120,9 @@ resource "grafana_notification_policy" "my_notification_policy" {
 <a id="nestedblock--policy"></a>
 ### Nested Schema for `policy`
 
-Required:
-
-- `contact_point` (String) The contact point to route notifications that match this rule to.
-
 Optional:
 
+- `contact_point` (String) The contact point to route notifications that match this rule to.
 - `continue` (Boolean) Whether to continue matching subsequent rules if an alert matches the current rule. Otherwise, the rule will be 'consumed' by the first policy to match it.
 - `group_by` (List of String) A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. Required for root policy only. If empty, the parent grouping is used.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
@@ -148,12 +145,9 @@ Required:
 <a id="nestedblock--policy--policy"></a>
 ### Nested Schema for `policy.policy`
 
-Required:
-
-- `contact_point` (String) The contact point to route notifications that match this rule to.
-
 Optional:
 
+- `contact_point` (String) The contact point to route notifications that match this rule to.
 - `continue` (Boolean) Whether to continue matching subsequent rules if an alert matches the current rule. Otherwise, the rule will be 'consumed' by the first policy to match it.
 - `group_by` (List of String) A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. Required for root policy only. If empty, the parent grouping is used.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
@@ -176,12 +170,9 @@ Required:
 <a id="nestedblock--policy--policy--policy"></a>
 ### Nested Schema for `policy.policy.policy`
 
-Required:
-
-- `contact_point` (String) The contact point to route notifications that match this rule to.
-
 Optional:
 
+- `contact_point` (String) The contact point to route notifications that match this rule to.
 - `continue` (Boolean) Whether to continue matching subsequent rules if an alert matches the current rule. Otherwise, the rule will be 'consumed' by the first policy to match it.
 - `group_by` (List of String) A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. Required for root policy only. If empty, the parent grouping is used.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
@@ -206,11 +197,11 @@ Required:
 
 Required:
 
-- `contact_point` (String) The contact point to route notifications that match this rule to.
 - `group_by` (List of String) A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. Required for root policy only. If empty, the parent grouping is used.
 
 Optional:
 
+- `contact_point` (String) The contact point to route notifications that match this rule to.
 - `continue` (Boolean) Whether to continue matching subsequent rules if an alert matches the current rule. Otherwise, the rule will be 'consumed' by the first policy to match it.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
 - `group_wait` (String) Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.

--- a/examples/resources/grafana_notification_policy/resource.tf
+++ b/examples/resources/grafana_notification_policy/resource.tf
@@ -40,7 +40,7 @@ resource "grafana_notification_policy" "my_notification_policy" {
       match = "=~"
       value = "host.*|host-b.*"
     }
-    contact_point = grafana_contact_point.a_contact_point.name
+    contact_point = grafana_contact_point.a_contact_point.name // This can be omitted to inherit from the parent
     continue      = true
     mute_timings  = [grafana_mute_timing.a_mute_timing.name]
 
@@ -54,7 +54,7 @@ resource "grafana_notification_policy" "my_notification_policy" {
         match = "="
         value = "subvalue"
       }
-      contact_point = grafana_contact_point.a_contact_point.name
+      contact_point = grafana_contact_point.a_contact_point.name // This can also be omitted to inherit from the parent's parent
       group_by      = ["..."]
     }
   }

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -109,7 +109,7 @@ func policySchema(depth uint) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"contact_point": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The contact point to route notifications that match this rule to.",
 			},
 			"group_by": {


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1007 
Following this PR: https://github.com/grafana/grafana/pull/82007, this is now available in Grafana v11

Also made an improvement to `TestAccExampleWithReplace` which ensures that any replacement configured in the tests is actually done