### PR TITLE
Alert Rule Group: Fix moving rules between groups

### DIFF
--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"reflect"
 	"strconv"
@@ -340,72 +341,85 @@ func readAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta int
 func putAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, orgID := OAPIClientFromNewOrgResource(meta, data)
 
-	respAlertRules, err := client.Provisioning.GetAlertRules()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	if data.IsNewResource() {
-		// Check if a rule group with the same name already exists. The API either:
-		// - overwrites the existing rule group if it exists in the same folder, which is not expected of a TF provider.
-
-		for _, rule := range respAlertRules.Payload {
-			name := data.Get("name").(string)
-			folder := data.Get("folder_uid").(string)
-			if *rule.RuleGroup == name && *rule.FolderUID == folder {
-				return diag.Errorf("rule group with name %q already exists", name)
-			}
-		}
-	}
-
-	group := data.Get("name").(string)
-	folder := data.Get("folder_uid").(string)
-	interval := data.Get("interval_seconds").(int)
-
-	packedRules := data.Get("rule").([]interface{})
-	rules := make([]*models.ProvisionedAlertRule, 0, len(packedRules))
-
-	for i := range packedRules {
-		rule, err := unpackAlertRule(packedRules[i], group, folder, orgID)
+	retryErr := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		respAlertRules, err := client.Provisioning.GetAlertRules()
 		if err != nil {
-			return diag.FromErr(err)
+			return retry.NonRetryableError(err)
 		}
 
-		// Check if a rule with the same name already exists.
-		for _, r := range rules {
-			if *r.Title == *rule.Title {
-				return diag.Errorf("rule with name %q is defined more than once", *rule.Title)
+		if data.IsNewResource() {
+			// Check if a rule group with the same name already exists. The API either:
+			// - overwrites the existing rule group if it exists in the same folder, which is not expected of a TF provider.
+			for _, rule := range respAlertRules.Payload {
+				name := data.Get("name").(string)
+				folder := data.Get("folder_uid").(string)
+				if *rule.RuleGroup == name && *rule.FolderUID == folder {
+					return retry.NonRetryableError(fmt.Errorf("rule group with name %q already exists", name))
+				}
 			}
 		}
 
-		for _, r := range respAlertRules.Payload {
-			if r.UID != rule.UID && *r.Title == *rule.Title && *r.FolderUID == *rule.FolderUID {
-				return diag.Errorf("rule with name %q already exists in the alert group", *rule.Title)
+		group := data.Get("name").(string)
+		folder := data.Get("folder_uid").(string)
+		interval := data.Get("interval_seconds").(int)
+
+		packedRules := data.Get("rule").([]interface{})
+		rules := make([]*models.ProvisionedAlertRule, 0, len(packedRules))
+
+		for i := range packedRules {
+			ruleToApply, err := unpackAlertRule(packedRules[i], group, folder, orgID)
+			if err != nil {
+				return retry.NonRetryableError(err)
 			}
+
+			// Check if a rule with the same name already exists within the same rule group
+			for _, r := range rules {
+				if *r.Title == *ruleToApply.Title {
+					return retry.NonRetryableError(fmt.Errorf("rule with name %q is defined more than once", *ruleToApply.Title))
+				}
+			}
+
+			// Check if a rule with the same name already exists within the same folder (changing the ordering is allowed within the same rule group)
+			for _, existingRule := range respAlertRules.Payload {
+				if *existingRule.Title == *ruleToApply.Title && *existingRule.FolderUID == *ruleToApply.FolderUID {
+					if *ruleToApply.RuleGroup == *existingRule.RuleGroup {
+						break
+					}
+
+					// Retry so that if the user is moving a rule from one group to another, it will pass on the next iteration.
+					return retry.RetryableError(fmt.Errorf("rule with name %q already exists in the folder", *ruleToApply.Title))
+				}
+			}
+
+			rules = append(rules, ruleToApply)
 		}
 
-		rules = append(rules, rule)
-	}
+		putParams := provisioning.NewPutAlertRuleGroupParams().
+			WithFolderUID(folder).
+			WithGroup(group).WithBody(&models.AlertRuleGroup{
+			Title:     group,
+			FolderUID: folder,
+			Rules:     rules,
+			Interval:  int64(interval),
+		})
 
-	putParams := provisioning.NewPutAlertRuleGroupParams().
-		WithFolderUID(folder).
-		WithGroup(group).WithBody(&models.AlertRuleGroup{
-		Title:     group,
-		FolderUID: folder,
-		Rules:     rules,
-		Interval:  int64(interval),
+		if data.Get("disable_provenance").(bool) {
+			putParams.SetXDisableProvenance(&provenanceDisabled)
+		}
+
+		resp, err := client.Provisioning.PutAlertRuleGroup(putParams)
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+
+		data.SetId(resourceRuleGroupID.Make(orgID, resp.Payload.FolderUID, resp.Payload.Title))
+		return nil
 	})
 
-	if data.Get("disable_provenance").(bool) {
-		putParams.SetXDisableProvenance(&provenanceDisabled)
+	if retryErr != nil {
+		return diag.FromErr(retryErr)
 	}
 
-	resp, err := client.Provisioning.PutAlertRuleGroup(putParams)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	data.SetId(resourceRuleGroupID.Make(orgID, resp.Payload.FolderUID, resp.Payload.Title))
 	return readAlertRuleGroup(ctx, data, meta)
 }
 

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -457,6 +457,104 @@ resource "grafana_rule_group" "first" {
 	})
 }
 
+func TestAccAlertRule_moveRules(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	name := acctest.RandString(10)
+	ruleFunc := func(ruleName string) string {
+		return fmt.Sprintf(`
+	rule {
+		name           = "%[1]s"
+		for            = "2m"
+		condition      = "B"
+		no_data_state  = "NoData"
+		exec_err_state = "Alerting"
+		is_paused = false
+		data {
+			ref_id     = "A"
+			query_type = ""
+			relative_time_range {
+				from = 600
+				to   = 0
+			}
+			datasource_uid = "PD8C576611E62080A"
+			model = jsonencode({
+				hide          = false
+				intervalMs    = 1000
+				maxDataPoints = 43200
+				refId         = "A"
+			})
+		}
+	}
+	`, ruleName)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_folder" "test" {
+	title = "%[1]s"
+	uid   = "%[1]s"
+}
+
+resource "grafana_rule_group" "first" {
+	name             = "%[1]s-first"
+	folder_uid       = grafana_folder.test.uid
+	interval_seconds = 60
+	%[2]s
+	%[3]s
+}
+
+resource "grafana_rule_group" "second" {
+	name             = "%[1]s-second"
+	folder_uid       = grafana_folder.test.uid
+	interval_seconds = 60
+	%[4]s
+}
+				`, name, ruleFunc("My Alert Rule 1"), ruleFunc("My Alert Rule 2"), ruleFunc("My Alert Rule 3")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.#", "2"),
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.0.name", "My Alert Rule 1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.1.name", "My Alert Rule 2"),
+					resource.TestCheckResourceAttr("grafana_rule_group.second", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.second", "rule.0.name", "My Alert Rule 3"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_folder" "test" {
+	title = "%[1]s"
+	uid   = "%[1]s"
+}
+
+resource "grafana_rule_group" "first" {
+	name             = "%[1]s-first"
+	folder_uid       = grafana_folder.test.uid
+	interval_seconds = 60
+	%[2]s
+}
+
+resource "grafana_rule_group" "second" {
+	name             = "%[1]s-second"
+	folder_uid       = grafana_folder.test.uid
+	interval_seconds = 60
+	%[3]s
+	%[4]s
+}`, name, ruleFunc("My Alert Rule 1"), ruleFunc("My Alert Rule 2"), ruleFunc("My Alert Rule 3")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.0.name", "My Alert Rule 1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.second", "rule.#", "2"),
+					resource.TestCheckResourceAttr("grafana_rule_group.second", "rule.0.name", "My Alert Rule 2"),
+					resource.TestCheckResourceAttr("grafana_rule_group.second", "rule.1.name", "My Alert Rule 3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAlertRule_disableProvenance(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
 


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1332 
Add a retry so that updates will have multiple tries to pass, allowing the move from one group to another (first go deletes the rule from the first group, second go adds it to the second group)