### PR TITLE
fix(SLO provenance) Add request header for SLO app to track which resources are terraform-provisioned

### DIFF
--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -132,6 +132,7 @@ func createSLOClient(client *common.Client, providerConfig ProviderConfig) error
 	sloConfig.Host = client.GrafanaAPIURLParsed.Host
 	sloConfig.Scheme = client.GrafanaAPIURLParsed.Scheme
 	sloConfig.DefaultHeader["Authorization"] = "Bearer " + providerConfig.Auth.ValueString()
+	sloConfig.DefaultHeader["Grafana-Terraform-Provider"] = "true"
 	sloConfig.HTTPClient = getRetryClient(providerConfig)
 	client.SLOClient = slo.NewAPIClient(sloConfig)
 	return nil


### PR DESCRIPTION
We seemed to stop getting this header sometime between provider version 2.7 and 2.17

Changes:
* Adds the `Grafana-Terraform-Provider` header back for the SLO-specific HTTP client


I see the header we were expecting in 

https://github.com/grafana/terraform-provider-grafana/blob/b090854f4b2ba308f2dc6c0c1457299ebeb49cf2/pkg/provider/configure_clients.go#L170


But I guess since the SLO client using the default `createGrafanaAPIClient()` SLOs aren't using that code path

Fixes: https://github.com/grafana/slo/issues/2001