### PR TITLE
Config Generation: Do not crash when everything is filtered out

### DIFF
--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -204,15 +204,23 @@ func generateImportBlocks(ctx context.Context, client *common.Client, listerData
 		allBlocks = append(allBlocks, r.blocks...)
 	}
 
+	if len(allBlocks) == 0 {
+		if err := os.WriteFile(generatedFilename("resources.tf"), []byte("# No resources were found\n"), 0600); err != nil {
+			return err
+		}
+		if err := os.WriteFile(generatedFilename("imports.tf"), []byte("# No resources were found\n"), 0600); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if err := writeBlocks(generatedFilename("imports.tf"), allBlocks...); err != nil {
 		return err
 	}
-
 	_, err = cfg.Terraform.Plan(ctx, tfexec.GenerateConfigOut(generatedFilename("resources.tf")))
 	if err != nil {
 		return fmt.Errorf("failed to generate resources: %w", err)
 	}
-
 	return sortResourcesFile(generatedFilename("resources.tf"))
 }
 

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -91,6 +91,19 @@ func TestAccGenerate(t *testing.T) {
 			},
 		},
 		{
+			name:   "filter-all",
+			config: testutils.TestAccExample(t, "resources/grafana_dashboard/resource.tf"),
+			generateConfig: func(cfg *generate.Config) {
+				cfg.IncludeResources = []string{"doesnot.exist"}
+			},
+			check: func(t *testing.T, tempDir string) {
+				assertFiles(t, tempDir, "testdata/generate/empty", []string{
+					".terraform",
+					".terraform.lock.hcl",
+				})
+			},
+		},
+		{
 			name: "alerting-in-org",
 			config: func() string {
 				content, err := os.ReadFile("testdata/generate/alerting-in-org.tf")

--- a/pkg/generate/testdata/generate/empty/imports.tf
+++ b/pkg/generate/testdata/generate/empty/imports.tf
@@ -1,0 +1,1 @@
+# No resources were found

--- a/pkg/generate/testdata/generate/empty/provider.tf
+++ b/pkg/generate/testdata/generate/empty/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.0.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}

--- a/pkg/generate/testdata/generate/empty/resources.tf
+++ b/pkg/generate/testdata/generate/empty/resources.tf
@@ -1,0 +1,1 @@
+# No resources were found


### PR DESCRIPTION
Instead, generate empty files that tell the user what happened