### PR TITLE
SSO: Fix validation for SAML certificate and private key

### DIFF
--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -720,8 +720,8 @@ var validationsByProvider = map[string][]validateFunc{
 		ssoValidateEmpty("api_url"),
 	},
 	"saml": {
-		ssoValidateOnlyOneOf("certificate", "certificate_path"),
-		ssoValidateOnlyOneOf("private_key", "private_key_path"),
+		ssoValidateInterdependencyXOR("certificate", "private_key"),
+		ssoValidateInterdependencyXOR("certificate_path", "private_key_path"),
 		ssoValidateOnlyOneOf("idp_metadata", "idp_metadata_path", "idp_metadata_url"),
 		ssoValidateURL("idp_metadata_url"),
 		ssoValidateInterdependencyXOR("client_id", "client_secret", "token_url"),
@@ -909,7 +909,7 @@ func ssoValidateInterdependencyXOR(keys ...string) validateFunc {
 		}
 
 		if configuredKeys != len(keys) && nonConfiguredKeys != len(keys) {
-			return fmt.Errorf("all varialbes in %v must be configured or empty for provider %s", keys, provider)
+			return fmt.Errorf("all variables in %v must be configured or empty for provider %s", keys, provider)
 		}
 
 		return nil

--- a/internal/resources/grafana/resource_sso_settings_test.go
+++ b/internal/resources/grafana/resource_sso_settings_test.go
@@ -566,11 +566,10 @@ var testConfigsWithValidationErrors = []string{
     api_url  = "https://login.microsoftonline.com/12345/oauth2/v2.0/userinfo"
   }
 }`,
-	// certificate and certificate_path are both configured for saml
+	// mixed path and value are configured for saml for certificate and private_key
 	`resource "grafana_sso_settings" "saml_sso_settings" {
   provider_name = "saml"
   saml_settings {
-    certificate = "this-is-a-valid-certificate"
     certificate_path = "/valid/certificate/path"
     private_key = "this-is-a-valid-private-key"
     idp_metadata_path = "/path/to/metadata"
@@ -584,7 +583,7 @@ var testConfigsWithValidationErrors = []string{
     private_key = "this-is-a-valid-private-key"
   }
 }`,
-	// missing value value for client_secret
+	// missing value for client_secret
 	`resource "grafana_sso_settings" "saml_sso_settings" {
 	provider_name = "saml"
 	saml_settings {


### PR DESCRIPTION
SAML validations for the certificate and private key are fixed in this PR. The correct rules are:
- Certificate and private key are either both configured or none of them is configured.
- Cannot mix value and path when configuring the certificate and private key.  If they are configured then they both have to use either the value or file paths.