### PR TITLE
Config Generation: Run tests on local provider code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ website/vendor
 testdata/*.crt
 testdata/*.key
 testdata/integration/*
+testdata/plugins
 !testdata/integration/main.tf
 !testdata/integration/test.sh
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,7 @@ GRAFANA_VERSION ?= 11.0.0
 DOCKER_COMPOSE_ARGS ?= --force-recreate --detach --remove-orphans --wait --renew-anon-volumes
 
 testacc:
+	go build -o testdata/plugins/registry.terraform.io/grafana/grafana/999.999.999/$$(go env GOOS)_$$(go env GOARCH)/terraform-provider-grafana_v999.999.999_$$(go env GOOS)_$$(go env GOARCH) .
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
 # Test OSS features

--- a/pkg/generate/config.go
+++ b/pkg/generate/config.go
@@ -35,6 +35,7 @@ type CloudConfig struct {
 type TerraformInstallConfig struct {
 	InstallDir string
 	Version    *version.Version
+	PluginDir  string
 }
 
 type Config struct {

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -197,13 +197,14 @@ func TestAccGenerate(t *testing.T) {
 								OutputDir:       tempDir,
 								Clobber:         true,
 								Format:          generate.OutputFormatHCL,
-								ProviderVersion: "v3.0.0",
+								ProviderVersion: "999.999.999", // Using the code from the current branch
 								Grafana: &generate.GrafanaConfig{
 									URL:  "http://localhost:3000",
 									Auth: "admin:admin",
 								},
 								TerraformInstallConfig: generate.TerraformInstallConfig{
 									InstallDir: installDir,
+									PluginDir:  pluginDir(t),
 								},
 							}
 							if tc.generateConfig != nil {
@@ -293,10 +294,13 @@ func TestAccGenerate_RestrictedPermissions(t *testing.T) {
 						OutputDir:       tempDir,
 						Clobber:         true,
 						Format:          generate.OutputFormatHCL,
-						ProviderVersion: "v3.0.0",
+						ProviderVersion: "999.999.999", // Using the code from the current branch
 						Grafana: &generate.GrafanaConfig{
 							URL:  "http://localhost:3000",
 							Auth: saToken.Payload.Key,
+						},
+						TerraformInstallConfig: generate.TerraformInstallConfig{
+							PluginDir: pluginDir(t),
 						},
 					}
 
@@ -381,4 +385,12 @@ func assertFilesSubdir(t *testing.T, gotFilesDir, expectedFilesDir, subdir strin
 
 		assert.Equal(t, strings.TrimSpace(string(expectedContent)), strings.TrimSpace(string(gotContent)))
 	}
+}
+
+func pluginDir(t *testing.T) string {
+	t.Helper()
+
+	repoRoot, err := filepath.Abs("../..")
+	require.NoError(t, err)
+	return filepath.Join(repoRoot, "testdata", "plugins")
 }

--- a/pkg/generate/terraform.go
+++ b/pkg/generate/terraform.go
@@ -65,7 +65,14 @@ func setupTerraform(cfg *Config) (*tfexec.Terraform, error) {
 		return nil, fmt.Errorf("error running NewTerraform: %s", err)
 	}
 
-	err = tf.Init(context.Background(), tfexec.Upgrade(true))
+	initOptions := []tfexec.InitOption{
+		tfexec.Upgrade(true),
+	}
+	if cfg.TerraformInstallConfig.PluginDir != "" {
+		initOptions = append(initOptions, tfexec.PluginDir(cfg.TerraformInstallConfig.PluginDir))
+	}
+
+	err = tf.Init(context.Background(), initOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("error running Init: %s", err)
 	}

--- a/pkg/generate/testdata/generate/alerting-in-org/provider.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "3.0.0"
+      version = "999.999.999"
     }
   }
 }

--- a/pkg/generate/testdata/generate/dashboard-filtered/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "3.0.0"
+      version = "999.999.999"
     }
   }
 }

--- a/pkg/generate/testdata/generate/dashboard-json/provider.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/provider.tf.json
@@ -13,7 +13,7 @@
         {
           "grafana": {
             "source": "grafana/grafana",
-            "version": "3.0.0"
+            "version": "999.999.999"
           }
         }
       ]

--- a/pkg/generate/testdata/generate/dashboard-restricted-permissions/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard-restricted-permissions/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "3.0.0"
+      version = "999.999.999"
     }
   }
 }

--- a/pkg/generate/testdata/generate/dashboard/provider.tf
+++ b/pkg/generate/testdata/generate/dashboard/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "3.0.0"
+      version = "999.999.999"
     }
   }
 }

--- a/pkg/generate/testdata/generate/empty-with-creds/provider.tf
+++ b/pkg/generate/testdata/generate/empty-with-creds/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "3.0.0"
+      version = "999.999.999"
     }
   }
 }

--- a/pkg/generate/testdata/generate/empty/provider.tf
+++ b/pkg/generate/testdata/generate/empty/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "3.0.0"
+      version = "999.999.999"
     }
   }
 }


### PR DESCRIPTION
Rather than using v3.0.0 of the provider, we can run a local build of the code 
This will make tests faster and allows to test the integration between the generator and the provider