### PR TITLE
fix(SLO): Handle resource 404 gracefully

### DIFF
--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -323,8 +323,11 @@ func resourceSloRead(ctx context.Context, d *schema.ResourceData, client *slo.AP
 	sloID := d.Id()
 
 	req := client.DefaultAPI.V1SloIdGet(ctx, sloID)
-	slo, _, err := req.Execute()
+	slo, r, err := req.Execute()
 	if err != nil {
+		if r != nil && r.StatusCode == 404 {
+			return common.WarnMissing("SLO", d)
+		}
 		return apiError("Unable to read SLO - API", err)
 	}
 

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccResourceSlo(t *testing.T) {
@@ -133,6 +134,69 @@ func TestAccResourceSlo(t *testing.T) {
 			},
 		},
 	})
+}
+
+// Tests that recreating an out-of-band deleted SLO works without error.
+func TestAccSLO_recreate(t *testing.T) {
+	testutils.CheckCloudInstanceTestsEnabled(t)
+	var slo slo.SloV00Slo
+	randomName := acctest.RandomWithPrefix("SLO Terraform Testing")
+	config := testutils.TestAccExampleWithReplace(t, "resources/grafana_slo/resource.tf", map[string]string{
+		"Terraform Testing": randomName,
+	})
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+
+		// Implicitly tests destroy
+		CheckDestroy: testAccSloCheckDestroy(&slo),
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSloCheckExists("grafana_slo.test", &slo),
+					resource.TestCheckResourceAttrSet("grafana_slo.test", "id"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "name", randomName),
+					resource.TestCheckResourceAttr("grafana_slo.test", "description", "Terraform Description"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "query.0.type", "freeform"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "query.0.freeform.0.query", "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "objectives.0.value", "0.995"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "objectives.0.window", "30d"),
+					resource.TestCheckNoResourceAttr("grafana_slo.test", "folder_uid"),
+					testutils.CheckLister("grafana_slo.test"),
+				),
+			},
+			// Delete out-of-band
+			{
+				PreConfig: func() {
+					client := testutils.Provider.Meta().(*common.Client).SLOClient
+					req := client.DefaultAPI.V1SloIdDelete(context.Background(), slo.Uuid)
+					_, err := req.Execute()
+					require.NoError(t, err)
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Re-create
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccSloCheckExists("grafana_slo.test", &slo),
+					resource.TestCheckResourceAttrSet("grafana_slo.test", "id"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "name", randomName),
+					resource.TestCheckResourceAttr("grafana_slo.test", "description", "Terraform Description"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "query.0.type", "freeform"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "query.0.freeform.0.query", "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "objectives.0.value", "0.995"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "objectives.0.window", "30d"),
+					resource.TestCheckNoResourceAttr("grafana_slo.test", "folder_uid"),
+					testutils.CheckLister("grafana_slo.test"),
+				),
+			},
+		},
+	})
+
 }
 
 func testAccSloCheckExists(rn string, slo *slo.SloV00Slo) resource.TestCheckFunc {

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -196,7 +196,6 @@ func TestAccSLO_recreate(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccSloCheckExists(rn string, slo *slo.SloV00Slo) resource.TestCheckFunc {


### PR DESCRIPTION
Terraform providers should react to a 404 as a "remove from tf state" command, but the SLO resource was not handling this correctly. This change fixes that in the SLO read path.