### PR TITLE
Config Generation: Handle read failures

### DIFF
--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -7,8 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-openapi-client-go/client/access_control"
+	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
 	"github.com/grafana/terraform-provider-grafana/v3/pkg/generate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
@@ -226,6 +231,99 @@ func TestAccGenerate(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAccGenerate_RestrictedPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0")
+
+	// Create SA with no permissions
+	randString := acctest.RandString(10)
+	client := testutils.Provider.Meta().(*common.Client).GrafanaAPI.Clone().WithOrgID(0)
+	sa, err := client.ServiceAccounts.CreateServiceAccount(
+		service_accounts.NewCreateServiceAccountParams().WithBody(&models.CreateServiceAccountForm{
+			Name: "test-no-permissions-" + randString,
+			Role: "None",
+		},
+		))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		client.ServiceAccounts.DeleteServiceAccount(sa.Payload.ID)
+	})
+
+	saToken, err := client.ServiceAccounts.CreateToken(
+		service_accounts.NewCreateTokenParams().WithBody(&models.AddServiceAccountTokenCommand{
+			Name: "test-no-permissions-" + randString,
+		},
+		).WithServiceAccountID(sa.Payload.ID),
+	)
+	require.NoError(t, err)
+
+	// Allow the SA to read dashboards
+	if _, err := client.AccessControl.CreateRole(&models.CreateRoleForm{
+		Name: randString,
+		Permissions: []*models.Permission{
+			{
+				Action: "dashboards:read",
+				Scope:  "dashboards:*",
+			},
+			{
+				Action: "folders:read",
+				Scope:  "folders:*",
+			},
+		},
+		UID: randString,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		client.AccessControl.DeleteRole(access_control.NewDeleteRoleParams().WithRoleUID(randString))
+	})
+	if _, err := client.AccessControl.SetUserRoles(sa.Payload.ID, &models.SetUserRolesCommand{
+		RoleUids: []string{randString},
+		Global:   false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/resource.tf"),
+				Check: func(s *terraform.State) error {
+					tempDir := t.TempDir()
+					config := generate.Config{
+						OutputDir:       tempDir,
+						Clobber:         true,
+						Format:          generate.OutputFormatHCL,
+						ProviderVersion: "v3.0.0",
+						Grafana: &generate.GrafanaConfig{
+							URL:  "http://localhost:3000",
+							Auth: saToken.Payload.Key,
+						},
+					}
+
+					result := generate.Generate(context.Background(), &config)
+					assert.NotEmpty(t, result.Errors, "expected errors, got: %+v", result)
+					for _, err := range result.Errors {
+						// Check that all errors are non critical
+						_, ok := err.(generate.NonCriticalError)
+						assert.True(t, ok, "expected NonCriticalError, got: %v (Type: %T)", err, err)
+					}
+
+					assertFiles(t, tempDir, "testdata/generate/dashboard-restricted-permissions", []string{
+						".terraform",
+						".terraform.lock.hcl",
+					})
+
+					return nil
+				},
+			},
+		},
+	})
 }
 
 // assertFiles checks that all files in the "expectedFilesDir" directory match the files in the "gotFilesDir" directory.

--- a/pkg/generate/postprocessing/postprocessing.go
+++ b/pkg/generate/postprocessing/postprocessing.go
@@ -1,24 +1,18 @@
 package postprocessing
 
 import (
-	"errors"
 	"os"
 
-	"github.com/hashicorp/hcl/v2"
+	"github.com/grafana/terraform-provider-grafana/v3/pkg/generate/utils"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
 type postprocessingFunc func(*hclwrite.File) error
 
 func postprocessFile(fpath string, fn postprocessingFunc) error {
-	src, err := os.ReadFile(fpath)
+	file, err := utils.ReadHCLFile(fpath)
 	if err != nil {
 		return err
-	}
-
-	file, diags := hclwrite.ParseConfig(src, fpath, hcl.Pos{Line: 1, Column: 1})
-	if diags.HasErrors() {
-		return errors.New(diags.Error())
 	}
 	initialBytes := file.Bytes()
 

--- a/pkg/generate/terraform.go
+++ b/pkg/generate/terraform.go
@@ -74,12 +74,18 @@ func setupTerraform(cfg *Config) (*tfexec.Terraform, error) {
 }
 
 func writeBlocks(filepath string, blocks ...*hclwrite.Block) error {
+	return writeBlocksFile(filepath, false, blocks...)
+}
+
+func writeBlocksFile(filepath string, new bool, blocks ...*hclwrite.Block) error {
 	contents := hclwrite.NewFile()
-	if fileBytes, err := os.ReadFile(filepath); err == nil {
-		var diags hcl.Diagnostics
-		contents, diags = hclwrite.ParseConfig(fileBytes, filepath, hcl.InitialPos)
-		if diags.HasErrors() {
-			return errors.Join(diags.Errs()...)
+	if !new {
+		if fileBytes, err := os.ReadFile(filepath); err == nil {
+			var diags hcl.Diagnostics
+			contents, diags = hclwrite.ParseConfig(fileBytes, filepath, hcl.InitialPos)
+			if diags.HasErrors() {
+				return errors.Join(diags.Errs()...)
+			}
 		}
 	}
 

--- a/pkg/generate/testdata/generate/dashboard-restricted-permissions/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard-restricted-permissions/imports.tf
@@ -1,0 +1,9 @@
+import {
+  to = grafana_dashboard._0_my-dashboard-uid
+  id = "0:my-dashboard-uid"
+}
+
+import {
+  to = grafana_folder._0_my-folder-uid
+  id = "0:my-folder-uid"
+}

--- a/pkg/generate/testdata/generate/dashboard-restricted-permissions/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-restricted-permissions/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "3.0.0"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "REDACTED"
+}

--- a/pkg/generate/testdata/generate/dashboard-restricted-permissions/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard-restricted-permissions/resources.tf
@@ -1,0 +1,17 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "0:my-dashboard-uid"
+resource "grafana_dashboard" "_0_my-dashboard-uid" {
+  config_json = jsonencode({
+    title = "My Dashboard"
+    uid   = "my-dashboard-uid"
+  })
+  folder = grafana_folder._0_my-folder-uid.uid
+}
+
+# __generated__ by Terraform from "0:my-folder-uid"
+resource "grafana_folder" "_0_my-folder-uid" {
+  title = "My Folder"
+  uid   = "my-folder-uid"
+}

--- a/pkg/generate/utils/hcl.go
+++ b/pkg/generate/utils/hcl.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"errors"
+	"os"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func ReadHCLFile(fpath string) (*hclwrite.File, error) {
+	src, err := os.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	file, diags := hclwrite.ParseConfig(src, fpath, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, errors.New(diags.Error())
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
Sometimes, Grafana allows list operations but not read operations when using a SA with limited permissions 
What happens then is that the import blocks are generated, but the process crashes on the resource generation step (tf plan) 

With this PR, this is turned into a "non-critical" error which can be displayed and ignored. The superfluous import blocks are removed