### PR TITLE
Add goreleaser config for code generation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+dist
 
 website/vendor
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
     - goos: darwin
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
-- id: terraform-provider-grafana-gen
+- id: terraform-provider-grafana-generate
   env:
     - CGO_ENABLED=0
   mod_timestamp: '{{ .CommitTimestamp }}'
@@ -50,11 +50,11 @@ archives:
   name_template: 'terraform-provider-grafana_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
   builds:
     - terraform-provider-grafana
-- id: terraform-provider-grafana-gen
+- id: terraform-provider-grafana-generate
   format: binary
-  name_template: 'terraform-provider-grafana-gen_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  name_template: 'terraform-provider-grafana-generate_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
   builds:
-    - terraform-provider-grafana-gen
+    - terraform-provider-grafana-generate
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,10 +5,8 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
+- id: terraform-provider-grafana
+  env:
     - CGO_ENABLED=0
   mod_timestamp: '{{ .CommitTimestamp }}'
   flags:
@@ -29,9 +27,34 @@ builds:
     - goos: darwin
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
+- id: terraform-provider-grafana-gen
+  env:
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}}'
+  goos:
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - arm64
+  main: ./cmd/generate
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+- id: terraform-provider-grafana
+  format: zip
+  name_template: 'terraform-provider-grafana_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  builds:
+    - terraform-provider-grafana
+- id: terraform-provider-grafana-gen
+  format: binary
+  name_template: 'terraform-provider-grafana-gen_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  builds:
+    - terraform-provider-grafana-gen
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256


### PR DESCRIPTION
This will release `terraform-provider-grafana-gen` binaries alongside the actual provider