### PR TITLE
Standardize setting empty ID

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -338,9 +337,7 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	}
 
 	if stack.Status == "deleted" {
-		log.Printf("[WARN] removing stack %s from state because it was deleted outside of Terraform", stack.Name)
-		d.SetId("")
-		return nil
+		return common.WarnMissing("stack", d)
 	}
 
 	connectionsReq := client.InstancesAPI.GetConnections(ctx, id.(string))

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -124,8 +124,7 @@ func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudC
 
 	resp, httpResp, err := cloudClient.InstancesAPI.GetInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
 	if httpResp != nil && httpResp.StatusCode == 404 {
-		d.SetId("")
-		return nil
+		return common.WarnMissing("stack service account", d)
 	}
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
@@ -155,10 +154,7 @@ func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, c
 		}
 	}
 
-	log.Printf("[WARN] removing service account token %d from state because it no longer exists in grafana", id)
-	d.SetId("")
-
-	return nil
+	return common.WarnMissing("stack service account token", d)
 }
 
 func stackServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation.go
@@ -3,7 +3,6 @@ package cloud
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -114,8 +113,7 @@ func resourceInstallationRead(ctx context.Context, d *schema.ResourceData, meta 
 	apiURL := strings.Split(d.Id(), ";")[0]
 	tempClient := SMAPI.NewClient(apiURL, d.Get("sm_access_token").(string), nil)
 	if err := tempClient.ValidateToken(ctx); err != nil {
-		log.Printf("[WARN] removing SM installation from state because it is no longer valid")
-		d.SetId("")
+		return common.WarnMissing("synthetic monitoring installation", d)
 	}
 
 	return nil
@@ -124,9 +122,6 @@ func resourceInstallationRead(ctx context.Context, d *schema.ResourceData, meta 
 func resourceInstallationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiURL := strings.Split(d.Id(), ";")[0]
 	tempClient := SMAPI.NewClient(apiURL, d.Get("sm_access_token").(string), nil)
-	if err := tempClient.DeleteToken(ctx); err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return nil
+	err := tempClient.DeleteToken(ctx)
+	return diag.FromErr(err)
 }

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"context"
-	"log"
 	"strconv"
 
 	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
@@ -138,10 +137,7 @@ func serviceAccountTokenRead(ctx context.Context, d *schema.ResourceData, m inte
 		}
 	}
 
-	log.Printf("[WARN] removing service account token%d from state because it no longer exists in grafana", id)
-	d.SetId("")
-
-	return nil
+	return common.WarnMissing("service account token", d)
 }
 
 func serviceAccountTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/resources/machinelearning/resource_holiday.go
+++ b/internal/resources/machinelearning/resource_holiday.go
@@ -180,11 +180,7 @@ func resourceHolidayUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceHolidayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	err := c.DeleteHoliday(ctx, d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return nil
+	return diag.FromErr(err)
 }
 
 func makeMLHoliday(d *schema.ResourceData) (mlapi.Holiday, error) {

--- a/internal/resources/machinelearning/resource_job.go
+++ b/internal/resources/machinelearning/resource_job.go
@@ -175,11 +175,7 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 func resourceJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	err := c.DeleteJob(ctx, d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return nil
+	return diag.FromErr(err)
 }
 
 func makeMLJob(d *schema.ResourceData, meta interface{}) (mlapi.Job, error) {

--- a/internal/resources/machinelearning/resource_outlier_detector.go
+++ b/internal/resources/machinelearning/resource_outlier_detector.go
@@ -186,11 +186,7 @@ func resourceOutlierUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceOutlierDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*common.Client).MLAPI
 	err := c.DeleteOutlierDetector(ctx, d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return nil
+	return diag.FromErr(err)
 }
 
 func convertToSetStructure(al mlapi.OutlierAlgorithm) []interface{} {

--- a/internal/resources/oncall/resource_escalation.go
+++ b/internal/resources/oncall/resource_escalation.go
@@ -3,7 +3,6 @@ package oncall
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -356,9 +355,7 @@ func resourceEscalationRead(ctx context.Context, d *schema.ResourceData, client 
 	escalation, r, err := client.Escalations.GetEscalation(d.Id(), &onCallAPI.GetEscalationOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing escalation %s from state because it no longer exists", d.Id())
-			d.SetId("")
-			return nil
+			return common.WarnMissing("escalation", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -473,11 +470,5 @@ func resourceEscalationUpdate(ctx context.Context, d *schema.ResourceData, clien
 
 func resourceEscalationDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.Escalations.DeleteEscalation(d.Id(), &onCallAPI.DeleteEscalationOptions{})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }

--- a/internal/resources/oncall/resource_escalation_chain.go
+++ b/internal/resources/oncall/resource_escalation_chain.go
@@ -2,7 +2,6 @@ package oncall
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
@@ -80,9 +79,7 @@ func resourceEscalationChainRead(ctx context.Context, d *schema.ResourceData, cl
 	escalationChain, r, err := client.EscalationChains.GetEscalationChain(d.Id(), &onCallAPI.GetEscalationChainOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing escalation chain %s from state because it no longer exists", d.Get("name").(string))
-			d.SetId("")
-			return nil
+			return common.WarnMissing("escalation chain", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -113,11 +110,5 @@ func resourceEscalationChainUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceEscalationChainDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.EscalationChains.DeleteEscalationChain(d.Id(), &onCallAPI.DeleteEscalationChainOptions{})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -3,7 +3,6 @@ package oncall
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -345,9 +344,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, client
 	integration, r, err := client.Integrations.GetIntegration(d.Id(), options)
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing integreation %s from state because it no longer exists", d.Get("name").(string))
-			d.SetId("")
-			return nil
+			return common.WarnMissing("integration", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -365,13 +362,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, client
 func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.DeleteIntegrationOptions{}
 	_, err := client.Integrations.DeleteIntegration(d.Id(), options)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }
 
 func flattenRouteSlack(in *onCallAPI.SlackRoute) []map[string]interface{} {

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -2,7 +2,6 @@ package oncall
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
@@ -206,9 +205,7 @@ func resourceOutgoingWebhookRead(ctx context.Context, d *schema.ResourceData, cl
 	outgoingWebhook, r, err := client.Webhooks.GetWebhook(d.Id(), &onCallAPI.GetWebhookOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing outgoingWebhook %s from state because it no longer exists", d.Get("name").(string))
-			d.SetId("")
-			return nil
+			return common.WarnMissing("outgoing webhook", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -309,11 +306,5 @@ func resourceOutgoingWebhookUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceOutgoingWebhookDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.Webhooks.DeleteWebhook(d.Id(), &onCallAPI.DeleteWebhookOptions{})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }

--- a/internal/resources/oncall/resource_route.go
+++ b/internal/resources/oncall/resource_route.go
@@ -3,7 +3,6 @@ package oncall
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -185,9 +184,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, client *onCa
 	route, r, err := client.Routes.GetRoute(d.Id(), &onCallAPI.GetRouteOptions{})
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing route %s from state because it no longer exists", d.Id())
-			d.SetId("")
-			return nil
+			return common.WarnMissing("route", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -246,11 +243,5 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, client *on
 
 func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	_, err := client.Routes.DeleteRoute(d.Id(), &onCallAPI.DeleteRouteOptions{})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -2,7 +2,6 @@ package oncall
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"strings"
 
@@ -252,9 +251,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, client *o
 	schedule, r, err := client.Schedules.GetSchedule(d.Id(), options)
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing schedule %s from state because it no longer exists", d.Get("name").(string))
-			d.SetId("")
-			return nil
+			return common.WarnMissing("schedule", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -275,13 +272,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, client *o
 func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.DeleteScheduleOptions{}
 	_, err := client.Schedules.DeleteSchedule(d.Id(), options)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }
 
 func flattenScheduleSlack(in *onCallAPI.SlackSchedule) []map[string]interface{} {

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -3,7 +3,6 @@ package oncall
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -448,9 +447,7 @@ func resourceOnCallShiftRead(ctx context.Context, d *schema.ResourceData, client
 	onCallShift, r, err := client.OnCallShifts.GetOnCallShift(d.Id(), options)
 	if err != nil {
 		if r != nil && r.StatusCode == http.StatusNotFound {
-			log.Printf("[WARN] removing on-call shift %s from state because it no longer exists", d.Id())
-			d.SetId("")
-			return nil
+			return common.WarnMissing("on-call shift", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -478,11 +475,5 @@ func resourceOnCallShiftRead(ctx context.Context, d *schema.ResourceData, client
 func resourceOnCallShiftDelete(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	options := &onCallAPI.DeleteOnCallShiftOptions{}
 	_, err := client.OnCallShifts.DeleteOnCallShift(d.Id(), options)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId("")
-
-	return nil
+	return diag.FromErr(err)
 }

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -836,9 +835,7 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 	chk, err := c.GetCheck(ctx, id.(int64))
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
-			log.Printf("[WARN] removing check %s from state because it no longer exists", d.Id())
-			d.SetId("")
-			return nil
+			return common.WarnMissing("check", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -1166,17 +1163,12 @@ func resourceCheckUpdate(ctx context.Context, d *schema.ResourceData, c *smapi.C
 }
 
 func resourceCheckDelete(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {
-	var diags diag.Diagnostics
 	id, err := resourceCheckID.Single(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	err = c.DeleteCheck(ctx, id.(int64))
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return diags
+	return diag.FromErr(err)
 }
 
 // makeCheck populates an instance of sm.Check. We need this for create and

--- a/internal/resources/syntheticmonitoring/resource_probe.go
+++ b/internal/resources/syntheticmonitoring/resource_probe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -160,9 +159,7 @@ func resourceProbeRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 	prb, err := c.GetProbe(ctx, id.(int64))
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
-			log.Printf("[WARN] removing probe %s from state because it no longer exists", d.Id())
-			d.SetId("")
-			return nil
+			return common.WarnMissing("probe", d)
 		}
 		return diag.FromErr(err)
 	}
@@ -225,7 +222,6 @@ You must also taint the check, or assign a new probe to it before deleting this 
 		}
 	}
 
-	d.SetId("")
 	return diag.FromErr(c.DeleteProbe(ctx, id))
 }
 


### PR DESCRIPTION
Two things:
- No need to do it in delete functions
- Use `common.WarnMissing` so that we have a consistent diagnostic and log