### PR TITLE
Config Generation: Bubble up generation errors

### DIFF
--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -272,13 +272,7 @@ func listSlos(ctx context.Context, client *common.Client, data any) ([]string, e
 
 	slolist, _, err := sloClient.DefaultAPI.V1SloGet(ctx).Execute()
 	if err != nil {
-		// // TODO: Uninitialized SLO plugin. This should be handled better
-		// cast, ok := err.(*slo.GenericOpenAPIError)
-		// if ok && strings.Contains(cast.Error(), "status: 500") {
-		// 	return nil, nil
-		// }
-
-		return nil, nil
+		return nil, err
 	}
 
 	var ids []string

--- a/pkg/generate/grafana.go
+++ b/pkg/generate/grafana.go
@@ -78,8 +78,13 @@ func generateGrafanaResources(ctx context.Context, cfg *Config, stack stack, gen
 		resources = append(resources, slo.Resources...)
 		resources = append(resources, machinelearning.Resources...)
 	}
+	var generationErrors GenerationErrors
 	if err := generateImportBlocks(ctx, client, listerData, resources, cfg, stack.name); err != nil {
-		return err
+		if errors, ok := err.(GenerationErrors); ok {
+			generationErrors = errors
+		} else {
+			return err
+		}
 	}
 
 	stripDefaultsExtraFields := map[string]any{}
@@ -108,5 +113,5 @@ func generateGrafanaResources(ctx context.Context, cfg *Config, stack stack, gen
 		return err
 	}
 
-	return nil
+	return generationErrors
 }


### PR DESCRIPTION
When a single resource fails to generate, it's not a critical error. 
We want to bubble these up with a special type so that we can catch them and display them in a special way (or ignore them)