### PR TITLE
Support expired access policy tokens

### DIFF
--- a/internal/common/errcheck.go
+++ b/internal/common/errcheck.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const NotFoundError = "status: 404"
+const NotFoundError = "404"
 
 // CheckReadError checks for common cases on resource read/delete paths:
 // - If the resource no longer exists and 404s, it should be removed from state and return nil, to stop processing the read.

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -78,7 +78,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 			{
 				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "", "us", initialScopes, expiresAt),
 				PreConfig: func() {
-					orgID, err := strconv.Atoi(*policy.OrgId)
+					orgID, err := strconv.ParseInt(*policy.OrgId, 10, 32)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/cloud"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -38,6 +39,12 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 		"metrics:write",
 	}
 
+	randomName := acctest.RandStringFromCharSet(6, acctest.CharSetAlpha)
+	initialName := fmt.Sprintf("initial-%s", randomName)
+	initialToken := fmt.Sprintf("token-%s", initialName)
+	rotationName := fmt.Sprintf("rotation-%s", randomName)
+	updatedName := fmt.Sprintf("updated-%s", randomName)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -46,13 +53,13 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic("initial", "", "us", initialScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "", "us", initialScopes, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),
 
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", "initial"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "display_name", "initial"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", initialName),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "display_name", initialName),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.#", "6"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "accesspolicies:delete"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.1", "accesspolicies:read"),
@@ -63,37 +70,37 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.0.type", "org"),
 
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "name", "token-initial"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "display_name", "token-initial"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "name", initialToken),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "display_name", initialToken),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "expires_at", expiresAt),
 				),
 			},
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic("initial", "updated", "us", updatedScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "updated", "us", updatedScopes, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),
 
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", "initial"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", initialName),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "display_name", "updated"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "metrics:write"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.0.type", "org"),
 
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "name", "token-initial"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "name", initialToken),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "display_name", "updated"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy_token.test", "expires_at", expiresAt),
 				),
 			},
 			// Recreate
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic("updated", "updated", "us", updatedScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(updatedName, "updated", "us", updatedScopes, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),
 
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", "updated"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", updatedName),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "display_name", "updated"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "metrics:write"),
@@ -123,11 +130,12 @@ func TestResourceAccessPolicyToken_NoExpiration(t *testing.T) {
 	var policy gcom.AuthAccessPolicy
 	var policyToken gcom.AuthToken
 
+	randomName := fmt.Sprintf("initial-no-expiration-%s", acctest.RandStringFromCharSet(6, acctest.CharSetAlpha))
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic("initial-no-expiration", "", "us", []string{"metrics:read"}, ""),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(randomName, "", "us", []string{"metrics:read"}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),


### PR DESCRIPTION
When a Cloud access policy token expires, the Cloud API deletes it, breaking the Terraform provider resource.

This PR correctly detects the 404 response and fixes Terraform.
