### PR TITLE
Deprecate global `org_id` config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,7 +213,6 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 - `insecure_skip_verify` (Boolean) Skip TLS certificate verification. May alternatively be set via the `GRAFANA_INSECURE_SKIP_VERIFY` environment variable.
 - `oncall_access_token` (String, Sensitive) A Grafana OnCall access token. May alternatively be set via the `GRAFANA_ONCALL_ACCESS_TOKEN` environment variable.
 - `oncall_url` (String) An Grafana OnCall backend address. May alternatively be set via the `GRAFANA_ONCALL_URL` environment variable.
-- `org_id` (Number, Deprecated) Deprecated: Use the `org_id` attributes on resources instead.
 - `retries` (Number) The amount of retries to use for Grafana API and Grafana Cloud API calls. May alternatively be set via the `GRAFANA_RETRIES` environment variable.
 - `retry_status_codes` (Set of String) The status codes to retry on for Grafana API and Grafana Cloud API calls. Use `x` as a digit wildcard. Defaults to 429 and 5xx. May alternatively be set via the `GRAFANA_RETRY_STATUS_CODES` environment variable.
 - `retry_wait` (Number) The amount of time in seconds to wait between retries for Grafana API and Grafana Cloud API calls. May alternatively be set via the `GRAFANA_RETRY_WAIT` environment variable.

--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -204,16 +204,10 @@ func createTempFileIfLiteral(value string) (path string, tempFile bool, err erro
 func parseAuth(providerConfig ProviderConfig) (*url.Userinfo, int64, string, error) {
 	auth := strings.SplitN(providerConfig.Auth.ValueString(), ":", 2)
 	var orgID int64 = 1
-	if !providerConfig.OrgID.IsNull() {
-		orgID = providerConfig.OrgID.ValueInt64()
-	}
 
 	if len(auth) == 2 {
 		return url.UserPassword(auth[0], auth[1]), orgID, "", nil
 	} else if auth[0] != "anonymous" {
-		if orgID > 1 {
-			return nil, 0, "", fmt.Errorf("org_id is only supported with basic auth. API keys are already org-scoped")
-		}
 		return nil, 0, auth[0], nil
 	}
 	return nil, 0, "", nil

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -23,7 +23,6 @@ type ProviderConfig struct {
 	Retries          types.Int64  `tfsdk:"retries"`
 	RetryStatusCodes types.Set    `tfsdk:"retry_status_codes"`
 	RetryWait        types.Int64  `tfsdk:"retry_wait"`
-	OrgID            types.Int64  `tfsdk:"org_id"`
 
 	TLSKey             types.String `tfsdk:"tls_key"`
 	TLSCert            types.String `tfsdk:"tls_cert"`
@@ -63,9 +62,6 @@ func (c *ProviderConfig) SetDefaults() error {
 	c.SMURL = envDefaultFuncString(c.SMURL, "GRAFANA_SM_URL", "https://synthetic-monitoring-api.grafana.net")
 	c.OncallAccessToken = envDefaultFuncString(c.OncallAccessToken, "GRAFANA_ONCALL_ACCESS_TOKEN")
 	c.OncallURL = envDefaultFuncString(c.OncallURL, "GRAFANA_ONCALL_URL", "https://oncall-prod-us-central-0.grafana.net/oncall")
-	if c.OrgID, err = envDefaultFuncInt64(c.OrgID, "GRAFANA_ORG_ID"); err != nil {
-		return fmt.Errorf("failed to parse GRAFANA_ORG_ID: %w", err)
-	}
 	if c.StoreDashboardSha256, err = envDefaultFuncBool(c.StoreDashboardSha256, "GRAFANA_STORE_DASHBOARD_SHA256", false); err != nil {
 		return fmt.Errorf("failed to parse GRAFANA_STORE_DASHBOARD_SHA256: %w", err)
 	}
@@ -148,11 +144,6 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			"retry_wait": schema.Int64Attribute{
 				Optional:            true,
 				MarkdownDescription: "The amount of time in seconds to wait between retries for Grafana API and Grafana Cloud API calls. May alternatively be set via the `GRAFANA_RETRY_WAIT` environment variable.",
-			},
-			"org_id": schema.Int64Attribute{
-				Optional:            true,
-				DeprecationMessage:  "Use the `org_id` attributes on resources instead.",
-				MarkdownDescription: "Deprecated: Use the `org_id` attributes on resources instead.",
 			},
 			"tls_key": schema.StringAttribute{
 				Optional:            true,

--- a/pkg/provider/legacy_provider.go
+++ b/pkg/provider/legacy_provider.go
@@ -71,12 +71,6 @@ func Provider(version string) *schema.Provider {
 				Optional:    true,
 				Description: "The amount of time in seconds to wait between retries for Grafana API and Grafana Cloud API calls. May alternatively be set via the `GRAFANA_RETRY_WAIT` environment variable.",
 			},
-			"org_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Deprecated:  "Use the `org_id` attributes on resources instead.",
-				Description: "Deprecated: Use the `org_id` attributes on resources instead.",
-			},
 			"tls_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -192,7 +186,6 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 		cfg := ProviderConfig{
 			Auth:                   stringValueOrNull(d, "auth"),
 			URL:                    stringValueOrNull(d, "url"),
-			OrgID:                  int64ValueOrNull(d, "org_id"),
 			TLSKey:                 stringValueOrNull(d, "tls_key"),
 			TLSCert:                stringValueOrNull(d, "tls_cert"),
 			CACert:                 stringValueOrNull(d, "ca_cert"),


### PR DESCRIPTION
This attribute is not useful because:
- The attribute was already added on each resource, so it doesn't remove any functionality
- It's irrelevant to all parts of the provider other than Grafana resources, possibly causing confusing since there's also an org concept on cloud resources
- Even for Grafana, it does not apply to all resources. For example, `users` are not org-scoped. By setting it on a resource level, this is much better defined
- When using it globally, it prevents looping on multiple orgs. Ex: Create dashboards for a list of orgs. Providers cannot be created dynamically