### PR TITLE
Docs: update the Grafana Cloud docs link to create a cloud access policy token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -235,7 +235,7 @@ This can be a Grafana API key, basic auth `username:password`, or a
 
 ### `cloud_access_policy_token`
 
-An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/create-api-key/).
+An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/).
 
 ### `sm_access_token`
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -43,7 +43,7 @@ This can be a Grafana API key, basic auth `username:password`, or a
 
 ### `cloud_access_policy_token`
 
-An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/create-api-key/).
+An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/).
 
 ### `sm_access_token`
 


### PR DESCRIPTION
Terraform documentation: update a link to point to the [Authorize your service with an access policy and token documentation](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/).

 
For full context, see the [discussion and related PRs](https://github.com/grafana/website/pull/21369).