### PR TITLE
Update oncall_schedule.md

### DIFF
--- a/docs/resources/oncall_schedule.md
+++ b/docs/resources/oncall_schedule.md
@@ -50,7 +50,7 @@ resource "grafana_oncall_schedule" "example_schedule" {
 ### Required
 
 - `name` (String) The schedule's name.
-- `type` (String) The schedule's type.
+- `type` (String) The schedule's type. Valid values for this are "ical" and "calendar".
 
 ### Optional
 

--- a/docs/resources/oncall_schedule.md
+++ b/docs/resources/oncall_schedule.md
@@ -50,7 +50,7 @@ resource "grafana_oncall_schedule" "example_schedule" {
 ### Required
 
 - `name` (String) The schedule's name.
-- `type` (String) The schedule's type. Valid values for this are "ical" and "calendar".
+- `type` (String) The schedule's type. Valid values are `ical`, `calendar`.
 
 ### Optional
 

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"strings"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
@@ -47,7 +48,7 @@ func resourceSchedule() *common.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(scheduleTypeOptions, false),
-				Description:  "The schedule's type.",
+				Description:  "The schedule's type. Valid values are `" + strings.Join(scheduleTypeOptions, "`, `") + "`.",
 			},
 			"time_zone": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The Schedule HTTP API docs (https://grafana.com/docs/oncall/latest/oncall-api-reference/schedules/) that the oncall_schedule resource uses specify "web" as a valid type value.

However, this isn't an available option for the TF resource due to drift or conflict issues. It would be good to clarify the valid values ("ical" and "calendar") since this differs from the Schedule HTTP API docs.