### PR TITLE
Config Generation: Redact credentials from generated config

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -68,6 +68,12 @@ This supports a glob format. Examples:
 				EnvVars:  []string{"TFGEN_INCLUDE_RESOURCES"},
 				Required: false,
 			},
+			&cli.BoolFlag{
+				Name:    "output-credentials",
+				Usage:   "Output credentials in the generated resources",
+				EnvVars: []string{"TFGEN_OUTPUT_CREDENTIALS"},
+				Value:   false,
+			},
 
 			// Grafana OSS flags
 			&cli.StringFlag{
@@ -157,10 +163,11 @@ This supports a glob format. Examples:
 
 func parseFlags(ctx *cli.Context) (*generate.Config, error) {
 	config := &generate.Config{
-		OutputDir:       ctx.String("output-dir"),
-		Clobber:         ctx.Bool("clobber"),
-		Format:          generate.OutputFormat(ctx.String("output-format")),
-		ProviderVersion: ctx.String("terraform-provider-version"),
+		OutputDir:         ctx.String("output-dir"),
+		Clobber:           ctx.Bool("clobber"),
+		Format:            generate.OutputFormat(ctx.String("output-format")),
+		ProviderVersion:   ctx.String("terraform-provider-version"),
+		OutputCredentials: ctx.Bool("output-credentials"),
 		Grafana: &generate.GrafanaConfig{
 			URL:                 ctx.String("grafana-url"),
 			Auth:                ctx.String("grafana-auth"),

--- a/pkg/generate/cloud.go
+++ b/pkg/generate/cloud.go
@@ -76,17 +76,17 @@ func generateCloudResources(ctx context.Context, cfg *Config) ([]stack, error) {
 		return nil, err
 	}
 
-	postprocessor := &postprocessor{}
-	if postprocessor.plannedState, err = getPlannedState(ctx, cfg); err != nil {
+	plannedState, err := getPlannedState(ctx, cfg)
+	if err != nil {
 		return nil, err
 	}
-	if err := postprocessor.stripDefaults(filepath.Join(cfg.OutputDir, "cloud-resources.tf"), nil); err != nil {
+	if err := stripDefaults(filepath.Join(cfg.OutputDir, "cloud-resources.tf"), nil); err != nil {
 		return nil, err
 	}
-	if err := postprocessor.wrapJSONFieldsInFunction(filepath.Join(cfg.OutputDir, "cloud-resources.tf")); err != nil {
+	if err := wrapJSONFieldsInFunction(filepath.Join(cfg.OutputDir, "cloud-resources.tf")); err != nil {
 		return nil, err
 	}
-	if err := postprocessor.replaceReferences(filepath.Join(cfg.OutputDir, "cloud-resources.tf"), nil); err != nil {
+	if err := replaceReferences(filepath.Join(cfg.OutputDir, "cloud-resources.tf"), plannedState, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -37,10 +37,11 @@ type Config struct {
 	// OutputDir is the directory to write the generated files to.
 	OutputDir string
 	// Clobber will overwrite existing files in the output directory.
-	Clobber         bool
-	Format          OutputFormat
-	ProviderVersion string
-	Grafana         *GrafanaConfig
-	Cloud           *CloudConfig
-	Terraform       *tfexec.Terraform
+	Clobber           bool
+	OutputCredentials bool
+	Format            OutputFormat
+	ProviderVersion   string
+	Grafana           *GrafanaConfig
+	Cloud             *CloudConfig
+	Terraform         *tfexec.Terraform
 }

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -91,11 +91,18 @@ func Generate(ctx context.Context, cfg *Config) error {
 		}
 	}
 
-	if cfg.Format == OutputFormatJSON {
-		return convertToTFJSON(cfg.OutputDir)
-	}
 	if cfg.Format == OutputFormatCrossplane {
 		return convertToCrossplane(cfg)
+	}
+
+	if !cfg.OutputCredentials {
+		if err := redactCredentials(cfg.OutputDir); err != nil {
+			return fmt.Errorf("failed to redact credentials: %w", err)
+		}
+	}
+
+	if cfg.Format == OutputFormatJSON {
+		return convertToTFJSON(cfg.OutputDir)
 	}
 
 	return nil

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -114,6 +114,20 @@ func TestAccGenerate(t *testing.T) {
 			},
 		},
 		{
+			name:   "with-creds",
+			config: testutils.TestAccExample(t, "resources/grafana_dashboard/resource.tf"),
+			generateConfig: func(cfg *generate.Config) {
+				cfg.IncludeResources = []string{"doesnot.exist"}
+				cfg.OutputCredentials = true
+			},
+			check: func(t *testing.T, tempDir string) {
+				assertFiles(t, tempDir, "testdata/generate/empty-with-creds", []string{
+					".terraform",
+					".terraform.lock.hcl",
+				})
+			},
+		},
+		{
 			name: "alerting-in-org",
 			config: func() string {
 				content, err := os.ReadFile("testdata/generate/alerting-in-org.tf")

--- a/pkg/generate/grafana.go
+++ b/pkg/generate/grafana.go
@@ -88,20 +88,20 @@ func generateGrafanaResources(ctx context.Context, cfg *Config, stack stack, gen
 		stripDefaultsExtraFields["org_id"] = `"1"` // Remove org_id if it's the default
 	}
 
-	postprocessor := &postprocessor{}
-	if postprocessor.plannedState, err = getPlannedState(ctx, cfg); err != nil {
+	plannedState, err := getPlannedState(ctx, cfg)
+	if err != nil {
 		return err
 	}
-	if err := postprocessor.stripDefaults(generatedFilename("resources.tf"), stripDefaultsExtraFields); err != nil {
+	if err := stripDefaults(generatedFilename("resources.tf"), stripDefaultsExtraFields); err != nil {
 		return err
 	}
-	if err := postprocessor.abstractDashboards(generatedFilename("resources.tf")); err != nil {
+	if err := abstractDashboards(generatedFilename("resources.tf")); err != nil {
 		return err
 	}
-	if err := postprocessor.wrapJSONFieldsInFunction(generatedFilename("resources.tf")); err != nil {
+	if err := wrapJSONFieldsInFunction(generatedFilename("resources.tf")); err != nil {
 		return err
 	}
-	if err := postprocessor.replaceReferences(generatedFilename("resources.tf"), []string{
+	if err := replaceReferences(generatedFilename("resources.tf"), plannedState, []string{
 		"*.org_id=grafana_organization.id",
 	}); err != nil {
 		return err

--- a/pkg/generate/testdata/generate/dashboard-filtered/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/provider.tf
@@ -9,5 +9,5 @@ terraform {
 
 provider "grafana" {
   url  = "http://localhost:3000"
-  auth = "admin:admin"
+  auth = "REDACTED"
 }

--- a/pkg/generate/testdata/generate/dashboard-json/provider.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/provider.tf.json
@@ -2,7 +2,7 @@
   "provider": {
     "grafana": [
       {
-        "auth": "admin:admin",
+        "auth": "REDACTED",
         "url": "http://localhost:3000"
       }
     ]

--- a/pkg/generate/testdata/generate/dashboard/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard/provider.tf
@@ -9,5 +9,5 @@ terraform {
 
 provider "grafana" {
   url  = "http://localhost:3000"
-  auth = "admin:admin"
+  auth = "REDACTED"
 }

--- a/pkg/generate/testdata/generate/empty-with-creds/imports.tf
+++ b/pkg/generate/testdata/generate/empty-with-creds/imports.tf
@@ -1,0 +1,1 @@
+# No resources were found

--- a/pkg/generate/testdata/generate/empty-with-creds/provider.tf
+++ b/pkg/generate/testdata/generate/empty-with-creds/provider.tf
@@ -9,5 +9,5 @@ terraform {
 
 provider "grafana" {
   url  = "http://localhost:3000"
-  auth = "REDACTED"
+  auth = "admin:admin"
 }

--- a/pkg/generate/testdata/generate/empty-with-creds/resources.tf
+++ b/pkg/generate/testdata/generate/empty-with-creds/resources.tf
@@ -1,0 +1,1 @@
+# No resources were found

--- a/pkg/generate/testdata/generate/empty/provider.tf
+++ b/pkg/generate/testdata/generate/empty/provider.tf
@@ -9,5 +9,5 @@ terraform {
 
 provider "grafana" {
   url  = "http://localhost:3000"
-  auth = "admin:admin"
+  auth = "REDACTED"
 }

--- a/testdata/integration/test.sh
+++ b/testdata/integration/test.sh
@@ -53,7 +53,8 @@ ${REPO_ROOT}/terraform-provider-grafana-generate \
   --grafana-url ${GRAFANA_URL} \
   --grafana-auth "admin:admin" \
   --clobber \
-  --output-dir ${SCRIPT_DIR}/generated
+  --output-dir ${SCRIPT_DIR}/generated \
+  --output-credentials
 
 ${REPO_ROOT}/terraform-provider-grafana-generate \
   --terraform-provider-version "v3.0.0" \
@@ -61,7 +62,8 @@ ${REPO_ROOT}/terraform-provider-grafana-generate \
   --grafana-auth "admin:admin" \
   --clobber \
   --output-dir ${SCRIPT_DIR}/generated-json \
-  --output-format json
+  --output-format json \
+  --output-credentials
 
 # Test the generated code
 for dir in "generated" "generated-json" ; do


### PR DESCRIPTION
Creds will now be redacted by default. The behaviour can be changed through the `OutputCredentials` config 

Also, I've reworked the postprocessor stuff a bit so that the file-writing logic isn't repeated a bunch of times. I will rework it further once this is merged. I want post-processing to be its own package and each process an interface implementation