### PR TITLE
Config Generation: Add tests for alerting resources

### DIFF
--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -90,6 +90,20 @@ func TestAccGenerate(t *testing.T) {
 				})
 			},
 		},
+		{
+			name: "alerting-in-org",
+			config: func() string {
+				content, err := os.ReadFile("testdata/generate/alerting-in-org.tf")
+				require.NoError(t, err)
+				return string(content)
+			}(),
+			check: func(t *testing.T, tempDir string) {
+				assertFiles(t, tempDir, "testdata/generate/alerting-in-org", []string{
+					".terraform",
+					".terraform.lock.hcl",
+				})
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/generate/testdata/generate/alerting-in-org.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org.tf
@@ -1,0 +1,129 @@
+resource "grafana_organization" "test" {
+  name = "alerting-org"
+}
+
+resource "grafana_contact_point" "test" {
+  org_id = grafana_organization.test.id
+  name   = "my-contact-point"
+  email {
+    addresses = ["hello@example.com"]
+  }
+}
+
+resource "grafana_notification_policy" "test" {
+  org_id        = grafana_organization.test.id
+  contact_point = grafana_contact_point.test.name
+  group_by      = ["..."]
+}
+
+resource "grafana_mute_timing" "my_mute_timing" {
+  org_id = grafana_organization.test.id
+  name   = "My Mute Timing"
+
+  intervals {
+    times {
+      start = "04:56"
+      end   = "14:17"
+    }
+    weekdays      = ["monday", "tuesday:thursday"]
+    days_of_month = ["1:7", "-1"]
+    months        = ["1:3", "december"]
+    years         = ["2030", "2025:2026"]
+    location      = "America/New_York"
+  }
+}
+
+resource "grafana_message_template" "my_template" {
+  org_id   = grafana_organization.test.id
+  name     = "My Reusable Template"
+  template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+}
+
+resource "grafana_folder" "rule_folder" {
+  org_id = grafana_organization.test.id
+  title  = "My Alert Rule Folder"
+  uid    = "alert-rule-folder"
+}
+
+resource "grafana_rule_group" "my_alert_rule" {
+  org_id           = grafana_organization.test.id
+  name             = "My Rule Group"
+  folder_uid       = grafana_folder.rule_folder.uid
+  interval_seconds = 240
+  rule {
+    name           = "My Alert Rule 1"
+    for            = "2m"
+    condition      = "B"
+    no_data_state  = "NoData"
+    exec_err_state = "Alerting"
+    annotations = {
+      "a" = "b"
+      "c" = "d"
+    }
+    labels = {
+      "e" = "f"
+      "g" = "h"
+    }
+    is_paused = false
+    data {
+      ref_id     = "A"
+      query_type = ""
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      datasource_uid = "PD8C576611E62080A"
+      model = jsonencode({
+        hide          = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+        refId         = "A"
+      })
+    }
+    data {
+      ref_id     = "B"
+      query_type = ""
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      datasource_uid = "-100"
+      model          = <<EOT
+{
+    "conditions": [
+        {
+        "evaluator": {
+            "params": [
+            3
+            ],
+            "type": "gt"
+        },
+        "operator": {
+            "type": "and"
+        },
+        "query": {
+            "params": [
+            "A"
+            ]
+        },
+        "reducer": {
+            "params": [],
+            "type": "last"
+        },
+        "type": "query"
+        }
+    ],
+    "datasource": {
+        "type": "__expr__",
+        "uid": "-100"
+    },
+    "hide": false,
+    "intervalMs": 1000,
+    "maxDataPoints": 43200,
+    "refId": "B",
+    "type": "classic_conditions"
+}
+EOT
+    }
+  }
+}

--- a/pkg/generate/testdata/generate/alerting-in-org/imports.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/imports.tf
@@ -1,0 +1,44 @@
+import {
+  to = grafana_folder._2_alert-rule-folder
+  id = "2:alert-rule-folder"
+}
+
+import {
+  to = grafana_message_template._2_My_Reusable_Template
+  id = "2:My Reusable Template"
+}
+
+import {
+  to = grafana_mute_timing._2_My_Mute_Timing
+  id = "2:My Mute Timing"
+}
+
+import {
+  to = grafana_notification_policy._2_policy
+  id = "2:policy"
+}
+
+import {
+  to = grafana_notification_policy._1_policy
+  id = "1:policy"
+}
+
+import {
+  to = grafana_organization._2
+  id = "2"
+}
+
+import {
+  to = grafana_organization_preferences._2
+  id = "2"
+}
+
+import {
+  to = grafana_organization_preferences._1
+  id = "1"
+}
+
+import {
+  to = grafana_rule_group._2_alert-rule-folder_My_Rule_Group
+  id = "2:alert-rule-folder:My Rule Group"
+}

--- a/pkg/generate/testdata/generate/alerting-in-org/provider.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.0.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}

--- a/pkg/generate/testdata/generate/alerting-in-org/resources.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/resources.tf
@@ -1,0 +1,134 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "2:alert-rule-folder"
+resource "grafana_folder" "_2_alert-rule-folder" {
+  org_id = jsonencode(2)
+  title  = "My Alert Rule Folder"
+  uid    = "alert-rule-folder"
+}
+
+# __generated__ by Terraform from "2:My Reusable Template"
+resource "grafana_message_template" "_2_My_Reusable_Template" {
+  name     = "My Reusable Template"
+  org_id   = jsonencode(2)
+  template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+}
+
+# __generated__ by Terraform from "2:My Mute Timing"
+resource "grafana_mute_timing" "_2_My_Mute_Timing" {
+  name   = "My Mute Timing"
+  org_id = jsonencode(2)
+  intervals {
+    days_of_month = ["1:7", "-1"]
+    location      = "America/New_York"
+    months        = ["1:3", "12"]
+    weekdays      = ["monday", "tuesday:thursday"]
+    years         = ["2030", "2025:2026"]
+    times {
+      end   = "14:17"
+      start = "04:56"
+    }
+  }
+}
+
+# __generated__ by Terraform from "1:policy"
+resource "grafana_notification_policy" "_1_policy" {
+  contact_point      = "grafana-default-email"
+  disable_provenance = true
+  group_by           = ["grafana_folder", "alertname"]
+}
+
+# __generated__ by Terraform from "2:policy"
+resource "grafana_notification_policy" "_2_policy" {
+  contact_point      = "my-contact-point"
+  disable_provenance = false
+  group_by           = ["..."]
+  org_id             = jsonencode(2)
+}
+
+# __generated__ by Terraform from "2"
+resource "grafana_organization" "_2" {
+  admins = ["admin@localhost"]
+  name   = "alerting-org"
+}
+
+# __generated__ by Terraform from "1"
+resource "grafana_organization_preferences" "_1" {
+}
+
+# __generated__ by Terraform from "2"
+resource "grafana_organization_preferences" "_2" {
+  org_id = jsonencode(2)
+}
+
+# __generated__ by Terraform from "2:alert-rule-folder:My Rule Group"
+resource "grafana_rule_group" "_2_alert-rule-folder_My_Rule_Group" {
+  disable_provenance = false
+  folder_uid         = "alert-rule-folder"
+  interval_seconds   = 240
+  name               = "My Rule Group"
+  org_id             = jsonencode(2)
+  rule {
+    annotations = {
+      a = "b"
+      c = "d"
+    }
+    condition      = "B"
+    exec_err_state = "Alerting"
+    for            = "2m0s"
+    is_paused      = false
+    labels = {
+      e = "f"
+      g = "h"
+    }
+    name          = "My Alert Rule 1"
+    no_data_state = "NoData"
+    data {
+      datasource_uid = "PD8C576611E62080A"
+      model = jsonencode({
+        hide  = false
+        refId = "A"
+      })
+      ref_id = "A"
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+    }
+    data {
+      datasource_uid = jsonencode(-100)
+      model = jsonencode({
+        conditions = [{
+          evaluator = {
+            params = [3]
+            type   = "gt"
+          }
+          operator = {
+            type = "and"
+          }
+          query = {
+            params = ["A"]
+          }
+          reducer = {
+            params = []
+            type   = "last"
+          }
+          type = "query"
+        }]
+        datasource = {
+          type = "__expr__"
+          uid  = "-100"
+        }
+        hide  = false
+        refId = "B"
+        type  = "classic_conditions"
+      })
+      ref_id = "B"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
They deal with an alertmanager that needs to be provisioned for each org so it's good to add a test for this 
I also investigated why contact points can't be generated. I think it's fixable. To be seen