### PR TITLE
cw scrape job: fix modifyplan when creating a new resource

### DIFF
--- a/internal/resources/cloudprovider/resources.go
+++ b/internal/resources/cloudprovider/resources.go
@@ -32,6 +32,15 @@ func withClientForResource(req resource.ConfigureRequest, resp *resource.Configu
 		return nil, fmt.Errorf("unexpected Resource Configure Type: %T, expected *common.Client", req.ProviderData)
 	}
 
+	if client.CloudProviderAPI == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the Cloud Provider API.",
+			"Please ensure that cloud_provider_url and cloud_provider_access_token are set in the provider configuration.",
+		)
+
+		return nil, fmt.Errorf("CloudProviderAPI is nil")
+	}
+
 	return client.CloudProviderAPI, nil
 }
 
@@ -45,6 +54,15 @@ func withClientForDataSource(req datasource.ConfigureRequest, resp *datasource.C
 		)
 
 		return nil, fmt.Errorf("unexpected DataSource Configure Type: %T, expected *common.Client", req.ProviderData)
+	}
+
+	if client.CloudProviderAPI == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the Cloud Provider API.",
+			"Please ensure that cloud_provider_url and cloud_provider_access_token are set in the provider configuration.",
+		)
+
+		return nil, fmt.Errorf("CloudProviderAPI is nil")
 	}
 
 	return client.CloudProviderAPI, nil

--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -59,7 +59,7 @@ func CreateClients(providerConfig ProviderConfig) (*common.Client, error) {
 		onCallClient.UserAgent = providerConfig.UserAgent.ValueString()
 		c.OnCallClient = onCallClient
 	}
-	if !providerConfig.CloudProviderURL.IsNull() && !providerConfig.CloudProviderAccessToken.IsNull() {
+	if !providerConfig.CloudProviderAccessToken.IsNull() {
 		if err := createCloudProviderClient(c, providerConfig); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We implemented [ModifyPlan](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithModifyPlan) on the AWS CW scrape job resources in https://github.com/grafana/terraform-provider-grafana/pull/1789. This was done in order to only make `disabled_reason` computed when the `enabled` state is being set to `false`. This function apparently runs even on resource creation, however, so an error was being thrown because the `state` was nil.

This PR handles the case that the state is nil, again depending on the planned `enabled` state.

`enabled=true`
```
  + resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "sandbox-ec2" {
      + aws_account_resource_id = (known after apply)
      + enabled                 = true
      + export_tags             = true
      + id                      = (known after apply)
      + name                    = "tf-managed-scrape-job"
      + regions                 = [
          + "us-east-1",
          + "us-east-2",
        ]
      + stack_id                = "1"
        # (1 unchanged attribute hidden)

      + service {
          + name                    = "AWS/EC2"
          + scrape_interval_seconds = 300
          + tags_to_add_to_metrics  = [
              + "eks:cluster-name",
            ]

          + metric {
              + name       = "CPUUtilization"
              + statistics = [
                  + "Average",
                ]
            }
          + metric {
              + name       = "StatusCheckFailed"
              + statistics = [
                  + "Maximum",
                ]
            }
        }
    }
```

`enabled=false`
```
  + resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "sandbox-ec2" {
      + aws_account_resource_id = (known after apply)
      + disabled_reason         = (known after apply)
      + enabled                 = false
      + export_tags             = true
      + id                      = (known after apply)
      + name                    = "tf-managed-scrape-job"
      + regions                 = [
          + "us-east-1",
          + "us-east-2",
        ]
      + stack_id                = "1"

      + service {
          + name                    = "AWS/EC2"
          + scrape_interval_seconds = 300
          + tags_to_add_to_metrics  = [
              + "eks:cluster-name",
            ]

          + metric {
              + name       = "CPUUtilization"
              + statistics = [
                  + "Average",
                ]
            }
          + metric {
              + name       = "StatusCheckFailed"
              + statistics = [
                  + "Maximum",
                ]
            }
        }
    }
```