### PR TITLE
[Fix] Adds check to ensure that the Grafana-Terraform-Provider header is set

### DIFF
--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -2,6 +2,7 @@ package slo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -593,7 +594,7 @@ func setTerraformState(d *schema.ResourceData, slo slo.SloV00Slo) error {
 	// After CREATE / UPDATE - the modified SLO is readback. Verify that the Provenance field is appropriately set
 	var terraform string
 	if slo.ReadOnly.Provenance != &terraform {
-		return fmt.Errorf(`Provenance header missing. Verify within the Grafana Terraform Provider that the 'Grafana-Terraform-Provider' request header is set to 'true'`)
+		return errors.New(`provenance header missing - verify within the Grafana Terraform Provider that the 'Grafana-Terraform-Provider' request header is set to 'true'`)
 	}
 
 	d.Set("name", slo.Name)

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -592,8 +592,7 @@ func packAlertMetadata(metadata []interface{}) slo.SloV00AlertingMetadata {
 
 func setTerraformState(d *schema.ResourceData, slo slo.SloV00Slo) error {
 	// After CREATE / UPDATE - the modified SLO is readback. Verify that the Provenance field is appropriately set
-	var terraform string
-	if slo.ReadOnly.Provenance != &terraform {
+	if *slo.ReadOnly.Provenance != "terraform" {
 		return errors.New(`provenance header missing - verify within the Grafana Terraform Provider that the 'Grafana-Terraform-Provider' request header is set to 'true'`)
 	}
 

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -120,6 +120,8 @@ func testAccSloCheckExists(rn string, slo *slo.SloV00Slo) resource.TestCheckFunc
 			return fmt.Errorf("provenance header missing - verify within the Grafana Terraform Provider that the 'Grafana-Terraform-Provider' request header is set to 'true'")
 		}
 
+		*slo = *gotSlo
+
 		return nil
 	}
 }

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -116,12 +116,7 @@ func testAccSloCheckExists(rn string, slo *slo.SloV00Slo) resource.TestCheckFunc
 			return fmt.Errorf("error getting SLO: %s", err)
 		}
 
-		readOnly := gotSlo.GetReadOnly()
-		if readOnly == nil {
-			return nil
-		}
-
-		if readOnly.GetProvenance() != "terraform" {
+		if *gotSlo.ReadOnly.Provenance != "terraform" {
 			return fmt.Errorf("provenance header missing - verify within the Grafana Terraform Provider that the 'Grafana-Terraform-Provider' request header is set to 'true'")
 		}
 
@@ -162,22 +157,7 @@ func testAccSloCheckDestroy(slo *slo.SloV00Slo) resource.TestCheckFunc {
 			return nil
 		}
 
-		readOnly := gotSlo.GetReadOnly()
-		if readOnly == nil {
-			return fmt.Errorf("readOnly is nil")
-		}
-
-		status, ok := readOnly.GetStatusOk()
-		if !ok {
-			return fmt.Errorf("status is nil")
-		}
-
-		statusType, ok := status.GetTypeOk()
-		if !ok {
-			return fmt.Errorf("type is nil")
-		}
-
-		if statusType == "deleting" {
+		if *gotSlo.ReadOnly.Status.Type == "deleting" {
 			return nil
 		}
 

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -112,12 +112,13 @@ func testAccSloCheckExists(rn string, slo *slo.SloV00Slo) resource.TestCheckFunc
 		client := testutils.Provider.Meta().(*common.Client).SLOClient
 		req := client.DefaultAPI.V1SloIdGet(context.Background(), rs.Primary.ID)
 		gotSlo, _, err := req.Execute()
-
 		if err != nil {
 			return fmt.Errorf("error getting SLO: %s", err)
 		}
 
-		*slo = *gotSlo
+		if *gotSlo.ReadOnly.Provenance != "terraform" {
+			return fmt.Errorf("provenance header missing - verify within the Grafana Terraform Provider that the 'Grafana-Terraform-Provider' request header is set to 'true'")
+		}
 
 		return nil
 	}

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -157,7 +157,7 @@ func testAccSloCheckDestroy(slo *slo.SloV00Slo) resource.TestCheckFunc {
 			return nil
 		}
 
-		if *gotSlo.ReadOnly.Status.Type == "deleting" {
+		if gotSlo.ReadOnly.Status.Type == "deleting" {
 			return nil
 		}
 


### PR DESCRIPTION
To prevent regression due to missing request headers from the Terraform Provider, we add a check in the TF Provider Tests that ensures that following a successful CREATE or UPDATE, that a SLO returned from the READ call to the SLO API has a `provenance` field of `terraform`. 

This is **done directly in the TF Provider Tests** `resource_slo_test` and does **NOT** affect the actual function of the Terraform Provider, which means it does not interfere with IMPORT functionality.

Fixes #1630 