### PR TITLE
Release workflow: Replace deprecated things

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
+# This uses an action (crazy-max/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
@@ -33,7 +33,7 @@ jobs:
         go-version: '1.21'
     - name: Import GPG key
       id: import_gpg
-      uses: paultyng/ghaction-import-gpg@v2.1.0
+      uses: crazy-max/ghaction-import-@v6.1.0
       env:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         PASSPHRASE: ${{ secrets.PASSPHRASE }}
@@ -41,7 +41,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v5
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,4 +74,4 @@ release:
   # If you want to manually examine the release before it's live, uncomment this line:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
- hashicorp/paultyng action is deprecated: https://github.com/hashicorp/ghaction-import-gpg
- Deprecated goreleaser features. See the build logs here: https://github.com/grafana/terraform-provider-grafana/actions/runs/9387165736/job/25849806601