### PR TITLE
docs(slo): Fixing value description getting inappropriately attribued to all value tags

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -218,8 +218,8 @@ Optional:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 
 <a id="nestedblock--alerting--fastburn"></a>
@@ -235,8 +235,8 @@ Optional:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 
 <a id="nestedblock--alerting--fastburn--label"></a>
@@ -244,8 +244,8 @@ Required:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 
 
@@ -254,8 +254,8 @@ Required:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 
 <a id="nestedblock--alerting--slowburn"></a>
@@ -271,8 +271,8 @@ Optional:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 
 <a id="nestedblock--alerting--slowburn--label"></a>
@@ -280,8 +280,8 @@ Required:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 
 
@@ -299,8 +299,8 @@ Optional:
 
 Required:
 
-- `key` (String)
-- `value` (String)
+- `key` (String) Key for filtering and identification
+- `value` (String) Templatable value
 
 ## Import
 

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -259,12 +259,14 @@ Resource manages Grafana SLOs.
 var keyvalueSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"key": {
-			Type:     schema.TypeString,
-			Required: true,
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: `Key for filtering and identification`,
 		},
 		"value": {
-			Type:     schema.TypeString,
-			Required: true,
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: `Templatable value`,
 		},
 	},
 }


### PR DESCRIPTION
This thread https://raintank-corp.slack.com/archives/C03G40X1ZK6/p1721833406517089 shows that when our terraform docs get to [crossplane](https://marketplace.upbound.io/providers/grafana/provider-grafana/v0.18.0/resources/slo.grafana.crossplane.io/SLO/v1alpha1) they have the value description thats should only be for the value in the objective part of the structure. 

We add these descriptions to prevent this from happening.