### PR TITLE
cloudprovider: update CW scrape job regions field description text

### DIFF
--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -148,7 +148,7 @@ data "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 - `enabled` (Boolean) Whether the CloudWatch Scrape Job is enabled or not.
 - `export_tags` (Boolean) When enabled, AWS resource tags are exported as Prometheus labels to metrics formatted as `aws_<service_name>_info`.
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ name }}".
-- `regions` (Set of String) A set of AWS region names that this CloudWatch Scrape Job applies to.
+- `regions` (Set of String) A set of AWS region names that this CloudWatch Scrape Job applies to. This must be a subset of the regions that are configured in the associated AWS Account resource.
 - `service` (Block List) One or more configuration blocks to dictate what this CloudWatch Scrape Job should scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--service))
 
 <a id="nestedblock--custom_namespace"></a>

--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
@@ -46,7 +46,7 @@ Read-Only:
 - `export_tags` (Boolean) When enabled, AWS resource tags are exported as Prometheus labels to metrics formatted as `aws_<service_name>_info`.
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ name }}".
 - `name` (String) The name of the CloudWatch Scrape Job. Part of the Terraform Resource ID.
-- `regions` (Set of String) A set of AWS region names that this CloudWatch Scrape Job applies to.
+- `regions` (Set of String) A set of AWS region names that this CloudWatch Scrape Job applies to. This must be a subset of the regions that are configured in the associated AWS Account resource.
 - `service` (Block List) One or more configuration blocks to dictate what this CloudWatch Scrape Job should scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--scrape_job--service))
 - `stack_id` (String) The Stack ID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 

--- a/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -133,7 +133,7 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 
 - `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job.
 - `name` (String) The name of the CloudWatch Scrape Job. Part of the Terraform Resource ID.
-- `regions` (Set of String) A set of AWS region names that this CloudWatch Scrape Job applies to.
+- `regions` (Set of String) A set of AWS region names that this CloudWatch Scrape Job applies to. This must be a subset of the regions that are configured in the associated AWS Account resource.
 - `stack_id` (String) The Stack ID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 
 ### Optional

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
@@ -36,7 +36,7 @@ var (
 				Computed:    true,
 			},
 			"regions": schema.SetAttribute{
-				Description: "A set of AWS region names that this CloudWatch Scrape Job applies to.",
+				Description: "A set of AWS region names that this CloudWatch Scrape Job applies to. This must be a subset of the regions that are configured in the associated AWS Account resource.",
 				Computed:    true,
 				ElementType: types.StringType,
 			},

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
@@ -96,7 +96,7 @@ func (r *resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resourc
 				Required:    true,
 			},
 			"regions": schema.SetAttribute{
-				Description: "A set of AWS region names that this CloudWatch Scrape Job applies to.",
+				Description: "A set of AWS region names that this CloudWatch Scrape Job applies to. This must be a subset of the regions that are configured in the associated AWS Account resource.",
 				Required:    true,
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),


### PR DESCRIPTION
Update description to specify that job regions must be a subset of the associated account resource's regions.