### PR TITLE
Common Resource and DataSource framework

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -5,9 +5,42 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+type ResourceCommon struct {
+	Name   string
+	Schema *schema.Resource // Legacy SDKv2 schema
+	// Category string // TODO
+}
+
+// DataSource represents a Terraform data source, implemented either with the SDKv2 or Terraform Plugin Framework.
+type DataSource struct {
+	ResourceCommon
+	PluginFrameworkSchema datasource.DataSourceWithConfigure
+}
+
+func NewLegacySDKDataSource(name string, schema *schema.Resource) *DataSource {
+	d := &DataSource{
+		ResourceCommon: ResourceCommon{
+			Name:   name,
+			Schema: schema,
+		},
+	}
+	return d
+}
+
+func NewDataSource(name string, schema datasource.DataSourceWithConfigure) *DataSource {
+	d := &DataSource{
+		ResourceCommon: ResourceCommon{
+			Name: name,
+		},
+		PluginFrameworkSchema: schema,
+	}
+	return d
+}
 
 // ResourceListIDsFunc is a function that returns a list of resource IDs.
 // This is used to generate TF config from existing resources.
@@ -16,25 +49,28 @@ type ResourceListIDsFunc func(ctx context.Context, client *Client, data any) ([]
 
 // Resource represents a Terraform resource, implemented either with the SDKv2 or Terraform Plugin Framework.
 type Resource struct {
-	Name                  string
+	ResourceCommon
 	IDType                *ResourceID
 	ListIDsFunc           ResourceListIDsFunc
-	Schema                *schema.Resource
 	PluginFrameworkSchema resource.ResourceWithConfigure
 }
 
 func NewLegacySDKResource(name string, idType *ResourceID, schema *schema.Resource) *Resource {
 	r := &Resource{
-		Name:   name,
+		ResourceCommon: ResourceCommon{
+			Name:   name,
+			Schema: schema,
+		},
 		IDType: idType,
-		Schema: schema,
 	}
 	return r
 }
 
 func NewResource(name string, idType *ResourceID, schema resource.ResourceWithConfigure) *Resource {
 	r := &Resource{
-		Name:                  name,
+		ResourceCommon: ResourceCommon{
+			Name: name,
+		},
 		IDType:                idType,
 		PluginFrameworkSchema: schema,
 	}

--- a/internal/resources/cloud/data_source_cloud_ips.go
+++ b/internal/resources/cloud/data_source_cloud_ips.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceIPs() *schema.Resource {
-	return &schema.Resource{
+func datasourceIPs() *common.DataSource {
+	schema := &schema.Resource{
 		Description: "Data source for retrieving sets of cloud IPs. See https://grafana.com/docs/grafana-cloud/reference/allow-list/ for more info",
 		ReadContext: datasourceIPsRead,
 		Schema: map[string]*schema.Schema{
@@ -57,6 +58,7 @@ func datasourceIPs() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_cloud_ips", schema)
 }
 
 func datasourceIPsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/cloud/data_source_cloud_organization.go
+++ b/internal/resources/cloud/data_source_cloud_organization.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceOrganization() *schema.Resource {
-	return &schema.Resource{
+func datasourceOrganization() *common.DataSource {
+	schema := &schema.Resource{
 		ReadContext: withClient[schema.ReadContextFunc](datasourceOrganizationRead),
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -41,6 +42,7 @@ func datasourceOrganization() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_cloud_organization", schema)
 }
 
 func datasourceOrganizationRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {

--- a/internal/resources/cloud/data_source_cloud_stack.go
+++ b/internal/resources/cloud/data_source_cloud_stack.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceStack() *schema.Resource {
-	return &schema.Resource{
+func datasourceStack() *common.DataSource {
+	schema := &schema.Resource{
 		Description: "Data source for Grafana Stack",
 		ReadContext: withClient[schema.ReadContextFunc](datasourceStackRead),
 		Schema: common.CloneResourceSchemaForDatasource(resourceStack().Schema, map[string]*schema.Schema{
@@ -30,6 +30,7 @@ available at “https://<stack_slug>.grafana.net".`,
 			"wait_for_readiness_timeout": nil,
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_cloud_stack", schema)
 }
 
 func datasourceStackRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {

--- a/internal/resources/cloud/resources.go
+++ b/internal/resources/cloud/resources.go
@@ -2,13 +2,12 @@ package cloud
 
 import (
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var DatasourcesMap = map[string]*schema.Resource{
-	"grafana_cloud_ips":          datasourceIPs(),
-	"grafana_cloud_organization": datasourceOrganization(),
-	"grafana_cloud_stack":        datasourceStack(),
+var DataSources = []*common.DataSource{
+	datasourceIPs(),
+	datasourceOrganization(),
+	datasourceStack(),
 }
 
 var Resources = []*common.Resource{

--- a/internal/resources/grafana/data_source_dashboard.go
+++ b/internal/resources/grafana/data_source_dashboard.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceDashboard() *schema.Resource {
-	return &schema.Resource{
+func datasourceDashboard() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
 * [Folder/Dashboard Search HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/)
@@ -74,6 +74,7 @@ func datasourceDashboard() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_dashboard", schema)
 }
 
 func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_dashboards.go
+++ b/internal/resources/grafana/data_source_dashboards.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceDashboards() *schema.Resource {
-	return &schema.Resource{
+func datasourceDashboards() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 Datasource for retrieving all dashboards. Specify list of folder IDs to search in for dashboards.
 
@@ -63,6 +63,7 @@ Datasource for retrieving all dashboards. Specify list of folder IDs to search i
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_dashboards", schema)
 }
 
 func dataSourceReadDashboards(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_data_source.go
+++ b/internal/resources/grafana/data_source_data_source.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceDatasource() *schema.Resource {
-	return &schema.Resource{
+func datasourceDatasource() *common.DataSource {
+	schema := &schema.Resource{
 		Description: "Get details about a Grafana Datasource querying by either name, uid or ID",
 		ReadContext: datasourceDatasourceRead,
 		Schema: common.CloneResourceSchemaForDatasource(resourceDataSource().Schema, map[string]*schema.Schema{
@@ -31,6 +31,7 @@ func datasourceDatasource() *schema.Resource {
 			"http_headers":             nil,
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_data_source", schema)
 }
 
 func datasourceDatasourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_folder.go
+++ b/internal/resources/grafana/data_source_folder.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceFolder() *schema.Resource {
-	return &schema.Resource{
+func datasourceFolder() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
@@ -28,6 +28,7 @@ func datasourceFolder() *schema.Resource {
 			"prevent_destroy_if_not_empty": nil,
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_folder", schema)
 }
 
 func findFolderWithTitle(client *goapi.GrafanaHTTPAPI, title string) (string, error) {

--- a/internal/resources/grafana/data_source_folders.go
+++ b/internal/resources/grafana/data_source_folders.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceFolders() *schema.Resource {
-	return &schema.Resource{
+func datasourceFolders() *common.DataSource {
+	schema := &schema.Resource{
 		ReadContext: readFolders,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -55,6 +55,7 @@ func datasourceFolders() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_folders", schema)
 }
 
 func readFolders(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_library_panel.go
+++ b/internal/resources/grafana/data_source_library_panel.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceLibraryPanel() *schema.Resource {
-	return &schema.Resource{
+func datasourceLibraryPanel() *common.DataSource {
+	schema := &schema.Resource{
 		Description: "Data source for retrieving a single library panel by name or uid.",
 		ReadContext: dataSourceLibraryPanelRead,
 		Schema: common.CloneResourceSchemaForDatasource(resourceLibraryPanel().Schema, map[string]*schema.Schema{
@@ -26,6 +26,7 @@ func datasourceLibraryPanel() *schema.Resource {
 			},
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_library_panel", schema)
 }
 
 func dataSourceLibraryPanelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_organization.go
+++ b/internal/resources/grafana/data_source_organization.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceOrganization() *schema.Resource {
-	return &schema.Resource{
+func datasourceOrganization() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
@@ -49,6 +50,7 @@ func datasourceOrganization() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_organization", schema)
 }
 
 func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_organization_preferences.go
+++ b/internal/resources/grafana/data_source_organization_preferences.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceOrganizationPreferences() *schema.Resource {
-	return &schema.Resource{
+func datasourceOrganizationPreferences() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
@@ -20,6 +20,7 @@ func datasourceOrganizationPreferences() *schema.Resource {
 			"org_id": orgIDAttribute(),
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_organization_preferences", schema)
 }
 
 func dataSourceOrganizationPreferencesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_role.go
+++ b/internal/resources/grafana/data_source_role.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceRole() *schema.Resource {
-	return &schema.Resource{
+func datasourceRole() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
@@ -27,6 +27,7 @@ func datasourceRole() *schema.Resource {
 			"auto_increment_version": nil,
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_role", schema)
 }
 
 func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_service_account.go
+++ b/internal/resources/grafana/data_source_service_account.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceServiceAccount() *schema.Resource {
-	return &schema.Resource{
+func datasourceServiceAccount() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 		* [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
 		* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
@@ -28,6 +28,7 @@ func datasourceServiceAccount() *schema.Resource {
 			},
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_service_account", schema)
 }
 
 func datasourceServiceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_team.go
+++ b/internal/resources/grafana/data_source_team.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceTeam() *schema.Resource {
-	return &schema.Resource{
+func datasourceTeam() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
@@ -32,6 +32,7 @@ func datasourceTeam() *schema.Resource {
 			"ignore_externally_synced_members": nil,
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_team", schema)
 }
 
 func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_user.go
+++ b/internal/resources/grafana/data_source_user.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceUser() *schema.Resource {
-	return &schema.Resource{
+func datasourceUser() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
@@ -50,6 +51,7 @@ does not currently work with API Tokens. You must use basic auth.
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_user", schema)
 }
 
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/data_source_users.go
+++ b/internal/resources/grafana/data_source_users.go
@@ -6,12 +6,13 @@ import (
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/users"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceUsers() *schema.Resource {
-	return &schema.Resource{
+func datasourceUsers() *common.DataSource {
+	schema := &schema.Resource{
 		ReadContext: readUsers,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -62,6 +63,7 @@ does not currently work with API Tokens. You must use basic auth.
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_users", schema)
 }
 
 func readUsers(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/resources.go
+++ b/internal/resources/grafana/resources.go
@@ -70,37 +70,37 @@ func addValidationToSchema(r *schema.Resource) {
 	}
 }
 
-func addValidationToMap(resources map[string]*schema.Resource) map[string]*schema.Resource {
-	for _, r := range resources {
-		addValidationToSchema(r)
+func addValidationToDataSources(dataSources ...*common.DataSource) []*common.DataSource {
+	for _, d := range dataSources {
+		addValidationToSchema(d.Schema)
 	}
-	return resources
+	return dataSources
 }
 
-func addValidationToList(resources []*common.Resource) []*common.Resource {
+func addValidationToResources(resources ...*common.Resource) []*common.Resource {
 	for _, r := range resources {
 		addValidationToSchema(r.Schema)
 	}
 	return resources
 }
 
-var DatasourcesMap = addValidationToMap(map[string]*schema.Resource{
-	"grafana_dashboard":                datasourceDashboard(),
-	"grafana_dashboards":               datasourceDashboards(),
-	"grafana_data_source":              datasourceDatasource(),
-	"grafana_folder":                   datasourceFolder(),
-	"grafana_folders":                  datasourceFolders(),
-	"grafana_library_panel":            datasourceLibraryPanel(),
-	"grafana_user":                     datasourceUser(),
-	"grafana_users":                    datasourceUsers(),
-	"grafana_role":                     datasourceRole(),
-	"grafana_service_account":          datasourceServiceAccount(),
-	"grafana_team":                     datasourceTeam(),
-	"grafana_organization":             datasourceOrganization(),
-	"grafana_organization_preferences": datasourceOrganizationPreferences(),
-})
+var DataSources = addValidationToDataSources(
+	datasourceDashboard(),
+	datasourceDashboards(),
+	datasourceDatasource(),
+	datasourceFolder(),
+	datasourceFolders(),
+	datasourceLibraryPanel(),
+	datasourceUser(),
+	datasourceUsers(),
+	datasourceRole(),
+	datasourceServiceAccount(),
+	datasourceTeam(),
+	datasourceOrganization(),
+	datasourceOrganizationPreferences(),
+)
 
-var Resources = addValidationToList([]*common.Resource{
+var Resources = addValidationToResources(
 	makeResourceFolderPermissionItem(),
 	makeResourceDashboardPermissionItem(),
 	makeResourceDatasourcePermissionItem(),
@@ -134,4 +134,4 @@ var Resources = addValidationToList([]*common.Resource{
 	resourceServiceAccountPermission(),
 	resourceSSOSettings(),
 	resourceUser(),
-})
+)

--- a/internal/resources/machinelearning/resources.go
+++ b/internal/resources/machinelearning/resources.go
@@ -18,7 +18,7 @@ func checkClient(f func(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 }
 
-var DatasourcesMap = map[string]*schema.Resource{}
+var DataSources = []*common.DataSource{}
 
 var Resources = []*common.Resource{
 	resourceJob(),

--- a/internal/resources/oncall/data_source_escalation_chain.go
+++ b/internal/resources/oncall/data_source_escalation_chain.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceEscalationChain() *schema.Resource {
-	return &schema.Resource{
+func dataSourceEscalationChain() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_chains/)
 `,
@@ -22,6 +23,7 @@ func dataSourceEscalationChain() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_escalation_chain", schema)
 }
 
 func dataSourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_integration.go
+++ b/internal/resources/oncall/data_source_integration.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceIntegration() *schema.Resource {
-	return &schema.Resource{
+func dataSourceIntegration() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/integrations/)
 `,
@@ -28,6 +29,7 @@ func dataSourceIntegration() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_integration", schema)
 }
 
 func dataSourceIntegrationRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_outgoing_webhook.go
+++ b/internal/resources/oncall/data_source_outgoing_webhook.go
@@ -7,10 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 )
 
-func dataSourceOutgoingWebhook() *schema.Resource {
-	return &schema.Resource{
+func dataSourceOutgoingWebhook() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/outgoing_webhooks/)
 `,
@@ -23,6 +24,7 @@ func dataSourceOutgoingWebhook() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_outgoing_webhook", schema)
 }
 
 func dataSourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_schedule.go
+++ b/internal/resources/oncall/data_source_schedule.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceSchedule() *schema.Resource {
-	return &schema.Resource{
+func dataSourceSchedule() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/oncall/latest/manage/on-call-schedules/)
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/schedules/)
@@ -28,6 +29,7 @@ func dataSourceSchedule() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_schedule", schema)
 }
 
 func dataSourceScheduleRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_slack_channel.go
+++ b/internal/resources/oncall/data_source_slack_channel.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceSlackChannel() *schema.Resource {
-	return &schema.Resource{
+func dataSourceSlackChannel() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/slack_channels/)
 `,
@@ -27,6 +28,7 @@ func dataSourceSlackChannel() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_slack_channel", schema)
 }
 
 func dataSourceSlackChannelRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_team.go
+++ b/internal/resources/oncall/data_source_team.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceTeam() *schema.Resource {
-	return &schema.Resource{
+func dataSourceTeam() *common.DataSource {
+	schema := &schema.Resource{
 		ReadContext: withClient[schema.ReadContextFunc](dataSourceTeamRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -30,6 +31,7 @@ func dataSourceTeam() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_team", schema)
 }
 
 func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_user.go
+++ b/internal/resources/oncall/data_source_user.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceUser() *schema.Resource {
-	return &schema.Resource{
+func dataSourceUser() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/users/)
 `,
@@ -32,6 +33,7 @@ func dataSourceUser() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_user", schema)
 }
 
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/data_source_user_group.go
+++ b/internal/resources/oncall/data_source_user_group.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceUserGroup() *schema.Resource {
-	return &schema.Resource{
+func dataSourceUserGroup() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 * [HTTP API](https://grafana.com/docs/oncall/latest/oncall-api-reference/user_groups/)
 `,
@@ -25,6 +26,7 @@ func dataSourceUserGroup() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_oncall_user_group", schema)
 }
 
 func dataSourceUserGroupRead(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {

--- a/internal/resources/oncall/resources.go
+++ b/internal/resources/oncall/resources.go
@@ -24,15 +24,15 @@ func withClient[T schema.CreateContextFunc | schema.UpdateContextFunc | schema.R
 	}
 }
 
-var DatasourcesMap = map[string]*schema.Resource{
-	"grafana_oncall_user":             dataSourceUser(),
-	"grafana_oncall_escalation_chain": dataSourceEscalationChain(),
-	"grafana_oncall_schedule":         dataSourceSchedule(),
-	"grafana_oncall_slack_channel":    dataSourceSlackChannel(),
-	"grafana_oncall_outgoing_webhook": dataSourceOutgoingWebhook(),
-	"grafana_oncall_user_group":       dataSourceUserGroup(),
-	"grafana_oncall_team":             dataSourceTeam(),
-	"grafana_oncall_integration":      dataSourceIntegration(),
+var DataSources = []*common.DataSource{
+	dataSourceUser(),
+	dataSourceEscalationChain(),
+	dataSourceSchedule(),
+	dataSourceSlackChannel(),
+	dataSourceOutgoingWebhook(),
+	dataSourceUserGroup(),
+	dataSourceTeam(),
+	dataSourceIntegration(),
 }
 
 var Resources = []*common.Resource{

--- a/internal/resources/slo/data_source_slo.go
+++ b/internal/resources/slo/data_source_slo.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func datasourceSlo() *schema.Resource {
-	return &schema.Resource{
+func datasourceSlo() *common.DataSource {
+	schema := &schema.Resource{
 		Description: `
 Datasource for retrieving all SLOs.
 		
@@ -36,6 +36,7 @@ Datasource for retrieving all SLOs.
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_slos", schema)
 }
 
 // Function sends a GET request to the SLO API Endpoint which returns a list of all SLOs

--- a/internal/resources/slo/resources.go
+++ b/internal/resources/slo/resources.go
@@ -21,8 +21,8 @@ func withClient[T schema.CreateContextFunc | schema.UpdateContextFunc | schema.R
 	}
 }
 
-var DatasourcesMap = map[string]*schema.Resource{
-	"grafana_slos": datasourceSlo(),
+var DataSources = []*common.DataSource{
+	datasourceSlo(),
 }
 
 var Resources = []*common.Resource{

--- a/internal/resources/syntheticmonitoring/data_source_probe.go
+++ b/internal/resources/syntheticmonitoring/data_source_probe.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 )
 
-func dataSourceProbe() *schema.Resource {
-	return &schema.Resource{
+func dataSourceProbe() *common.DataSource {
+	schema := &schema.Resource{
 		Description: "Data source for retrieving a single probe by name.",
 		ReadContext: withClient[schema.ReadContextFunc](dataSourceProbeRead),
 		Schema: common.CloneResourceSchemaForDatasource(resourceProbe().Schema, map[string]*schema.Schema{
@@ -25,6 +25,7 @@ func dataSourceProbe() *schema.Resource {
 			"auth_token": nil,
 		}),
 	}
+	return common.NewLegacySDKDataSource("grafana_synthetic_monitoring_probe", schema)
 }
 
 func dataSourceProbeRead(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {

--- a/internal/resources/syntheticmonitoring/data_source_probes.go
+++ b/internal/resources/syntheticmonitoring/data_source_probes.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	smapi "github.com/grafana/synthetic-monitoring-api-go-client"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func dataSourceProbes() *schema.Resource {
-	return &schema.Resource{
+func dataSourceProbes() *common.DataSource {
+	schema := &schema.Resource{
 		Description: "Data source for retrieving all probes.",
 		ReadContext: withClient[schema.ReadContextFunc](dataSourceProbesRead),
 		Schema: map[string]*schema.Schema{
@@ -29,6 +30,7 @@ func dataSourceProbes() *schema.Resource {
 			},
 		},
 	}
+	return common.NewLegacySDKDataSource("grafana_synthetic_monitoring_probes", schema)
 }
 
 func dataSourceProbesRead(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {

--- a/internal/resources/syntheticmonitoring/resources.go
+++ b/internal/resources/syntheticmonitoring/resources.go
@@ -21,9 +21,9 @@ func withClient[T schema.CreateContextFunc | schema.UpdateContextFunc | schema.R
 	}
 }
 
-var DatasourcesMap = map[string]*schema.Resource{
-	"grafana_synthetic_monitoring_probe":  dataSourceProbe(),
-	"grafana_synthetic_monitoring_probes": dataSourceProbes(),
+var DataSources = []*common.DataSource{
+	dataSourceProbe(),
+	dataSourceProbes(),
 }
 
 var Resources = []*common.Resource{

--- a/pkg/generate/postprocessing.go
+++ b/pkg/generate/postprocessing.go
@@ -76,6 +76,7 @@ var knownReferences = []string{
 	"grafana_library_panel.org_id=grafana_organization.id",
 	"grafana_machine_learning_job.datasource_uid=grafana_data_source.uid",
 	"grafana_message_template.org_id=grafana_organization.id",
+	"grafana_mute_timing.org_id=grafana_organization.id",
 	"grafana_notification_policy.contact_point=grafana_contact_point.name",
 	"grafana_notification_policy.mute_timings=grafana_mute_timing.name",
 	"grafana_notification_policy.org_id=grafana_organization.id",

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -220,7 +220,7 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 
 // DataSources defines the data sources implemented in the provider.
 func (p *frameworkProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return nil
+	return pluginFrameworkDataSources()
 }
 
 // Resources defines the resources implemented in the provider.

--- a/pkg/provider/legacy_provider.go
+++ b/pkg/provider/legacy_provider.go
@@ -10,12 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/cloud"
-	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/grafana"
-	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/machinelearning"
-	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/oncall"
-	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/slo"
-	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/syntheticmonitoring"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -137,16 +131,8 @@ func Provider(version string) *schema.Provider {
 			},
 		},
 
-		ResourcesMap: resourceMap(),
-
-		DataSourcesMap: mergeResourceMaps(
-			grafana.DatasourcesMap,
-			machinelearning.DatasourcesMap,
-			slo.DatasourcesMap,
-			syntheticmonitoring.DatasourcesMap,
-			oncall.DatasourcesMap,
-			cloud.DatasourcesMap,
-		),
+		ResourcesMap:   legacySDKResources(),
+		DataSourcesMap: legacySDKDataSources(),
 	}
 
 	p.ConfigureContextFunc = configure(version, p)

--- a/pkg/provider/resources.go
+++ b/pkg/provider/resources.go
@@ -10,9 +10,45 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/oncall"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/slo"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/syntheticmonitoring"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func DataSources() []*common.DataSource {
+	var resources []*common.DataSource
+	resources = append(resources, cloud.DataSources...)
+	resources = append(resources, grafana.DataSources...)
+	resources = append(resources, machinelearning.DataSources...)
+	resources = append(resources, oncall.DataSources...)
+	resources = append(resources, slo.DataSources...)
+	resources = append(resources, syntheticmonitoring.DataSources...)
+	return resources
+}
+
+func legacySDKDataSources() map[string]*schema.Resource {
+	result := make(map[string]*schema.Resource)
+	for _, d := range DataSources() {
+		schema := d.Schema
+		if schema == nil {
+			continue
+		}
+		result[d.Name] = schema
+	}
+	return result
+}
+
+func pluginFrameworkDataSources() []func() datasource.DataSource {
+	var dataSources []func() datasource.DataSource
+	for _, d := range DataSources() {
+		schema := d.PluginFrameworkSchema
+		if schema == nil {
+			continue
+		}
+		dataSources = append(dataSources, func() datasource.DataSource { return schema })
+	}
+	return dataSources
+}
 
 func Resources() []*common.Resource {
 	var resources []*common.Resource
@@ -25,7 +61,7 @@ func Resources() []*common.Resource {
 	return resources
 }
 
-func resourceMap() map[string]*schema.Resource {
+func legacySDKResources() map[string]*schema.Resource {
 	result := make(map[string]*schema.Resource)
 	for _, r := range Resources() {
 		schema := r.Schema
@@ -33,16 +69,6 @@ func resourceMap() map[string]*schema.Resource {
 			continue
 		}
 		result[r.Name] = schema
-	}
-	return result
-}
-
-func mergeResourceMaps(maps ...map[string]*schema.Resource) map[string]*schema.Resource {
-	result := make(map[string]*schema.Resource)
-	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
 	}
 	return result
 }


### PR DESCRIPTION
Just like it was done for resources, expose the datasource as structs that wrap their name and schema 
This will allow us to add the category to the these objects and get rid of this: https://github.com/grafana/terraform-provider-grafana/blob/main/tools/subcategories.json