### PR TITLE
Folder: Fix flaky test

### DIFF
--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -45,7 +45,7 @@ resource "grafana_folder" "test_folder_with_uid" {
 
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `parent_folder_uid` (String) The uid of the parent folder. If set, the folder will be nested. If not set, the folder will be created in the root folder. Note: This requires the nestedFolders feature flag to be enabled on your Grafana instance.
-- `prevent_destroy_if_not_empty` (Boolean) Prevent deletion of the folder if it is not empty (contains dashboards or alert rules). Defaults to `false`.
+- `prevent_destroy_if_not_empty` (Boolean) Prevent deletion of the folder if it is not empty (contains dashboards or alert rules). This feature requires Grafana 10.2 or later. Defaults to `false`.
 - `uid` (String) Unique identifier.
 
 ### Read-Only

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -59,7 +59,7 @@ func resourceFolder() *common.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Prevent deletion of the folder if it is not empty (contains dashboards or alert rules).",
+				Description: "Prevent deletion of the folder if it is not empty (contains dashboards or alert rules). This feature requires Grafana 10.2 or later.",
 			},
 			"parent_folder_uid": {
 				Type:     schema.TypeString,

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -170,7 +170,7 @@ resource grafana_folder child2 {
 }
 
 func TestAccFolder_PreventDeletion(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t, ">=10.2.0") // Searching by folder UID was added in 10.2.0
 
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var folder models.Folder
@@ -222,7 +222,7 @@ func TestAccFolder_PreventDeletion(t *testing.T) {
 }
 
 func TestAccFolder_PreventDeletionNested(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t, ">=10.2.0") // Searching by folder UID was added in 10.2.0
 
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	var folder models.Folder


### PR DESCRIPTION
Just noticed why this test has been flaky. 
The folder UID filter only works starting from Grafana 10.2 (see https://github.com/grafana/grafana/pull/65040) so the test was randomly failing in lower versions (whenever ANY dashboard was found, due to parallel tests)