### PR TITLE
Deprecate old ID separators

### DIFF
--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	//nolint:staticcheck
-	resourceAccessPolicyID = common.NewResourceIDWithLegacySeparator("/",
+	resourceAccessPolicyID = common.NewResourceID(
 		common.StringIDField("region"),
 		common.StringIDField("policyId"),
 	)

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	//nolint:staticcheck
-	resourceAccessPolicyTokenID = common.NewResourceIDWithLegacySeparator("/",
+	resourceAccessPolicyTokenID = common.NewResourceID(
 		common.StringIDField("region"),
 		common.StringIDField("tokenId"),
 	)

--- a/internal/resources/cloud/resource_cloud_api_key.go
+++ b/internal/resources/cloud/resource_cloud_api_key.go
@@ -13,8 +13,7 @@ import (
 
 var (
 	cloudAPIKeyRoles = []string{"Viewer", "Editor", "Admin", "MetricsPublisher", "PluginPublisher"}
-	//nolint:staticcheck
-	resourceAPIKeyID = common.NewResourceIDWithLegacySeparator("-",
+	resourceAPIKeyID = common.NewResourceID(
 		common.StringIDField("orgSlug"),
 		common.StringIDField("apiKeyName"),
 	)

--- a/internal/resources/cloud/resource_cloud_plugin.go
+++ b/internal/resources/cloud/resource_cloud_plugin.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	//nolint:staticcheck
-	resourcePluginInstallationID = common.NewResourceIDWithLegacySeparator("_",
+	resourcePluginInstallationID = common.NewResourceID(
 		common.StringIDField("stackSlug"),
 		common.StringIDField("pluginSlug"),
 	)

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-openapi/runtime"
@@ -145,37 +144,6 @@ func readContactPoint(ctx context.Context, data *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 	points := resp.Payload
-	if len(points) == 0 && !strings.Contains(name, ":") {
-		// If the contact point was not found by name, try to fetch it by UID.
-		// This is a deprecated ID format (uid;uid2;uid3)
-		// TODO: Remove on the next major version
-		uidsMap := map[string]bool{}
-		for _, uid := range strings.Split(data.Id(), ";") {
-			uidsMap[uid] = false
-		}
-		resp, err := client.Provisioning.GetContactpoints(provisioning.NewGetContactpointsParams())
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		for i, p := range resp.Payload {
-			if _, ok := uidsMap[p.UID]; !ok {
-				continue
-			}
-			uidsMap[p.UID] = true
-			points = append(points, p)
-			if i > 0 && p.Name != points[0].Name {
-				return diag.FromErr(fmt.Errorf("contact point with UID %s has a different name (%s) than the contact point with UID %s (%s)", p.UID, p.Name, points[0].UID, points[0].Name))
-			}
-		}
-
-		for uid, found := range uidsMap {
-			if !found {
-				// Since this is an import, all UIDs should exist
-				return diag.FromErr(fmt.Errorf("contact point with UID %s was not found", uid))
-			}
-		}
-	}
-
 	if len(points) == 0 {
 		return common.WarnMissing("contact point", data)
 	}

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -97,15 +97,6 @@ func TestAccContactPoint_compound(t *testing.T) {
 				ImportStateId:     "Compound Contact Point",
 				ImportStateVerify: true,
 			},
-			// Test import by UID
-			{
-				ResourceName:      "grafana_contact_point.compound_contact_point",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					return strings.Join([]string{points[0].UID, points[1].UID}, ";"), nil
-				},
-			},
 			// Test update.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/_acc_compound_receiver.tf", map[string]string{

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -20,8 +20,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v2/internal/common"
 )
 
-//nolint:staticcheck
-var resourceRuleGroupID = common.NewResourceIDWithLegacySeparator(";",
+var resourceRuleGroupID = common.NewResourceID(
 	common.OptionalIntIDField("orgID"),
 	common.StringIDField("folderUID"),
 	common.StringIDField("title"),

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -66,34 +66,6 @@ func TestAccAlertRule_basic(t *testing.T) {
 					return fmt.Sprintf("%s:%s", rs.Primary.Attributes["folder_uid"], rs.Primary.Attributes["name"]), nil
 				},
 			},
-			// Support import with a weird hybrid separated ID.
-			// When org ID was first supported, and the ID had the old ; separator, this was valid
-			// TODO: Remove this on next major release.
-			{
-				ResourceName:      "grafana_rule_group.my_alert_rule",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs := s.RootModule().Resources["grafana_rule_group.my_alert_rule"]
-					if rs == nil {
-						return "", fmt.Errorf("resource not found")
-					}
-					return fmt.Sprintf("1:%s;%s", rs.Primary.Attributes["folder_uid"], rs.Primary.Attributes["name"]), nil
-				},
-			},
-			// Test import with legacy ID (split by ;). TODO: Remove this on next major release.
-			{
-				ResourceName:      "grafana_rule_group.my_alert_rule",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs := s.RootModule().Resources["grafana_rule_group.my_alert_rule"]
-					if rs == nil {
-						return "", fmt.Errorf("resource not found")
-					}
-					return fmt.Sprintf("%s;%s", rs.Primary.Attributes["folder_uid"], rs.Primary.Attributes["name"]), nil
-				},
-			},
 			// Test update content.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_rule_group/resource.tf", map[string]string{


### PR DESCRIPTION
In previous versions, all legacy IDs were deprecated in favor of a common `:` 

Anyone running the latest version should have had all their resources migrated to the new separator so we can remove all the legacy ones 

This PR will be merged in the next major version