### PR TITLE
Fix SLO client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240322153219-42c6a1d2bcab
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240523010106-657d101fcbd9
 	github.com/grafana/machine-learning-go-client v0.8.0
-	github.com/grafana/slo-openapi-client/go v0.0.0-20240626093634-e6741482b090
+	github.com/grafana/slo-openapi-client/go v0.0.0-20240717162314-26344962b4c5
 	github.com/grafana/synthetic-monitoring-agent v0.25.0
 	github.com/grafana/synthetic-monitoring-api-go-client v0.8.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.7 h1:C11j63y7gymiW8VugJ9ZW0pWfxTZugdSJyC48olk5KY=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.7/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
-github.com/grafana/slo-openapi-client/go v0.0.0-20240626093634-e6741482b090 h1:gDkJPpTL84zx+UkSY6a1pPlUm9aDEVBzPlVOkUbXmgM=
-github.com/grafana/slo-openapi-client/go v0.0.0-20240626093634-e6741482b090/go.mod h1:HgbbeH2gFfCk2XZCrCly39DB13WkwWyQ+Ww+HTxePCs=
+github.com/grafana/slo-openapi-client/go v0.0.0-20240717162314-26344962b4c5 h1:qUb8ZPVC/QQDh8uCH9ZObZnsdT9S7iX3qe3q73XLj/o=
+github.com/grafana/slo-openapi-client/go v0.0.0-20240717162314-26344962b4c5/go.mod h1:HgbbeH2gFfCk2XZCrCly39DB13WkwWyQ+Ww+HTxePCs=
 github.com/grafana/synthetic-monitoring-agent v0.25.0 h1:krGprYHKs6Yc6ObGzt2b8u9wAKBGJs+MKys/pulpk1I=
 github.com/grafana/synthetic-monitoring-agent v0.25.0/go.mod h1:jqe7JItP1mNo1n/O3ufbmdRpk4T8nj8d/aH+T8ywUzc=
 github.com/grafana/synthetic-monitoring-api-go-client v0.8.0 h1:Tm4MtwwYmPNInGfnj66l6j6KOshMkNV4emIVKJdlXMg=


### PR DESCRIPTION
The current version has validation that prevents unknown fields from being returned by the API. This new version has no such validations: https://github.com/grafana/slo-openapi-client/pull/1

This should ensure that the SLO client doesn't break unexpectedly in the future