### PR TITLE
Config Generation: Fix oncall

### DIFF
--- a/internal/resources/oncall/resource_escalation.go
+++ b/internal/resources/oncall/resource_escalation.go
@@ -363,16 +363,36 @@ func resourceEscalationRead(ctx context.Context, d *schema.ResourceData, client 
 	d.Set("escalation_chain_id", escalation.EscalationChainId)
 	d.Set("position", escalation.Position)
 	d.Set("type", escalation.Type)
-	d.Set("duration", escalation.Duration)
-	d.Set("notify_on_call_from_schedule", escalation.NotifyOnCallFromSchedule)
-	d.Set("persons_to_notify", escalation.PersonsToNotify)
-	d.Set("persons_to_notify_next_each_time", escalation.PersonsToNotifyEachTime)
-	d.Set("notify_to_team_members", escalation.TeamToNotify)
-	d.Set("group_to_notify", escalation.GroupToNotify)
-	d.Set("action_to_trigger", escalation.ActionToTrigger)
-	d.Set("important", escalation.Important)
-	d.Set("notify_if_time_from", escalation.NotifyIfTimeFrom)
-	d.Set("notify_if_time_to", escalation.NotifyIfTimeTo)
+	if escalation.Duration != nil {
+		d.Set("duration", escalation.Duration)
+	}
+	if escalation.NotifyOnCallFromSchedule != nil {
+		d.Set("notify_on_call_from_schedule", escalation.NotifyOnCallFromSchedule)
+	}
+	if escalation.PersonsToNotify != nil {
+		d.Set("persons_to_notify", escalation.PersonsToNotify)
+	}
+	if escalation.PersonsToNotifyEachTime != nil {
+		d.Set("persons_to_notify_next_each_time", escalation.PersonsToNotifyEachTime)
+	}
+	if escalation.TeamToNotify != nil {
+		d.Set("notify_to_team_members", escalation.TeamToNotify)
+	}
+	if escalation.GroupToNotify != nil {
+		d.Set("group_to_notify", escalation.GroupToNotify)
+	}
+	if escalation.ActionToTrigger != nil {
+		d.Set("action_to_trigger", escalation.ActionToTrigger)
+	}
+	if escalation.Important != nil {
+		d.Set("important", escalation.Important)
+	}
+	if escalation.NotifyIfTimeFrom != nil {
+		d.Set("notify_if_time_from", escalation.NotifyIfTimeFrom)
+	}
+	if escalation.NotifyIfTimeTo != nil {
+		d.Set("notify_if_time_to", escalation.NotifyIfTimeTo)
+	}
 
 	return nil
 }

--- a/internal/resources/oncall/resource_escalation_test.go
+++ b/internal/resources/oncall/resource_escalation_test.go
@@ -40,6 +40,21 @@ func TestAccOnCallEscalation_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("grafana_oncall_escalation.test-acc-escalation-policy-team", "notify_to_team_members"),
 				),
 			},
+			{
+				ImportState:       true,
+				ResourceName:      "grafana_oncall_escalation.test-acc-escalation",
+				ImportStateVerify: true,
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "grafana_oncall_escalation.test-acc-escalation-repeat",
+				ImportStateVerify: true,
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "grafana_oncall_escalation.test-acc-escalation-policy-team",
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -3,6 +3,7 @@ package oncall
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 
 	onCallAPI "github.com/grafana/amixr-api-go-client"
@@ -114,6 +115,9 @@ func listSchedules(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) 
 		return nil, nil, err
 	}
 	for _, i := range resp.Schedules {
+		if !slices.Contains(scheduleTypeOptions, i.Type) {
+			continue
+		}
 		ids = append(ids, i.ID)
 	}
 	return ids, resp.Next, nil

--- a/internal/resources/oncall/resource_schedule_test.go
+++ b/internal/resources/oncall/resource_schedule_test.go
@@ -29,6 +29,11 @@ func TestAccOnCallSchedule_basic(t *testing.T) {
 				),
 			},
 			{
+				ImportState:       true,
+				ResourceName:      "grafana_oncall_schedule.test-acc-schedule",
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccOnCallScheduleConfigOverrides(scheduleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOnCallScheduleResourceExists("grafana_oncall_schedule.test-acc-schedule"),
@@ -36,11 +41,21 @@ func TestAccOnCallSchedule_basic(t *testing.T) {
 				),
 			},
 			{
+				ImportState:       true,
+				ResourceName:      "grafana_oncall_schedule.test-acc-schedule",
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccOnCallScheduleConfigOverrides(scheduleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOnCallScheduleResourceExists("grafana_oncall_schedule.test-acc-schedule"),
 					resource.TestCheckResourceAttr("grafana_oncall_schedule.test-acc-schedule", "enable_web_overrides", "false"),
 				),
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "grafana_oncall_schedule.test-acc-schedule",
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/pkg/generate/testdata/generate/oncall-resources/imports.tf.tmpl
+++ b/pkg/generate/testdata/generate/oncall-resources/imports.tf.tmpl
@@ -1,0 +1,19 @@
+import {
+  to = grafana_oncall_escalation._{{ .EscalationID }}
+  id = "{{ .EscalationID }}"
+}
+
+import {
+  to = grafana_oncall_escalation_chain._{{ .EscalationChainID }}
+  id = "{{ .EscalationChainID }}"
+}
+
+import {
+  to = grafana_oncall_integration._{{ .IntegrationID }}
+  id = "{{ .IntegrationID }}"
+}
+
+import {
+  to = grafana_oncall_schedule._{{ .ScheduleID }}
+  id = "{{ .ScheduleID }}"
+}

--- a/pkg/generate/testdata/generate/oncall-resources/provider.tf
+++ b/pkg/generate/testdata/generate/oncall-resources/provider.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "999.999.999"
+    }
+  }
+}
+
+provider "grafana" {
+  url                 = "https://tfprovidertests.grafana.net/"
+  auth                = "REDACTED"
+  oncall_url          = "https://oncall-prod-us-central-0.grafana.net/oncall"
+  oncall_access_token = "REDACTED"
+}

--- a/pkg/generate/testdata/generate/oncall-resources/resources.tf.tmpl
+++ b/pkg/generate/testdata/generate/oncall-resources/resources.tf.tmpl
@@ -1,0 +1,29 @@
+# __generated__ by Terraform
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by Terraform from "{{ .EscalationID }}"
+resource "grafana_oncall_escalation" "_{{ .EscalationID }}" {
+  duration            = 300
+  escalation_chain_id = grafana_oncall_escalation_chain._{{ .EscalationChainID }}.id
+  position            = 0
+  type                = "wait"
+}
+
+# __generated__ by Terraform from "{{ .EscalationChainID }}"
+resource "grafana_oncall_escalation_chain" "_{{ .EscalationChainID }}" {
+  name = "{{ .Name }}"
+}
+
+# __generated__ by Terraform from "{{ .IntegrationID }}"
+resource "grafana_oncall_integration" "_{{ .IntegrationID }}" {
+  name = "{{ .Name }}"
+  type = "grafana"
+}
+
+# __generated__ by Terraform from "{{ .ScheduleID }}"
+resource "grafana_oncall_schedule" "_{{ .ScheduleID }}" {
+  enable_web_overrides = false
+  name                 = "{{ .Name }}"
+  time_zone            = "America/New_York"
+  type                 = "calendar"
+}


### PR DESCRIPTION
Currently, we have errors with two oncall resources:
- Schedule: `web` type schedules are fetched but they can't be managed with TF
- Escalation: Mutually exclusive attributes are being set. With this change, all `nil` attributes won't be set in the TF state (rather than a zero value)