### PR TITLE
Ignore hidden dirs when listing possible references

### DIFF
--- a/pkg/generate/postprocessing/genreferences/main.go
+++ b/pkg/generate/postprocessing/genreferences/main.go
@@ -28,10 +28,21 @@ func main() {
 		log.Fatal("examples-dir and file flags are required")
 	}
 
+	walkDir, err := filepath.Abs(walkDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	exampleFiles := []string{}
 	if err := filepath.Walk(walkDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		if info.IsDir() {
+			if strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if filepath.Ext(path) == ".tf" {
 			exampleFiles = append(exampleFiles, path)


### PR DESCRIPTION
This PR https://github.com/grafana/terraform-provider-grafana/pull/1754 generates a drift for me because I have some gitignored test files with refs in them 

This PR ignores them and the drift is gone