### PR TITLE
Config Generation: Structured Result

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -167,7 +168,8 @@ This supports a glob format. Examples:
 			if err != nil {
 				return fmt.Errorf("failed to parse flags: %w", err)
 			}
-			return generate.Generate(ctx.Context, cfg)
+			result := generate.Generate(ctx.Context, cfg)
+			return errors.Join(result.Errors...)
 		},
 	}
 

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -272,13 +272,7 @@ func listSlos(ctx context.Context, client *common.Client, data any) ([]string, e
 
 	slolist, _, err := sloClient.DefaultAPI.V1SloGet(ctx).Execute()
 	if err != nil {
-		// // TODO: Uninitialized SLO plugin. This should be handled better
-		// cast, ok := err.(*slo.GenericOpenAPIError)
-		// if ok && strings.Contains(cast.Error(), "status: 500") {
-		// 	return nil, nil
-		// }
-
-		return nil, nil
+		return nil, err
 	}
 
 	var ids []string


### PR DESCRIPTION
This result is something we can build upon and it allows the following:
- Bubbling up multiple errors: Resource A and Resource B failed, but resource C worked
- Ignoring or treating differently some errors (by casting). For example, ResourceErrors are not critical because they only mean that a single resource failed
- Building up a single result object as we go along. Collecting success or errors from multiple parts of the generation process