### PR TITLE
Grafana rule group detect rule name conflicts

### DIFF
--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -293,7 +293,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 	})
 }
 
-func TestAccAlertRule_nameConflict(t *testing.T) {
+func TestAccAlertRule_ruleNameConflict(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	name := acctest.RandString(10)
@@ -314,11 +314,11 @@ resource "grafana_folder" "first" {
 
 resource "grafana_rule_group" "first" {
 	org_id = grafana_organization.test.id
-	name             = "%[1]s"
+	name             = "alert rule group 1"
 	folder_uid       = grafana_folder.first.uid
 	interval_seconds = 60
 	rule {
-		name           = "My Alert Rule first"
+		name           = "My Alert Rule"
 		for            = "2m"
 		condition      = "B"
 		no_data_state  = "NoData"
@@ -340,21 +340,8 @@ resource "grafana_rule_group" "first" {
 			})
 		}
 	}
-}
-
-resource "grafana_folder" "second" {
-	depends_on = [grafana_rule_group.first]
-	org_id = grafana_organization.test.id
-	title = "%[1]s-second"
-}
-
-resource "grafana_rule_group" "second" {
-	org_id = grafana_organization.test.id
-	name             = "%[1]s"
-	folder_uid       = grafana_folder.second.uid
-	interval_seconds = 60
 	rule {
-		name           = "My Alert Rule second"
+		name           = "My Alert Rule"
 		for            = "2m"
 		condition      = "B"
 		no_data_state  = "NoData"
@@ -378,7 +365,7 @@ resource "grafana_rule_group" "second" {
 	}
 }
 				`, name),
-				ExpectError: regexp.MustCompile(`rule group with name "` + name + `" already exists`),
+				ExpectError: regexp.MustCompile(`rule with name "My Alert Rule" is defined more than once`),
 			},
 		},
 	})


### PR DESCRIPTION
Based on Issue #1534, it has been clarified that the non-duplicative aspect should apply to `rule names` rather than `rule group names`.

The modifications in PR #1550 will result in disallowing the existence of duplicate `rule group names` within different folders. However, this should be permissible.

This adjustment will entail checking for duplicate `rule names` within the same `rule group` and also verifying if duplicate `rule names` exist for rules already present on `Grafana`.

Upon testing, it has been observed that blocking identical rule names will only occur within the same rule group. 
It is indeed permissible for rule groups in different folders to have duplicate `rule names`.