### PR TITLE
Config Generation: Find references between resources

### DIFF
--- a/pkg/generate/cloud.go
+++ b/pkg/generate/cloud.go
@@ -79,6 +79,9 @@ func generateCloudResources(ctx context.Context, cfg *Config) ([]stack, error) {
 	if err := wrapJSONFieldsInFunction(filepath.Join(cfg.OutputDir, "cloud-resources.tf")); err != nil {
 		return nil, err
 	}
+	if err := replaceReferences(filepath.Join(cfg.OutputDir, "cloud-resources.tf"), nil); err != nil {
+		return nil, err
+	}
 
 	if !cfg.Cloud.CreateStackServiceAccount {
 		return nil, nil

--- a/pkg/generate/genreferences/main.go
+++ b/pkg/generate/genreferences/main.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/format"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Find all references in the examples directory and in test files and generate a map of known references.
+// Write that map in the specified file (in args).
+func main() {
+	// Parse flags
+	var (
+		walkDir     string
+		fileToWrite string
+	)
+	flag.StringVar(&walkDir, "walk-dir", "", "directory to walk and find references in")
+	flag.StringVar(&fileToWrite, "file", "", "file to write the known references to")
+	flag.Parse()
+
+	if walkDir == "" || fileToWrite == "" {
+		log.Fatal("examples-dir and file flags are required")
+	}
+
+	exampleFiles := []string{}
+	if err := filepath.Walk(walkDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ".tf" {
+			exampleFiles = append(exampleFiles, path)
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			exampleFiles = append(exampleFiles, path)
+		}
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	resourceRe := regexp.MustCompile(`resource\s+"(\w+)"\s+"([\w-]+)"\s+\{`)
+	assignmentRe := regexp.MustCompile(`\s*(\w+)\s*=\s*(?:\[\s*)?(\w+)\.(\w+)\.(\w+)`)
+	knownReferencesMap := map[string]struct{}{}
+	for _, file := range exampleFiles {
+		log.Printf("Processing file: %s\n", file)
+
+		bytes, err := os.ReadFile(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		lines := strings.Split(string(bytes), "\n")
+		var currentResource string
+		for _, line := range lines {
+			trimmedLine := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmedLine, "output ") || strings.HasPrefix(trimmedLine, "data ") {
+				currentResource = ""
+				continue
+			}
+
+			resourceMatch := resourceRe.FindStringSubmatch(line)
+			if resourceMatch != nil {
+				currentResource = resourceMatch[1]
+				continue
+			}
+
+			if currentResource == "" {
+				continue
+			}
+
+			assignmentMatch := assignmentRe.FindStringSubmatch(line)
+			if assignmentMatch != nil {
+				refToResource, refToAttribute := assignmentMatch[2], assignmentMatch[4]
+				if !strings.HasPrefix(refToResource, "grafana_") { // TODO: Enable data resources
+					continue
+				}
+				entry := fmt.Sprintf("%s.%s=%s.%s", currentResource, assignmentMatch[1], refToResource, refToAttribute)
+				knownReferencesMap[entry] = struct{}{}
+			}
+		}
+	}
+	var knownReferences []string
+	for k := range knownReferencesMap {
+		knownReferences = append(knownReferences, k)
+	}
+	sort.Strings(knownReferences)
+
+	// Write the known references to the specified file
+	// Find the knownReferences var and replace it
+	log.Printf("Writing known references to %s\n", fileToWrite)
+	bytes, err := os.ReadFile(fileToWrite)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stat, err := os.Stat(fileToWrite)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	content := string(bytes)
+	start := strings.Index(content, "var knownReferences = []string{")
+	if start == -1 {
+		log.Fatal("Could not find knownReferences var")
+	}
+	end := strings.Index(content[start:], "}")
+
+	knownReferencesStr := "var knownReferences = []string{\n"
+	for _, v := range knownReferences {
+		knownReferencesStr += fmt.Sprintf("%q,\n", v)
+	}
+	knownReferencesStr += "}"
+	fmt.Println(knownReferencesStr)
+
+	content = content[:start] + knownReferencesStr + content[start+end+1:]
+
+	// Run gofmt on the content
+	bytesToWrite, err := format.Source([]byte(content))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := os.WriteFile(fileToWrite, bytesToWrite, stat.Mode()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/generate/grafana.go
+++ b/pkg/generate/grafana.go
@@ -85,6 +85,11 @@ func generateGrafanaResources(ctx context.Context, cfg *Config, stack stack, gen
 	if err := wrapJSONFieldsInFunction(generatedFilename("resources.tf")); err != nil {
 		return err
 	}
+	if err := replaceReferences(generatedFilename("resources.tf"), []string{
+		"*.org_id=grafana_organization.id",
+	}); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/generate/postprocessing.go
+++ b/pkg/generate/postprocessing.go
@@ -16,6 +16,196 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// knownReferences is a map of all resource fields that can be referenced from another resource.
+// For example, the `folder` field of a `grafana_dashboard` resource can be a `grafana_folder` reference.
+//
+//go:generate go run ./genreferences --file=$GOFILE --walk-dir=../..
+var knownReferences = []string{
+	"grafana_annotation.dashboard_uid=grafana_dashboard.uid",
+	"grafana_annotation.org_id=grafana_organization.id",
+	"grafana_api_key.auth=grafana_api_key.key",
+	"grafana_cloud_access_policy.identifier=grafana_cloud_stack.id",
+	"grafana_cloud_access_policy_token.access_policy_id=grafana_cloud_access_policy.policy_id",
+	"grafana_cloud_plugin_installation.stack_slug=grafana_cloud_stack.slug",
+	"grafana_cloud_stack_service_account.stack_slug=grafana_cloud_stack.slug",
+	"grafana_cloud_stack_service_account_token.auth=grafana_cloud_stack_service_account_token.key",
+	"grafana_cloud_stack_service_account_token.service_account_id=grafana_cloud_stack_service_account.id",
+	"grafana_cloud_stack_service_account_token.stack_slug=grafana_cloud_stack.slug",
+	"grafana_cloud_stack_service_account_token.url=grafana_cloud_stack.url",
+	"grafana_contact_point.org_id=grafana_organization.id",
+	"grafana_dashboard.folder=grafana_folder.id",
+	"grafana_dashboard.folder=grafana_folder.uid",
+	"grafana_dashboard.name=grafana_library_panel.name",
+	"grafana_dashboard.org_id=grafana_organization.id",
+	"grafana_dashboard.org_id=grafana_organization.org_id",
+	"grafana_dashboard.uid=grafana_library_panel.uid",
+	"grafana_dashboard_permission.dashboard_uid=grafana_dashboard.uid",
+	"grafana_dashboard_permission.team_id=grafana_team.id",
+	"grafana_dashboard_permission.user_id=grafana_user.id",
+	"grafana_dashboard_permission_item.dashboard_uid=grafana_dashboard.uid",
+	"grafana_dashboard_permission_item.team=grafana_team.id",
+	"grafana_dashboard_permission_item.user=grafana_service_account.id",
+	"grafana_dashboard_permission_item.user=grafana_user.id",
+	"grafana_dashboard_public.dashboard_uid=grafana_dashboard.uid",
+	"grafana_dashboard_public.org_id=grafana_organization.org_id",
+	"grafana_data_source.datasourceUid=grafana_data_source.uid",
+	"grafana_data_source.org_id=grafana_organization.id",
+	"grafana_data_source_config.datasourceUid=grafana_data_source.uid",
+	"grafana_data_source_config.uid=grafana_data_source.uid",
+	"grafana_data_source_permission.datasource_uid=grafana_data_source.uid",
+	"grafana_data_source_permission.team_id=grafana_team.id",
+	"grafana_data_source_permission.user_id=grafana_service_account.id",
+	"grafana_data_source_permission.user_id=grafana_user.id",
+	"grafana_data_source_permission_item.datasource_uid=grafana_data_source.uid",
+	"grafana_data_source_permission_item.team=grafana_team.id",
+	"grafana_data_source_permission_item.user=grafana_service_account.id",
+	"grafana_data_source_permission_item.user=grafana_user.id",
+	"grafana_folder.org_id=grafana_organization.id",
+	"grafana_folder.org_id=grafana_organization.org_id",
+	"grafana_folder.parent_folder_uid=grafana_folder.uid",
+	"grafana_folder_permission.folder_uid=grafana_folder.uid",
+	"grafana_folder_permission.team_id=grafana_team.id",
+	"grafana_folder_permission.user_id=grafana_service_account.id",
+	"grafana_folder_permission.user_id=grafana_user.id",
+	"grafana_folder_permission_item.folder_uid=grafana_folder.uid",
+	"grafana_folder_permission_item.team=grafana_team.id",
+	"grafana_folder_permission_item.user=grafana_service_account.id",
+	"grafana_folder_permission_item.user=grafana_user.id",
+	"grafana_library_panel.folder_uid=grafana_folder.uid",
+	"grafana_library_panel.org_id=grafana_organization.id",
+	"grafana_machine_learning_job.datasource_uid=grafana_data_source.uid",
+	"grafana_message_template.org_id=grafana_organization.id",
+	"grafana_notification_policy.contact_point=grafana_contact_point.name",
+	"grafana_notification_policy.mute_timings=grafana_mute_timing.name",
+	"grafana_notification_policy.org_id=grafana_organization.id",
+	"grafana_oncall_escalation.escalation_chain_id=grafana_oncall_escalation_chain.id",
+	"grafana_oncall_integration.escalation_chain_id=grafana_oncall_escalation_chain.id",
+	"grafana_oncall_route.escalation_chain_id=grafana_oncall_escalation_chain.id",
+	"grafana_oncall_route.integration_id=grafana_oncall_integration.id",
+	"grafana_organization.org_id=grafana_organization.id",
+	"grafana_organization_preferences.home_dashboard_uid=grafana_dashboard.uid",
+	"grafana_organization_preferences.org_id=grafana_organization.id",
+	"grafana_playlist.org_id=grafana_organization.id",
+	"grafana_report.dashboard_id=grafana_dashboard.dashboard_id",
+	"grafana_report.org_id=grafana_organization.id",
+	"grafana_report.uid=grafana_dashboard.uid",
+	"grafana_role.org_id=grafana_organization.id",
+	"grafana_role_assignment.auth=grafana_cloud_stack_service_account_token.key",
+	"grafana_role_assignment.org_id=grafana_organization.id",
+	"grafana_role_assignment.role_uid=grafana_role.uid",
+	"grafana_role_assignment.service_accounts=grafana_cloud_stack_service_account.id",
+	"grafana_role_assignment.service_accounts=grafana_service_account.id",
+	"grafana_role_assignment.teams=grafana_team.id",
+	"grafana_role_assignment.url=grafana_cloud_stack.url",
+	"grafana_role_assignment.users=grafana_user.id",
+	"grafana_role_assignment_item.role_uid=grafana_role.uid",
+	"grafana_role_assignment_item.service_account_id=grafana_service_account.id",
+	"grafana_role_assignment_item.team_id=grafana_team.id",
+	"grafana_role_assignment_item.user_id=grafana_user.id",
+	"grafana_rule_group.folder_uid=grafana_folder.uid",
+	"grafana_rule_group.org_id=grafana_organization.id",
+	"grafana_service_account.org_id=grafana_organization.id",
+	"grafana_service_account.role_uid=grafana_role.uid",
+	"grafana_service_account.service_account_id=grafana_service_account.id",
+	"grafana_service_account.team_id=grafana_team.id",
+	"grafana_service_account.user_id=grafana_user.id",
+	"grafana_service_account_permission.org_id=grafana_organization.id",
+	"grafana_service_account_permission.service_account_id=grafana_cloud_stack_service_account.id",
+	"grafana_service_account_permission.service_account_id=grafana_service_account.id",
+	"grafana_service_account_permission.team_id=grafana_team.id",
+	"grafana_service_account_permission.user_id=grafana_user.id",
+	"grafana_service_account_permission_item.auth=grafana_cloud_stack_service_account_token.key",
+	"grafana_service_account_permission_item.org_id=grafana_organization.id",
+	"grafana_service_account_permission_item.service_account_id=grafana_cloud_stack_service_account.id",
+	"grafana_service_account_permission_item.service_account_id=grafana_service_account.id",
+	"grafana_service_account_permission_item.team=grafana_team.id",
+	"grafana_service_account_permission_item.url=grafana_cloud_stack.url",
+	"grafana_service_account_permission_item.user=grafana_user.id",
+	"grafana_service_account_token.auth=grafana_service_account_token.key",
+	"grafana_service_account_token.service_account_id=grafana_service_account.id",
+	"grafana_slo.folder_uid=grafana_folder.uid",
+	"grafana_synthetic_monitoring_installation.logs_instance_id=grafana_cloud_stack.logs_user_id",
+	"grafana_synthetic_monitoring_installation.metrics_instance_id=grafana_cloud_stack.prometheus_user_id",
+	"grafana_synthetic_monitoring_installation.metrics_publisher_key=grafana_cloud_access_policy_token.token",
+	"grafana_synthetic_monitoring_installation.metrics_publisher_key=grafana_cloud_api_key.key",
+	"grafana_synthetic_monitoring_installation.sm_access_token=grafana_synthetic_monitoring_installation.sm_access_token",
+	"grafana_synthetic_monitoring_installation.sm_url=grafana_synthetic_monitoring_installation.stack_sm_api_url",
+	"grafana_synthetic_monitoring_installation.stack_id=grafana_cloud_stack.id",
+	"grafana_team.home_dashboard_uid=grafana_dashboard.uid",
+	"grafana_team.org_id=grafana_organization.id",
+	"grafana_team_external_group.team_id=grafana_team.id",
+	"grafana_team_preferences.home_dashboard_uid=grafana_dashboard.uid",
+	"grafana_team_preferences.team_id=grafana_team.id",
+}
+
+// TODO: Also find references from the state (computed fields, like ID)
+func replaceReferences(fpath string, extraKnownReferences []string) error {
+	file, err := readHCLFile(fpath)
+	if err != nil {
+		return err
+	}
+
+	hasChanges := false
+
+	knownReferences := knownReferences
+	knownReferences = append(knownReferences, extraKnownReferences...)
+	// Find all resources. This map will be used to search for references
+	resourcesBlocks := map[string]*hclwrite.Block{}
+	for _, block := range file.Body().Blocks() {
+		if block.Type() == "resource" {
+			resourcesBlocks[block.Labels()[0]+"."+block.Labels()[1]] = block
+		}
+	}
+
+	for _, block := range file.Body().Blocks() {
+		for attrName, attr := range block.Body().Attributes() {
+			attrValue := string(attr.Expr().BuildTokens(nil).Bytes())
+			attrReplaced := false
+
+			// Check the field name. If it has a possible reference, we have to search for it in the resources
+			for _, ref := range knownReferences {
+				if attrReplaced {
+					break
+				}
+
+				refFrom := strings.Split(ref, "=")[0]
+				refTo := strings.Split(ref, "=")[1]
+				hasPossibleReference := refFrom == fmt.Sprintf("%s.%s", block.Labels()[0], attrName) || (strings.HasPrefix(refFrom, "*.") && strings.HasSuffix(refFrom, fmt.Sprintf(".%s", attrName)))
+				if !hasPossibleReference {
+					continue
+				}
+
+				refToResource := strings.Split(refTo, ".")[0]
+				refToAttr := strings.Split(refTo, ".")[1]
+
+				for possibleResourceRefName, possibleResourceRef := range resourcesBlocks {
+					if strings.HasPrefix(possibleResourceRefName, refToResource+".") {
+						valueFromRef := ""
+						if possibleResourceRef.Body().GetAttribute(refToAttr) != nil {
+							valueFromRef = string(possibleResourceRef.Body().GetAttribute(refToAttr).Expr().BuildTokens(nil).Bytes())
+						}
+						// If the value from the first block matches the value from the second block, we have a reference
+						if attrValue == valueFromRef {
+							// Replace the value with the reference
+							block.Body().SetAttributeTraversal(attrName, traversal(possibleResourceRefName, refToAttr))
+							hasChanges = true
+							attrReplaced = true
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if hasChanges {
+		log.Printf("Updating file: %s\n", fpath)
+		return os.WriteFile(fpath, file.Bytes(), 0600)
+	}
+
+	return nil
+}
+
 func stripDefaults(fpath string, extraFieldsToRemove map[string]any) error {
 	file, err := readHCLFile(fpath)
 	if err != nil {

--- a/pkg/generate/testdata/generate/alerting-in-org/resources.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/resources.tf
@@ -65,7 +65,7 @@ resource "grafana_organization_preferences" "_2" {
 # __generated__ by Terraform from "2:alert-rule-folder:My Rule Group"
 resource "grafana_rule_group" "_2_alert-rule-folder_My_Rule_Group" {
   disable_provenance = false
-  folder_uid         = "alert-rule-folder"
+  folder_uid         = grafana_folder._2_alert-rule-folder.uid
   interval_seconds   = 240
   name               = "My Rule Group"
   org_id             = jsonencode(2)

--- a/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
@@ -4,7 +4,7 @@
       "_1_my-dashboard-uid": [
         {
           "config_json": "${jsonencode({\n    title = \"My Dashboard\"\n    uid   = \"my-dashboard-uid\"\n  })}",
-          "folder": "my-folder-uid"
+          "folder": "${grafana_folder._1_my-folder-uid.uid}"
         }
       ]
     },

--- a/pkg/generate/testdata/generate/dashboard/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard/resources.tf
@@ -7,7 +7,7 @@ resource "grafana_dashboard" "_1_my-dashboard-uid" {
     title = "My Dashboard"
     uid   = "my-dashboard-uid"
   })
-  folder = "my-folder-uid"
+  folder = grafana_folder._1_my-folder-uid.uid
 }
 
 # __generated__ by Terraform from "1:my-folder-uid"


### PR DESCRIPTION
- Step 1: Find all possible references (ex: `folder` attribute from dashboard can be a `grafana_folder.uid` attribute) from tests and examples
- Step 2: Use those known references to match values between resources

TODO next: Also use the plan state to find refs. Computed fields are not going to be in the configuration (this includes the ID)