### PR TITLE
Config Generation: Set a preferred field for resource names

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -66,8 +66,11 @@ type ResourceListIDsFunc func(ctx context.Context, client *Client, data any) ([]
 type Resource struct {
 	ResourceCommon
 	IDType                *ResourceID
-	ListIDsFunc           ResourceListIDsFunc
 	PluginFrameworkSchema resource.ResourceWithConfigure
+
+	// Generation configuration
+	ListIDsFunc                ResourceListIDsFunc
+	PreferredResourceNameField string // This field will be used as the resource name instead of the ID. This is useful if the ID is not ideal for humans (ex: UUID or numeric). The field value should uniquely identify the resource.
 }
 
 func NewLegacySDKResource(category ResourceCategory, name string, idType *ResourceID, schema *schema.Resource) *Resource {
@@ -96,6 +99,11 @@ func NewResource(category ResourceCategory, name string, idType *ResourceID, sch
 
 func (r *Resource) WithLister(lister ResourceListIDsFunc) *Resource {
 	r.ListIDsFunc = lister
+	return r
+}
+
+func (r *Resource) WithPreferredResourceNameField(fieldName string) *Resource {
+	r.PreferredResourceNameField = fieldName
 	return r
 }
 

--- a/internal/resources/oncall/resource_escalation.go
+++ b/internal/resources/oncall/resource_escalation.go
@@ -224,7 +224,8 @@ func resourceEscalation() *common.Resource {
 		"grafana_oncall_escalation",
 		resourceID,
 		schema,
-	).WithLister(oncallListerFunction(listEscalations))
+	).
+		WithLister(oncallListerFunction(listEscalations))
 }
 
 func listEscalations(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (ids []string, nextPage *string, err error) {

--- a/internal/resources/oncall/resource_escalation_chain.go
+++ b/internal/resources/oncall/resource_escalation_chain.go
@@ -42,7 +42,9 @@ func resourceEscalationChain() *common.Resource {
 		"grafana_oncall_escalation_chain",
 		resourceID,
 		schema,
-	).WithLister(oncallListerFunction(listEscalationChains))
+	).
+		WithLister(oncallListerFunction(listEscalationChains)).
+		WithPreferredResourceNameField("name")
 }
 
 func listEscalationChains(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (ids []string, nextPage *string, err error) {

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -239,7 +239,9 @@ func resourceIntegration() *common.Resource {
 		"grafana_oncall_integration",
 		resourceID,
 		schema,
-	).WithLister(oncallListerFunction(listIntegrations))
+	).
+		WithLister(oncallListerFunction(listIntegrations)).
+		WithPreferredResourceNameField("name")
 }
 
 func listIntegrations(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (ids []string, nextPage *string, err error) {

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -108,7 +108,9 @@ func resourceOutgoingWebhook() *common.Resource {
 		"grafana_oncall_outgoing_webhook",
 		resourceID,
 		schema,
-	).WithLister(oncallListerFunction(listWebhooks))
+	).
+		WithLister(oncallListerFunction(listWebhooks)).
+		WithPreferredResourceNameField("name")
 }
 
 func listWebhooks(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (ids []string, nextPage *string, err error) {

--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -106,7 +106,9 @@ func resourceSchedule() *common.Resource {
 		"grafana_oncall_schedule",
 		resourceID,
 		schema,
-	).WithLister(oncallListerFunction(listSchedules))
+	).
+		WithLister(oncallListerFunction(listSchedules)).
+		WithPreferredResourceNameField("name")
 }
 
 func listSchedules(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (ids []string, nextPage *string, err error) {

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -186,7 +186,9 @@ func resourceOnCallShift() *common.Resource {
 		"grafana_oncall_on_call_shift",
 		resourceID,
 		schema,
-	).WithLister(oncallListerFunction(listShifts))
+	).
+		WithLister(oncallListerFunction(listShifts)).
+		WithPreferredResourceNameField("name")
 }
 
 func listShifts(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (ids []string, nextPage *string, err error) {

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -253,7 +253,9 @@ Resource manages Grafana SLOs.
 		"grafana_slo",
 		resourceSloID,
 		schema,
-	).WithLister(listSlos)
+	).
+		WithLister(listSlos).
+		WithPreferredResourceNameField("name")
 }
 
 var keyvalueSchema = &schema.Resource{

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -790,7 +790,9 @@ multiple checks for a single endpoint to check different capabilities.
 		"grafana_synthetic_monitoring_check",
 		resourceCheckID,
 		schema,
-	).WithLister(listChecks)
+	).
+		WithLister(listChecks).
+		WithPreferredResourceNameField("job")
 }
 
 func listChecks(ctx context.Context, client *common.Client, data any) ([]string, error) {

--- a/internal/resources/syntheticmonitoring/resource_probe.go
+++ b/internal/resources/syntheticmonitoring/resource_probe.go
@@ -115,7 +115,9 @@ Grafana Synthetic Monitoring Agent.
 		"grafana_synthetic_monitoring_probe",
 		resourceProbeID,
 		schema,
-	).WithLister(listProbes)
+	).
+		WithLister(listProbes).
+		WithPreferredResourceNameField("name")
 }
 
 func listProbes(ctx context.Context, client *common.Client, data any) ([]string, error) {

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -332,16 +332,15 @@ func generateImportBlocks(ctx context.Context, client *common.Client, listerData
 		}
 	}
 
-	if err := postprocessing.ReplaceNullSensitiveAttributes(generatedFilename("resources.tf")); err != nil {
-		return failure(err)
-	}
-
-	if err := removeOrphanedImports(generatedFilename("imports.tf"), generatedFilename("resources.tf")); err != nil {
-		return failure(err)
-	}
-
-	if err := sortResourcesFile(generatedFilename("resources.tf")); err != nil {
-		return failure(err)
+	for _, err := range []error{
+		postprocessing.ReplaceNullSensitiveAttributes(generatedFilename("resources.tf")),
+		removeOrphanedImports(generatedFilename("imports.tf"), generatedFilename("resources.tf")),
+		postprocessing.UsePreferredResourceNames(generatedFilename("resources.tf"), generatedFilename("imports.tf")),
+		sortResourcesFile(generatedFilename("resources.tf")),
+	} {
+		if err != nil {
+			return failure(err)
+		}
 	}
 
 	return returnResult

--- a/pkg/generate/postprocessing/postprocessing.go
+++ b/pkg/generate/postprocessing/postprocessing.go
@@ -34,3 +34,12 @@ func postprocessFile(fpath string, fn postprocessingFunc) error {
 
 	return nil
 }
+
+func postprocessFiles(fpaths []string, fn postprocessingFunc) error {
+	for _, fpath := range fpaths {
+		if err := postprocessFile(fpath, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/generate/postprocessing/preferred_resource_name.go
+++ b/pkg/generate/postprocessing/preferred_resource_name.go
@@ -1,0 +1,65 @@
+package postprocessing
+
+import (
+	"strings"
+
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v3/pkg/provider"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// UsePreferredResourceNames replaces the resource name with the value of the preferred resource name field.
+// The input files (resources.tf + imports.tf) are modified in place.
+func UsePreferredResourceNames(fpaths ...string) error {
+	providerResources := map[string]*common.Resource{}
+	for _, r := range provider.Resources() {
+		providerResources[r.Name] = r
+	}
+
+	replaceMap := map[string]hcl.Traversal{}
+
+	// Go through all resource blocks first
+	if err := postprocessFiles(fpaths, func(file *hclwrite.File) error {
+		for _, block := range file.Body().Blocks() {
+			if block.Type() != "resource" {
+				continue
+			}
+
+			resourceType := block.Labels()[0]
+			resourceInfo := providerResources[resourceType]
+
+			if resourceInfo.PreferredResourceNameField == "" {
+				continue
+			}
+
+			nameAttr := block.Body().GetAttribute(resourceInfo.PreferredResourceNameField)
+			if nameAttr == nil {
+				continue
+			}
+			newResourceName := strings.Trim(string(nameAttr.Expr().BuildTokens(nil).Bytes()), "\" ") // Unquote + trim spaces
+
+			replaceMap[strings.Join(block.Labels(), ".")] = traversal(resourceType, newResourceName)
+			block.SetLabels([]string{resourceType, newResourceName})
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Go through all import blocks
+	return postprocessFiles(fpaths, func(file *hclwrite.File) error {
+		for _, block := range file.Body().Blocks() {
+			if block.Type() != "import" {
+				continue
+			}
+
+			resourceTo := strings.TrimSpace(string(block.Body().GetAttribute("to").Expr().BuildTokens(nil).Bytes()))
+			if newResourceTo, ok := replaceMap[resourceTo]; ok {
+				block.Body().SetAttributeTraversal("to", newResourceTo)
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/generate/postprocessing/preferred_resource_name_test.go
+++ b/pkg/generate/postprocessing/preferred_resource_name_test.go
@@ -1,0 +1,13 @@
+package postprocessing
+
+import "testing"
+
+func TestUsePreferredResourceNames(t *testing.T) {
+	for _, testFile := range []string{
+		"testdata/preferred-resource-name.tf",
+	} {
+		postprocessingTest(t, testFile, func(fpath string) {
+			UsePreferredResourceNames(fpath)
+		})
+	}
+}

--- a/pkg/generate/postprocessing/testdata/preferred-resource-name.golden.tf
+++ b/pkg/generate/postprocessing/testdata/preferred-resource-name.golden.tf
@@ -1,13 +1,14 @@
-# __generated__ by Terraform
-# Please review these resources and move them into your main configuration files.
+import {
+  id = "12345"
+  to = grafana_synthetic_monitoring_check.testname
+}
 
-# __generated__ by Terraform from "{{ .ID }}"
-resource "grafana_synthetic_monitoring_check" "{{ .Job }}" {
+resource "grafana_synthetic_monitoring_check" "testname" {
   alert_sensitivity  = "none"
   basic_metrics_only = true
   enabled            = false
   frequency          = 60000
-  job                = "{{ .Job }}"
+  job                = "testname"
   labels = {
     foo = "bar"
   }

--- a/pkg/generate/postprocessing/testdata/preferred-resource-name.tf
+++ b/pkg/generate/postprocessing/testdata/preferred-resource-name.tf
@@ -1,13 +1,14 @@
-# __generated__ by Terraform
-# Please review these resources and move them into your main configuration files.
+import {
+  id = "12345"
+  to = grafana_synthetic_monitoring_check._12345
+}
 
-# __generated__ by Terraform from "{{ .ID }}"
-resource "grafana_synthetic_monitoring_check" "{{ .Job }}" {
+resource "grafana_synthetic_monitoring_check" "_12345" {
   alert_sensitivity  = "none"
   basic_metrics_only = true
   enabled            = false
   frequency          = 60000
-  job                = "{{ .Job }}"
+  job                = "testname"
   labels = {
     foo = "bar"
   }

--- a/pkg/generate/testdata/generate/oncall-resources/imports.tf.tmpl
+++ b/pkg/generate/testdata/generate/oncall-resources/imports.tf.tmpl
@@ -4,16 +4,16 @@ import {
 }
 
 import {
-  to = grafana_oncall_escalation_chain._{{ .EscalationChainID }}
+  to = grafana_oncall_escalation_chain.{{ .Name }}
   id = "{{ .EscalationChainID }}"
 }
 
 import {
-  to = grafana_oncall_integration._{{ .IntegrationID }}
+  to = grafana_oncall_integration.{{ .Name }}
   id = "{{ .IntegrationID }}"
 }
 
 import {
-  to = grafana_oncall_schedule._{{ .ScheduleID }}
+  to = grafana_oncall_schedule.{{ .Name }}
   id = "{{ .ScheduleID }}"
 }

--- a/pkg/generate/testdata/generate/oncall-resources/resources.tf.tmpl
+++ b/pkg/generate/testdata/generate/oncall-resources/resources.tf.tmpl
@@ -4,24 +4,24 @@
 # __generated__ by Terraform from "{{ .EscalationID }}"
 resource "grafana_oncall_escalation" "_{{ .EscalationID }}" {
   duration            = 300
-  escalation_chain_id = grafana_oncall_escalation_chain._{{ .EscalationChainID }}.id
+  escalation_chain_id = grafana_oncall_escalation_chain.{{ .Name }}.id
   position            = 0
   type                = "wait"
 }
 
 # __generated__ by Terraform from "{{ .EscalationChainID }}"
-resource "grafana_oncall_escalation_chain" "_{{ .EscalationChainID }}" {
+resource "grafana_oncall_escalation_chain" "{{ .Name }}" {
   name = "{{ .Name }}"
 }
 
 # __generated__ by Terraform from "{{ .IntegrationID }}"
-resource "grafana_oncall_integration" "_{{ .IntegrationID }}" {
+resource "grafana_oncall_integration" "{{ .Name }}" {
   name = "{{ .Name }}"
   type = "grafana"
 }
 
 # __generated__ by Terraform from "{{ .ScheduleID }}"
-resource "grafana_oncall_schedule" "_{{ .ScheduleID }}" {
+resource "grafana_oncall_schedule" "{{ .Name }}" {
   enable_web_overrides = false
   name                 = "{{ .Name }}"
   time_zone            = "America/New_York"

--- a/pkg/generate/testdata/generate/sm-check/imports.tf.tmpl
+++ b/pkg/generate/testdata/generate/sm-check/imports.tf.tmpl
@@ -1,4 +1,4 @@
 import {
-  to = grafana_synthetic_monitoring_check._{{ .ID }}
+  to = grafana_synthetic_monitoring_check.{{ .Job }}
   id = "{{ .ID }}"
 }


### PR DESCRIPTION
Part of https://github.com/grafana/terraform-provider-grafana/issues/1745

SM and OnCall resources are covered in this PR. For these, the user configures a unique "name" but what is used as the resource ID is a unique database numerical ID

For the user's purposes, it's better to use the given "name" as the resource name. The numerical ID then remains internal, as it should

### Example

This:

```terraform
resource "grafana_synthetic_monitoring_check" "_12345" {
  job                = "testname"
  ...
}
```

Becomes

```terraform
resource "grafana_synthetic_monitoring_check" "testname" {
  job                = "testname"
  ...
}
```