### PR TITLE
SM Check: Fix crashing config generation

### DIFF
--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -73,6 +73,11 @@ func TestAccResourceCheck_dns(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.dns", "settings.0.dns.0.validate_additional_rrs.0.fail_if_not_matches_regexp.0", ".+-good-stuff*"),
 				),
 			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.dns",
+			},
 		},
 	})
 }
@@ -137,6 +142,11 @@ func TestAccResourceCheck_http(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.fail_if_header_matches_regexp.0.allow_missing", "true"),
 				),
 			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.http",
+			},
 		},
 	})
 }
@@ -181,6 +191,11 @@ func TestAccResourceCheck_ping(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.ping", "settings.0.ping.0.payload_size", "20"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.ping", "settings.0.ping.0.dont_fragment", "true"),
 				),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.ping",
 			},
 		},
 	})
@@ -233,6 +248,11 @@ func TestAccResourceCheck_tcp(t *testing.T) {
 					resource.TestMatchResourceAttr("grafana_synthetic_monitoring_check.tcp", "settings.0.tcp.0.tls_config.0.ca_cert", regexp.MustCompile((`^-{5}BEGIN CERTIFICATE`))),
 				),
 			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.tcp",
+			},
 		},
 	})
 }
@@ -279,6 +299,11 @@ func TestAccResourceCheck_traceroute(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.traceroute", "settings.0.traceroute.0.max_unknown_hops", "10"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.traceroute", "settings.0.traceroute.0.ptr_lookup", "false"),
 				),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.traceroute",
 			},
 		},
 	})
@@ -364,6 +389,11 @@ func TestAccResourceCheck_multihttp(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.multihttp", "settings.0.multihttp.0.entries.1.assertions.4.type", "JSON_PATH_ASSERTION"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.multihttp", "settings.0.multihttp.0.entries.1.assertions.4.expression", "$.slideshow.slides"),
 				),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.multihttp",
 			},
 		},
 	})
@@ -524,7 +554,7 @@ func TestAccResourceCheck_multiple(t *testing.T) {
 			{
 				Config:      testAccResourceCheck_multiple,
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("exactly one check setting must be defined, got 2"),
+				ExpectError: regexp.MustCompile(`"settings.0.http": conflicts with settings.0.traceroute`),
 			},
 		},
 	})


### PR DESCRIPTION
We get a panic from the `CustomizeDiff` function when generating the checks. 
We can replace that whole function with `ConflictsWith` statements