### PR TITLE
Rule group detect rule name conflicts 

### DIFF
--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -351,6 +351,7 @@ func putAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta inte
 
 		for _, rule := range respAlertRules.Payload {
 			name := data.Get("name").(string)
+			folder := data.Get("folder").(string)
 			if *rule.RuleGroup == name && *rule.FolderUID == folder {
 				return diag.Errorf("rule group with name %q already exists", name)
 			}

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -351,7 +351,7 @@ func putAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta inte
 
 		for _, rule := range respAlertRules.Payload {
 			name := data.Get("name").(string)
-			folder := data.Get("folder").(string)
+			folder := data.Get("folder_uid").(string)
 			if *rule.RuleGroup == name && *rule.FolderUID == folder {
 				return diag.Errorf("rule group with name %q already exists", name)
 			}

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -293,6 +293,91 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 	})
 }
 
+func TestAccAlertRule_nameConflict(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_organization" "test" {
+	name = "%[1]s"
+}
+
+resource "grafana_folder" "test" {
+	org_id = grafana_organization.test.id
+	title = "%[1]s-test"
+}
+
+resource "grafana_rule_group" "test" {
+	org_id = grafana_organization.test.id
+	name             = "%[1]s"
+	folder_uid       = grafana_folder.test.uid
+	interval_seconds = 60
+	rule {
+		name           = "My Alert Rule first"
+		for            = "2m"
+		condition      = "B"
+		no_data_state  = "NoData"
+		exec_err_state = "Alerting"
+		is_paused = false
+		data {
+			ref_id     = "A"
+			query_type = ""
+			relative_time_range {
+				from = 600
+				to   = 0
+			}
+			datasource_uid = "PD8C576611E62080A"
+			model = jsonencode({
+				hide          = false
+				intervalMs    = 1000
+				maxDataPoints = 43200
+				refId         = "A"
+			})
+		}
+	}
+}
+
+resource "grafana_rule_group" "test" {
+	org_id = grafana_organization.test.id
+	name             = "%[1]s"
+	folder_uid       = grafana_folder.test.uid
+	interval_seconds = 60
+	rule {
+		name           = "My Alert Rule second"
+		for            = "2m"
+		condition      = "B"
+		no_data_state  = "NoData"
+		exec_err_state = "Alerting"
+		is_paused = false
+		data {
+			ref_id     = "A"
+			query_type = ""
+			relative_time_range {
+				from = 600
+				to   = 0
+			}
+			datasource_uid = "PD8C576611E62080A"
+			model = jsonencode({
+				hide          = false
+				intervalMs    = 1000
+				maxDataPoints = 43200
+				refId         = "A"
+			})
+		}
+	}
+}
+				`, name),
+				ExpectError: regexp.MustCompile(`rule group with name "` + name + `" already exists`),
+			},
+		},
+	})
+}
+
 func TestAccAlertRule_ruleNameConflict(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -312,7 +312,7 @@ resource "grafana_folder" "test" {
 	title = "%[1]s-test"
 }
 
-resource "grafana_rule_group" "test" {
+resource "grafana_rule_group" "first" {
 	org_id = grafana_organization.test.id
 	name             = "%[1]s"
 	folder_uid       = grafana_folder.test.uid
@@ -342,7 +342,8 @@ resource "grafana_rule_group" "test" {
 	}
 }
 
-resource "grafana_rule_group" "test" {
+resource "grafana_rule_group" "second" {
+	depends_on = [ grafana_rule_group.first ]
 	org_id = grafana_organization.test.id
 	name             = "%[1]s"
 	folder_uid       = grafana_folder.test.uid
@@ -450,7 +451,7 @@ resource "grafana_rule_group" "first" {
 	}
 }
 				`, name),
-				ExpectError: regexp.MustCompile(`rule with name "My Alert Rule" is defined more than oncendnndndndn`),
+				ExpectError: regexp.MustCompile(`rule with name "My Alert Rule" is defined more than once`),
 			},
 		},
 	})

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -293,7 +293,7 @@ func TestAccAlertRule_inOrg(t *testing.T) {
 	})
 }
 
-func TestAccAlertRule_nameConflict(t *testing.T) {
+func TestAccAlertRule_ruleNameConflict(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 
 	name := acctest.RandString(10)
@@ -314,11 +314,11 @@ resource "grafana_folder" "first" {
 
 resource "grafana_rule_group" "first" {
 	org_id = grafana_organization.test.id
-	name             = "%[1]s"
+	name             = "alert rule group"
 	folder_uid       = grafana_folder.first.uid
 	interval_seconds = 60
 	rule {
-		name           = "My Alert Rule first"
+		name           = "My Alert Rule"
 		for            = "2m"
 		condition      = "B"
 		no_data_state  = "NoData"
@@ -340,21 +340,8 @@ resource "grafana_rule_group" "first" {
 			})
 		}
 	}
-}
-
-resource "grafana_folder" "second" {
-	depends_on = [grafana_rule_group.first]
-	org_id = grafana_organization.test.id
-	title = "%[1]s-second"
-}
-
-resource "grafana_rule_group" "second" {
-	org_id = grafana_organization.test.id
-	name             = "%[1]s"
-	folder_uid       = grafana_folder.second.uid
-	interval_seconds = 60
 	rule {
-		name           = "My Alert Rule second"
+		name           = "My Alert Rule"
 		for            = "2m"
 		condition      = "B"
 		no_data_state  = "NoData"
@@ -378,7 +365,7 @@ resource "grafana_rule_group" "second" {
 	}
 }
 				`, name),
-				ExpectError: regexp.MustCompile(`rule group with name "` + name + `" already exists`),
+				ExpectError: regexp.MustCompile(`rule with name "My Alert Rule" is defined more than oncendnndndndn`),
 			},
 		},
 	})


### PR DESCRIPTION
Based on Issue #1534, it has been clarified that the non-duplicative aspect should apply to `rule names` rather than `rule group names`.

The modifications in PR #1550 will result in disallowing the existence of duplicate `rule group names` within different folders. However, this should be permissible.

This adjustment will entail checking for duplicate `rule names` within the same `rule group` and also verifying if duplicate `rule names` exist for rules already present on `Grafana`.

Upon testing, it has been observed that blocking identical rule names will only occur within the same rule group. 
It is indeed permissible for rule groups in different folders to have duplicate `rule names`.