### PR TITLE
Deny the `http` scheme in Grafana Cloud

### DIFF
--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -75,6 +75,11 @@ func createGrafanaAPIClient(client *common.Client, providerConfig ProviderConfig
 	if err != nil {
 		return fmt.Errorf("failed to parse API url: %v", err.Error())
 	}
+
+	if client.GrafanaAPIURLParsed.Scheme == "http" && strings.Contains(client.GrafanaAPIURLParsed.Host, "grafana.net") {
+		return fmt.Errorf("http not supported in Grafana Cloud. Use the https scheme")
+	}
+
 	apiPath, err := url.JoinPath(client.GrafanaAPIURLParsed.Path, "api")
 	if err != nil {
 		return fmt.Errorf("failed to join API path: %v", err.Error())


### PR DESCRIPTION
Closes https://github.com/grafana/terraform-provider-grafana/issues/1714 
The redirect leads to weird/obscure errors in the client. We can detect this misconfiguration earlier