### PR TITLE
Contact Points: Avoid 500 errors by listing

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -141,12 +141,17 @@ func readContactPoint(ctx context.Context, data *schema.ResourceData, meta inter
 
 	// First, try to fetch the contact point by name.
 	// If that fails, try to fetch it by the UID of its notifiers.
-	resp, err := client.Provisioning.GetContactpoints(provisioning.NewGetContactpointsParams().WithName(&name))
+	resp, err := client.Provisioning.GetContactpoints(provisioning.NewGetContactpointsParams())
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	points := resp.Payload
-	if len(points) == 0 && !strings.Contains(name, ":") {
+	var points []*models.EmbeddedContactPoint
+	for _, p := range resp.Payload {
+		if p.Name == name {
+			points = append(points, p)
+		}
+	}
+	if len(points) == 0 && !strings.Contains(data.Id(), ":") {
 		// If the contact point was not found by name, try to fetch it by UID.
 		// This is a deprecated ID format (uid;uid2;uid3)
 		// TODO: Remove on the next major version

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/terraform-provider-grafana/v2/internal/testutils"
 )
@@ -485,6 +486,53 @@ func TestAccContactPoint_inOrg(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					orgCheckExists.exists("grafana_organization.test", &org),
 					alertingContactPointCheckExists.destroyed(&points, nil),
+				),
+			},
+		},
+	})
+}
+
+func TestAccContactPoint_recreate(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	var points models.ContactPoints
+	name := acctest.RandString(10)
+	config := testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/resource.tf", map[string]string{
+		"My Contact Point": name,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkAlertingContactPointExistsWithLength("grafana_contact_point.my_contact_point", &points, 1),
+					resource.TestCheckResourceAttr("grafana_contact_point.my_contact_point", "name", name),
+					resource.TestCheckResourceAttr("grafana_contact_point.my_contact_point", "email.#", "1"),
+				),
+			},
+			// Delete the contact point and check that it is missing
+			{
+				PreConfig: func() {
+					client := grafanaTestClient()
+					for _, point := range points {
+						_, err := client.Provisioning.DeleteContactpoints(point.UID)
+						require.NoError(t, err)
+					}
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Recreate the contact point
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkAlertingContactPointExistsWithLength("grafana_contact_point.my_contact_point", &points, 1),
+					resource.TestCheckResourceAttr("grafana_contact_point.my_contact_point", "name", name),
+					resource.TestCheckResourceAttr("grafana_contact_point.my_contact_point", "email.#", "1"),
 				),
 			},
 		},

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -499,7 +499,7 @@ func TestAccAlertRule_zeroSeconds(t *testing.T) {
 }
 
 func TestAccAlertRule_NotificationSettings(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t) // TODO: Run on v10.4.0 once it's released
+	testutils.CheckOSSTestsEnabled(t, ">=10.4.0")
 
 	var group models.AlertRuleGroup
 	var name = acctest.RandString(10)


### PR DESCRIPTION
Issue: https://github.com/grafana/terraform-provider-grafana/issues/1606

There is a bug in Grafana 10.4 where listing contact points by name results in a Grafana panic (500) 
By doing the filtering on the provider side, we can avoid that