### PR TITLE
Alerting docs: update links to Grafana Docs

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -4,7 +4,7 @@ page_title: "grafana_contact_point Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting contact points.
-  Official documentation https://grafana.com/docs/grafana/next/alerting/fundamentals/notifications/contact-points/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting contact points.
 
-* [Official documentation](https://grafana.com/docs/grafana/next/alerting/fundamentals/notifications/contact-points/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.

--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -4,7 +4,7 @@ page_title: "grafana_message_template Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting message templates.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#templates
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -13,7 +13,7 @@ description: |-
 Manages Grafana Alerting message templates.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#templates)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -4,7 +4,7 @@ page_title: "grafana_message_template Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting message templates.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/create-notification-templates/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting message templates.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/create-notification-templates/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#templates)
 
 This resource requires Grafana 9.1.0 or later.

--- a/docs/resources/mute_timing.md
+++ b/docs/resources/mute_timing.md
@@ -4,7 +4,7 @@ page_title: "grafana_mute_timing Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting mute timings.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/configure-notifications/mute-timings/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#mute-timings
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,8 +12,8 @@ description: |-
 
 Manages Grafana Alerting mute timings.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/mute-timings/)
-* [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/alerting_provisioning/#mute-timings)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#mute-timings)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -5,7 +5,7 @@ subcategory: "Alerting"
 description: |-
   Sets the global notification policy for Grafana.
   !> This resource manages the entire notification policy tree, and will overwrite any existing policies.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/configure-notifications/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/
   This resource requires Grafana 9.1.0 or later.
 ---
 

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -5,7 +5,7 @@ subcategory: "Alerting"
 description: |-
   Sets the global notification policy for Grafana.
   !> This resource manages the entire notification policy tree, and will overwrite any existing policies.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-policies
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -16,7 +16,7 @@ Sets the global notification policy for Grafana.
 !> This resource manages the entire notification policy tree, and will overwrite any existing policies.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-policies)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -4,7 +4,7 @@ page_title: "grafana_rule_group Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting rule groups.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/alerting-rules/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/ API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 Manages Grafana Alerting rule groups.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/alerting-rules/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
 
 This resource requires Grafana 9.1.0 or later.


### PR DESCRIPTION
Minor doc changes for Alerting resources:

- Update the `Official documentation` hyperlink to link to the latest [Alerting Terraform docs](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
- Update some `HTTP API` links to use `latest` instead of `next`