### PR TITLE
Code Generation: Initial tests

### DIFF
--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -1,0 +1,109 @@
+package generate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/terraform-provider-grafana/v2/internal/testutils"
+	"github.com/grafana/terraform-provider-grafana/v2/pkg/generate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestAccGenerate_Dashboard(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/resource.tf"),
+				Check: func(s *terraform.State) error {
+					tempDir := t.TempDir()
+					config := generate.Config{
+						OutputDir:       tempDir,
+						Clobber:         true,
+						Format:          generate.OutputFormatHCL,
+						ProviderVersion: "v3.0.0",
+						Grafana: &generate.GrafanaConfig{
+							URL:  "http://localhost:3000",
+							Auth: "admin:admin",
+						},
+					}
+
+					require.NoError(t, generate.Generate(context.Background(), &config))
+					assertFiles(t, tempDir, "testdata/generate/dashboard-expected", "", []string{
+						".terraform",
+						".terraform.lock.hcl",
+					})
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// assertFiles checks that all files in the "expectedFilesDir" directory match the files in the "gotFilesDir" directory.
+func assertFiles(t *testing.T, gotFilesDir, expectedFilesDir, subdir string, ignoreDirEntries []string) {
+	t.Helper()
+
+	originalGotFilesDir := gotFilesDir
+	originalExpectedFilesDir := expectedFilesDir
+	if subdir != "" {
+		gotFilesDir = filepath.Join(gotFilesDir, subdir)
+		expectedFilesDir = filepath.Join(expectedFilesDir, subdir)
+	}
+
+	// Check that all generated files are expected (recursively)
+	gotFiles, err := os.ReadDir(gotFilesDir)
+	if err != nil {
+		t.Logf("folder %s was not generated as expected", subdir)
+		t.Fail()
+		return
+	}
+	for _, gotFile := range gotFiles {
+		relativeName := filepath.Join(subdir, gotFile.Name())
+		if slices.Contains(ignoreDirEntries, relativeName) {
+			continue
+		}
+
+		if gotFile.IsDir() {
+			assertFiles(t, originalGotFilesDir, originalExpectedFilesDir, filepath.Join(subdir, gotFile.Name()), ignoreDirEntries)
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(expectedFilesDir, gotFile.Name())); err != nil {
+			t.Logf("file %s was generated but wasn't expected", relativeName)
+			t.Fail()
+		}
+	}
+
+	// Verify the contents of the generated files (recursively)
+	// All files in the expected directory should be present in the generated directory
+	expectedFiles, err := os.ReadDir(expectedFilesDir)
+	if err != nil {
+		t.Logf("folder %s was generated but wasn't expected", subdir)
+		t.Fail()
+		return
+	}
+	for _, expectedFile := range expectedFiles {
+		if expectedFile.IsDir() {
+			assertFiles(t, originalGotFilesDir, originalExpectedFilesDir, filepath.Join(subdir, expectedFile.Name()), ignoreDirEntries)
+			continue
+		}
+		expectedContent, err := os.ReadFile(filepath.Join(expectedFilesDir, expectedFile.Name()))
+		require.NoError(t, err)
+
+		gotContent, err := os.ReadFile(filepath.Join(gotFilesDir, expectedFile.Name()))
+		require.NoError(t, err)
+
+		assert.Equal(t, strings.TrimSpace(string(expectedContent)), strings.TrimSpace(string(gotContent)))
+	}
+}

--- a/pkg/generate/testdata/generate/dashboard-expected/localhost-imports.tf
+++ b/pkg/generate/testdata/generate/dashboard-expected/localhost-imports.tf
@@ -1,0 +1,17 @@
+import {
+  provider = grafana.localhost
+  to       = grafana_dashboard.localhost_1_my-dashboard-uid
+  id       = "1:my-dashboard-uid"
+}
+
+import {
+  provider = grafana.localhost
+  to       = grafana_folder.localhost_1_my-folder-uid
+  id       = "1:my-folder-uid"
+}
+
+import {
+  provider = grafana.localhost
+  to       = grafana_notification_policy.localhost_1_policy
+  id       = "1:policy"
+}

--- a/pkg/generate/testdata/generate/dashboard-expected/localhost-provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-expected/localhost-provider.tf
@@ -1,0 +1,5 @@
+provider "grafana" {
+  alias = "localhost"
+  url   = "http://localhost:3000"
+  auth  = "admin:admin"
+}

--- a/pkg/generate/testdata/generate/dashboard-expected/localhost-resources.tf
+++ b/pkg/generate/testdata/generate/dashboard-expected/localhost-resources.tf
@@ -1,0 +1,30 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "1:my-dashboard-uid"
+resource "grafana_dashboard" "localhost_1_my-dashboard-uid" {
+  provider = grafana.localhost
+  config_json = jsonencode({
+    title = "My Dashboard"
+    uid   = "my-dashboard-uid"
+  })
+  folder = "my-folder-uid"
+  org_id = jsonencode(1)
+}
+
+# __generated__ by Terraform from "1:my-folder-uid"
+resource "grafana_folder" "localhost_1_my-folder-uid" {
+  provider = grafana.localhost
+  org_id   = jsonencode(1)
+  title    = "My Folder"
+  uid      = "my-folder-uid"
+}
+
+# __generated__ by Terraform from "1:policy"
+resource "grafana_notification_policy" "localhost_1_policy" {
+  provider           = grafana.localhost
+  contact_point      = "grafana-default-email"
+  disable_provenance = true
+  group_by           = ["grafana_folder", "alertname"]
+  org_id             = jsonencode(1)
+}

--- a/pkg/generate/testdata/generate/dashboard-expected/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-expected/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/grafana/terraform-provider-grafana/pull/1582

Implements a full integration test using the dashboard example file: This test applies the dashboard shown in the TF docs and tests that the expected files are there after generating the TF config from the instance

Note: The generated files are not optimal. This PR is not meant to modify behaviour. It just sets up a base testing framework that we can build upon