### PR TITLE
Code Generation: Add helper for block creation

### DIFF
--- a/cmd/generate/terraform.go
+++ b/cmd/generate/terraform.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func runTerraform(dir string, command ...string) error {
@@ -32,4 +34,39 @@ func writeBlocks(filepath string, blocks ...*hclwrite.Block) error {
 		return err
 	}
 	return hclFile.Close()
+}
+
+func newBlock(labels []string, attributes map[string]any) *hclwrite.Block {
+	b := hclwrite.NewBlock(labels[0], labels[1:])
+	for k, v := range attributes {
+		switch v := v.(type) {
+		case hcl.Traversal:
+			b.Body().SetAttributeTraversal(k, v)
+		case string:
+			b.Body().SetAttributeValue(k, cty.StringVal(v))
+		case cty.Value:
+			b.Body().SetAttributeValue(k, v)
+		case []map[string]any: // Simplified blocks
+			for _, blockAttributes := range v {
+				b.Body().AppendBlock(newBlock([]string{k}, blockAttributes))
+			}
+		}
+	}
+	return b
+}
+
+func providerBlock(attributes map[string]any) *hclwrite.Block {
+	return newBlock([]string{"provider", "grafana"}, attributes)
+}
+
+func resourceBlock(resourceType, resourceName string, attributes map[string]any) *hclwrite.Block {
+	return newBlock([]string{"resource", resourceType, resourceName}, attributes)
+}
+
+func traversal(root string, attrs ...string) hcl.Traversal {
+	tr := hcl.Traversal{hcl.TraverseRoot{Name: root}}
+	for _, attr := range attrs {
+		tr = append(tr, hcl.TraverseAttr{Name: attr})
+	}
+	return tr
 }

--- a/cmd/generate/terraform_test.go
+++ b/cmd/generate/terraform_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestBlocks(t *testing.T) {
+	t.Parallel()
+
+	tempFile := filepath.Join(t.TempDir(), "testblocks.tf")
+	err := writeBlocks(tempFile,
+		providerBlock(map[string]any{
+			"auth": "admin:admin", // Supports strings without cty wrapper
+			"http_headers": cty.MapVal(map[string]cty.Value{
+				"header1": cty.StringVal("val2"),
+			}),
+			"url": cty.StringVal("hello.com"),
+		}),
+		resourceBlock("grafana_cloud_stack", "my-stack", map[string]any{
+			"region": traversal("data", "region", "slug"),
+			"slug":   "hello",
+			"other":  cty.ListVal([]cty.Value{cty.StringVal("123"), cty.StringVal("456")}),
+			"sub_block": []map[string]any{
+				{},
+				{
+					"attr": "val",
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	gotContent, err := os.ReadFile(tempFile)
+	require.NoError(t, err)
+
+	expectedContent, err := os.ReadFile("testdata/testblocks.hcl")
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedContent), string(gotContent))
+
+}

--- a/cmd/generate/terraform_test.go
+++ b/cmd/generate/terraform_test.go
@@ -42,5 +42,4 @@ func TestBlocks(t *testing.T) {
 	expectedContent, err := os.ReadFile("testdata/testblocks.hcl")
 	require.NoError(t, err)
 	assert.Equal(t, string(expectedContent), string(gotContent))
-
 }

--- a/cmd/generate/testdata/testblocks.hcl
+++ b/cmd/generate/testdata/testblocks.hcl
@@ -1,0 +1,18 @@
+provider "grafana" {
+  auth = "admin:admin"
+  http_headers = {
+    header1 = "val2"
+  }
+  url = "hello.com"
+}
+
+resource "grafana_cloud_stack" "my-stack" {
+  region = data.region.slug
+  slug   = "hello"
+  other  = ["123", "456"]
+  sub_block {
+  }
+  sub_block {
+    attr = "val"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -25,11 +25,11 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.22.2
 	github.com/hashicorp/terraform-plugin-mux v0.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
+	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.1
+	github.com/zclconf/go-cty v1.14.4
 	golang.org/x/text v0.14.0
 )
-
-require github.com/zclconf/go-cty v1.14.4
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
@@ -45,6 +45,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -92,6 +93,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect


### PR DESCRIPTION
The builder to build Terraform blocks/resources is very verbose and not very easy to understand

This adds helpers and tests that the all the Terraform helpers work correctly together

**Note that this PR isn't used yet but this will be used to simplify future PRs)**