### PR TITLE
Terraform Code Generation: Add listers for Grafana resources

### DIFF
--- a/internal/resources/grafana/common_lister.go
+++ b/internal/resources/grafana/common_lister.go
@@ -1,0 +1,69 @@
+package grafana
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/orgs"
+	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
+)
+
+// ListerData is used as the data arg in "ListIDs" functions. It allows getting data common to multiple resources.
+type ListerData struct {
+	singleOrg bool
+	orgIDs    []int64
+	orgsInit  sync.Once
+}
+
+func NewListerData(singleOrg bool) *ListerData {
+	return &ListerData{
+		singleOrg: singleOrg,
+	}
+}
+
+func (ld *ListerData) OrgIDs(client *goapi.GrafanaHTTPAPI) ([]int64, error) {
+	if ld.singleOrg {
+		return nil, nil
+	}
+
+	var err error
+	ld.orgsInit.Do(func() {
+		client = client.Clone().WithOrgID(0)
+
+		var page int64 = 1
+		for {
+			var resp *orgs.SearchOrgsOK
+			if resp, err = client.Orgs.SearchOrgs(orgs.NewSearchOrgsParams().WithPage(&page)); err != nil {
+				return
+			}
+			for _, org := range resp.Payload {
+				ld.orgIDs = append(ld.orgIDs, org.ID)
+			}
+			if len(resp.Payload) == 0 {
+				break
+			}
+			page++
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ld.orgIDs, nil
+}
+
+// listerFunction is a helper function that wraps a lister function be used more easily in grafana resources.
+func listerFunction(listerFunc func(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error)) common.ResourceListIDsFunc {
+	return func(ctx context.Context, client *common.Client, data any) ([]string, error) {
+		lm, ok := data.(*ListerData)
+		if !ok {
+			return nil, fmt.Errorf("unexpected data type: %T", data)
+		}
+		if client.GrafanaAPI == nil {
+			return nil, fmt.Errorf("client not configured for Grafana API")
+		}
+		return listerFunc(ctx, client.GrafanaAPI, lm)
+	}
+}

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime"
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -89,7 +90,7 @@ This resource requires Grafana 9.1.0 or later.
 		"grafana_notification_policy",
 		orgResourceIDString("anyString"),
 		schema,
-	)
+	).WithLister(listerFunction(listNotificationPolicies))
 }
 
 // The maximum depth of policy tree that the provider supports, as Terraform does not allow for infinitely recursive schemas.
@@ -187,6 +188,20 @@ func policySchema(depth uint) *schema.Resource {
 	}
 
 	return resource
+}
+
+func listNotificationPolicies(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
+	orgIDs, err := data.OrgIDs(client)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, orgID := range orgIDs {
+		ids = append(ids, MakeOrgResourceID(orgID, PolicySingletonID))
+	}
+
+	return ids, nil
 }
 
 func readNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/client/search"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -71,7 +72,11 @@ func resourceFolder() *common.Resource {
 		"grafana_folder",
 		orgResourceIDString("uid"),
 		schema,
-	)
+	).WithLister(listerFunction(listFolders))
+}
+
+func listFolders(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
+	return listDashboardOrFolder(client, data, "dash-folder")
 }
 
 func CreateFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/orgs"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
@@ -147,7 +148,20 @@ set to true. This feature is only available in Grafana 10.2+.
 		"grafana_organization",
 		common.NewResourceID(common.IntIDField("id")),
 		schema,
-	)
+	).WithLister(listerFunction(listOrganizations))
+}
+
+func listOrganizations(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
+	orgIDs, err := data.OrgIDs(client)
+	if err != nil {
+		return nil, err
+	}
+
+	var orgIDsString []string
+	for _, id := range orgIDs {
+		orgIDsString = append(orgIDsString, strconv.FormatInt(id, 10))
+	}
+	return orgIDsString, nil
 }
 
 func CreateOrganization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -744,7 +744,29 @@ multiple checks for a single endpoint to check different capabilities.
 		},
 	}
 
-	return common.NewLegacySDKResource("grafana_synthetic_monitoring_check", resourceCheckID, schema)
+	return common.NewLegacySDKResource(
+		"grafana_synthetic_monitoring_check",
+		resourceCheckID,
+		schema,
+	).WithLister(listChecks)
+}
+
+func listChecks(ctx context.Context, client *common.Client, data any) ([]string, error) {
+	smClient := client.SMAPI
+	if smClient == nil {
+		return nil, fmt.Errorf("client not configured for SM API")
+	}
+
+	checkList, err := smClient.ListChecks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, check := range checkList {
+		ids = append(ids, strconv.FormatInt(check.Id, 10))
+	}
+	return ids, nil
 }
 
 func resourceCheckCreate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {

--- a/internal/resources/syntheticmonitoring/resource_probe.go
+++ b/internal/resources/syntheticmonitoring/resource_probe.go
@@ -105,7 +105,32 @@ Grafana Synthetic Monitoring Agent.
 		},
 	}
 
-	return common.NewLegacySDKResource("grafana_synthetic_monitoring_probe", resourceProbeID, schema)
+	return common.NewLegacySDKResource(
+		"grafana_synthetic_monitoring_probe",
+		resourceProbeID,
+		schema,
+	).WithLister(listProbes)
+}
+
+func listProbes(ctx context.Context, client *common.Client, data any) ([]string, error) {
+	smClient := client.SMAPI
+	if smClient == nil {
+		return nil, fmt.Errorf("client not configured for SM API")
+	}
+
+	probeList, err := smClient.ListProbes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, probe := range probeList {
+		if probe.Public {
+			continue
+		}
+		ids = append(ids, strconv.FormatInt(probe.Id, 10))
+	}
+	return ids, nil
 }
 
 func resourceProbeCreate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {


### PR DESCRIPTION
Adding the rest of the "listers" that were developed during our hackathon project 
There are lots of missing resources but this is a good start 

This PR follows the same pattern as this previous PR that added "cloud" resources (https://github.com/grafana/terraform-provider-grafana/pull/1501)