### PR TITLE
Config Generation: Better names for all resources

### DIFF
--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -135,7 +135,9 @@ Required access policy scopes:
 		"grafana_cloud_access_policy",
 		resourceAccessPolicyID,
 		schema,
-	).WithLister(cloudListerFunction(listAccessPolicies))
+	).
+		WithLister(cloudListerFunction(listAccessPolicies)).
+		WithPreferredResourceNameField("name")
 }
 
 func listAccessPolicies(ctx context.Context, client *gcom.APIClient, data *ListerData) ([]string, error) {

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -204,7 +204,9 @@ Required access policy scopes:
 		"grafana_cloud_stack",
 		resourceStackID,
 		schema,
-	).WithLister(cloudListerFunction(listStacks))
+	).
+		WithLister(cloudListerFunction(listStacks)).
+		WithPreferredResourceNameField("name")
 }
 
 func listStacks(ctx context.Context, client *gcom.APIClient, data *ListerData) ([]string, error) {

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -127,7 +127,9 @@ source selected (via the 'type' argument).
 		"grafana_data_source",
 		orgResourceIDString("uid"),
 		schema,
-	).WithLister(listerFunctionOrgResource(listDatasources))
+	).
+		WithLister(listerFunctionOrgResource(listDatasources)).
+		WithPreferredResourceNameField("name")
 }
 
 func datasourceHTTPHeadersAttribute() *schema.Schema {

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -149,7 +149,9 @@ set to true. This feature is only available in Grafana 10.2+.
 		"grafana_organization",
 		common.NewResourceID(common.IntIDField("id")),
 		schema,
-	).WithLister(listerFunction(listOrganizations))
+	).
+		WithLister(listerFunction(listOrganizations)).
+		WithPreferredResourceNameField("name")
 }
 
 func listOrganizations(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -77,7 +77,9 @@ func resourcePlaylist() *common.Resource {
 		"grafana_playlist",
 		orgResourceIDString("uid"),
 		schema,
-	).WithLister(listerFunctionOrgResource(listPlaylists))
+	).
+		WithLister(listerFunctionOrgResource(listPlaylists)).
+		WithPreferredResourceNameField("name")
 }
 
 func listPlaylists(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -249,7 +249,9 @@ func resourceReport() *common.Resource {
 		"grafana_report",
 		orgResourceIDInt("id"),
 		schema,
-	).WithLister(listerFunctionOrgResource(listReports))
+	).
+		WithLister(listerFunctionOrgResource(listReports)).
+		WithPreferredResourceNameField("name")
 }
 
 func listReports(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -62,7 +62,9 @@ func resourceServiceAccount() *common.Resource {
 		"grafana_service_account",
 		orgResourceIDInt("id"),
 		schema,
-	).WithLister(listerFunctionOrgResource(listServiceAccounts))
+	).
+		WithLister(listerFunctionOrgResource(listServiceAccounts)).
+		WithPreferredResourceNameField("name")
 }
 
 func listServiceAccounts(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -158,7 +158,9 @@ Team Sync can be provisioned using [grafana_team_external_group resource](https:
 		"grafana_team",
 		orgResourceIDInt("id"),
 		schema,
-	).WithLister(listerFunctionOrgResource(listTeams))
+	).
+		WithLister(listerFunctionOrgResource(listTeams)).
+		WithPreferredResourceNameField("name")
 }
 
 func listTeams(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {

--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -77,7 +77,9 @@ You must use basic auth.
 		"grafana_user",
 		resourceUserID,
 		schema,
-	).WithLister(listerFunction(listUsers))
+	).
+		WithLister(listerFunction(listUsers)).
+		WithPreferredResourceNameField("login")
 }
 
 func listUsers(ctx context.Context, client *goapi.GrafanaHTTPAPI, data *ListerData) ([]string, error) {

--- a/internal/resources/machinelearning/resource_holiday.go
+++ b/internal/resources/machinelearning/resource_holiday.go
@@ -109,7 +109,9 @@ resource "grafana_machine_learning_job" "test_job" {
 		"grafana_machine_learning_holiday",
 		resourceHolidayID,
 		schema,
-	).WithLister(lister(listHolidays))
+	).
+		WithLister(lister(listHolidays)).
+		WithPreferredResourceNameField("name")
 }
 
 func listHolidays(ctx context.Context, client *mlapi.Client) ([]string, error) {

--- a/internal/resources/machinelearning/resource_job.go
+++ b/internal/resources/machinelearning/resource_job.go
@@ -104,7 +104,9 @@ A job defines the queries and model parameters for a machine learning task.
 		"grafana_machine_learning_job",
 		resourceJobID,
 		schema,
-	).WithLister(lister(listJobs))
+	).
+		WithLister(lister(listJobs)).
+		WithPreferredResourceNameField("name")
 }
 
 func listJobs(ctx context.Context, client *mlapi.Client) ([]string, error) {

--- a/internal/resources/machinelearning/resource_outlier_detector.go
+++ b/internal/resources/machinelearning/resource_outlier_detector.go
@@ -122,7 +122,9 @@ Visit https://grafana.com/docs/grafana-cloud/machine-learning/outlier-detection/
 		"grafana_machine_learning_outlier_detector",
 		resourceOutlierDetectorID,
 		schema,
-	).WithLister(lister(listOutliers))
+	).
+		WithLister(lister(listOutliers)).
+		WithPreferredResourceNameField("name")
 }
 
 func listOutliers(ctx context.Context, client *mlapi.Client) ([]string, error) {

--- a/pkg/generate/testdata/generate/alerting-in-org/imports.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/imports.tf
@@ -39,7 +39,7 @@ import {
 }
 
 import {
-  to = grafana_organization._2
+  to = grafana_organization.alerting-org
   id = "2"
 }
 

--- a/pkg/generate/testdata/generate/alerting-in-org/resources.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/resources.tf
@@ -16,7 +16,7 @@ resource "grafana_contact_point" "_1_email_receiver" {
 resource "grafana_contact_point" "_2_email_receiver" {
   disable_provenance = true
   name               = "email receiver"
-  org_id             = grafana_organization._2.id
+  org_id             = grafana_organization.alerting-org.id
   email {
     addresses               = ["<example@email.com>"]
     disable_resolve_message = false
@@ -28,7 +28,7 @@ resource "grafana_contact_point" "_2_email_receiver" {
 resource "grafana_contact_point" "_2_my-contact-point" {
   disable_provenance = false
   name               = "my-contact-point"
-  org_id             = grafana_organization._2.id
+  org_id             = grafana_organization.alerting-org.id
   email {
     addresses               = ["hello@example.com"]
     disable_resolve_message = false
@@ -38,7 +38,7 @@ resource "grafana_contact_point" "_2_my-contact-point" {
 
 # __generated__ by Terraform from "2:alert-rule-folder"
 resource "grafana_folder" "_2_alert-rule-folder" {
-  org_id = grafana_organization._2.id
+  org_id = grafana_organization.alerting-org.id
   title  = "My Alert Rule Folder"
   uid    = "alert-rule-folder"
 }
@@ -46,14 +46,14 @@ resource "grafana_folder" "_2_alert-rule-folder" {
 # __generated__ by Terraform from "2:My Reusable Template"
 resource "grafana_message_template" "_2_My_Reusable_Template" {
   name     = "My Reusable Template"
-  org_id   = grafana_organization._2.id
+  org_id   = grafana_organization.alerting-org.id
   template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
 }
 
 # __generated__ by Terraform from "2:My Mute Timing"
 resource "grafana_mute_timing" "_2_My_Mute_Timing" {
   name   = "My Mute Timing"
-  org_id = grafana_organization._2.id
+  org_id = grafana_organization.alerting-org.id
   intervals {
     days_of_month = ["1:7", "-1"]
     location      = "America/New_York"
@@ -79,11 +79,11 @@ resource "grafana_notification_policy" "_2_policy" {
   contact_point      = grafana_contact_point._2_my-contact-point.name
   disable_provenance = false
   group_by           = ["..."]
-  org_id             = grafana_organization._2.id
+  org_id             = grafana_organization.alerting-org.id
 }
 
 # __generated__ by Terraform from "2"
-resource "grafana_organization" "_2" {
+resource "grafana_organization" "alerting-org" {
   admins = ["admin@localhost"]
   name   = "alerting-org"
 }
@@ -94,7 +94,7 @@ resource "grafana_rule_group" "_2_alert-rule-folder_My_Rule_Group" {
   folder_uid         = grafana_folder._2_alert-rule-folder.uid
   interval_seconds   = 240
   name               = "My Rule Group"
-  org_id             = grafana_organization._2.id
+  org_id             = grafana_organization.alerting-org.id
   rule {
     annotations = {
       a = "b"

--- a/pkg/generate/testdata/generate/dashboard-crossplane/user-admin.yaml
+++ b/pkg/generate/testdata/generate/dashboard-crossplane/user-admin.yaml
@@ -1,7 +1,7 @@
 apiVersion: oss.grafana.crossplane.io/v1alpha1
 kind: User
 metadata:
-  name: "1"
+  name: admin
   annotations:
     crossplane.io/external-name: "1"
 spec:

--- a/pkg/generate/testdata/generate/dashboard-json/imports.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/imports.tf.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "1",
-      "to": "grafana_user._1"
+      "to": "grafana_user.admin"
     }
   ]
 }

--- a/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
+++ b/pkg/generate/testdata/generate/dashboard-json/resources.tf.json
@@ -51,7 +51,7 @@
       ]
     },
     "grafana_user": {
-      "_1": [
+      "admin": [
         {
           "email": "admin@localhost",
           "is_admin": true,

--- a/pkg/generate/testdata/generate/dashboard/imports.tf
+++ b/pkg/generate/testdata/generate/dashboard/imports.tf
@@ -24,6 +24,6 @@ import {
 }
 
 import {
-  to = grafana_user._1
+  to = grafana_user.admin
   id = "1"
 }

--- a/pkg/generate/testdata/generate/dashboard/resources.tf
+++ b/pkg/generate/testdata/generate/dashboard/resources.tf
@@ -39,7 +39,7 @@ resource "grafana_organization_preferences" "_1" {
 }
 
 # __generated__ by Terraform
-resource "grafana_user" "_1" {
+resource "grafana_user" "admin" {
   email    = "admin@localhost"
   is_admin = true
   login    = "admin"


### PR DESCRIPTION
Follow-up to https://github.com/grafana/terraform-provider-grafana/pull/1759: Added the resources that were missing + a safety cleanup so that all characters are allowed in the resource names 

Closes https://github.com/grafana/terraform-provider-grafana/issues/1745

Before:
```
resource "grafana_user" "_1" {
  email    = "admin@localhost"
  is_admin = true
  login    = "admin"
  password = "SENSITIVE_VALUE_TO_REPLACE"
}
```

After:
```
resource "grafana_user" "admin" {
  email    = "admin@localhost"
  is_admin = true
  login    = "admin"
  password = "SENSITIVE_VALUE_TO_REPLACE"
}
```