### PR TITLE
docs(data_source): add CloudWatch ARN example

### DIFF
--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -64,6 +64,21 @@ resource "grafana_data_source" "cloudwatch" {
   })
 }
 
+resource "grafana_data_source" "cloudwatch_assumeARN" {
+  type = "cloudwatch"
+  name = "cw-assumeARN-example"
+
+  # Requires `assume_role_enabled` feature flag to be enabled
+  # OSS: use authType = "default" on OSS
+  # Cloud: use authType = "grafana_assume_role" which is in private preview on Cloud:
+  # https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/aws-authentication/#use-grafana-assume-role
+  json_data_encoded = jsonencode({
+    defaultRegion = "us-east-1"
+    authType      = "grafana_assume_role"
+    assumeRoleArn = "arn:aws:iam::123456789012:root"
+  })
+}
+
 resource "grafana_data_source" "prometheus" {
   type                = "prometheus"
   name                = "mimir"

--- a/examples/resources/grafana_data_source/resource.tf
+++ b/examples/resources/grafana_data_source/resource.tf
@@ -43,6 +43,21 @@ resource "grafana_data_source" "cloudwatch" {
   })
 }
 
+resource "grafana_data_source" "cloudwatch_assumeARN" {
+  type = "cloudwatch"
+  name = "cw-assumeARN-example"
+
+  # Requires `assume_role_enabled` feature flag to be enabled
+  # OSS: use authType = "default" on OSS
+  # Cloud: use authType = "grafana_assume_role" which is in private preview on Cloud:
+  # https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/aws-authentication/#use-grafana-assume-role
+  json_data_encoded = jsonencode({
+    defaultRegion = "us-east-1"
+    authType      = "grafana_assume_role"
+    assumeRoleArn = "arn:aws:iam::123456789012:root"
+  })
+}
+
 resource "grafana_data_source" "prometheus" {
   type                = "prometheus"
   name                = "mimir"


### PR DESCRIPTION
A question through customer support brought up this example, figured it'd be a nice example to include here.

Ref for full docs: https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/aws-authentication/#select-an-authentication-method
