### PR TITLE
Config Generation: Add type and name filter

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -57,6 +57,17 @@ func run() error {
 				EnvVars: []string{"TFGEN_TERRAFORM_PROVIDER_VERSION"},
 				Value:   version,
 			},
+			&cli.StringSliceFlag{
+				Name: "include-resources",
+				Usage: `List of resources to include in the "resourceType.resourceName" format. If not set, all resources will be included
+This supports a glob format. Examples:
+  * Generate all dashboards and folders: --resource-names 'grafana_dashboard.*' --resource-names 'grafana_folder.*'
+  * Generate all resources with "hello" in their ID (this is usually the resource UIDs): --resource-names '*.*hello*'
+  * Generate all resources (same as default behaviour): --resource-names '*.*'
+`,
+				EnvVars:  []string{"TFGEN_INCLUDE_RESOURCES"},
+				Required: false,
+			},
 
 			// Grafana OSS flags
 			&cli.StringFlag{
@@ -130,6 +141,7 @@ func parseFlags(ctx *cli.Context) (*generate.Config, error) {
 			CreateStackServiceAccount: ctx.Bool("cloud-create-stack-service-account"),
 			StackServiceAccountName:   ctx.String("cloud-stack-service-account-name"),
 		},
+		IncludeResources: ctx.StringSlice("include-resources"),
 	}
 
 	if config.ProviderVersion == "" {

--- a/pkg/generate/cloud.go
+++ b/pkg/generate/cloud.go
@@ -66,7 +66,7 @@ func generateCloudResources(ctx context.Context, cfg *Config) ([]stack, error) {
 	}
 
 	data := cloud.NewListerData(cfg.Cloud.Org)
-	if err := generateImportBlocks(ctx, client, data, cloud.Resources, cfg.OutputDir, "cloud"); err != nil {
+	if err := generateImportBlocks(ctx, client, data, cloud.Resources, cfg.OutputDir, "cloud", cfg.IncludeResources); err != nil {
 		return nil, err
 	}
 

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -23,7 +23,13 @@ type CloudConfig struct {
 }
 
 type Config struct {
-	OutputDir       string
+	// IncludeResources is a list of patterns to filter resources by.
+	// If a resource name matches any of the patterns, it will be included in the output.
+	// Patterns are in the form of `resourceType.resourceName` and support * as a wildcard.
+	IncludeResources []string
+	// OutputDir is the directory to write the generated files to.
+	OutputDir string
+	// Clobber will overwrite existing files in the output directory.
 	Clobber         bool
 	Format          OutputFormat
 	ProviderVersion string

--- a/pkg/generate/grafana.go
+++ b/pkg/generate/grafana.go
@@ -15,7 +15,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func generateGrafanaResources(ctx context.Context, auth, url, stackName string, genProvider bool, outPath, smURL, smToken string) error {
+// TODO: Refactor this sig
+func generateGrafanaResources(ctx context.Context, auth, url, stackName string, genProvider bool, outPath, smURL, smToken string, includedResources []string) error {
 	generatedFilename := func(suffix string) string {
 		if stackName == "" {
 			return filepath.Join(outPath, suffix)
@@ -65,7 +66,7 @@ func generateGrafanaResources(ctx context.Context, auth, url, stackName string, 
 		resources = append(resources, machinelearning.Resources...)
 		resources = append(resources, syntheticmonitoring.Resources...)
 	}
-	if err := generateImportBlocks(ctx, client, listerData, resources, outPath, stackName); err != nil {
+	if err := generateImportBlocks(ctx, client, listerData, resources, outPath, stackName, includedResources); err != nil {
 		return err
 	}
 

--- a/pkg/generate/testdata/generate/dashboard-filtered/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/imports.tf
@@ -1,0 +1,4 @@
+import {
+  to = grafana_dashboard._1_my-dashboard-uid
+  id = "1:my-dashboard-uid"
+}

--- a/pkg/generate/testdata/generate/dashboard-filtered/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.0.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}

--- a/pkg/generate/testdata/generate/dashboard-filtered/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/resources.tf
@@ -1,0 +1,11 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "1:my-dashboard-uid"
+resource "grafana_dashboard" "_1_my-dashboard-uid" {
+  config_json = jsonencode({
+    title = "My Dashboard"
+    uid   = "my-dashboard-uid"
+  })
+  folder = "my-folder-uid"
+}


### PR DESCRIPTION
Allows generating only a subset of resources, or all resources containing a certain string in their ID (or a combination of that)