### PR TITLE
fix: use distinct names for ML forecast and outlier alerts

### DIFF
--- a/docs/resources/machine_learning_alert.md
+++ b/docs/resources/machine_learning_alert.md
@@ -25,7 +25,7 @@ resource "grafana_machine_learning_job" "test_alert_job" {
 
 resource "grafana_machine_learning_alert" "test_job_alert" {
   job_id            = grafana_machine_learning_job.test_alert_job.id
-  title             = "Test Alert"
+  title             = "Test Alert for Job"
   anomaly_condition = "any"
   threshold         = ">0.8"
   window            = "15m"

--- a/examples/resources/grafana_machine_learning_alert/outlier_alert.tf
+++ b/examples/resources/grafana_machine_learning_alert/outlier_alert.tf
@@ -20,6 +20,6 @@ resource "grafana_machine_learning_outlier_detector" "test_alert_outlier_detecto
 
 resource "grafana_machine_learning_alert" "test_outlier_alert" {
   outlier_id = grafana_machine_learning_outlier_detector.test_alert_outlier_detector.id
-  title      = "Test Alert"
+  title      = "Test Alert for Outlier"
   window     = "1h"
 }

--- a/examples/resources/grafana_machine_learning_alert/resource.tf
+++ b/examples/resources/grafana_machine_learning_alert/resource.tf
@@ -10,7 +10,7 @@ resource "grafana_machine_learning_job" "test_alert_job" {
 
 resource "grafana_machine_learning_alert" "test_job_alert" {
   job_id            = grafana_machine_learning_job.test_alert_job.id
-  title             = "Test Alert"
+  title             = "Test Alert for Job"
   anomaly_condition = "any"
   threshold         = ">0.8"
   window            = "15m"

--- a/internal/resources/machinelearning/resource_alert_test.go
+++ b/internal/resources/machinelearning/resource_alert_test.go
@@ -18,7 +18,7 @@ func TestAccResourceJobAlert(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	randomJobName := acctest.RandomWithPrefix("Test Job")
-	randomAlertName := acctest.RandomWithPrefix("Test Alert")
+	randomAlertName := acctest.RandomWithPrefix("Test Alert for Job")
 
 	var job mlapi.Job
 	var alert mlapi.Alert
@@ -31,8 +31,8 @@ func TestAccResourceJobAlert(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_alert/resource.tf", map[string]string{
-					"Test Job":   randomJobName,
-					"Test Alert": randomAlertName,
+					"Test Job":           randomJobName,
+					"Test Alert for Job": randomAlertName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLJobCheckExists("grafana_machine_learning_job.test_alert_job", &job),
@@ -47,9 +47,9 @@ func TestAccResourceJobAlert(t *testing.T) {
 			// Update the alert with a new anomaly condition.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_alert/resource.tf", map[string]string{
-					"Test Job":   randomJobName,
-					"Test Alert": randomAlertName,
-					"\"any\"":    "\"low\"",
+					"Test Job":           randomJobName,
+					"Test Alert for Job": randomAlertName,
+					"\"any\"":            "\"low\"",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLJobCheckExists("grafana_machine_learning_job.test_alert_job", &job),
@@ -77,7 +77,7 @@ func TestAccResourceOutlierAlert(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	randomOutlierName := acctest.RandomWithPrefix("Test Outlier")
-	randomAlertName := acctest.RandomWithPrefix("Test Alert")
+	randomAlertName := acctest.RandomWithPrefix("Test Alert for Outlier")
 
 	var outlier mlapi.OutlierDetector
 	var alert mlapi.Alert
@@ -90,8 +90,8 @@ func TestAccResourceOutlierAlert(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_alert/outlier_alert.tf", map[string]string{
-					"Test Outlier": randomOutlierName,
-					"Test Alert":   randomAlertName,
+					"Test Outlier":           randomOutlierName,
+					"Test Alert for Outlier": randomAlertName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLOutlierCheckExists("grafana_machine_learning_outlier_detector.test_alert_outlier_detector", &outlier),
@@ -103,9 +103,9 @@ func TestAccResourceOutlierAlert(t *testing.T) {
 			// Test updating the window.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_machine_learning_alert/outlier_alert.tf", map[string]string{
-					"Test Outlier": randomOutlierName,
-					"Test Alert":   randomAlertName,
-					"\"1h\"":       "\"30m\"",
+					"Test Outlier":           randomOutlierName,
+					"Test Alert for Outlier": randomAlertName,
+					"\"1h\"":                 "\"30m\"",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMLOutlierCheckExists("grafana_machine_learning_outlier_detector.test_alert_outlier_detector", &outlier),


### PR DESCRIPTION
The alerts may be created at the same time which results in a conflict,
as encountered [here](https://github.com/grafana/terraform-provider-grafana/pull/1789#issuecomment-2332452686).
