### PR TITLE
ci: disable flakey cloud acc tests for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
     - 'v*'
 jobs:
   # Cloud tests don't run on every PR. We need to be sure they all pass before we release.
-  # Temporarily disabling for release of 3.9.0 as the tests are flakey.
+  # Temporarily disabling for release of 3.8.0 as the tests are flakey.
   #run-cloud-tests:
   #  uses: ./.github/workflows/cloud-acc-tests.yml
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ on:
     - 'v*'
 jobs:
   # Cloud tests don't run on every PR. We need to be sure they all pass before we release.
-  run-cloud-tests:
-    uses: ./.github/workflows/cloud-acc-tests.yml
+  # Temporarily disabling for release of 3.9.0 as the tests are flakey.
+  #run-cloud-tests:
+  #  uses: ./.github/workflows/cloud-acc-tests.yml
   goreleaser:
     runs-on: ubuntu-latest
     needs: 


### PR DESCRIPTION
For v3.8.0 I was running these acceptance tests (5 retries) and each time different tests failed, they were receiving 429 Too Many Requests, even with retries: https://github.com/grafana/terraform-provider-grafana/actions/runs/11034219081

This PR disables the flakey test suite so we can release v3.8.0.
