### PR TITLE
`grafana_cloud_stack_service_account`: Compatibility with roles/permissions

### DIFF
--- a/internal/resources/grafana/common_resource_permission.go
+++ b/internal/resources/grafana/common_resource_permission.go
@@ -170,7 +170,11 @@ func (r *resourcePermissionBase) writeItem(itemID string, data *resourcePermissi
 	}
 
 	data.OrgID = types.StringValue(strconv.FormatInt(orgID, 10))
-	_, itemID = SplitOrgResourceID(itemID)
+	if r.resourceType == serviceAccountsPermissionsType {
+		_, itemID = SplitServiceAccountID(itemID)
+	} else {
+		_, itemID = SplitOrgResourceID(itemID)
+	}
 	data.ResourceID = types.StringValue(itemID)
 
 	switch {

--- a/internal/resources/grafana/oss_org_id.go
+++ b/internal/resources/grafana/oss_org_id.go
@@ -51,6 +51,21 @@ func SplitOrgResourceID(id string) (int64, string) {
 	return 0, id
 }
 
+// SplitServiceAccountID is like SplitOrgResourceID but for service accounts
+// Service accounts can also come from Grafana Cloud where the format is <stackSlug>:<serviceAccountID>
+func SplitServiceAccountID(id string) (int64, string) {
+	if strings.ContainsRune(id, ':') {
+		parts := strings.SplitN(id, ":", 2)
+		orgID, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			return 1, parts[1]
+		}
+		return orgID, parts[1]
+	}
+
+	return 0, id
+}
+
 // OAPIClientFromExistingOrgResource creates a client from the ID of an org-scoped resource
 // Those IDs are in the <orgID>:<resourceID> format
 func OAPIClientFromExistingOrgResource(meta interface{}, id string) (*goapi.GrafanaHTTPAPI, int64, string) {

--- a/internal/resources/grafana/resource_role_assignment.go
+++ b/internal/resources/grafana/resource_role_assignment.go
@@ -63,7 +63,7 @@ Manages the entire set of assignments for a role. Assignments that aren't specif
 				Description: "IDs of service accounts that the role should be assigned to.",
 				// Ignore the org ID of the team when hashing. It works with or without it.
 				Set: func(i interface{}) int {
-					_, saID := SplitOrgResourceID(i.(string))
+					_, saID := SplitServiceAccountID(i.(string))
 					return schema.HashString(saID)
 				},
 				Elem: &schema.Schema{
@@ -152,7 +152,7 @@ func collectRoleAssignents(r interface{}, orgScoped bool) []int64 {
 	for _, rID := range r.(*schema.Set).List() {
 		var id int64
 		if orgScoped {
-			_, idStr := SplitOrgResourceID(rID.(string))
+			_, idStr := SplitServiceAccountID(rID.(string))
 			id, _ = strconv.ParseInt(idStr, 10, 64)
 		} else {
 			if idInt, ok := rID.(int); ok {

--- a/internal/resources/grafana/resource_service_account_permission.go
+++ b/internal/resources/grafana/resource_service_account_permission.go
@@ -36,8 +36,8 @@ Manages the entire set of permissions for a service account. Permissions that ar
 				ForceNew:    true,
 				Description: "The id of the service account.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					_, old = SplitOrgResourceID(old)
-					_, new = SplitOrgResourceID(new)
+					_, old = SplitServiceAccountID(old)
+					_, new = SplitServiceAccountID(new)
 					return old == new
 				},
 			},
@@ -54,7 +54,7 @@ Manages the entire set of permissions for a service account. Permissions that ar
 
 func resourceServiceAccountPermissionGet(d *schema.ResourceData, meta interface{}) (string, error) {
 	client, _ := OAPIClientFromNewOrgResource(meta, d)
-	_, id := SplitOrgResourceID(d.Get("service_account_id").(string))
+	_, id := SplitServiceAccountID(d.Get("service_account_id").(string))
 	if d.Id() != "" {
 		client, _, id = OAPIClientFromExistingOrgResource(meta, d.Id())
 	}


### PR DESCRIPTION
Currently, service accounts created on Grafana Cloud stacks cannot be assigned permissions and roles (See the test in `internal/resources/cloud/resource_cloud_stack_service_account_test.go` for an example