### PR TITLE
`grafana_service_account`: Fix updates on v11

### DIFF
--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -132,15 +132,10 @@ func UpdateServiceAccount(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	updateRequest := models.UpdateServiceAccountForm{}
-	if d.HasChange("name") {
-		updateRequest.Name = d.Get("name").(string)
-	}
-	if d.HasChange("role") {
-		updateRequest.Role = d.Get("role").(string)
-	}
-	if d.HasChange("is_disabled") {
-		updateRequest.IsDisabled = d.Get("is_disabled").(bool)
+	updateRequest := models.UpdateServiceAccountForm{
+		Name:       d.Get("name").(string),
+		Role:       d.Get("role").(string),
+		IsDisabled: d.Get("is_disabled").(bool),
 	}
 
 	params := service_accounts.NewUpdateServiceAccountParams().


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/1493 
Seems to be a regression in Grafana 11 where not passing the Role in an SA update results in a 500 error 
This should fix it, we can pass all the fields all the time in TF