### PR TITLE
Config Generation: Configurable Terraform Install

### DIFF
--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -1,6 +1,9 @@
 package generate
 
-import "github.com/hashicorp/terraform-exec/tfexec"
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
 
 type OutputFormat string
 
@@ -29,6 +32,11 @@ type CloudConfig struct {
 	StackServiceAccountName   string
 }
 
+type TerraformInstallConfig struct {
+	InstallDir string
+	Version    *version.Version
+}
+
 type Config struct {
 	// IncludeResources is a list of patterns to filter resources by.
 	// If a resource name matches any of the patterns, it will be included in the output.
@@ -43,5 +51,7 @@ type Config struct {
 	ProviderVersion   string
 	Grafana           *GrafanaConfig
 	Cloud             *CloudConfig
-	Terraform         *tfexec.Terraform
+
+	TerraformInstallConfig TerraformInstallConfig
+	Terraform              *tfexec.Terraform
 }

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -63,6 +63,7 @@ func Generate(ctx context.Context, cfg *Config) error {
 	cfg.Terraform = tf
 
 	if cfg.Cloud != nil {
+		log.Printf("Generating cloud resources")
 		stacks, err := generateCloudResources(ctx, cfg)
 		if err != nil {
 			return err
@@ -86,6 +87,7 @@ func Generate(ctx context.Context, cfg *Config) error {
 			onCallToken:   cfg.Grafana.OnCallAccessToken,
 			onCallURL:     cfg.Grafana.OnCallURL,
 		}
+		log.Printf("Generating Grafana resources")
 		if err := generateGrafanaResources(ctx, cfg, stack, true); err != nil {
 			return err
 		}

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -22,6 +22,9 @@ func TestAccGenerate(t *testing.T) {
 	}
 	testutils.CheckOSSTestsEnabled(t)
 
+	// Install Terraform to a temporary directory to avoid reinstalling it for each test case.
+	installDir := t.TempDir()
+
 	cases := []struct {
 		name           string
 		config         string
@@ -174,6 +177,9 @@ func TestAccGenerate(t *testing.T) {
 								Grafana: &generate.GrafanaConfig{
 									URL:  "http://localhost:3000",
 									Auth: "admin:admin",
+								},
+								TerraformInstallConfig: generate.TerraformInstallConfig{
+									InstallDir: installDir,
 								},
 							}
 							if tc.generateConfig != nil {


### PR DESCRIPTION
Allow configuring the install dir and version. 
The benefit is that you can install it only once and reuse the executable