### PR TITLE
SSO: add skip_org_role_sync field to SAML settings

### DIFF
--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -127,6 +127,7 @@ Optional:
 - `role_values_none` (String) List of comma- or space-separated roles which will be mapped into the None role.
 - `signature_algorithm` (String) Signature algorithm used for signing requests to the IdP. Supported values are rsa-sha1, rsa-sha256, rsa-sha512.
 - `single_logout` (Boolean) Whether SAML Single Logout is enabled.
+- `skip_org_role_sync` (Boolean) Prevent synchronizing users’ organization roles from your IdP.
 
 ## Import
 

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -429,6 +429,11 @@ var samlSettingsSchema = &schema.Resource{
 			Optional:    true,
 			Description: "The Name ID Format to request within the SAML assertion. Defaults to urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
 		},
+		"skip_org_role_sync": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Prevent synchronizing users’ organization roles from your IdP.",
+		},
 	},
 }
 


### PR DESCRIPTION
The `skip_org_role_sync` field was missing from the SAML settings.