### PR TITLE
Add @grafana/alerting-backend to CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @grafana/terraform-provider
+
+/internal/resources/grafana/resource_alerting_* @grafana/terraform-provider @grafana/alerting-backend


### PR DESCRIPTION
This is mainly so that we can be notified of changes to the Alerting resources.
