### PR TITLE
docs: fix create-api-tokens-for-org/ url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -231,7 +231,7 @@ One, or many, of the following authentication settings must be set. Each authent
 ### `auth`
 
 This can be a Grafana API key, basic auth `username:password`, or a
-[Grafana Service Account token](https://grafana.com/docs/grafana/latest/developers/http_api/create-api-tokens-for-org/).
+[Grafana Service Account token](https://grafana.com/docs/grafana/latest/developers/http_api/examples/create-api-tokens-for-org/).
 
 ### `cloud_access_policy_token`
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -39,7 +39,7 @@ One, or many, of the following authentication settings must be set. Each authent
 ### `auth`
 
 This can be a Grafana API key, basic auth `username:password`, or a
-[Grafana Service Account token](https://grafana.com/docs/grafana/latest/developers/http_api/create-api-tokens-for-org/).
+[Grafana Service Account token](https://grafana.com/docs/grafana/latest/developers/http_api/examples/create-api-tokens-for-org/).
 
 ### `cloud_access_policy_token`
 


### PR DESCRIPTION
This page moved, updating URL to fix failing test case.
