### PR TITLE
`grafana_service_account`: Require role attribute

### DIFF
--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -30,12 +30,12 @@ resource "grafana_service_account" "admin" {
 ### Required
 
 - `name` (String) The name of the service account.
+- `role` (String) The basic role of the service account in the organization.
 
 ### Optional
 
 - `is_disabled` (Boolean) The disabled status for the service account. Defaults to `false`.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
-- `role` (String) The basic role of the service account in the organization.
 
 ### Read-Only
 

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -43,7 +43,7 @@ func resourceServiceAccount() *common.Resource {
 			},
 			"role": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"Viewer", "Editor", "Admin", "None"}, false),
 				Description:  "The basic role of the service account in the organization.",
 			},


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1493 
The other option would've been to default to `None` BUT the `None` role is only available from 10.3, so this would not work for most Grafana versions