### PR TITLE
Terraform Code Generation: Add provider installation

### DIFF
--- a/cmd/generate/cli.go
+++ b/cmd/generate/cli.go
@@ -7,6 +7,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var version = "" // set by ldflags
+
 func run() error {
 	app := &cli.App{
 		Name:      "terraform-provider-grafana-generate",
@@ -33,6 +35,12 @@ func run() error {
 					"Supported formats are: %v", outputFormats),
 				Value:   string(outputFormatHCL),
 				EnvVars: []string{"TFGEN_OUTPUT_FORMAT"},
+			},
+			&cli.StringFlag{
+				Name:    "terraform-provider-version",
+				Usage:   "Version of the Grafana provider to generate resources for. Defaults to the release version (same as the generator version).",
+				EnvVars: []string{"TFGEN_TERRAFORM_PROVIDER_VERSION"},
+				Value:   version,
 			},
 
 			// Grafana OSS flags
@@ -96,12 +104,17 @@ func parseFlags(ctx *cli.Context) (*config, error) {
 		outputDir:                      ctx.String("output-dir"),
 		clobber:                        ctx.Bool("clobber"),
 		format:                         outputFormat(ctx.String("output-format")),
+		providerVersion:                ctx.String("terraform-provider-version"),
 		grafanaURL:                     ctx.String("grafana-url"),
 		grafanaAuth:                    ctx.String("grafana-auth"),
 		cloudAccessPolicyToken:         ctx.String("cloud-access-policy-token"),
 		cloudOrg:                       ctx.String("cloud-org"),
 		cloudCreateStackServiceAccount: ctx.Bool("cloud-create-stack-service-account"),
 		cloudStackServiceAccountName:   ctx.String("cloud-stack-service-account-name"),
+	}
+
+	if config.providerVersion == "" {
+		return nil, fmt.Errorf("terraform-provider-version must be set")
 	}
 
 	// Validate flags

--- a/cmd/generate/cloud.go
+++ b/cmd/generate/cloud.go
@@ -1,6 +1,8 @@
 package main
 
-func generateCloudResources(accessPolicyToken, org string) error {
+import "context"
+
+func generateCloudResources(ctx context.Context, accessPolicyToken, org string) error {
 	// TODO: Implement
 	return nil
 }

--- a/cmd/generate/grafana.go
+++ b/cmd/generate/grafana.go
@@ -1,6 +1,8 @@
 package main
 
-func generateGrafanaResources(url, auth string) error {
+import "context"
+
+func generateGrafanaResources(ctx context.Context, url, auth string) error {
 	// TODO: Implement
 	return nil
 }

--- a/cmd/generate/terraform.go
+++ b/cmd/generate/terraform.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func runTerraform(dir string, command ...string) error {
+	cmd := exec.Command("terraform", command...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func writeBlocks(filepath string, blocks ...*hclwrite.Block) error {
+	contents := hclwrite.NewFile()
+	for i, b := range blocks {
+		if i > 0 {
+			contents.Body().AppendNewline()
+		}
+		contents.Body().AppendBlock(b)
+	}
+
+	hclFile, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	if _, err := contents.WriteTo(hclFile); err != nil {
+		return err
+	}
+	return hclFile.Close()
+}


### PR DESCRIPTION
The first step of generating TF config is having a provider.

This PR adds that: The `required_providers` settings is added and a `terraform init` command is run in order to download/install the provider 
The version that we use is injected through `ldflags` (to be set on a release by goreleaser). When running this outside of a release, the TF provider version can be passed through a flag