### PR TITLE
Terraform Code Generation: Isolate CLI code

### DIFF
--- a/cmd/generate/cli.go
+++ b/cmd/generate/cli.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+)
+
+func run() error {
+	app := &cli.App{
+		Name:      "terraform-provider-grafana-generate",
+		Usage:     "Generate `terraform-provider-grafana` resources from your Grafana instance or Grafana Cloud account.",
+		UsageText: "terraform-provider-grafana-generate [options]",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "output-dir",
+				Aliases:  []string{"o"},
+				Usage:    "Output directory for generated resources",
+				Required: true,
+				EnvVars:  []string{"TFGEN_OUTPUT_DIR"},
+			},
+			&cli.BoolFlag{
+				Name:    "clobber",
+				Aliases: []string{"c"},
+				Usage:   "Delete all files in the output directory before generating resources",
+				EnvVars: []string{"TFGEN_CLOBBER"},
+			},
+			&cli.StringFlag{
+				Name:    "output-format",
+				Aliases: []string{"f"},
+				Usage: fmt.Sprintf("Output format for generated resources. "+
+					"Supported formats are: %v", outputFormats),
+				Value:   string(outputFormatHCL),
+				EnvVars: []string{"TFGEN_OUTPUT_FORMAT"},
+			},
+
+			// Grafana OSS flags
+			&cli.StringFlag{
+				Name:     "grafana-url",
+				Usage:    "URL of the Grafana instance to generate resources from",
+				Category: "Grafana",
+				EnvVars:  []string{"TF_GEN_GRAFANA_URL"},
+			},
+			&cli.StringFlag{
+				Name:     "grafana-auth",
+				Usage:    "Service account token or username:password for the Grafana instance",
+				Category: "Grafana",
+				EnvVars:  []string{"TFGEN_GRAFANA_AUTH"},
+			},
+
+			// Grafana Cloud flags
+			&cli.StringFlag{
+				Name:     "cloud-access-policy-token",
+				Usage:    "Access policy token for Grafana Cloud",
+				Category: "Grafana Cloud",
+				EnvVars:  []string{"TFGEN_CLOUD_ACCESS_POLICY_TOKEN"},
+			},
+			&cli.StringFlag{
+				Name:     "cloud-org",
+				Usage:    "Organization ID or name for Grafana Cloud",
+				Category: "Grafana Cloud",
+				EnvVars:  []string{"TFGEN_CLOUD_ORG"},
+			},
+			&cli.BoolFlag{
+				Name:     "cloud-create-stack-service-account",
+				Usage:    "Create a service account for each Grafana Cloud stack, allowing generation and management of resources in that stack.",
+				Category: "Grafana Cloud",
+				EnvVars:  []string{"TFGEN_CLOUD_CREATE_STACK_SERVICE_ACCOUNT"},
+			},
+			&cli.StringFlag{
+				Name:     "cloud-stack-service-account-name",
+				Usage:    "Name of the service account to create for each Grafana Cloud stack.",
+				Category: "Grafana Cloud",
+				EnvVars:  []string{"TFGEN_CLOUD_STACK_SERVICE_ACCOUNT_NAME"},
+				Value:    "tfgen-management",
+			},
+		},
+		InvalidFlagAccessHandler: func(ctx *cli.Context, s string) {
+			panic(fmt.Errorf("invalid flag access: %s", s))
+		},
+		Action: func(ctx *cli.Context) error {
+			cfg, err := parseFlags(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to parse flags: %w", err)
+			}
+			return generate(ctx.Context, cfg)
+		},
+	}
+
+	return app.Run(os.Args)
+}
+
+func parseFlags(ctx *cli.Context) (*config, error) {
+	config := &config{
+		outputDir:                      ctx.String("output-dir"),
+		clobber:                        ctx.Bool("clobber"),
+		format:                         outputFormat(ctx.String("output-format")),
+		grafanaURL:                     ctx.String("grafana-url"),
+		grafanaAuth:                    ctx.String("grafana-auth"),
+		cloudAccessPolicyToken:         ctx.String("cloud-access-policy-token"),
+		cloudOrg:                       ctx.String("cloud-org"),
+		cloudCreateStackServiceAccount: ctx.Bool("cloud-create-stack-service-account"),
+		cloudStackServiceAccountName:   ctx.String("cloud-stack-service-account-name"),
+	}
+
+	// Validate flags
+	err := newFlagValidations().
+		atLeastOne("grafana-url", "cloud-access-policy-token").
+		conflicting(
+			[]string{"grafana-url", "grafana-auth"},
+			[]string{"cloud-access-policy-token", "cloud-org", "cloud-create-stack-service-account", "cloud-stack-service-account-name"},
+		).
+		requiredWhenSet("grafana-url", "grafana-auth").
+		requiredWhenSet("cloud-access-policy-token", "cloud-org").
+		requiredWhenSet("cloud-stack-service-account-name", "cloud-create-stack-service-account").
+		validate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}

--- a/cmd/generate/cli_validation.go
+++ b/cmd/generate/cli_validation.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+type flagValidation func(ctx *cli.Context) error
+type flagValidations []flagValidation
+
+func newFlagValidations() flagValidations {
+	return flagValidations{}
+}
+
+func (v flagValidations) atLeastOne(flags ...string) flagValidations {
+	validateFunc := func(ctx *cli.Context) error {
+		for _, flag := range flags {
+			if ctx.IsSet(flag) {
+				return nil
+			}
+		}
+		return fmt.Errorf("at least one of flags %s must be specified", flags)
+	}
+	return append(v, validateFunc)
+}
+
+// requiredWhenSet checks that the second flag is set if the first flag is set
+func (v flagValidations) requiredWhenSet(setFlag, shouldAlsoBeSetFlag string) flagValidations {
+	validateFunc := func(ctx *cli.Context) error {
+		if ctx.IsSet(setFlag) && !ctx.IsSet(shouldAlsoBeSetFlag) {
+			return fmt.Errorf("flag %s is required when flag %s is set", shouldAlsoBeSetFlag, setFlag)
+		}
+		return nil
+	}
+	return append(v, validateFunc)
+}
+
+func (v flagValidations) conflicting(firstGroup []string, secondGroup []string) flagValidations {
+	validateFunc := func(ctx *cli.Context) error {
+		var isSetFirstGroup []string
+		for _, flag := range firstGroup {
+			if ctx.IsSet(flag) {
+				isSetFirstGroup = append(isSetFirstGroup, flag)
+			}
+		}
+		for _, flag := range secondGroup {
+			if ctx.IsSet(flag) {
+				if len(isSetFirstGroup) > 0 {
+					return fmt.Errorf("flags %v and %v are mutually exclusive", firstGroup, secondGroup)
+				}
+			}
+		}
+		return nil
+	}
+	return append(v, validateFunc)
+}
+
+func (v flagValidations) validate(ctx *cli.Context) error {
+	for _, f := range v {
+		if err := f(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+)
+
+type outputFormat string
+
+const (
+	outputFormatJSON       outputFormat = "json"
+	outputFormatHCL        outputFormat = "hcl"
+	outputFormatCrossplane outputFormat = "crossplane"
+)
+
+var outputFormats = []outputFormat{outputFormatJSON, outputFormatHCL, outputFormatCrossplane}
+
+type config struct {
+	outputDir string
+	clobber   bool
+	format    outputFormat
+
+	grafanaURL  string
+	grafanaAuth string
+
+	cloudAccessPolicyToken         string
+	cloudOrg                       string
+	cloudCreateStackServiceAccount bool
+	cloudStackServiceAccountName   string
+}
+
+func generate(ctx context.Context, cfg *config) error {
+	if _, err := os.Stat(cfg.outputDir); err == nil && cfg.clobber {
+		log.Printf("Deleting all files in %s", cfg.outputDir)
+		if err := os.RemoveAll(cfg.outputDir); err != nil {
+			return fmt.Errorf("failed to delete %s: %s", cfg.outputDir, err)
+		}
+	} else if err == nil && !cfg.clobber {
+		return fmt.Errorf("output dir %q already exists. Use --clobber to delete it", cfg.outputDir)
+	}
+
+	log.Printf("Generating resources to %s", cfg.outputDir)
+	if err := os.MkdirAll(cfg.outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory %s: %s", cfg.outputDir, err)
+	}
+
+	if cfg.cloudAccessPolicyToken != "" {
+		return generateCloudResources(cfg.cloudAccessPolicyToken, cfg.cloudOrg)
+	}
+
+	return generateGrafanaResources(cfg.grafanaURL, cfg.grafanaAuth)
+}

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -1,114 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
-
-	"github.com/urfave/cli/v2"
 )
-
-type outputFormat string
-
-const (
-	outputFormatJSON       outputFormat = "json"
-	outputFormatHCL        outputFormat = "hcl"
-	outputFormatCrossplane outputFormat = "crossplane"
-)
-
-var outputFormats = []outputFormat{outputFormatJSON, outputFormatHCL, outputFormatCrossplane}
 
 func main() {
-	app := &cli.App{
-		Name:      "terraform-provider-grafana-generate",
-		Usage:     "Generate `terraform-provider-grafana` resources from your Grafana instance or Grafana Cloud account.",
-		UsageText: "terraform-provider-grafana-generate [options]",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:     "output-dir",
-				Aliases:  []string{"o"},
-				Usage:    "Output directory for generated resources",
-				Required: true,
-			},
-			&cli.BoolFlag{
-				Name:    "clobber",
-				Aliases: []string{"c"},
-				Usage:   "Delete all files in the output directory before generating resources",
-			},
-			&cli.StringFlag{
-				Name: "format",
-				Usage: fmt.Sprintf("Output format for generated resources. "+
-					"Supported formats are: %v", outputFormats),
-				Value: string(outputFormatHCL),
-			},
-
-			// Grafana OSS flags
-			&cli.StringFlag{
-				Name:     "grafana-url",
-				Usage:    "URL of the Grafana instance to generate resources from",
-				Category: "Grafana",
-			},
-			&cli.StringFlag{
-				Name:     "grafana-auth",
-				Usage:    "Service account token or username:password for the Grafana instance",
-				Category: "Grafana",
-			},
-
-			// Grafana Cloud flags
-			&cli.StringFlag{
-				Name:     "grafana-cloud-access-policy-token",
-				Usage:    "Access policy token for Grafana Cloud",
-				Category: "Grafana Cloud",
-			},
-			&cli.StringFlag{
-				Name:     "grafana-cloud-org",
-				Usage:    "Organization ID or name for Grafana Cloud",
-				Category: "Grafana Cloud",
-			},
-		},
-		Action: run,
-	}
-
-	if err := app.Run(os.Args); err != nil {
+	err := run()
+	if err != nil {
 		log.Fatal(err)
-	}
-}
-
-func run(ctx *cli.Context) error {
-	clobber := ctx.Bool("clobber")
-	outputDir := ctx.String("output-dir")
-	if _, err := os.Stat(outputDir); err == nil && clobber {
-		log.Printf("Deleting all files in %s", outputDir)
-		if err := os.RemoveAll(outputDir); err != nil {
-			return cli.Exit(fmt.Sprintf("Failed to delete %s: %s", outputDir, err), 1)
-		}
-	} else if err == nil && !clobber {
-		return cli.Exit(fmt.Sprintf("Output dir %q already exists. Use --clobber to delete it", outputDir), 1)
-	}
-
-	log.Printf("Generating resources to %s", outputDir)
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return cli.Exit(fmt.Sprintf("Failed to create output directory %s: %s", outputDir, err), 1)
-	}
-
-	grafanaAuth := ctx.String("grafana-auth")
-	cloudAccessPolicyToken := ctx.String("grafana-cloud-access-policy-token")
-	switch {
-	case grafanaAuth != "" && cloudAccessPolicyToken != "":
-		return cli.Exit("Cannot specify both Grafana and Grafana Cloud credentials", 1)
-	case cloudAccessPolicyToken != "":
-		org := ctx.String("grafana-cloud-org")
-		if org == "" {
-			return cli.Exit("Must specify --grafana-cloud-org when using Grafana Cloud credentials", 1)
-		}
-		return generateCloudResources(cloudAccessPolicyToken, org)
-	case grafanaAuth != "":
-		url := ctx.String("grafana-url")
-		if url == "" {
-			return cli.Exit("Must specify --grafana-url when using Grafana credentials", 1)
-		}
-		return generateGrafanaResources(url, grafanaAuth)
-	default:
-		return cli.Exit("Must specify either Grafana or Grafana Cloud credentials", 1)
 	}
 }


### PR DESCRIPTION
Further improvement on https://github.com/grafana/terraform-provider-grafana/pull/1492 Isolate CLI flag parsing + validation into separate file. Keep all the validation out of the code that actually does the work