### PR TITLE
Update synthetic monitoring frequency value validation

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -423,7 +423,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 - `alert_sensitivity` (String) Can be set to `none`, `low`, `medium`, or `high` to correspond to the check [alert levels](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/). Defaults to `none`.
 - `basic_metrics_only` (Boolean) Metrics are reduced by default. Set this to `false` if you'd like to publish all metrics. We maintain a [full list of metrics](https://github.com/grafana/synthetic-monitoring-agent/tree/main/internal/scraper/testdata) collected for each. Defaults to `true`.
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
-- `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 120 seconds (120000 ms). Defaults to `60000`.
+- `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 10 second (10000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.
 - `labels` (Map of String) Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
 - `timeout` (Number) Specifies the maximum running time for the check in milliseconds. The minimum acceptable value is 1 second (1000 ms), and the maximum 10 seconds (10000 ms). Defaults to `3000`.
 

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -423,7 +423,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 - `alert_sensitivity` (String) Can be set to `none`, `low`, `medium`, or `high` to correspond to the check [alert levels](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/). Defaults to `none`.
 - `basic_metrics_only` (Boolean) Metrics are reduced by default. Set this to `false` if you'd like to publish all metrics. We maintain a [full list of metrics](https://github.com/grafana/synthetic-monitoring-agent/tree/main/internal/scraper/testdata) collected for each. Defaults to `true`.
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
-- `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 10 second (10000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.
+- `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.
 - `labels` (Map of String) Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
 - `timeout` (Number) Specifies the maximum running time for the check in milliseconds. The minimum acceptable value is 1 second (1000 ms), and the maximum 10 seconds (10000 ms). Defaults to `3000`.
 

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -676,7 +676,7 @@ multiple checks for a single endpoint to check different capabilities.
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      60000,
-				ValidateFunc: validation.IntBetween(10000, 3600000),
+				ValidateFunc: validation.IntBetween(1000, 3600000),
 			},
 			"timeout": {
 				Description: "Specifies the maximum running time for the check in milliseconds. " +

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -672,7 +672,7 @@ multiple checks for a single endpoint to check different capabilities.
 			},
 			"frequency": {
 				Description: "How often the check runs in milliseconds (the value is not truly a \"frequency\" but a \"period\"). " +
-					"The minimum acceptable value is 10 second (10000 ms), and the maximum is 1 hour (3600000 ms).",
+					"The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms).",
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      60000,

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -672,11 +672,11 @@ multiple checks for a single endpoint to check different capabilities.
 			},
 			"frequency": {
 				Description: "How often the check runs in milliseconds (the value is not truly a \"frequency\" but a \"period\"). " +
-					"The minimum acceptable value is 1 second (1000 ms), and the maximum is 120 seconds (120000 ms).",
+					"The minimum acceptable value is 10 second (10000 ms), and the maximum is 1 hour (3600000 ms).",
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      60000,
-				ValidateFunc: validation.IntBetween(1000, 120000),
+				ValidateFunc: validation.IntBetween(10000, 3600000),
 			},
 			"timeout": {
 				Description: "Specifies the maximum running time for the check in milliseconds. " +


### PR DESCRIPTION
**Summary**
This aims to update changes introduced in this PR: https://github.com/grafana/terraform-provider-grafana/pull/409/files#diff-2881232238e1b6d6b1e702da359aa74b21307f47f450d817a97f1fe9cf10f74bR480 

When using the Grafana UI (Grafana v11.1.0-69950 (a4bb4c8400)) to create a new Synthetic Check, the range for the frequency is between 10 seconds and 1 hour. 

The terraform validation function range is between 1 second and 120 seconds. 
![image](https://github.com/grafana/terraform-provider-grafana/assets/111283611/e6daaca8-3757-483b-aabd-457491c8671e)
![image](https://github.com/grafana/terraform-provider-grafana/assets/111283611/dfdfb81d-3063-4daa-b11c-c33d205b2128)

It is possible to create a check with Terraform and update it in the UI:
```
  # grafana_synthetic_monitoring_check.uptime_checks["test"] will be updated in-place
  ~ resource "grafana_synthetic_monitoring_check" "this" {
      ~ frequency          = 3600000 -> 60000
```
