### PR TITLE
Fix `grafana_alert_rule_group` imports

### DIFF
--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -41,7 +41,10 @@ func MakeOrgResourceID(orgID int64, resourceID interface{}) string {
 func SplitOrgResourceID(id string) (int64, string) {
 	if strings.ContainsRune(id, ':') {
 		parts := strings.SplitN(id, ":", 2)
-		orgID, _ := strconv.ParseInt(parts[0], 10, 64)
+		orgID, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 0, id
+		}
 		return orgID, parts[1]
 	}
 

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -53,6 +53,34 @@ func TestAccAlertRule_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test import without org ID.
+			{
+				ResourceName:      "grafana_rule_group.my_alert_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["grafana_rule_group.my_alert_rule"]
+					if rs == nil {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["folder_uid"], rs.Primary.Attributes["name"]), nil
+				},
+			},
+			// Support import with a weird hybrid separated ID.
+			// When org ID was first supported, and the ID had the old ; separator, this was valid
+			// TODO: Remove this on next major release.
+			{
+				ResourceName:      "grafana_rule_group.my_alert_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["grafana_rule_group.my_alert_rule"]
+					if rs == nil {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("1:%s;%s", rs.Primary.Attributes["folder_uid"], rs.Primary.Attributes["name"]), nil
+				},
+			},
 			// Test import with legacy ID (split by ;). TODO: Remove this on next major release.
 			{
 				ResourceName:      "grafana_rule_group.my_alert_rule",


### PR DESCRIPTION
Currently, importing a rule group without the org ID fails (it works when the org ID is specified) 
Also, make sure the older, deprecated `orgID:folder;title` format is also supported for now