### PR TITLE
Config Generation: Generate resources with sensitive attributes

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime"
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -103,48 +104,37 @@ This resource requires Grafana 9.1.0 or later.
 		"grafana_contact_point",
 		orgResourceIDString("name"),
 		resource,
-	)
+	).WithLister(listerFunctionOrgResource(listContactPoints))
 }
 
-// TODO: Fix contact points lister. Terraform doesn't read any of the sensitive fields (or their container)
-// It outputs an empty `email {}` block for example, which is not valid.
-// func listContactPoints(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-// 	orgIDs, err := data.OrgIDs(client)
-// 	if err != nil {
-// 		return nil, err
-// 	}
+func listContactPoints(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
+	idMap := map[string]bool{}
+	// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
+	// The alertmanager is provisioned asynchronously when the org is created.
+	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		resp, err := client.Provisioning.GetContactpoints(provisioning.NewGetContactpointsParams())
+		if err != nil {
+			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
 
-// 	idMap := map[string]bool{}
-// 	for _, orgID := range orgIDs {
-// 		client = client.Clone().WithOrgID(orgID)
+		for _, contactPoint := range resp.Payload {
+			idMap[MakeOrgResourceID(orgID, contactPoint.Name)] = true
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 
-// 		// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
-// 		// The alertmanager is provisioned asynchronously when the org is created.
-// 		if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-// 			resp, err := client.Provisioning.GetContactpoints(provisioning.NewGetContactpointsParams())
-// 			if err != nil {
-// 				if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
-// 					return retry.RetryableError(err)
-// 				}
-// 				return retry.NonRetryableError(err)
-// 			}
+	var ids []string
+	for id := range idMap {
+		ids = append(ids, id)
+	}
 
-// 			for _, contactPoint := range resp.Payload {
-// 				idMap[MakeOrgResourceID(orgID, contactPoint.Name)] = true
-// 			}
-// 			return nil
-// 		}); err != nil {
-// 			return nil, err
-// 		}
-// 	}
-
-// 	var ids []string
-// 	for id := range idMap {
-// 		ids = append(ids, id)
-// 	}
-
-// 	return ids, nil
-// }
+	return ids, nil
+}
 
 func readContactPoint(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, orgID, name := OAPIClientFromExistingOrgResource(meta, data.Id())

--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/users"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -75,34 +77,32 @@ You must use basic auth.
 		"grafana_user",
 		resourceUserID,
 		schema,
-	)
-	// ).WithLister(listerFunction(listUsers))
+	).WithLister(listerFunction(listUsers))
 }
 
-// TODO: Fix issues with password
-// func listUsers(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
-// 	var ids []string
-// 	var page int64 = 1
-// 	for {
-// 		params := users.NewSearchUsersParams().WithPage(&page)
-// 		resp, err := client.Users.SearchUsers(params)
-// 		if err != nil {
-// 			return nil, err
-// 		}
+func listUsers(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {
+	var ids []string
+	var page int64 = 1
+	for {
+		params := users.NewSearchUsersParams().WithPage(&page)
+		resp, err := client.Users.SearchUsers(params)
+		if err != nil {
+			return nil, err
+		}
 
-// 		for _, user := range resp.Payload {
-// 			ids = append(ids, strconv.FormatInt(user.ID, 10))
-// 		}
+		for _, user := range resp.Payload {
+			ids = append(ids, strconv.FormatInt(user.ID, 10))
+		}
 
-// 		if len(resp.Payload) == 0 {
-// 			break
-// 		}
+		if len(resp.Payload) == 0 {
+			break
+		}
 
-// 		page++
-// 	}
+		page++
+	}
 
-// 	return ids, nil
-// }
+	return ids, nil
+}
 
 func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, err := OAPIGlobalClient(meta)

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,7 +51,11 @@ var (
 			configureResp, err := server.ConfigureProvider(context.Background(), &tfprotov5.ConfigureProviderRequest{Config: &testDynamicValue})
 			if err != nil || len(configureResp.Diagnostics) > 0 {
 				if err == nil {
-					err = fmt.Errorf("provider configuration failed: %v", configureResp.Diagnostics)
+					errs := []error{}
+					for _, diag := range configureResp.Diagnostics {
+						errs = append(errs, fmt.Errorf("%s %s: %s", diag.Severity, diag.Summary, diag.Detail))
+					}
+					err = errors.Join(errs...)
 				}
 				return nil, fmt.Errorf("failed to configure provider: %v", err)
 			}

--- a/pkg/generate/postprocessing/postprocessing_test.go
+++ b/pkg/generate/postprocessing/postprocessing_test.go
@@ -1,0 +1,35 @@
+package postprocessing
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func postprocessingTest(t *testing.T, testFile string, fn func(fpath string)) {
+	t.Helper()
+
+	t.Run(testFile, func(t *testing.T) {
+		goldenFilepath := strings.Replace(testFile, ".tf", ".golden.tf", 1)
+
+		// Copy the file to a temporary location
+		tmpFilepath := filepath.Join(t.TempDir(), filepath.Base(testFile))
+		file, err := os.ReadFile(testFile)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tmpFilepath, file, 0644))
+
+		// Run the postprocessing function
+		fn(tmpFilepath)
+
+		// Compare the file with the golden file
+		got, err := os.ReadFile(tmpFilepath)
+		require.NoError(t, err)
+		want, err := os.ReadFile(goldenFilepath)
+		require.NoError(t, err)
+
+		require.Equal(t, string(want), string(got))
+	})
+}

--- a/pkg/generate/postprocessing/postprocessing_test.go
+++ b/pkg/generate/postprocessing/postprocessing_test.go
@@ -19,7 +19,7 @@ func postprocessingTest(t *testing.T, testFile string, fn func(fpath string)) {
 		tmpFilepath := filepath.Join(t.TempDir(), filepath.Base(testFile))
 		file, err := os.ReadFile(testFile)
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(tmpFilepath, file, 0644))
+		require.NoError(t, os.WriteFile(tmpFilepath, file, 0600))
 
 		// Run the postprocessing function
 		fn(tmpFilepath)

--- a/pkg/generate/postprocessing/replace_null_sensitive.go
+++ b/pkg/generate/postprocessing/replace_null_sensitive.go
@@ -1,0 +1,46 @@
+package postprocessing
+
+import (
+	"log"
+
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v3/pkg/provider"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ReplaceNullSensitiveAttributes(fpath string) error {
+	providerResources := map[string]*common.Resource{}
+	for _, r := range provider.Resources() {
+		providerResources[r.Name] = r
+	}
+
+	return postprocessFile(fpath, func(file *hclwrite.File) error {
+		for _, block := range file.Body().Blocks() {
+			if block.Type() != "resource" {
+				continue
+			}
+
+			resourceType := block.Labels()[0]
+			resourceInfo := providerResources[resourceType]
+			resourceSchema := resourceInfo.Schema
+			if resourceSchema == nil {
+				// Plugin Framework schema not implemented because we have no resources with sensitive attributes in it yet
+				log.Printf("resource %s doesn't use the legacy SDK", resourceType)
+				continue
+			}
+
+			for key := range block.Body().Attributes() {
+				attrSchema := resourceSchema.Schema[key]
+				if attrSchema == nil {
+					// Attribute not found in schema
+					continue
+				}
+				if attrSchema.Sensitive && attrSchema.Required {
+					block.Body().SetAttributeValue(key, cty.StringVal("SENSITIVE_VALUE_TO_REPLACE"))
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/generate/postprocessing/replace_null_sensitive_test.go
+++ b/pkg/generate/postprocessing/replace_null_sensitive_test.go
@@ -1,0 +1,13 @@
+package postprocessing
+
+import "testing"
+
+func TestReplaceNullSensitiveAttributes(t *testing.T) {
+	for _, testFile := range []string{
+		"testdata/replace-user-password.tf",
+	} {
+		postprocessingTest(t, testFile, func(fpath string) {
+			ReplaceNullSensitiveAttributes(fpath)
+		})
+	}
+}

--- a/pkg/generate/postprocessing/testdata/replace-user-password.golden.tf
+++ b/pkg/generate/postprocessing/testdata/replace-user-password.golden.tf
@@ -1,0 +1,8 @@
+# __generated__ by Terraform
+resource "grafana_user" "_1" {
+  email    = "admin@localhost"
+  is_admin = true
+  login    = "admin"
+  name     = null
+  password = "SENSITIVE_VALUE_TO_REPLACE"
+}

--- a/pkg/generate/postprocessing/testdata/replace-user-password.tf
+++ b/pkg/generate/postprocessing/testdata/replace-user-password.tf
@@ -1,0 +1,8 @@
+# __generated__ by Terraform
+resource "grafana_user" "_1" {
+  email    = "admin@localhost"
+  is_admin = true
+  login    = "admin"
+  name     = null
+  password = null
+}

--- a/pkg/generate/terraform.go
+++ b/pkg/generate/terraform.go
@@ -74,7 +74,7 @@ func setupTerraform(cfg *Config) (*tfexec.Terraform, error) {
 
 	err = tf.Init(context.Background(), initOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("error running Init: %s", err)
+		return nil, fmt.Errorf("error running Init: %w", err)
 	}
 
 	return tf, nil

--- a/pkg/generate/testdata/generate/alerting-in-org/imports.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/imports.tf
@@ -1,4 +1,19 @@
 import {
+  to = grafana_contact_point._1_email_receiver
+  id = "1:email receiver"
+}
+
+import {
+  to = grafana_contact_point._2_email_receiver
+  id = "2:email receiver"
+}
+
+import {
+  to = grafana_contact_point._2_my-contact-point
+  id = "2:my-contact-point"
+}
+
+import {
   to = grafana_folder._2_alert-rule-folder
   id = "2:alert-rule-folder"
 }

--- a/pkg/generate/testdata/generate/alerting-in-org/resources.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/resources.tf
@@ -1,6 +1,41 @@
 # __generated__ by Terraform
 # Please review these resources and move them into your main configuration files.
 
+# __generated__ by Terraform from "1:email receiver"
+resource "grafana_contact_point" "_1_email_receiver" {
+  disable_provenance = true
+  name               = "email receiver"
+  email {
+    addresses               = ["<example@email.com>"]
+    disable_resolve_message = false
+    single_email            = false
+  }
+}
+
+# __generated__ by Terraform from "2:email receiver"
+resource "grafana_contact_point" "_2_email_receiver" {
+  disable_provenance = true
+  name               = "email receiver"
+  org_id             = grafana_organization._2.id
+  email {
+    addresses               = ["<example@email.com>"]
+    disable_resolve_message = false
+    single_email            = false
+  }
+}
+
+# __generated__ by Terraform from "2:my-contact-point"
+resource "grafana_contact_point" "_2_my-contact-point" {
+  disable_provenance = false
+  name               = "my-contact-point"
+  org_id             = grafana_organization._2.id
+  email {
+    addresses               = ["hello@example.com"]
+    disable_resolve_message = false
+    single_email            = false
+  }
+}
+
 # __generated__ by Terraform from "2:alert-rule-folder"
 resource "grafana_folder" "_2_alert-rule-folder" {
   org_id = grafana_organization._2.id
@@ -41,7 +76,7 @@ resource "grafana_notification_policy" "_1_policy" {
 
 # __generated__ by Terraform from "2:policy"
 resource "grafana_notification_policy" "_2_policy" {
-  contact_point      = "my-contact-point"
+  contact_point      = grafana_contact_point._2_my-contact-point.name
   disable_provenance = false
   group_by           = ["..."]
   org_id             = grafana_organization._2.id

--- a/pkg/generate/testdata/generate/dashboard-crossplane/contact-point-1-email-receiver.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/contact-point-1-email-receiver.yaml
@@ -1,0 +1,17 @@
+apiVersion: alerting.grafana.crossplane.io/v1alpha1
+kind: ContactPoint
+metadata:
+  name: 1-email-receiver
+  annotations:
+    crossplane.io/external-name: 1:email receiver
+spec:
+  forProvider:
+    disableProvenance: true
+    email:
+    - addresses:
+      - <example@email.com>
+      disable_resolve_message: false
+      single_email: false
+    name: email receiver
+  providerConfigRef:
+    name: grafana-provider

--- a/pkg/generate/testdata/generate/dashboard-crossplane/user-1.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/user-1.yaml
@@ -1,0 +1,14 @@
+apiVersion: oss.grafana.crossplane.io/v1alpha1
+kind: User
+metadata:
+  name: "1"
+  annotations:
+    crossplane.io/external-name: "1"
+spec:
+  forProvider:
+    email: admin@localhost
+    isAdmin: true
+    login: admin
+    password: SENSITIVE_VALUE_TO_REPLACE
+  providerConfigRef:
+    name: grafana-provider

--- a/pkg/generate/testdata/generate/dashboard-json/imports.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/imports.tf.json
@@ -1,6 +1,10 @@
 {
   "import": [
     {
+      "id": "1:email receiver",
+      "to": "grafana_contact_point._1_email_receiver"
+    },
+    {
       "id": "1:my-dashboard-uid",
       "to": "grafana_dashboard._1_my-dashboard-uid"
     },
@@ -15,6 +19,10 @@
     {
       "id": "1",
       "to": "grafana_organization_preferences._1"
+    },
+    {
+      "id": "1",
+      "to": "grafana_user._1"
     }
   ]
 }

--- a/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
@@ -1,5 +1,22 @@
 {
   "resource": {
+    "grafana_contact_point": {
+      "_1_email_receiver": [
+        {
+          "disable_provenance": true,
+          "email": [
+            {
+              "addresses": [
+                "\u003cexample@email.com\u003e"
+              ],
+              "disable_resolve_message": false,
+              "single_email": false
+            }
+          ],
+          "name": "email receiver"
+        }
+      ]
+    },
     "grafana_dashboard": {
       "_1_my-dashboard-uid": [
         {
@@ -31,6 +48,16 @@
     "grafana_organization_preferences": {
       "_1": [
         {}
+      ]
+    },
+    "grafana_user": {
+      "_1": [
+        {
+          "email": "admin@localhost",
+          "is_admin": true,
+          "login": "admin",
+          "password": "SENSITIVE_VALUE_TO_REPLACE"
+        }
       ]
     }
   }

--- a/pkg/generate/testdata/generate/dashboard/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard/imports.tf
@@ -1,4 +1,9 @@
 import {
+  to = grafana_contact_point._1_email_receiver
+  id = "1:email receiver"
+}
+
+import {
   to = grafana_dashboard._1_my-dashboard-uid
   id = "1:my-dashboard-uid"
 }
@@ -15,5 +20,10 @@ import {
 
 import {
   to = grafana_organization_preferences._1
+  id = "1"
+}
+
+import {
+  to = grafana_user._1
   id = "1"
 }

--- a/pkg/generate/testdata/generate/dashboard/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard/resources.tf
@@ -1,6 +1,17 @@
 # __generated__ by Terraform
 # Please review these resources and move them into your main configuration files.
 
+# __generated__ by Terraform from "1:email receiver"
+resource "grafana_contact_point" "_1_email_receiver" {
+  disable_provenance = true
+  name               = "email receiver"
+  email {
+    addresses               = ["<example@email.com>"]
+    disable_resolve_message = false
+    single_email            = false
+  }
+}
+
 # __generated__ by Terraform from "1:my-dashboard-uid"
 resource "grafana_dashboard" "_1_my-dashboard-uid" {
   config_json = jsonencode({
@@ -25,4 +36,12 @@ resource "grafana_notification_policy" "_1_policy" {
 
 # __generated__ by Terraform from "1"
 resource "grafana_organization_preferences" "_1" {
+}
+
+# __generated__ by Terraform
+resource "grafana_user" "_1" {
+  email    = "admin@localhost"
+  is_admin = true
+  login    = "admin"
+  password = "SENSITIVE_VALUE_TO_REPLACE"
 }

--- a/pkg/provider/legacy_provider.go
+++ b/pkg/provider/legacy_provider.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	"fmt"
 	"strings"
@@ -12,6 +14,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	EnableGenerateEnvVar     = "TF_GENERATE_UNSENSITIVE"
+	EnableGenerateMarkerFile = ".generate-make-all-fields-unsensitive"
 )
 
 func init() {
@@ -135,6 +142,29 @@ func Provider(version string) *schema.Provider {
 		DataSourcesMap: legacySDKDataSources(),
 	}
 
+	if os.Getenv(EnableGenerateEnvVar) != "" {
+		// If TF_GENERATE_UNSENSITIVE envvar is set and there's the "marker file" in the current directory,
+		// generate the provider with all fields marked as non-sensitive.
+		// The Terraform generation feature is overly-aggressive in redacting sensitive fields, it redacts all blocks at the root level.
+		// Security note:
+		// Setting an envvar + creating a marker file in the TF dir means that the user has full control over the TF context.
+		// This means that the user could also read sensitive data from the state, or use the `unsensitive` TF function to read sensitive data.
+		// So, this feature doesn't introduce a new way to extract sensitive data.
+
+		wd, err := os.Getwd()
+		if err != nil {
+			panic(err) // It's ok to panic, this is only meant to be used in the context of the generator.
+		}
+		_, err = os.Stat(filepath.Join(wd, EnableGenerateMarkerFile))
+		if err == nil {
+			for k := range p.ResourcesMap {
+				unsensitive(p.ResourcesMap[k])
+			}
+		} else {
+			fmt.Println("The marker file for generating unsensitive fields is not present, skipping.")
+		}
+	}
+
 	p.ConfigureContextFunc = configure(version, p)
 
 	return p
@@ -210,4 +240,16 @@ func int64ValueOrNull(d *schema.ResourceData, key string) types.Int64 {
 		return types.Int64Value(int64(v.(int)))
 	}
 	return types.Int64Null()
+}
+
+func unsensitive(r *schema.Resource) {
+	for _, s := range r.Schema {
+		s.Sensitive = false
+		if r, ok := s.Elem.(*schema.Resource); ok {
+			unsensitive(r)
+		}
+		if _, ok := s.Elem.(*schema.Schema); ok {
+			s.Elem.(*schema.Schema).Sensitive = false
+		}
+	}
 }

--- a/testdata/integration/test.sh
+++ b/testdata/integration/test.sh
@@ -54,6 +54,8 @@ ${REPO_ROOT}/terraform-provider-grafana-generate \
   --grafana-auth "admin:admin" \
   --clobber \
   --output-dir ${SCRIPT_DIR}/generated \
+  --include-resources "grafana_folder.*" \
+  --include-resources "grafana_team.*" \
   --output-credentials
 
 ${REPO_ROOT}/terraform-provider-grafana-generate \
@@ -63,6 +65,8 @@ ${REPO_ROOT}/terraform-provider-grafana-generate \
   --clobber \
   --output-dir ${SCRIPT_DIR}/generated-json \
   --output-format json \
+  --include-resources "grafana_folder.*" \
+  --include-resources "grafana_team.*" \
   --output-credentials
 
 # Test the generated code


### PR DESCRIPTION
This is a fairly complex one but it's the last missing piece to full config generation

The `terraform plan -generate-config-out` command is overly aggressive in redacting sensitive values

Whenever a child attribute of a block is sensitive, the whole block is redacted, meaning that the generated resources are invalid if the block was required

In this PR:
- Add listers for `grafana_user` and `grafana_contact_point`
- Replace nulled sensitive attributes with a placeholder (example: `password` in `grafana_user`_)
- Generate "sensitive" blocks by making all attribute non-sensitive. This is a bit hacky but it's integrated well enough and I haven't found a better way (tried lots of things)