### PR TITLE
Prevent deletion on nested folders

### DIFF
--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -155,33 +155,18 @@ func DeleteFolder(ctx context.Context, d *schema.ResourceData, meta interface{})
 	client, _, uid := OAPIClientFromExistingOrgResource(meta, d.Id())
 	deleteParams := folders.NewDeleteFolderParams().WithFolderUID(uid)
 	if d.Get("prevent_destroy_if_not_empty").(bool) {
-		var dashboardAndFolderNames []string
-		searchType := "dash-db"
-		searchParams := search.NewSearchParams().WithFolderUIDs([]string{uid}).WithType(&searchType)
+		searchParams := search.NewSearchParams().WithFolderUIDs([]string{uid})
 		searchResp, err := client.Search.Search(searchParams)
 		if err != nil {
 			return diag.Errorf("failed to search for dashboards in folder: %s", err)
 		}
 		if len(searchResp.GetPayload()) > 0 {
+			var dashboardAndFolderNames []string
 			for _, dashboard := range searchResp.GetPayload() {
 				dashboardAndFolderNames = append(dashboardAndFolderNames, dashboard.Title)
 			}
-		}
-		searchType = "dash-folder"
-		searchParams = search.NewSearchParams().WithFolderUIDs([]string{uid}).WithType(&searchType)
-		searchResp, err = client.Search.Search(searchParams)
-		if err != nil {
-			return diag.Errorf("failed to search for folders in folder: %s", err)
-		}
-		if len(searchResp.GetPayload()) > 0 {
-			for _, folder := range searchResp.GetPayload() {
-				dashboardAndFolderNames = append(dashboardAndFolderNames, folder.Title)
-			}
-		}
-		if len(dashboardAndFolderNames) > 0 {
 			return diag.Errorf("folder %s is not empty and prevent_destroy_if_not_empty is set. It contains the following dashboards and/or folders: %v", uid, dashboardAndFolderNames)
 		}
-
 	} else {
 		// If we're not preventing destroys, then we can force delete folders that have alert rules
 		force := true


### PR DESCRIPTION
As described in #1620, if a folder contains a non-Terraform managed nested folder, `prevent_destroy_if_not_empty` will not protect the folder from deletion.

This PR fixes that. As well as looking for dashboards in the folder prior to deletion, it also checks the folder for inner folders.
