### PR TITLE
goreleaser: Set version field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
Gets rid of this warning: `only configurations files on version: 2 are supported, yours is version: 0, please update your configuration`