### PR TITLE
Add docs for setting up cloud provider provider section

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,5 +67,8 @@ golangci-lint:
 		--workdir "/src" \
 		golangci/golangci-lint:v1.54 golangci-lint run ./... -v
 
+docs:
+	go generate ./...
+
 linkcheck:
 	docker run --rm --entrypoint sh -v "$$PWD:$$PWD" -w "$$PWD" python:3.11-alpine -c "pip3 install linkchecker && linkchecker --config .linkcheckerrc docs"

--- a/docs/index.md
+++ b/docs/index.md
@@ -228,7 +228,9 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 
 ### Managing Cloud Provider
 
-Before using the cloud provider, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to Grafana's Cloud Provider API.
+#### Obtaining Cloud Provider access token
+
+Before using the Terraform Provider to manage Grafana Cloud Provider Observability resources, such as AWS CloudWatch scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Cloud Provider API.
 [These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create 
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
 
@@ -242,10 +244,12 @@ Also, by default the Access Policies UI will not show those scopes, to find name
 Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Cloud Provider API. You can do so just after creating the access policy, following
 the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
 
+#### Obtaining Cloud Provider API hostname
+
 Having created the token, we can find the correct Cloud Provider API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
 
 ```bash
-curl -sH "Authorization: Bearer token" "https://grafana.com/api/instances" | \
+curl -sH "Authorization: Bearer <Access Token from previous step>" "https://grafana.com/api/instances" | \
   jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
 ```
 
@@ -262,13 +266,15 @@ For example, in the following response, the correct hostname for the `herokublog
 ]
 ```
 
+#### Configuring Provider
+
 Once you have the token and Cloud Provider API hostanme, you can configure the provider as follows:
 
 ```hcl
 provider "grafana" {
   // ...
-  cloud_provider_url = "https://cloud-provider-api-url.com"
-  cloud_provider_access_token = "token"
+  cloud_provider_url = <Cloud Provider API URL from previous step>
+  cloud_provider_access_token = <Access Token from previous step>
 }
 ```
 
@@ -371,3 +377,8 @@ You can use the `grafana_synthetic_monitoring_installation` resource as shown ab
 
 [Grafana OnCall](https://grafana.com/docs/oncall/latest/oncall-api-reference/)
 uses API keys to allow access to the API. You can request a new OnCall API key in OnCall -> Settings page.
+
+### `cloud_provider_access_token`
+
+An access policy token created to manage [Grafana Cloud Provider Observability](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/).
+To create one, follow the instructions in the [manging cloud provider section](##obtaining-cloud-provider-access-token).

--- a/docs/index.md
+++ b/docs/index.md
@@ -228,6 +228,52 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 
 ### Managing Cloud Provider
 
+Before using the cloud provider, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to Grafana's Cloud Provider API.
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create 
+an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
+
+Also, by default the Access Policies UI will not show those scopes, to find name you need to use the `Add Scope` textbox, as shown in the following image:
+
+<img src="https://grafana.com/media/docs/grafana-cloud/aws/cloud-provider-terraform-access-policy-creation.png" width="700"/>
+
+1. Use the `Add Scope` textbox (1) to search for the permissions you need to add to the access policy.
+1. Make sure that you configure the three required scopes. Once done, you'll see the selected scopes as in (2).
+
+Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Cloud Provider API. You can do so just after creating the access policy, following
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+
+Having created the token, we can find the correct Cloud Provider API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
+
+```bash
+curl -sH "Authorization: Bearer token" "https://grafana.com/api/instances" | \
+  jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
+```
+
+This script will return a list of all the Grafana Cloud stacks you own, with the Cloud Provider API hostname for each one. Choose the correct hostname for the stack you want to manage.
+For example, in the following response, the correct hostname for the `herokublogpost` stack is `https://cloud-provider-api-prod-us-central-0.grafana.net`.
+
+```
+[
+  {
+    "stackName": "herokublogpost",
+    "clusterName": "prod-us-central-0",
+    "cloudProviderAPIURL": "https://cloud-provider-api-prod-us-central-0.grafana.net"
+  }
+]
+```
+
+Once you have the token and Cloud Provider API hostanme, you can configure the provider as follows:
+
+```hcl
+provider "grafana" {
+  // ...
+  cloud_provider_url = "https://cloud-provider-api-url.com"
+  cloud_provider_access_token = "token"
+}
+```
+
+The following are examples on how the *Account* and *Scrape Job* resources can be configured:
+
 ```terraform
 data "grafana_cloud_stack" "test" {
   slug = "gcloudstacktest"

--- a/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -31,53 +31,6 @@ resource "grafana_cloud_provider_aws_account" "test" {
   ]
 }
 
-locals {
-  services = [
-    {
-      name = "AWS/EC2",
-      metrics = [
-        {
-          name = "CPUUtilization",
-          statistics = [
-            "Average",
-          ],
-        },
-        {
-          name = "StatusCheckFailed",
-          statistics = [
-            "Maximum",
-          ],
-        },
-      ],
-      scrape_interval_seconds = 300,
-      resource_discovery_tag_filters = [
-        {
-          key   = "k8s.io/cluster-autoscaler/enabled",
-          value = "true",
-        }
-      ],
-      tags_to_add_to_metrics = [
-        "eks:cluster-name",
-      ]
-    },
-  ]
-  custom_namespaces = [
-    {
-      name = "CoolApp",
-      metrics = [
-        {
-          name = "CoolMetric",
-          statistics = [
-            "Maximum",
-            "Sum",
-          ]
-        },
-      ],
-      scrape_interval_seconds = 300,
-    },
-  ]
-}
-
 resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
   stack_id                = data.grafana_cloud_stack.test.id
   name                    = "my-cloudwatch-scrape-job"
@@ -85,43 +38,31 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
   regions                 = grafana_cloud_provider_aws_account.test.regions
   export_tags             = true
 
-  dynamic "service" {
-    for_each = local.services
-    content {
-      name = service.value.name
-      dynamic "metric" {
-        for_each = service.value.metrics
-        content {
-          name       = metric.value.name
-          statistics = metric.value.statistics
-        }
-      }
-      scrape_interval_seconds = service.value.scrape_interval_seconds
-      dynamic "resource_discovery_tag_filter" {
-        for_each = service.value.resource_discovery_tag_filters
-        content {
-          key   = resource_discovery_tag_filter.value.key
-          value = resource_discovery_tag_filter.value.value
-        }
-
-      }
-      tags_to_add_to_metrics = service.value.tags_to_add_to_metrics
+  service {
+    name = "AWS/EC2"
+    metric {
+      name       = "CPUUtilization"
+      statistics = ["Average"]
     }
+    metric {
+      name       = "StatusCheckFailed"
+      statistics = ["Maximum"]
+    }
+    scrape_interval_seconds = 300
+    resource_discovery_tag_filter {
+      key   = "k8s.io/cluster-autoscaler/enabled"
+      value = "true"
+    }
+    tags_to_add_to_metrics = ["eks:cluster-name"]
   }
 
-  dynamic "custom_namespace" {
-    for_each = local.custom_namespaces
-    content {
-      name = custom_namespace.value.name
-      dynamic "metric" {
-        for_each = custom_namespace.value.metrics
-        content {
-          name       = metric.value.name
-          statistics = metric.value.statistics
-        }
-      }
-      scrape_interval_seconds = custom_namespace.value.scrape_interval_seconds
+  custom_namespace {
+    name = "CoolApp"
+    metric {
+      name       = "CoolMetric"
+      statistics = ["Maximum", "Sum"]
     }
+    scrape_interval_seconds = 300
   }
 }
 ```

--- a/examples/resources/grafana_cloud_provider_aws_cloudwatch_scrape_job/resource.tf
+++ b/examples/resources/grafana_cloud_provider_aws_cloudwatch_scrape_job/resource.tf
@@ -16,53 +16,6 @@ resource "grafana_cloud_provider_aws_account" "test" {
   ]
 }
 
-locals {
-  services = [
-    {
-      name = "AWS/EC2",
-      metrics = [
-        {
-          name = "CPUUtilization",
-          statistics = [
-            "Average",
-          ],
-        },
-        {
-          name = "StatusCheckFailed",
-          statistics = [
-            "Maximum",
-          ],
-        },
-      ],
-      scrape_interval_seconds = 300,
-      resource_discovery_tag_filters = [
-        {
-          key   = "k8s.io/cluster-autoscaler/enabled",
-          value = "true",
-        }
-      ],
-      tags_to_add_to_metrics = [
-        "eks:cluster-name",
-      ]
-    },
-  ]
-  custom_namespaces = [
-    {
-      name = "CoolApp",
-      metrics = [
-        {
-          name = "CoolMetric",
-          statistics = [
-            "Maximum",
-            "Sum",
-          ]
-        },
-      ],
-      scrape_interval_seconds = 300,
-    },
-  ]
-}
-
 resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
   stack_id                = data.grafana_cloud_stack.test.id
   name                    = "my-cloudwatch-scrape-job"
@@ -70,42 +23,30 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
   regions                 = grafana_cloud_provider_aws_account.test.regions
   export_tags             = true
 
-  dynamic "service" {
-    for_each = local.services
-    content {
-      name = service.value.name
-      dynamic "metric" {
-        for_each = service.value.metrics
-        content {
-          name       = metric.value.name
-          statistics = metric.value.statistics
-        }
-      }
-      scrape_interval_seconds = service.value.scrape_interval_seconds
-      dynamic "resource_discovery_tag_filter" {
-        for_each = service.value.resource_discovery_tag_filters
-        content {
-          key   = resource_discovery_tag_filter.value.key
-          value = resource_discovery_tag_filter.value.value
-        }
-
-      }
-      tags_to_add_to_metrics = service.value.tags_to_add_to_metrics
+  service {
+    name = "AWS/EC2"
+    metric {
+      name       = "CPUUtilization"
+      statistics = ["Average"]
     }
+    metric {
+      name       = "StatusCheckFailed"
+      statistics = ["Maximum"]
+    }
+    scrape_interval_seconds = 300
+    resource_discovery_tag_filter {
+      key   = "k8s.io/cluster-autoscaler/enabled"
+      value = "true"
+    }
+    tags_to_add_to_metrics = ["eks:cluster-name"]
   }
 
-  dynamic "custom_namespace" {
-    for_each = local.custom_namespaces
-    content {
-      name = custom_namespace.value.name
-      dynamic "metric" {
-        for_each = custom_namespace.value.metrics
-        content {
-          name       = metric.value.name
-          statistics = metric.value.statistics
-        }
-      }
-      scrape_interval_seconds = custom_namespace.value.scrape_interval_seconds
+  custom_namespace {
+    name = "CoolApp"
+    metric {
+      name       = "CoolMetric"
+      statistics = ["Maximum", "Sum"]
     }
+    scrape_interval_seconds = 300
   }
 }

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -342,7 +342,13 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 		return common.WarnMissing("stack", d)
 	}
 
-	if err := flattenStack(d, stack); err != nil {
+	connectionsReq := client.InstancesAPI.GetConnections(ctx, id.(string))
+	connections, _, err := connectionsReq.Execute()
+	if err != nil {
+		return apiError(err)
+	}
+
+	if err := flattenStack(d, stack, connections); err != nil {
 		return diag.FromErr(err)
 	}
 	// Always set the wait attribute to true after creation
@@ -355,7 +361,7 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	return nil
 }
 
-func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance) error {
+func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, connections *gcom.FormattedApiInstanceConnections) error {
 	id := strconv.FormatInt(int64(stack.Id), 10)
 	d.SetId(id)
 	d.Set("name", stack.Name)
@@ -409,6 +415,14 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance) erro
 	d.Set("graphite_name", stack.HmInstanceGraphiteName)
 	d.Set("graphite_url", stack.HmInstanceGraphiteUrl)
 	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
+
+	if otlpURL := connections.OtlpHttpUrl; otlpURL.IsSet() {
+		d.Set("otlp_url", otlpURL.Get())
+	}
+
+	if influxURL := connections.InfluxUrl; influxURL.IsSet() {
+		d.Set("influx_url", influxURL.Get())
+	}
 
 	return nil
 }

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -342,13 +342,7 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 		return common.WarnMissing("stack", d)
 	}
 
-	connectionsReq := client.InstancesAPI.GetConnections(ctx, id.(string))
-	connections, _, err := connectionsReq.Execute()
-	if err != nil {
-		return apiError(err)
-	}
-
-	if err := flattenStack(d, stack, connections); err != nil {
+	if err := flattenStack(d, stack); err != nil {
 		return diag.FromErr(err)
 	}
 	// Always set the wait attribute to true after creation
@@ -361,7 +355,7 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	return nil
 }
 
-func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, connections *gcom.FormattedApiInstanceConnections) error {
+func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance) error {
 	id := strconv.FormatInt(int64(stack.Id), 10)
 	d.SetId(id)
 	d.Set("name", stack.Name)
@@ -415,14 +409,6 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("graphite_name", stack.HmInstanceGraphiteName)
 	d.Set("graphite_url", stack.HmInstanceGraphiteUrl)
 	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
-
-	if otlpURL := connections.OtlpHttpUrl; otlpURL.IsSet() {
-		d.Set("otlp_url", otlpURL.Get())
-	}
-
-	if influxURL := connections.InfluxUrl; influxURL.IsSet() {
-		d.Set("influx_url", influxURL.Get())
-	}
 
 	return nil
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -51,7 +51,7 @@ the in-screen instructions, of following [this guide](https://grafana.com/docs/g
 Having created the token, we can find the correct Cloud Provider API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
 
 ```bash
-curl -sH "Authorization: Bearer token" "https://grafana.com/api/instances" | \
+curl -sH "Authorization: Bearer <Access Token from previous step>" "https://grafana.com/api/instances" | \
   jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -34,7 +34,7 @@ The changelog for this provider can be found here: <https://github.com/grafana/t
 
 ### Managing Cloud Provider
 
-#### Obtaining access token
+#### Obtaining Cloud Provider access token
 
 Before using the Terraform Provider to manage Grafana Cloud Provider Observability resources, such as AWS CloudWatch scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Cloud Provider API.
 [These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create 
@@ -112,3 +112,8 @@ You can use the `grafana_synthetic_monitoring_installation` resource as shown ab
 
 [Grafana OnCall](https://grafana.com/docs/oncall/latest/oncall-api-reference/)
 uses API keys to allow access to the API. You can request a new OnCall API key in OnCall -> Settings page.
+
+### `cloud_provider_access_token`
+
+An access policy token created to manage [Grafana Cloud Provider Observability](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/).
+To create one, follow the instructions in the [manging cloud provider section](##obtaining-cloud-provider-access-token).

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -32,6 +32,12 @@ The changelog for this provider can be found here: <https://github.com/grafana/t
 
 {{ .SchemaMarkdown | trimspace }}
 
+### Managing Cloud Provider
+
+{{ tffile "examples/resources/grafana_cloud_provider_aws_account/resource.tf" }}
+
+{{ tffile "examples/resources/grafana_cloud_provider_aws_cloudwatch_scrape_job/resource.tf" }}
+
 ## Authentication
 
 One, or many, of the following authentication settings must be set. Each authentication setting allows a subset of resources to be used

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -34,6 +34,52 @@ The changelog for this provider can be found here: <https://github.com/grafana/t
 
 ### Managing Cloud Provider
 
+Before using the cloud provider, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to Grafana's Cloud Provider API.
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create 
+an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
+
+Also, by default the Access Policies UI will not show those scopes, to find name you need to use the `Add Scope` textbox, as shown in the following image:
+
+<img src="https://grafana.com/media/docs/grafana-cloud/aws/cloud-provider-terraform-access-policy-creation.png" width="700"/>
+
+1. Use the `Add Scope` textbox (1) to search for the permissions you need to add to the access policy.
+1. Make sure that you configure the three required scopes. Once done, you'll see the selected scopes as in (2).
+
+Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Cloud Provider API. You can do so just after creating the access policy, following
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+
+Having created the token, we can find the correct Cloud Provider API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
+
+```bash
+curl -sH "Authorization: Bearer token" "https://grafana.com/api/instances" | \
+  jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
+```
+
+This script will return a list of all the Grafana Cloud stacks you own, with the Cloud Provider API hostname for each one. Choose the correct hostname for the stack you want to manage.
+For example, in the following response, the correct hostname for the `herokublogpost` stack is `https://cloud-provider-api-prod-us-central-0.grafana.net`.
+
+```
+[
+  {
+    "stackName": "herokublogpost",
+    "clusterName": "prod-us-central-0",
+    "cloudProviderAPIURL": "https://cloud-provider-api-prod-us-central-0.grafana.net"
+  }
+]
+```
+
+Once you have the token and Cloud Provider API hostanme, you can configure the provider as follows:
+
+```hcl
+provider "grafana" {
+  // ...
+  cloud_provider_url = "https://cloud-provider-api-url.com"
+  cloud_provider_access_token = "token"
+}
+```
+
+The following are examples on how the *Account* and *Scrape Job* resources can be configured:
+
 {{ tffile "examples/resources/grafana_cloud_provider_aws_account/resource.tf" }}
 
 {{ tffile "examples/resources/grafana_cloud_provider_aws_cloudwatch_scrape_job/resource.tf" }}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -34,7 +34,7 @@ The changelog for this provider can be found here: <https://github.com/grafana/t
 
 ### Managing Cloud Provider
 
-Before using the cloud provider, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to Grafana's Cloud Provider API.
+Before using the Terraform Provider to manage Grafana Cloud Provider Observability resources, such as AWS CloudWatch scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Cloud Provider API.
 [These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create 
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
 
@@ -73,8 +73,8 @@ Once you have the token and Cloud Provider API hostanme, you can configure the p
 ```hcl
 provider "grafana" {
   // ...
-  cloud_provider_url = "https://cloud-provider-api-url.com"
-  cloud_provider_access_token = "token"
+  cloud_provider_url = <Cloud Provider API URL from previous step>
+  cloud_provider_access_token = <Access Token from previous step>
 }
 ```
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -34,6 +34,8 @@ The changelog for this provider can be found here: <https://github.com/grafana/t
 
 ### Managing Cloud Provider
 
+#### Obtaining access token
+
 Before using the Terraform Provider to manage Grafana Cloud Provider Observability resources, such as AWS CloudWatch scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Cloud Provider API.
 [These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create 
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
@@ -47,6 +49,8 @@ Also, by default the Access Policies UI will not show those scopes, to find name
 
 Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Cloud Provider API. You can do so just after creating the access policy, following
 the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+
+#### Obtaining Cloud Provider API hostname
 
 Having created the token, we can find the correct Cloud Provider API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
 
@@ -67,6 +71,8 @@ For example, in the following response, the correct hostname for the `herokublog
   }
 ]
 ```
+
+#### Configuring Provider
 
 Once you have the token and Cloud Provider API hostanme, you can configure the provider as follows:
 


### PR DESCRIPTION
This PR adapts the docs generator template to include instructions on how to setup the Cloud Provider terraoform provider section. It instructs how to create the api token and correct hostname.

For setting up the hostname, the UI is super misleading as the cluserSlug is not shown but rather something like friendly names:

<img width="962" alt="image" src="https://github.com/user-attachments/assets/d5836da0-f33c-4b2e-bd1f-5d538a561339">

The easiest solution is call Grafana's API with the same token the user has to create, as follows:

```
➜  work curl -sH "Authorization: Bearer $(cat ~/work/personal-stack-token.txt)" "https://grafana.com/api/instances"|jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
[
  {
    "stackName": "herokublogpost",
    "clusterName": "prod-us-central-0",
    "cloudProviderAPIURL": "https://cloud-provider-api-prod-us-central-0.grafana.net"
  },
  {
    "stackName": "pablobalbitest",
    "clusterName": "prod-us-east-0",
    "cloudProviderAPIURL": "https://cloud-provider-api-prod-us-east-0.grafana.net"
  },
  {
    "stackName": "palbiuscentral2",
    "clusterName": "us-central2",
    "cloudProviderAPIURL": "https://cloud-provider-api-us-central2.grafana.net"
  }
]
```

Also, adjusts the examples so that they are the easiest possible to read.

Solves https://github.com/grafana/grafana-csp-app/issues/140