### PR TITLE
Datasources: Fix numerical UIDs

### DIFF
--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -417,13 +417,11 @@ func removeHeadersFromJSONData(input map[string]interface{}) (map[string]interfa
 func getDatasourceByUIDOrID(client *goapi.GrafanaHTTPAPI, id string) (*models.DataSource, error) {
 	var resp interface{ GetPayload() *models.DataSource }
 	var err error
-
-	if _, parseErr := strconv.ParseInt(id, 10, 64); parseErr == nil {
-		resp, err = client.Datasources.GetDataSourceByID(id)
-	} else {
-		resp, err = client.Datasources.GetDataSourceByUID(id)
+	if resp, err = client.Datasources.GetDataSourceByUID(id); err != nil {
+		if _, parseErr := strconv.ParseInt(id, 10, 64); parseErr == nil {
+			resp, err = client.Datasources.GetDataSourceByID(id)
+		}
 	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resources/grafana/resource_data_source_test.go
+++ b/internal/resources/grafana/resource_data_source_test.go
@@ -284,6 +284,33 @@ func TestAccDataSource_changeUID(t *testing.T) {
 	})
 }
 
+func TestAccDataSource_numericalUID(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	var dataSource models.DataSource
+	uid := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             datasourceCheckExists.destroyed(&dataSource, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+	resource "grafana_data_source" "test" {
+		name = "numerical-%[1]d"
+		type = "prometheus"
+		url  = "http://localhost:9090"
+		uid  = "%[1]d"
+	}`, uid),
+				Check: resource.ComposeTestCheckFunc(
+					datasourceCheckExists.exists("grafana_data_source.test", &dataSource),
+					resource.TestCheckResourceAttr("grafana_data_source.test", "uid", strconv.Itoa(uid)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatasource_inOrg(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1511 
The current `getDatasourceByUIDOrID` logic does not support numerical UIDs 
Since the ID of the resource is now normalized, we should always start with trying the ID as a DS UID, and if that fails, try it as a numerical ID