### PR TITLE
Update Terraform Provider resource grafana_rule_group for option query_type documentation

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -162,7 +162,7 @@ Required:
 
 Optional:
 
-- `query_type` (String) An optional identifier for the type of query being executed. Defaults to ``.
+- `query_type` (String) An optional identifier for the type of query being executed. Defaults to `` with possible values of either "instant" or "range".
 
 <a id="nestedblock--rule--data--relative_time_range"></a>
 ### Nested Schema for `rule.data.relative_time_range`


### PR DESCRIPTION
Updates the Terraform Provider documentation for `grafana_rule_group` resource option `query_type` to include possible values of either instant or range.

Fixes: https://github.com/grafana/support-escalations/issues/8799