### PR TITLE
ML: Increase alert window max value

### DIFF
--- a/internal/resources/machinelearning/resource_alert.go
+++ b/internal/resources/machinelearning/resource_alert.go
@@ -150,7 +150,7 @@ func (r *alertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Computed:    true,
 				Default:     stringdefault.StaticString("0s"),
 				Validators: []validator.String{
-					maxDuration(12 * time.Hour),
+					maxDuration(24 * time.Hour),
 				},
 			},
 			"labels": schema.MapAttribute{

--- a/internal/resources/machinelearning/resource_alert_test.go
+++ b/internal/resources/machinelearning/resource_alert_test.go
@@ -231,10 +231,10 @@ resource "grafana_machine_learning_alert" "invalid" {
 resource "grafana_machine_learning_alert" "invalid" {
   job_id = "xyz"
   title  = "Test Job"
-  window = "24h"
+  window = "25h"
 }
 `,
-				ExpectError: regexp.MustCompile(".*value must be a duration less than: 12h.*"),
+				ExpectError: regexp.MustCompile(".*value must be a duration less than: 1d.*"),
 			},
 		},
 	})


### PR DESCRIPTION
Increased machine learning alert window value to be `1d` instead of `12h`