### PR TITLE
Config Generation: Add test for SM Check generation

### DIFF
--- a/pkg/generate/testdata/generate/sm-check/imports.tf.tmpl
+++ b/pkg/generate/testdata/generate/sm-check/imports.tf.tmpl
@@ -1,0 +1,4 @@
+import {
+  to = grafana_synthetic_monitoring_check._{{ .ID }}
+  id = "{{ .ID }}"
+}

--- a/pkg/generate/testdata/generate/sm-check/provider.tf
+++ b/pkg/generate/testdata/generate/sm-check/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "999.999.999"
+    }
+  }
+}
+
+provider "grafana" {
+  url             = "https://tfprovidertests.grafana.net/"
+  auth            = "REDACTED"
+  sm_url          = "https://synthetic-monitoring-api-us-east-0.grafana.net"
+  sm_access_token = "REDACTED"
+}

--- a/pkg/generate/testdata/generate/sm-check/resources.tf.tmpl
+++ b/pkg/generate/testdata/generate/sm-check/resources.tf.tmpl
@@ -1,0 +1,26 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "{{ .ID }}"
+resource "grafana_synthetic_monitoring_check" "_{{ .ID }}" {
+  alert_sensitivity  = "none"
+  basic_metrics_only = true
+  enabled            = false
+  frequency          = 60000
+  job                = "{{ .Job }}"
+  labels = {
+    foo = "bar"
+  }
+  probes  = [7]
+  target  = "https://grafana.com"
+  timeout = 3000
+  settings {
+    http {
+      fail_if_not_ssl     = false
+      fail_if_ssl         = false
+      ip_version          = "V4"
+      method              = "GET"
+      no_follow_redirects = false
+    }
+  }
+}


### PR DESCRIPTION
- Add new `TestAccGenerate_CloudInstance` test function
- Add test helper to template the expected files dir (for incrementing IDs or random names in a persistent test env)
- Add helper function hook (`stateCheck`) to access the Terraform state. This is used to extract the check ID which is computed after applying. This ID is part of the expected files output