### PR TITLE
Update Connections API client paths

### DIFF
--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -54,7 +54,7 @@ type apiResponseWrapper[T any] struct {
 }
 
 type MetricsEndpointScrapeJob struct {
-	Name                        string `json:"name"`
+	Name                        string `json:"-"`
 	Enabled                     bool   `json:"enabled"`
 	AuthenticationMethod        string `json:"authentication_method"`
 	AuthenticationBearerToken   string `json:"bearer_token,omitempty"`

--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -22,7 +22,7 @@ type Client struct {
 const (
 	defaultRetries = 3
 	defaultTimeout = 90 * time.Second
-	pathPrefix     = "/metrics-endpoint/stack"
+	pathPrefix     = "/api/v1/metrics-endpoint/stacks"
 )
 
 func NewClient(authToken string, rawURL string, client *http.Client) (*Client, error) {

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -31,7 +31,7 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, "/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
 			requestBody, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.JSONEq(t, `
@@ -107,7 +107,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
 
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`
@@ -178,7 +178,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			assert.Equal(t, "/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
 			requestBody, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.JSONEq(t, `
@@ -267,7 +267,7 @@ func TestClient_DeleteMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, "/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
 
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -31,12 +31,11 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
 			requestBody, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.JSONEq(t, `
 			{
-				"name":"test_job",
 				"enabled":true,
 				"authentication_method":"basic",
 				"basic_password":"my-password",
@@ -107,7 +106,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
 
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`
@@ -178,12 +177,11 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
 			requestBody, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.JSONEq(t, `
 			{
-				"name":"test_job",
 				"enabled":true,
 				"authentication_method":"bearer",
 				"bearer_token":"some token",
@@ -267,7 +265,7 @@ func TestClient_DeleteMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stack/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
 
 			w.WriteHeader(http.StatusOK)
 		}))


### PR DESCRIPTION
This PR modifies the paths for the Connections API client used to create metrics endpoint scrape jobs.
This PR also removes the Name field from the JSON request body to Connections API: the "Name" of the job is in the request path. 

The beginning of the Connections API is being designed [here](https://github.com/grafana/cloud-onboarding/pull/7742).