### PR TITLE
Config Generation: Omit org ID from Grafana resources

### DIFF
--- a/internal/testutils/lister.go
+++ b/internal/testutils/lister.go
@@ -46,7 +46,7 @@ func CheckLister(terraformResource string) resource.TestCheckFunc {
 
 		// Get the list of IDs from the lister function
 		ctx := context.Background()
-		var listerData any = grafana.NewListerData(false)
+		var listerData any = grafana.NewListerData(false, false)
 		if resource.Category == common.CategoryCloud {
 			listerData = cloud.NewListerData(os.Getenv("GRAFANA_CLOUD_ORG"))
 		}

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -134,7 +134,7 @@ func TestAccGenerate(t *testing.T) {
 			name:   "dashboard-filter-strict",
 			config: testutils.TestAccExample(t, "resources/grafana_dashboard/resource.tf"),
 			generateConfig: func(cfg *generate.Config) {
-				cfg.IncludeResources = []string{"grafana_dashboard._1_my-dashboard-uid"}
+				cfg.IncludeResources = []string{"grafana_dashboard.my-dashboard-uid"}
 			},
 			check: func(t *testing.T, tempDir string) {
 				assertFiles(t, tempDir, "testdata/generate/dashboard-filtered", []string{
@@ -147,7 +147,7 @@ func TestAccGenerate(t *testing.T) {
 			name:   "dashboard-filter-wildcard-on-resource-type",
 			config: testutils.TestAccExample(t, "resources/grafana_dashboard/resource.tf"),
 			generateConfig: func(cfg *generate.Config) {
-				cfg.IncludeResources = []string{"*._1_my-dashboard-uid"}
+				cfg.IncludeResources = []string{"*.my-dashboard-uid"}
 			},
 			check: func(t *testing.T, tempDir string) {
 				assertFiles(t, tempDir, "testdata/generate/dashboard-filtered", []string{
@@ -356,7 +356,7 @@ func TestAccGenerate_SMCheck(t *testing.T) {
 				SMURL:         os.Getenv("GRAFANA_SM_URL"),
 				SMAccessToken: os.Getenv("GRAFANA_SM_ACCESS_TOKEN"),
 			}
-			cfg.IncludeResources = []string{"grafana_synthetic_monitoring_check._" + smCheckID}
+			cfg.IncludeResources = []string{"grafana_synthetic_monitoring_check." + smCheckID}
 		},
 		check: func(t *testing.T, tempDir string) {
 			templateAttrs := map[string]string{
@@ -420,10 +420,10 @@ func TestAccGenerate_OnCall(t *testing.T) {
 				OnCallAccessToken: os.Getenv("GRAFANA_ONCALL_ACCESS_TOKEN"),
 			}
 			cfg.IncludeResources = []string{
-				"grafana_oncall_integration._" + oncallIntegrationID,
-				"grafana_oncall_escalation_chain._" + oncallEscalationChainID,
-				"grafana_oncall_escalation._" + oncallEscalationID,
-				"grafana_oncall_schedule._" + oncallScheduleID,
+				"grafana_oncall_integration." + oncallIntegrationID,
+				"grafana_oncall_escalation_chain." + oncallEscalationChainID,
+				"grafana_oncall_escalation." + oncallEscalationID,
+				"grafana_oncall_schedule." + oncallScheduleID,
 			}
 		},
 		stateCheck: func(s *terraform.State) error {

--- a/pkg/generate/grafana.go
+++ b/pkg/generate/grafana.go
@@ -47,7 +47,7 @@ func generateGrafanaResources(ctx context.Context, cfg *Config, stack stack, gen
 	}
 
 	singleOrg := !strings.Contains(stack.managementKey, ":")
-	listerData := grafana.NewListerData(singleOrg)
+	listerData := grafana.NewListerData(singleOrg, true)
 
 	// Generate resources
 	config := provider.ProviderConfig{

--- a/pkg/generate/testdata/generate/dashboard-crossplane/contact-point-email-receiver.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/contact-point-email-receiver.yaml
@@ -1,7 +1,7 @@
 apiVersion: alerting.grafana.crossplane.io/v1alpha1
 kind: ContactPoint
 metadata:
-  name: 1-email-receiver
+  name: email-receiver
   annotations:
     crossplane.io/external-name: 1:email receiver
 spec:

--- a/pkg/generate/testdata/generate/dashboard-crossplane/dashboard-my-dashboard-uid.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/dashboard-my-dashboard-uid.yaml
@@ -1,7 +1,7 @@
 apiVersion: oss.grafana.crossplane.io/v1alpha1
 kind: Dashboard
 metadata:
-  name: 1-my-dashboard-uid
+  name: my-dashboard-uid
   annotations:
     crossplane.io/external-name: 1:my-dashboard-uid
 spec:

--- a/pkg/generate/testdata/generate/dashboard-crossplane/folder-my-folder-uid.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/folder-my-folder-uid.yaml
@@ -1,7 +1,7 @@
 apiVersion: oss.grafana.crossplane.io/v1alpha1
 kind: Folder
 metadata:
-  name: 1-my-folder-uid
+  name: my-folder-uid
   annotations:
     crossplane.io/external-name: 1:my-folder-uid
 spec:

--- a/pkg/generate/testdata/generate/dashboard-crossplane/notification-policy-policy.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/notification-policy-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: alerting.grafana.crossplane.io/v1alpha1
 kind: NotificationPolicy
 metadata:
-  name: 1-policy
+  name: policy
   annotations:
     crossplane.io/external-name: 1:policy
 spec:

--- a/pkg/generate/testdata/generate/dashboard-filtered/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/imports.tf
@@ -1,4 +1,4 @@
 import {
-  to = grafana_dashboard._1_my-dashboard-uid
-  id = "1:my-dashboard-uid"
+  to = grafana_dashboard.my-dashboard-uid
+  id = "my-dashboard-uid"
 }

--- a/pkg/generate/testdata/generate/dashboard-filtered/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard-filtered/resources.tf
@@ -1,8 +1,8 @@
 # __generated__ by Terraform
 # Please review these resources and move them into your main configuration files.
 
-# __generated__ by Terraform from "1:my-dashboard-uid"
-resource "grafana_dashboard" "_1_my-dashboard-uid" {
+# __generated__ by Terraform from "my-dashboard-uid"
+resource "grafana_dashboard" "my-dashboard-uid" {
   config_json = jsonencode({
     title = "My Dashboard"
     uid   = "my-dashboard-uid"

--- a/pkg/generate/testdata/generate/dashboard-json/imports.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/imports.tf.json
@@ -1,20 +1,20 @@
 {
   "import": [
     {
-      "id": "1:email receiver",
-      "to": "grafana_contact_point._1_email_receiver"
+      "id": "email receiver",
+      "to": "grafana_contact_point.email_receiver"
     },
     {
-      "id": "1:my-dashboard-uid",
-      "to": "grafana_dashboard._1_my-dashboard-uid"
+      "id": "my-dashboard-uid",
+      "to": "grafana_dashboard.my-dashboard-uid"
     },
     {
-      "id": "1:my-folder-uid",
-      "to": "grafana_folder._1_my-folder-uid"
+      "id": "my-folder-uid",
+      "to": "grafana_folder.my-folder-uid"
     },
     {
-      "id": "1:policy",
-      "to": "grafana_notification_policy._1_policy"
+      "id": "policy",
+      "to": "grafana_notification_policy.policy"
     },
     {
       "id": "1",

--- a/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
@@ -1,7 +1,7 @@
 {
   "resource": {
     "grafana_contact_point": {
-      "_1_email_receiver": [
+      "email_receiver": [
         {
           "disable_provenance": true,
           "email": [
@@ -18,15 +18,15 @@
       ]
     },
     "grafana_dashboard": {
-      "_1_my-dashboard-uid": [
+      "my-dashboard-uid": [
         {
           "config_json": "${jsonencode({\n    title = \"My Dashboard\"\n    uid   = \"my-dashboard-uid\"\n  })}",
-          "folder": "${grafana_folder._1_my-folder-uid.uid}"
+          "folder": "${grafana_folder.my-folder-uid.uid}"
         }
       ]
     },
     "grafana_folder": {
-      "_1_my-folder-uid": [
+      "my-folder-uid": [
         {
           "title": "My Folder",
           "uid": "my-folder-uid"
@@ -34,7 +34,7 @@
       ]
     },
     "grafana_notification_policy": {
-      "_1_policy": [
+      "policy": [
         {
           "contact_point": "grafana-default-email",
           "disable_provenance": true,

--- a/pkg/generate/testdata/generate/dashboard-restricted-permissions/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard-restricted-permissions/imports.tf
@@ -1,9 +1,9 @@
 import {
-  to = grafana_dashboard._0_my-dashboard-uid
-  id = "0:my-dashboard-uid"
+  to = grafana_dashboard.my-dashboard-uid
+  id = "my-dashboard-uid"
 }
 
 import {
-  to = grafana_folder._0_my-folder-uid
-  id = "0:my-folder-uid"
+  to = grafana_folder.my-folder-uid
+  id = "my-folder-uid"
 }

--- a/pkg/generate/testdata/generate/dashboard-restricted-permissions/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard-restricted-permissions/resources.tf
@@ -1,17 +1,17 @@
 # __generated__ by Terraform
 # Please review these resources and move them into your main configuration files.
 
-# __generated__ by Terraform from "0:my-dashboard-uid"
-resource "grafana_dashboard" "_0_my-dashboard-uid" {
+# __generated__ by Terraform from "my-dashboard-uid"
+resource "grafana_dashboard" "my-dashboard-uid" {
   config_json = jsonencode({
     title = "My Dashboard"
     uid   = "my-dashboard-uid"
   })
-  folder = grafana_folder._0_my-folder-uid.uid
+  folder = grafana_folder.my-folder-uid.uid
 }
 
-# __generated__ by Terraform from "0:my-folder-uid"
-resource "grafana_folder" "_0_my-folder-uid" {
+# __generated__ by Terraform from "my-folder-uid"
+resource "grafana_folder" "my-folder-uid" {
   title = "My Folder"
   uid   = "my-folder-uid"
 }

--- a/pkg/generate/testdata/generate/dashboard/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard/imports.tf
@@ -1,21 +1,21 @@
 import {
-  to = grafana_contact_point._1_email_receiver
-  id = "1:email receiver"
+  to = grafana_contact_point.email_receiver
+  id = "email receiver"
 }
 
 import {
-  to = grafana_dashboard._1_my-dashboard-uid
-  id = "1:my-dashboard-uid"
+  to = grafana_dashboard.my-dashboard-uid
+  id = "my-dashboard-uid"
 }
 
 import {
-  to = grafana_folder._1_my-folder-uid
-  id = "1:my-folder-uid"
+  to = grafana_folder.my-folder-uid
+  id = "my-folder-uid"
 }
 
 import {
-  to = grafana_notification_policy._1_policy
-  id = "1:policy"
+  to = grafana_notification_policy.policy
+  id = "policy"
 }
 
 import {

--- a/pkg/generate/testdata/generate/dashboard/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard/resources.tf
@@ -1,8 +1,8 @@
 # __generated__ by Terraform
 # Please review these resources and move them into your main configuration files.
 
-# __generated__ by Terraform from "1:email receiver"
-resource "grafana_contact_point" "_1_email_receiver" {
+# __generated__ by Terraform from "email receiver"
+resource "grafana_contact_point" "email_receiver" {
   disable_provenance = true
   name               = "email receiver"
   email {
@@ -12,23 +12,23 @@ resource "grafana_contact_point" "_1_email_receiver" {
   }
 }
 
-# __generated__ by Terraform from "1:my-dashboard-uid"
-resource "grafana_dashboard" "_1_my-dashboard-uid" {
+# __generated__ by Terraform from "my-dashboard-uid"
+resource "grafana_dashboard" "my-dashboard-uid" {
   config_json = jsonencode({
     title = "My Dashboard"
     uid   = "my-dashboard-uid"
   })
-  folder = grafana_folder._1_my-folder-uid.uid
+  folder = grafana_folder.my-folder-uid.uid
 }
 
-# __generated__ by Terraform from "1:my-folder-uid"
-resource "grafana_folder" "_1_my-folder-uid" {
+# __generated__ by Terraform from "my-folder-uid"
+resource "grafana_folder" "my-folder-uid" {
   title = "My Folder"
   uid   = "my-folder-uid"
 }
 
-# __generated__ by Terraform from "1:policy"
-resource "grafana_notification_policy" "_1_policy" {
+# __generated__ by Terraform from "policy"
+resource "grafana_notification_policy" "policy" {
   contact_point      = "grafana-default-email"
   disable_provenance = true
   group_by           = ["grafana_folder", "alertname"]

--- a/pkg/generate/testdata/generate/oncall-resources/imports.tf.tmpl
+++ b/pkg/generate/testdata/generate/oncall-resources/imports.tf.tmpl
@@ -1,5 +1,5 @@
 import {
-  to = grafana_oncall_escalation._{{ .EscalationID }}
+  to = grafana_oncall_escalation.{{ .EscalationID }}
   id = "{{ .EscalationID }}"
 }
 

--- a/pkg/generate/testdata/generate/oncall-resources/resources.tf.tmpl
+++ b/pkg/generate/testdata/generate/oncall-resources/resources.tf.tmpl
@@ -2,7 +2,7 @@
 # Please review these resources and move them into your main configuration files.
 
 # __generated__ by Terraform from "{{ .EscalationID }}"
-resource "grafana_oncall_escalation" "_{{ .EscalationID }}" {
+resource "grafana_oncall_escalation" "{{ .EscalationID }}" {
   duration            = 300
   escalation_chain_id = grafana_oncall_escalation_chain.{{ .Name }}.id
   position            = 0


### PR DESCRIPTION
(If there's only one org being generated)
If all resources are in the default org, there's no reason to have the `1:` prefix to all resources 
This makes resource names and IDs much nicer to look at