### PR TITLE
Code Generation: Support json format

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -70,8 +70,18 @@ func generate(ctx context.Context, cfg *config) error {
 	}
 
 	if cfg.cloudAccessPolicyToken != "" {
-		return generateCloudResources(ctx, cfg.cloudAccessPolicyToken, cfg.cloudOrg)
+		if err := generateCloudResources(ctx, cfg.cloudAccessPolicyToken, cfg.cloudOrg); err != nil {
+			return err
+		}
+	} else {
+		if err := generateGrafanaResources(ctx, cfg.grafanaURL, cfg.grafanaAuth); err != nil {
+			return err
+		}
 	}
 
-	return generateGrafanaResources(ctx, cfg.grafanaURL, cfg.grafanaAuth)
+	if cfg.format == outputFormatJSON {
+		return convertToTFJSON(cfg.outputDir)
+	}
+
+	return nil
 }

--- a/cmd/generate/terraform_test.go
+++ b/cmd/generate/terraform_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTFJSON(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "testblocks.hcl")
+	testFileContent, err := os.ReadFile("testdata/testblocks.hcl")
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(testFile, testFileContent, 0777))
+	require.NoError(t, convertToTFJSON(tempDir))
+
+	gotDir, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	assert.Len(t, gotDir, 1) // Only the JSON file
+
+	gotContent, err := os.ReadFile(testFile + ".json")
+	require.NoError(t, err)
+
+	expectedContent, err := os.ReadFile("testdata/testblocks.hcl.json")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expectedContent), string(gotContent))
+}

--- a/cmd/generate/terraform_test.go
+++ b/cmd/generate/terraform_test.go
@@ -17,7 +17,7 @@ func TestTFJSON(t *testing.T) {
 	testFileContent, err := os.ReadFile("testdata/testblocks.hcl")
 	require.NoError(t, err)
 
-	require.NoError(t, os.WriteFile(testFile, testFileContent, 0777))
+	require.NoError(t, os.WriteFile(testFile, testFileContent, 0600))
 	require.NoError(t, convertToTFJSON(tempDir))
 
 	gotDir, err := os.ReadDir(tempDir)

--- a/cmd/generate/testdata/testblocks.hcl
+++ b/cmd/generate/testdata/testblocks.hcl
@@ -1,0 +1,18 @@
+provider "grafana" {
+  auth = "admin:admin"
+  http_headers = {
+    header1 = "val2"
+  }
+  url = "hello.com"
+}
+
+resource "grafana_cloud_stack" "my-stack" {
+  region = data.region.slug
+  slug   = "hello"
+  other  = ["123", "456"]
+  sub_block {
+  }
+  sub_block {
+    attr = "val"
+  }
+}

--- a/cmd/generate/testdata/testblocks.hcl.json
+++ b/cmd/generate/testdata/testblocks.hcl.json
@@ -1,0 +1,33 @@
+{
+  "provider": {
+    "grafana": [
+      {
+        "auth": "admin:admin",
+        "http_headers": {
+          "header1": "val2"
+        },
+        "url": "hello.com"
+      }
+    ]
+  },
+  "resource": {
+    "grafana_cloud_stack": {
+      "my-stack": [
+        {
+          "other": [
+            "123",
+            "456"
+          ],
+          "region": "${data.region.slug}",
+          "slug": "hello",
+          "sub_block": [
+            {},
+            {
+              "attr": "val"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -25,11 +25,12 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.22.2
 	github.com/hashicorp/terraform-plugin-mux v0.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/tmccombs/hcl2json v0.6.2
 	github.com/urfave/cli/v2 v2.27.1
+	github.com/zclconf/go-cty v1.14.4
 	golang.org/x/text v0.14.0
 )
-
-require github.com/zclconf/go-cty v1.14.4
 
 require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
@@ -37,7 +38,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
-	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -86,12 +88,13 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
-github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -78,8 +78,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3BumrGD58=
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
-github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
+github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -211,8 +211,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
-github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
-github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -253,6 +253,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tmccombs/hcl2json v0.6.2 h1:x/QYPvPotKUgVyVhU6djucGBzVr3DZxw5AY9HkpFDiQ=
+github.com/tmccombs/hcl2json v0.6.2/go.mod h1:+Dm4GVB3QVIIB0lj+zmkOf86E3gJ12pRD9VvfsYj5ZE=
 github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=
 github.com/urfave/cli/v2 v2.27.1/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
The config generation feature from the Terraform CLI supports only HCL format, but we can convert to JSON at the end of the process