### PR TITLE
Cloud Stacks: Better "wait for readiness"

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -81,6 +81,10 @@ Required access policy scopes:
 }
 
 func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
+	if err := waitForStackReadinessFromSlug(ctx, 1*time.Minute, d.Get("stack_slug").(string), cloudClient); err != nil {
+		return err
+	}
+
 	stackSlug := d.Get("stack_slug").(string)
 	req := gcom.PostInstanceServiceAccountsRequest{
 		Name:       d.Get("name").(string),
@@ -116,6 +120,10 @@ func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudC
 		stackSlug, serviceAccountID = split[0].(string), split[1].(int64)
 	}
 
+	if err := waitForStackReadinessFromSlug(ctx, 1*time.Minute, stackSlug, cloudClient); err != nil {
+		return err
+	}
+
 	resp, httpResp, err := cloudClient.InstancesAPI.GetInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
 	if httpResp != nil && httpResp.StatusCode == 404 {
 		d.SetId("")
@@ -135,6 +143,10 @@ func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudC
 }
 
 func deleteStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
+	if err := waitForStackReadinessFromSlug(ctx, 1*time.Minute, d.Get("stack_slug").(string), cloudClient); err != nil {
+		return err
+	}
+
 	split, err := resourceStackServiceAccountID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Seems like HEAD calls on the instance's URL doesn't work anymore. Instead, we can hit `/api/health` which gives us a better idea 

Then there's the cloud_stack_service_account resources which require an active instance but just 503 if it's not ready. Let's wait for the stack readiness before doing anything on those resources