### PR TITLE
Scaffold metrics endpoint scrape job resource

### DIFF
--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -21,6 +21,7 @@ var (
 	CategoryOnCall              ResourceCategory = "OnCall"
 	CategorySLO                 ResourceCategory = "SLO"
 	CategorySyntheticMonitoring ResourceCategory = "Synthetic Monitoring"
+	CategoryConnections         ResourceCategory = "Connections"
 )
 
 type ResourceCommon struct {

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -21,7 +21,6 @@ var (
 )
 
 type resourceMetricsEndpointScrapeJob struct {
-	client any // TODO
 }
 
 var Resources = makeResourceMetricsEndpointScrapeJob()
@@ -36,18 +35,8 @@ func makeResourceMetricsEndpointScrapeJob() *common.Resource {
 }
 
 func (r resourceMetricsEndpointScrapeJob) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Configure is called multiple times (sometimes when ProviderData is not yet available), we only want to configure once
-	if req.ProviderData == nil || r.client != nil {
-		return
-	}
-
-	// TODO
-	//client, err := withClientForResource(req, resp)
-	//if err != nil {
-	//	return
-	//}
-	//
-	//r.client = client
+	//TODO implement me
+	panic("implement me")
 }
 
 func (r resourceMetricsEndpointScrapeJob) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -30,7 +30,7 @@ var Resources = makeResourceMetricsEndpointScrapeJob()
 func makeResourceMetricsEndpointScrapeJob() *common.Resource {
 	return common.NewResource(
 		common.CategoryConnections,
-		"grafana_cloud_provider_aws_cloudwatch_scrape_job",
+		"grafana_metrics_endpoint_scrape_job",
 		resourceMetricsEndpointScrapeJobTerraformID,
 		&resourceMetricsEndpointScrapeJob{},
 	)

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -35,7 +35,7 @@ func makeResourceMetricsEndpointScrapeJob() *common.Resource {
 }
 
 func (r resourceMetricsEndpointScrapeJob) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -114,21 +114,21 @@ func (r resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resour
 }
 
 func (r resourceMetricsEndpointScrapeJob) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (r resourceMetricsEndpointScrapeJob) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (r resourceMetricsEndpointScrapeJob) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (r resourceMetricsEndpointScrapeJob) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -1,0 +1,145 @@
+package connections
+
+import (
+	"context"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"regexp"
+)
+
+var (
+	resourceMetricsEndpointScrapeJobTerraformName = "grafana_connections_metrics_endpoint_scrape_job"
+	resourceMetricsEndpointScrapeJobTerraformID   = common.NewResourceID(common.StringIDField("stack_id"), common.StringIDField("name"))
+)
+
+type resourceMetricsEndpointScrapeJob struct {
+	client any // TODO
+}
+
+var Resources = makeResourceMetricsEndpointScrapeJob()
+
+func makeResourceMetricsEndpointScrapeJob() *common.Resource {
+	return common.NewResource(
+		common.CategoryConnections,
+		"grafana_cloud_provider_aws_cloudwatch_scrape_job",
+		resourceMetricsEndpointScrapeJobTerraformID,
+		&resourceMetricsEndpointScrapeJob{},
+	)
+}
+
+func (r resourceMetricsEndpointScrapeJob) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Configure is called multiple times (sometimes when ProviderData is not yet available), we only want to configure once
+	if req.ProviderData == nil || r.client != nil {
+		return
+	}
+
+	// TODO
+	//client, err := withClientForResource(req, resp)
+	//if err != nil {
+	//	return
+	//}
+	//
+	//r.client = client
+}
+
+func (r resourceMetricsEndpointScrapeJob) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = resourceMetricsEndpointScrapeJobTerraformName
+}
+
+var urlRegexp = regexp.MustCompile(`((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)`)
+
+func (r resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ name }}\".",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					// See https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#usestateforunknown
+					// for details on how this works.
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"stack_id": schema.StringAttribute{
+				Description: "The Stack ID of the Grafana Cloud instance. Part of the Terraform Resource ID.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the Metrics Endpoint Scrape Job. Part of the Terraform Resource ID.",
+				Required:    true,
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the Metrics Endpoint Scrape Job is enabled or not.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+			},
+			"authentication_method": schema.StringAttribute{
+				Description: "Method to pass authentication credentials: basic or bearer.",
+				Validators: []validator.String{
+					stringvalidator.OneOf("basic", "bearer"),
+				},
+				Required: true,
+			},
+			"authentication_bearer_token": schema.StringAttribute{
+				Description: "Token for authentication bearer.",
+				Sensitive:   true,
+				Optional:    true,
+			},
+			"authentication_basic_username": schema.StringAttribute{
+				Description: "Username for basic authentication.",
+				Optional:    true,
+			},
+			"authentication_basic_password": schema.StringAttribute{
+				Description: "Password for basic authentication.",
+				Sensitive:   true,
+				Optional:    true,
+			},
+			"url": schema.StringAttribute{
+				Description: "Scrape job url.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(urlRegexp, ""),
+				},
+				Required: true,
+			},
+			"scrape_interval_seconds": schema.Int64Attribute{
+				Description: "Frequency for scraping the metrics endpoint: 30, 60, or 120 seconds.",
+				Computed:    true,
+				Validators:  []validator.Int64{int64validator.OneOf(30, 60, 120)},
+				Default:     int64default.StaticInt64(60),
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func (r resourceMetricsEndpointScrapeJob) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r resourceMetricsEndpointScrapeJob) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r resourceMetricsEndpointScrapeJob) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r resourceMetricsEndpointScrapeJob) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -98,7 +98,7 @@ func (r resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resour
 				Optional:    true,
 			},
 			"url": schema.StringAttribute{
-				Description: "Scrape job url.",
+				Description: "The url to scrape metrics; a valid HTTPs URL is required.",
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(urlRegexp, ""),
 				},

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -2,7 +2,6 @@ package connections
 
 import (
 	"context"
-	"regexp"
 
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 
@@ -30,7 +29,7 @@ var Resources = makeResourceMetricsEndpointScrapeJob()
 func makeResourceMetricsEndpointScrapeJob() *common.Resource {
 	return common.NewResource(
 		common.CategoryConnections,
-		"grafana_metrics_endpoint_scrape_job",
+		resourceMetricsEndpointScrapeJobTerraformName,
 		resourceMetricsEndpointScrapeJobTerraformID,
 		&resourceMetricsEndpointScrapeJob{},
 	)
@@ -44,8 +43,6 @@ func (r resourceMetricsEndpointScrapeJob) Configure(ctx context.Context, req res
 func (r resourceMetricsEndpointScrapeJob) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = resourceMetricsEndpointScrapeJobTerraformName
 }
-
-var urlRegexp = regexp.MustCompile(`((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)`)
 
 func (r resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
@@ -69,6 +66,9 @@ func (r resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resour
 			"name": schema.StringAttribute{
 				Description: "The name of the Metrics Endpoint Scrape Job. Part of the Terraform Resource ID.",
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"enabled": schema.BoolAttribute{
 				Description: "Whether the Metrics Endpoint Scrape Job is enabled or not.",
@@ -99,9 +99,7 @@ func (r resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resour
 			},
 			"url": schema.StringAttribute{
 				Description: "The url to scrape metrics; a valid HTTPs URL is required.",
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(urlRegexp, ""),
-				},
+				//Validators: []validator.String{}, // TODO: Find a validator for urls
 				Required: true,
 			},
 			"scrape_interval_seconds": schema.Int64Attribute{

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -2,7 +2,10 @@ package connections
 
 import (
 	"context"
+	"regexp"
+
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -12,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"regexp"
 )
 
 var (

--- a/pkg/provider/resources.go
+++ b/pkg/provider/resources.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/cloud"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/connections"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/grafana"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/machinelearning"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/resources/oncall"
@@ -58,6 +59,7 @@ func Resources() []*common.Resource {
 	resources = append(resources, oncall.Resources...)
 	resources = append(resources, slo.Resources...)
 	resources = append(resources, syntheticmonitoring.Resources...)
+	resources = append(resources, connections.Resources)
 	return resources
 }
 


### PR DESCRIPTION
This PR creates some initial code scaffolding for new Metrics Endpoint Scrape Job resources. See [this design doc](https://docs.google.com/document/d/1YVThjOtBjV0L7IvSlnCjyOVtmCOttLOhCYhiOsDwaps/edit#heading=h.5sybau7waq2q) for more details.

Contributes to: https://github.com/grafana/cloud-onboarding/issues/7670
This is being merged into our WIP branch: `metrics-endpoint`

Special notes:
To try this out with `terraform plan`, used the [instructions](https://github.com/grafana/terraform-provider-grafana?tab=readme-ov-file#local-development-with-grafana) for local development and created a directory with two files:
* main.tf with the following content
  ```hcl
  resource "grafana_connections_metrics_endpoint_scrape_job" "test_folder" {
     stack_id = "12345"
     name = "my_scrape_job"
     authentication_method = "basic"
     authentication_basic_username = "my_username"
     authentication_basic_password = "my_password"
     url = "https://dev.my-metrics-endpoint-url.com:9000/metrics"
   }
  ```
* terraform.tf with the following content
   ```
   terraform {
     required_providers {
       grafana = {
         source = "grafana/grafana"
       }
     }
   }
   ```
Result:
```
Terraform used the selected providers to generate the following execution plan. Resource
actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # grafana_connections_metrics_endpoint_scrape_job.test_folder will be created
  + resource "grafana_connections_metrics_endpoint_scrape_job" "test_folder" {
      + authentication_basic_password = (sensitive value)
      + authentication_basic_username = "my_username"
      + authentication_method         = "basic"
      + enabled                       = true
      + id                            = (known after apply)
      + name                          = "my_scrape_job"
      + scrape_interval_seconds       = 60
      + stack_id                      = "12345"
      + url                           = "https://dev.my-metrics-endpoint-url.com:9000/metrics"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```