### PR TITLE
Add common provider headers to cloud-provider-client

### DIFF
--- a/internal/common/cloudproviderapi/client.go
+++ b/internal/common/cloudproviderapi/client.go
@@ -14,9 +14,10 @@ import (
 )
 
 type Client struct {
-	authToken string
-	apiURL    url.URL
-	client    *http.Client
+	authToken      string
+	apiURL         url.URL
+	client         *http.Client
+	defaultHeaders map[string]string
 }
 
 const (
@@ -24,7 +25,7 @@ const (
 	defaultTimeout = 90 * time.Second
 )
 
-func NewClient(authToken string, rawAPIURL string, client *http.Client) (*Client, error) {
+func NewClient(authToken string, rawAPIURL string, client *http.Client, defualtHeaders map[string]string) (*Client, error) {
 	parsedAPIURL, err := url.Parse(rawAPIURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Cloud Provider API url: %w", err)
@@ -38,9 +39,10 @@ func NewClient(authToken string, rawAPIURL string, client *http.Client) (*Client
 	}
 
 	return &Client{
-		authToken: authToken,
-		apiURL:    *parsedAPIURL,
-		client:    client,
+		authToken:      authToken,
+		apiURL:         *parsedAPIURL,
+		client:         client,
+		defaultHeaders: defualtHeaders,
 	}, nil
 }
 
@@ -195,6 +197,9 @@ func (c *Client) doAPIRequest(ctx context.Context, method string, path string, b
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
 	req.Header.Add("Content-Type", "application/json")
+	for k, v := range c.defaultHeaders {
+		req.Header.Add(k, v)
+	}
 
 	resp, err = c.client.Do(req)
 	if err != nil {

--- a/internal/common/cloudproviderapi/client.go
+++ b/internal/common/cloudproviderapi/client.go
@@ -25,7 +25,7 @@ const (
 	defaultTimeout = 90 * time.Second
 )
 
-func NewClient(authToken string, rawAPIURL string, client *http.Client, defualtHeaders map[string]string) (*Client, error) {
+func NewClient(authToken string, rawAPIURL string, client *http.Client, defaultHeaders map[string]string) (*Client, error) {
 	parsedAPIURL, err := url.Parse(rawAPIURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Cloud Provider API url: %w", err)
@@ -42,7 +42,7 @@ func NewClient(authToken string, rawAPIURL string, client *http.Client, defualtH
 		authToken:      authToken,
 		apiURL:         *parsedAPIURL,
 		client:         client,
-		defaultHeaders: defualtHeaders,
+		defaultHeaders: defaultHeaders,
 	}, nil
 }
 

--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -179,10 +179,16 @@ func createOnCallClient(providerConfig ProviderConfig) (*onCallAPI.Client, error
 }
 
 func createCloudProviderClient(client *common.Client, providerConfig ProviderConfig) error {
+	providerHeaders, err := getHTTPHeadersMap(providerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to get provider default HTTP headers: %w", err)
+	}
+
 	apiClient, err := cloudproviderapi.NewClient(
 		providerConfig.CloudProviderAccessToken.ValueString(),
 		providerConfig.CloudProviderURL.ValueString(),
 		getRetryClient(providerConfig),
+		providerHeaders,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds provider headers the cloud-provider-client. This are basically:
- `Grafana-Terraform-Provider`: true if request coming from provider, allows us in the API to understand a request comes from the provider
- `Grafana-Terraform-Provider-Version`: contains version of provider, might be useful to propagate it through context and log it to debug provider issues

Also, once we have this, we can identify from which client a request is coming from, and then, store the "provenance" of a resource. Using here the same concept SLO uses https://github.com/grafana/slo/blob/346637b4ce113db1bc910f46fc397c72943e3426/pkg/api/slo.go#L410, which sounds just right.
