### PR TITLE
Config Generation: Simplify listing of org resources

### DIFF
--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -66,37 +66,28 @@ This resource requires Grafana 9.1.0 or later.
 		"grafana_message_template",
 		orgResourceIDString("name"),
 		schema,
-	).WithLister(listerFunction(listMessageTemplate))
+	).WithLister(listerFunctionOrgResource(listMessageTemplate))
 }
 
-func listMessageTemplate(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-	orgIDs, err := data.OrgIDs(client)
-	if err != nil {
-		return nil, err
-	}
-
+func listMessageTemplate(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
 	var ids []string
-	for _, orgID := range orgIDs {
-		client = client.Clone().WithOrgID(orgID)
-
-		// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
-		// The alertmanager is provisioned asynchronously when the org is created.
-		if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-			resp, err := client.Provisioning.GetTemplates()
-			if err != nil {
-				if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
-					return retry.RetryableError(err)
-				}
-				return retry.NonRetryableError(err)
+	// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
+	// The alertmanager is provisioned asynchronously when the org is created.
+	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		resp, err := client.Provisioning.GetTemplates()
+		if err != nil {
+			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+				return retry.RetryableError(err)
 			}
-
-			for _, template := range resp.Payload {
-				ids = append(ids, MakeOrgResourceID(orgID, template.Name))
-			}
-			return nil
-		}); err != nil {
-			return nil, err
+			return retry.NonRetryableError(err)
 		}
+
+		for _, template := range resp.Payload {
+			ids = append(ids, MakeOrgResourceID(orgID, template.Name))
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return ids, nil

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -255,37 +255,28 @@ This resource requires Grafana 9.1.0 or later.
 		"grafana_rule_group",
 		resourceRuleGroupID,
 		schema,
-	).WithLister(listerFunction(listRuleGroups))
+	).WithLister(listerFunctionOrgResource(listRuleGroups))
 }
 
-func listRuleGroups(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-	orgIDs, err := data.OrgIDs(client)
-	if err != nil {
-		return nil, err
-	}
-
+func listRuleGroups(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
 	idMap := map[string]bool{}
-	for _, orgID := range orgIDs {
-		client = client.Clone().WithOrgID(orgID)
-
-		// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
-		// The alertmanager is provisioned asynchronously when the org is created.
-		if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-			resp, err := client.Provisioning.GetAlertRules()
-			if err != nil {
-				if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
-					return retry.RetryableError(err)
-				}
-				return retry.NonRetryableError(err)
+	// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
+	// The alertmanager is provisioned asynchronously when the org is created.
+	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		resp, err := client.Provisioning.GetAlertRules()
+		if err != nil {
+			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+				return retry.RetryableError(err)
 			}
-
-			for _, rule := range resp.Payload {
-				idMap[resourceRuleGroupID.Make(orgID, rule.FolderUID, rule.RuleGroup)] = true
-			}
-			return nil
-		}); err != nil {
-			return nil, err
+			return retry.NonRetryableError(err)
 		}
+
+		for _, rule := range resp.Payload {
+			idMap[resourceRuleGroupID.Make(orgID, rule.FolderUID, rule.RuleGroup)] = true
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	var ids []string

--- a/internal/resources/grafana/resource_annotation.go
+++ b/internal/resources/grafana/resource_annotation.go
@@ -84,27 +84,18 @@ func resourceAnnotation() *common.Resource {
 		"grafana_annotation",
 		orgResourceIDInt("id"),
 		schema,
-	).WithLister(listerFunction(listAnnotations))
+	).WithLister(listerFunctionOrgResource(listAnnotations))
 }
 
-func listAnnotations(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-	orgIDs, err := data.OrgIDs(client)
+func listAnnotations(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
+	var ids []string
+	resp, err := client.Annotations.GetAnnotations(annotations.NewGetAnnotationsParams())
 	if err != nil {
 		return nil, err
 	}
 
-	var ids []string
-	for _, orgID := range orgIDs {
-		client = client.Clone().WithOrgID(orgID)
-
-		resp, err := client.Annotations.GetAnnotations(annotations.NewGetAnnotationsParams())
-		if err != nil {
-			return nil, err
-		}
-
-		for _, annotation := range resp.Payload {
-			ids = append(ids, MakeOrgResourceID(orgID, annotation.ID))
-		}
+	for _, annotation := range resp.Payload {
+		ids = append(ids, MakeOrgResourceID(orgID, annotation.ID))
 	}
 
 	return ids, nil

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -99,31 +99,22 @@ Manages Grafana dashboards.
 		"grafana_dashboard",
 		orgResourceIDString("uid"),
 		schema,
-	).WithLister(listerFunction(listDashboards))
+	).WithLister(listerFunctionOrgResource(listDashboards))
 }
 
-func listDashboards(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-	return listDashboardOrFolder(client, data, "dash-db")
+func listDashboards(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
+	return listDashboardOrFolder(client, orgID, "dash-db")
 }
 
-func listDashboardOrFolder(client *goapi.GrafanaHTTPAPI, data *ListerData, searchType string) ([]string, error) {
-	orgIDs, err := data.OrgIDs(client)
+func listDashboardOrFolder(client *goapi.GrafanaHTTPAPI, orgID int64, searchType string) ([]string, error) {
+	uids := []string{}
+	resp, err := client.Search.Search(search.NewSearchParams().WithType(common.Ref(searchType)))
 	if err != nil {
 		return nil, err
 	}
 
-	uids := []string{}
-	for _, orgID := range orgIDs {
-		client = client.Clone().WithOrgID(orgID)
-
-		resp, err := client.Search.Search(search.NewSearchParams().WithType(common.Ref(searchType)))
-		if err != nil {
-			return nil, err
-		}
-
-		for _, item := range resp.Payload {
-			uids = append(uids, MakeOrgResourceID(orgID, item.UID))
-		}
+	for _, item := range resp.Payload {
+		uids = append(uids, MakeOrgResourceID(orgID, item.UID))
 	}
 
 	return uids, nil

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -78,11 +78,11 @@ func resourceFolder() *common.Resource {
 		"grafana_folder",
 		orgResourceIDString("uid"),
 		schema,
-	).WithLister(listerFunction(listFolders))
+	).WithLister(listerFunctionOrgResource(listFolders))
 }
 
-func listFolders(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-	return listDashboardOrFolder(client, data, "dash-folder")
+func listFolders(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
+	return listDashboardOrFolder(client, orgID, "dash-folder")
 }
 
 func CreateFolder(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -77,27 +77,18 @@ func resourcePlaylist() *common.Resource {
 		"grafana_playlist",
 		orgResourceIDString("uid"),
 		schema,
-	).WithLister(listerFunction(listPlaylists))
+	).WithLister(listerFunctionOrgResource(listPlaylists))
 }
 
-func listPlaylists(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-	orgIDs, err := data.OrgIDs(client)
+func listPlaylists(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
+	var ids []string
+	resp, err := client.Playlists.SearchPlaylists(playlists.NewSearchPlaylistsParams())
 	if err != nil {
 		return nil, err
 	}
 
-	var ids []string
-	for _, orgID := range orgIDs {
-		client = client.Clone().WithOrgID(orgID)
-
-		resp, err := client.Playlists.SearchPlaylists(playlists.NewSearchPlaylistsParams())
-		if err != nil {
-			return nil, err
-		}
-
-		for _, playlist := range resp.Payload {
-			ids = append(ids, MakeOrgResourceID(orgID, playlist.UID))
-		}
+	for _, playlist := range resp.Payload {
+		ids = append(ids, MakeOrgResourceID(orgID, playlist.UID))
 	}
 
 	return ids, nil

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/client/access_control"
 	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
@@ -281,6 +282,8 @@ func TestAccGenerate_RestrictedPermissions(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+
+	time.Sleep(5 * time.Second) // Wait for permissions to propagate
 
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/client/access_control"
 	"github.com/grafana/grafana-openapi-client-go/client/service_accounts"
@@ -282,8 +281,6 @@ func TestAccGenerate_RestrictedPermissions(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
-	time.Sleep(5 * time.Second) // Wait for permissions to propagate
 
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,


### PR DESCRIPTION
It's always the same pattern: Run a function for all orgs 
We can extract the "for each org" part to a common helper