### PR TITLE
feat: add `until` parameter to `grafana_oncall_on_call_shift` resource

### DIFF
--- a/docs/resources/oncall_on_call_shift.md
+++ b/docs/resources/oncall_on_call_shift.md
@@ -110,10 +110,10 @@ output "emea_weekday__rolling_users" {
 - `start_rotation_from_user_index` (Number) The index of the list of users in rolling_users, from which on-call rotation starts.
 - `team_id` (String) The ID of the OnCall team. To get one, create a team in Grafana, and navigate to the OnCall plugin (to sync the team with OnCall). You can then get the ID using the `grafana_oncall_team` datasource.
 - `time_zone` (String) The shift's timezone.  Overrides schedule's timezone.
+- `until` (String) The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example "2020-09-05T08:00:00")
 - `users` (Set of String) The list of on-call users (for single_event and recurrent_event event type).
 - `week_start` (String) Start day of the week in iCal format. Can be MO, TU, WE, TH, FR, SA, SU
-- `until` (String) The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example "2020-09-05T08:00:00")
- 
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/oncall_on_call_shift.md
+++ b/docs/resources/oncall_on_call_shift.md
@@ -113,6 +113,7 @@ output "emea_weekday__rolling_users" {
 - `users` (Set of String) The list of on-call users (for single_event and recurrent_event event type).
 - `week_start` (String) Start day of the week in iCal format. Can be MO, TU, WE, TH, FR, SA, SU
 - `until` (String) The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example \"2020-09-05T08:00:00\")"
+ 
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/oncall_on_call_shift.md
+++ b/docs/resources/oncall_on_call_shift.md
@@ -112,7 +112,7 @@ output "emea_weekday__rolling_users" {
 - `time_zone` (String) The shift's timezone.  Overrides schedule's timezone.
 - `users` (Set of String) The list of on-call users (for single_event and recurrent_event event type).
 - `week_start` (String) Start day of the week in iCal format. Can be MO, TU, WE, TH, FR, SA, SU
-- `until` (String) The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example \"2020-09-05T08:00:00\")"
+- `until` (String) The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example "2020-09-05T08:00:00")
  
 ### Read-Only
 

--- a/docs/resources/oncall_on_call_shift.md
+++ b/docs/resources/oncall_on_call_shift.md
@@ -112,7 +112,7 @@ output "emea_weekday__rolling_users" {
 - `time_zone` (String) The shift's timezone.  Overrides schedule's timezone.
 - `users` (Set of String) The list of on-call users (for single_event and recurrent_event event type).
 - `week_start` (String) Start day of the week in iCal format. Can be MO, TU, WE, TH, FR, SA, SU
-
+- `until` (String) The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example \"2020-09-05T08:00:00\")"
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
-	github.com/grafana/amixr-api-go-client v0.0.13 // main branch
+	github.com/grafana/amixr-api-go-client v0.0.15 // main branch
 	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240807172819-ac10800522a3
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240723170622-ae2c94b7c9a3
 	github.com/grafana/machine-learning-go-client v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/grafana/amixr-api-go-client v0.0.13 h1:MwZ2DHnFOWY9EX7sMCd1GYvQSX6ZeEOiiONkomHQUNA=
-github.com/grafana/amixr-api-go-client v0.0.13/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
+github.com/grafana/amixr-api-go-client v0.0.15 h1:kq2C8QIsTm1lA7i8S5UA1PjeUJkSIRpNVXQXFLlxRAE=
+github.com/grafana/amixr-api-go-client v0.0.15/go.mod h1:N6x26XUrM5zGtK5zL5vNJnAn2JFMxLFPPLTw/6pDkFE=
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240807172819-ac10800522a3 h1:CVLTffnWgBGvVaXfUUcSgFrZbiMzvj0/Hpi909zdeG0=
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20240807172819-ac10800522a3/go.mod h1:u9d0BESoKlztYm93CpoRleQjMbYBcZ+JOLHHP2nN6Wg=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20240723170622-ae2c94b7c9a3 h1:W35ScJIkeyLuDlOo3F+u1JSRRvmoIYYf/ghA/17Y18Q=

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -315,7 +315,7 @@ func resourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, clie
 
 	untilData, untilOk := d.GetOk("until")
 	if untilOk {
-	    if typeData == singleEvent {
+		if typeData == singleEvent {
 			return diag.Errorf("`until` can not be set with type: %s", typeData)
 		} else {
 			u := untilData.(string)
@@ -434,9 +434,9 @@ func resourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, clie
 		}
 	}
 
-    untilData, untilOk := d.GetOk("until")
+	untilData, untilOk := d.GetOk("until")
 	if untilOk {
-	    if typeData == singleEvent {
+		if typeData == singleEvent {
 			return diag.Errorf("`until` can not be set with type: %s", typeData)
 		} else {
 			u := untilData.(string)

--- a/internal/resources/oncall/resource_shift.go
+++ b/internal/resources/oncall/resource_shift.go
@@ -105,6 +105,12 @@ func resourceOnCallShift() *common.Resource {
 					"interval",
 				},
 			},
+			"until": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				Description:  "The end time of recurrent on-call shifts (endless if null). This parameter takes a date format as yyyy-MM-dd'T'HH:mm:ss (for example \"2020-09-05T08:00:00\")",
+			},
 			"users": {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
@@ -307,6 +313,16 @@ func resourceOnCallShiftCreate(ctx context.Context, d *schema.ResourceData, clie
 		}
 	}
 
+	untilData, untilOk := d.GetOk("until")
+	if untilOk {
+	    if typeData == singleEvent {
+			return diag.Errorf("`until` can not be set with type: %s", typeData)
+		} else {
+			u := untilData.(string)
+			createOptions.Until = &u
+		}
+	}
+
 	timeZoneData, timeZoneOk := d.GetOk("time_zone")
 	if timeZoneOk {
 		tz := timeZoneData.(string)
@@ -418,6 +434,16 @@ func resourceOnCallShiftUpdate(ctx context.Context, d *schema.ResourceData, clie
 		}
 	}
 
+    untilData, untilOk := d.GetOk("until")
+	if untilOk {
+	    if typeData == singleEvent {
+			return diag.Errorf("`until` can not be set with type: %s", typeData)
+		} else {
+			u := untilData.(string)
+			updateOptions.Until = &u
+		}
+	}
+
 	timeZoneData, timeZoneOk := d.GetOk("time_zone")
 	if timeZoneOk {
 		tz := timeZoneData.(string)
@@ -471,6 +497,7 @@ func resourceOnCallShiftRead(ctx context.Context, d *schema.ResourceData, client
 	d.Set("type", onCallShift.Type)
 	d.Set("level", onCallShift.Level)
 	d.Set("start", onCallShift.Start)
+	d.Set("until", onCallShift.Until)
 	d.Set("duration", onCallShift.Duration)
 	d.Set("frequency", onCallShift.Frequency)
 	d.Set("week_start", onCallShift.WeekStart)

--- a/internal/resources/oncall/resource_shift_test.go
+++ b/internal/resources/oncall/resource_shift_test.go
@@ -38,6 +38,7 @@ func TestAccOnCallOnCallShift_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "by_day.#", "2"),
 					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "by_day.0", "FR"),
 					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "by_day.1", "MO"),
+					resource.TestCheckNoResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "until"),
 				),
 			},
 			{
@@ -63,6 +64,13 @@ func TestAccOnCallOnCallShift_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOnCallOnCallShiftResourceExists("grafana_oncall_on_call_shift.test-acc-on_call_shift"),
 					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "name", shiftName),
+				),
+			},
+			{
+				Config: testAccOnCallOnCallShiftConfigUntil(scheduleName, shiftName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallOnCallShiftResourceExists("grafana_oncall_on_call_shift.test-acc-on_call_shift"),
+					resource.TestCheckResourceAttr("grafana_oncall_on_call_shift.test-acc-on_call_shift", "until", "2020-10-04T16:00:00"),
 				),
 			},
 		},
@@ -184,6 +192,29 @@ resource "grafana_oncall_on_call_shift" "test-acc-on_call_shift" {
 	type = "single_event"
 	start = "2020-09-04T16:00:00"
 	duration = 60
+}
+`, scheduleName, shiftName)
+}
+
+func testAccOnCallOnCallShiftConfigUntil(scheduleName, shiftName string) string {
+	return fmt.Sprintf(`
+resource "grafana_oncall_schedule" "test-acc-schedule" {
+	type = "calendar"
+	name = "%s"
+	time_zone = "UTC"
+}
+
+resource "grafana_oncall_on_call_shift" "test-acc-on_call_shift" {
+	name = "%s"
+	type = "recurrent_event"
+	start = "2020-09-04T16:00:00"
+	start = "2020-10-04T16:00:00"
+	duration = 3600
+	level = 1
+	frequency = "weekly"
+	week_start = "SU"
+	interval = 2
+	by_day = ["MO", "FR"]
 }
 `, scheduleName, shiftName)
 }

--- a/internal/resources/oncall/resource_shift_test.go
+++ b/internal/resources/oncall/resource_shift_test.go
@@ -208,7 +208,7 @@ resource "grafana_oncall_on_call_shift" "test-acc-on_call_shift" {
 	name = "%s"
 	type = "recurrent_event"
 	start = "2020-09-04T16:00:00"
-	start = "2020-10-04T16:00:00"
+	until = "2020-10-04T16:00:00"
 	duration = 3600
 	level = 1
 	frequency = "weekly"


### PR DESCRIPTION
Manual tests:

#### Creating shift with `until`

```terraform
terraform {
  required_providers {
    grafana = {
      source = "grafana/grafana"
    }
  }
}

provider "grafana" {
  url                 = "http://localhost:3000"
  oncall_url          = "http://localhost:8080"
  oncall_access_token = "<revoked>"
}

data "grafana_oncall_user" "admin" {
  username = "admin"
}

resource "grafana_oncall_on_call_shift" "example_shift" {
  name       = "Example Shift"
  type       = "recurrent_event"
  start      = "2024-09-07T14:00:00"
  until      = "2024-10-07T14:00:00"
  duration   = 60 * 60 * 4
  frequency  = "weekly"
  interval   = 2
  by_day     = ["MO", "TU", "WE", "TH", "FR"]
  week_start = "MO"
  users      = [data.grafana_oncall_user.admin.id]
  time_zone  = "UTC"
}

resource "grafana_oncall_schedule" "example_schedule" {
  name      = "Example Schadule"
  type      = "calendar"
  time_zone = "UTC"
  shifts    = [grafana_oncall_on_call_shift.example_shift.id]
}
```

```bash
 terraform apply -auto-approve
data.grafana_oncall_user.admin: Reading...
data.grafana_oncall_user.admin: Read complete after 0s [id=U32XDMQA668KJ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # grafana_oncall_on_call_shift.example_shift will be created
  + resource "grafana_oncall_on_call_shift" "example_shift" {
      + by_day     = [
          + "FR",
          + "MO",
          + "TH",
          + "TU",
          + "WE",
        ]
      + duration   = 14400
      + frequency  = "weekly"
      + id         = (known after apply)
      + interval   = 2
      + name       = "Example Shift"
      + start      = "2024-09-07T14:00:00"
      + time_zone  = "UTC"
      + type       = "recurrent_event"
      + until      = "2024-10-07T14:00:00"
      + users      = [
          + "U32XDMQA668KJ",
        ]
      + week_start = "MO"
    }

  # grafana_oncall_schedule.example_schedule will be created
  + resource "grafana_oncall_schedule" "example_schedule" {
      + id        = (known after apply)
      + name      = "Example Schadule"
      + shifts    = (known after apply)
      + time_zone = "UTC"
      + type      = "calendar"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
grafana_oncall_on_call_shift.example_shift: Creating...
grafana_oncall_on_call_shift.example_shift: Creation complete after 0s [id=OHG7MJ9RASQ8Z]
grafana_oncall_schedule.example_schedule: Creating...
grafana_oncall_schedule.example_schedule: Creation complete after 0s [id=SDVXPQFWIA8C6]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

`recurrent` shift ends on `until` date (biweekly recurring shift):

![image](https://github.com/user-attachments/assets/cfcae13b-ab05-4c28-a958-ea3eccade4f0)

#### Update `until` of existing shift

```terraform
# ...
resource "grafana_oncall_on_call_shift" "example_shift" {
  name       = "Example Shift"
  type       = "recurrent_event"
  start      = "2024-09-07T14:00:00"
  until      = "2024-10-14T14:00:00"
  duration   = 60 * 60 * 4
  frequency  = "weekly"
  interval   = 2
  by_day     = ["MO", "TU", "WE", "TH", "FR"]
  week_start = "MO"
  users      = [data.grafana_oncall_user.admin.id]
  time_zone  = "UTC"
}
# ...
```

```bash
terraform apply -auto-approve
data.grafana_oncall_user.admin: Reading...
data.grafana_oncall_user.admin: Read complete after 1s [id=U32XDMQA668KJ]
grafana_oncall_on_call_shift.example_shift: Refreshing state... [id=OHG7MJ9RASQ8Z]
grafana_oncall_schedule.example_schedule: Refreshing state... [id=SDVXPQFWIA8C6]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # grafana_oncall_on_call_shift.example_shift will be updated in-place
  ~ resource "grafana_oncall_on_call_shift" "example_shift" {
        id                             = "OHG7MJ9RASQ8Z"
        name                           = "Example Shift"
      ~ until                          = "2024-10-07T14:00:00" -> "2024-10-14T14:00:00"
        # (14 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
grafana_oncall_on_call_shift.example_shift: Modifying... [id=OHG7MJ9RASQ8Z]
grafana_oncall_on_call_shift.example_shift: Modifications complete after 0s [id=OHG7MJ9RASQ8Z]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Shifts ends later (biweekly recurring shift):

![image](https://github.com/user-attachments/assets/e49519ed-f49a-4b62-9a0e-8dd6ad6c9553)

#### Update remove `until`

```terraform
# ...
resource "grafana_oncall_on_call_shift" "example_shift" {
  name       = "Example Shift"
  type       = "recurrent_event"
  start      = "2024-09-07T14:00:00"
  duration   = 60 * 60 * 4
  frequency  = "weekly"
  interval   = 2
  by_day     = ["MO", "TU", "WE", "TH", "FR"]
  week_start = "MO"
  users      = [data.grafana_oncall_user.admin.id]
  time_zone  = "UTC"
}
# ...
```

```bash
terraform apply -auto-approve
data.grafana_oncall_user.admin: Reading...
data.grafana_oncall_user.admin: Read complete after 0s [id=U32XDMQA668KJ]
grafana_oncall_on_call_shift.example_shift: Refreshing state... [id=OHG7MJ9RASQ8Z]
grafana_oncall_schedule.example_schedule: Refreshing state... [id=SDVXPQFWIA8C6]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # grafana_oncall_on_call_shift.example_shift will be updated in-place
  ~ resource "grafana_oncall_on_call_shift" "example_shift" {
        id                             = "OHG7MJ9RASQ8Z"
        name                           = "Example Shift"
      - until                          = "2024-10-14T14:00:00" -> null
        # (14 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
grafana_oncall_on_call_shift.example_shift: Modifying... [id=OHG7MJ9RASQ8Z]
grafana_oncall_on_call_shift.example_shift: Modifications complete after 0s [id=OHG7MJ9RASQ8Z]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Shift does not end anymore:

![image](https://github.com/user-attachments/assets/7d3e60d7-d7ae-41bd-a702-be804ec2d066)

#### `single_event` with `until` is not applied

```
# ...
resource "grafana_oncall_on_call_shift" "example_shift" {
  name       = "Example Shift"
  type       = "single_event"
  start      = "2024-09-07T14:00:00"
  until      = "2024-09-10T14:00:00"
  duration   = 60 * 60 * 4
  users      = [data.grafana_oncall_user.admin.id]
  time_zone  = "UTC"
}
# ...
```

```bash
terraform apply -auto-approve
data.grafana_oncall_user.admin: Reading...
data.grafana_oncall_user.admin: Read complete after 0s [id=U32XDMQA668KJ]
grafana_oncall_on_call_shift.example_shift: Refreshing state... [id=OHG7MJ9RASQ8Z]
grafana_oncall_schedule.example_schedule: Refreshing state... [id=SDVXPQFWIA8C6]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # grafana_oncall_on_call_shift.example_shift will be updated in-place
  ~ resource "grafana_oncall_on_call_shift" "example_shift" {
      ~ by_day                         = [
          - "FR",
          - "MO",
          - "TH",
          - "TU",
          - "WE",
        ]
      - frequency                      = "weekly" -> null
        id                             = "OHG7MJ9RASQ8Z"
      - interval                       = 2 -> null
        name                           = "Example Shift"
      ~ type                           = "recurrent_event" -> "single_event"
      + until                          = "2024-09-10T14:00:00"
      - week_start                     = "MO" -> null
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
grafana_oncall_on_call_shift.example_shift: Modifying... [id=OHG7MJ9RASQ8Z]
╷
│ Error: `until` can not be set with type: single_event
│ 
│   with grafana_oncall_on_call_shift.example_shift,
│   on main.tf line 19, in resource "grafana_oncall_on_call_shift" "example_shift":
│   19: resource "grafana_oncall_on_call_shift" "example_shift" {
│ 
╵
```




