### PR TITLE
Config Generation: Go implementation for executing Terraform binary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,11 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.6
 	github.com/hashicorp/go-uuid v1.0.3
+	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/hc-install v0.6.4
 	github.com/hashicorp/hcl/v2 v2.20.1
+	github.com/hashicorp/terraform-exec v0.21.0
+	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hashicorp/terraform-plugin-docs v0.19.2
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
@@ -30,15 +34,8 @@ require (
 	github.com/tmccombs/hcl2json v0.6.3
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/zclconf/go-cty v1.14.4
-	golang.org/x/text v0.15.0
-)
-
-require (
-	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hc-install v0.6.4
-	github.com/hashicorp/terraform-exec v0.21.0
-	github.com/hashicorp/terraform-json v0.22.1
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
+	golang.org/x/text v0.15.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,14 @@ require (
 )
 
 require (
+	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/hc-install v0.6.4
+	github.com/hashicorp/terraform-exec v0.21.0
+	github.com/hashicorp/terraform-json v0.22.1
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
+)
+
+require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -70,11 +78,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/hc-install v0.6.4 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.21.0 // indirect
-	github.com/hashicorp/terraform-json v0.22.1 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
@@ -111,7 +115,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/mod v0.16.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
@@ -125,3 +128,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/hashicorp/terraform-exec v0.21.0 => github.com/hrmsk66/terraform-exec v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/hashicorp/hcl/v2 v2.20.1 h1:M6hgdyz7HYt1UN9e61j+qKJBqR3orTWbI1HKBJEdx
 github.com/hashicorp/hcl/v2 v2.20.1/go.mod h1:TZDqQ4kNKCbh1iJp99FdPiUaVDDUPivbqxZulxDYqL4=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=
-github.com/hashicorp/terraform-exec v0.21.0/go.mod h1:1PPeMYou+KDUSSeRE9szMZ/oHf4fYUmB923Wzbq1ICg=
 github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7orfb5Ltvec=
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-plugin-docs v0.19.2 h1:YjdKa1vuqt9EnPYkkrv9HnGZz175HhSJ7Vsn8yZeWus=
@@ -171,6 +169,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/hrmsk66/terraform-exec v0.21.0 h1:k/hnRAZULf6rkzJW7v2fRKAA1wAshyiUv1clw3RklrQ=
+github.com/hrmsk66/terraform-exec v0.21.0/go.mod h1:rHqaL9Y7oPlRDZffl2xr/UkSrIhKL2l9G5P81Sza7Ts=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -1,5 +1,7 @@
 package generate
 
+import "github.com/hashicorp/terraform-exec/tfexec"
+
 type OutputFormat string
 
 const (
@@ -35,4 +37,5 @@ type Config struct {
 	ProviderVersion string
 	Grafana         *GrafanaConfig
 	Cloud           *CloudConfig
+	Terraform       *tfexec.Terraform
 }

--- a/pkg/generate/terraform_state.go
+++ b/pkg/generate/terraform_state.go
@@ -1,39 +1,16 @@
 package generate
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
-type state map[string]interface{}
-type resource map[string]interface{}
-
-func (s state) resources() []resource {
-	values := s["values"].(map[string]interface{})
-	rootModule := values["root_module"].(map[string]interface{})
-	var resources []resource
-	for _, resourceInterface := range rootModule["resources"].([]interface{}) {
-		resources = append(resources, resourceInterface.(map[string]interface{}))
-	}
-	return resources
-}
-
-func (r resource) resourceType() string {
-	return r["type"].(string)
-}
-
-func (r resource) values() map[string]interface{} {
-	return r["values"].(map[string]interface{})
-}
-
-func getState(dir string) (state, error) {
-	state, err := runTerraformWithOutput(dir, "show", "-json")
+func getState(ctx context.Context, cfg *Config) (*tfjson.State, error) {
+	state, err := cfg.Terraform.Show(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read terraform state: %w", err)
 	}
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(state, &parsed); err != nil {
-		return nil, fmt.Errorf("failed to parse terraform state: %w", err)
-	}
-	return parsed, nil
+	return state, nil
 }


### PR DESCRIPTION
This PR refactors the generator to use https://github.com/hashicorp/terraform-exec/ to execute the Terraform binary. This removes the need for the user to provide the Terraform binary as part of their runtime environment, allowing the generator to be used as a library with less friction.