### PR TITLE
Fix the expected response from Connections API

### DIFF
--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -66,32 +66,32 @@ type MetricsEndpointScrapeJob struct {
 
 func (c *Client) CreateMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobData MetricsEndpointScrapeJob) (MetricsEndpointScrapeJob, error) {
 	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobData.Name)
-	respData := apiResponseWrapper[map[string]MetricsEndpointScrapeJob]{}
+	respData := apiResponseWrapper[MetricsEndpointScrapeJob]{}
 	err := c.doAPIRequest(ctx, http.MethodPost, path, &jobData, &respData)
 	if err != nil {
 		return MetricsEndpointScrapeJob{}, fmt.Errorf("failed to create metrics endpoint scrape job: %w", err)
 	}
-	return respData.Data[jobData.Name], nil
+	return respData.Data, nil
 }
 
 func (c *Client) GetMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobName string) (MetricsEndpointScrapeJob, error) {
 	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobName)
-	respData := apiResponseWrapper[map[string]MetricsEndpointScrapeJob]{}
+	respData := apiResponseWrapper[MetricsEndpointScrapeJob]{}
 	err := c.doAPIRequest(ctx, http.MethodGet, path, nil, &respData)
 	if err != nil {
 		return MetricsEndpointScrapeJob{}, fmt.Errorf("failed to get metrics endpoint scrape job: %w", err)
 	}
-	return respData.Data[jobName], nil
+	return respData.Data, nil
 }
 
 func (c *Client) UpdateMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobName string, jobData MetricsEndpointScrapeJob) (MetricsEndpointScrapeJob, error) {
 	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobName)
-	respData := apiResponseWrapper[map[string]MetricsEndpointScrapeJob]{}
+	respData := apiResponseWrapper[MetricsEndpointScrapeJob]{}
 	err := c.doAPIRequest(ctx, http.MethodPut, path, &jobData, &respData)
 	if err != nil {
 		return MetricsEndpointScrapeJob{}, fmt.Errorf("failed to update metrics endpoint scrape job: %w", err)
 	}
-	return respData.Data[jobName], nil
+	return respData.Data, nil
 }
 
 func (c *Client) DeleteMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobName string) error {

--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -54,7 +54,7 @@ type apiResponseWrapper[T any] struct {
 }
 
 type MetricsEndpointScrapeJob struct {
-	Name                        string `json:"-"`
+	Name                        string `json:"name"`
 	Enabled                     bool   `json:"enabled"`
 	AuthenticationMethod        string `json:"authentication_method"`
 	AuthenticationBearerToken   string `json:"bearer_token,omitempty"`
@@ -103,7 +103,7 @@ func (c *Client) DeleteMetricsEndpointScrapeJob(ctx context.Context, stackID str
 	return nil
 }
 
-var ErrNotFound = fmt.Errorf("job not found")
+var ErrNotFound = fmt.Errorf("not found")
 
 func (c *Client) doAPIRequest(ctx context.Context, method string, path string, body any, responseData any) error {
 	var reqBodyBytes io.Reader

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -36,6 +36,7 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 			require.NoError(t, err)
 			assert.JSONEq(t, `
 			{
+				"name":"test_job",
 				"enabled":true,
 				"authentication_method":"basic",
 				"basic_password":"my-password",
@@ -49,6 +50,7 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 			{
 				"status":"success",
 				"data":{
+					"name":"test_job",
 					"enabled":true,
 					"authentication_method":"basic",
 					"basic_username":"my-username",
@@ -75,6 +77,7 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, connectionsapi.MetricsEndpointScrapeJob{
+			Name:                        "test_job",
 			Enabled:                     true,
 			AuthenticationMethod:        "basic",
 			AuthenticationBasicUsername: "my-username",
@@ -111,6 +114,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 			{
 				"status":"success",
 				"data":{
+					"name":"test_job",
 					"enabled":true,
 					"authentication_method":"basic",
 					"basic_username":"my-username",
@@ -129,6 +133,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, connectionsapi.MetricsEndpointScrapeJob{
+			Name:                        "test_job",
 			Enabled:                     true,
 			AuthenticationMethod:        "basic",
 			AuthenticationBasicUsername: "my-username",
@@ -150,7 +155,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, connectionsapi.ErrNotFound)
-		assert.Equal(t, `failed to get metrics endpoint scrape job: job not found`, err.Error())
+		assert.Equal(t, `failed to get metrics endpoint scrape job: not found`, err.Error())
 	})
 
 	t.Run("returns error when connections API responds 500", func(t *testing.T) {
@@ -178,6 +183,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 			require.NoError(t, err)
 			assert.JSONEq(t, `
 			{
+				"name":"test_job",
 				"enabled":true,
 				"authentication_method":"bearer",
 				"bearer_token":"some token",
@@ -190,6 +196,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 			{
 				"status":"success",
 				"data":{
+					"name":"test_job",
 					"enabled":true,
 					"authentication_method":"bearer",
 					"bearer_token":"some token",
@@ -215,6 +222,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, connectionsapi.MetricsEndpointScrapeJob{
+			Name:                      "test_job",
 			Enabled:                   true,
 			AuthenticationMethod:      "bearer",
 			AuthenticationBearerToken: "some token",
@@ -236,7 +244,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, connectionsapi.ErrNotFound)
-		assert.Equal(t, `failed to update metrics endpoint scrape job: job not found`, err.Error())
+		assert.Equal(t, `failed to update metrics endpoint scrape job: not found`, err.Error())
 	})
 
 	t.Run("returns error when connections API responds 500", func(t *testing.T) {
@@ -284,7 +292,7 @@ func TestClient_DeleteMetricsEndpointScrapeJob(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, connectionsapi.ErrNotFound)
-		assert.Equal(t, `failed to delete metrics endpoint scrape job: job not found`, err.Error())
+		assert.Equal(t, `failed to delete metrics endpoint scrape job: not found`, err.Error())
 	})
 
 	t.Run("returns error when connections API responds 500", func(t *testing.T) {

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -49,15 +49,13 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 			{
 				"status":"success",
 				"data":{
-					"test_job":{
-						"enabled":true,
-						"authentication_method":"basic",
-						"basic_username":"my-username",
-						"basic_password":"my-password",
-						"url":"https://my-example-url.com:9000/metrics",
-						"scrape_interval_seconds":120,
-						"flavor":"default"
-					}
+					"enabled":true,
+					"authentication_method":"basic",
+					"basic_username":"my-username",
+					"basic_password":"my-password",
+					"url":"https://my-example-url.com:9000/metrics",
+					"scrape_interval_seconds":120,
+					"flavor":"default"
 				}
 			}`))
 		}))
@@ -113,15 +111,13 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 			{
 				"status":"success",
 				"data":{
-					"test_job":{
-						"enabled":true,
-						"authentication_method":"basic",
-						"basic_username":"my-username",
-						"basic_password":"my-password",
-						"url":"https://my-example-url.com:9000/metrics",
-						"scrape_interval_seconds":120,
-						"flavor":"default"
-					}
+					"enabled":true,
+					"authentication_method":"basic",
+					"basic_username":"my-username",
+					"basic_password":"my-password",
+					"url":"https://my-example-url.com:9000/metrics",
+					"scrape_interval_seconds":120,
+					"flavor":"default"
 				}
 			}`))
 		}))
@@ -194,14 +190,12 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 			{
 				"status":"success",
 				"data":{
-					"test_job":{
-						"enabled":true,
-						"authentication_method":"bearer",
-						"bearer_token":"some token",
-						"url":"https://updated-url.com:9000/metrics",
-						"scrape_interval_seconds":120,
-						"flavor":"default"
-					}
+					"enabled":true,
+					"authentication_method":"bearer",
+					"bearer_token":"some token",
+					"url":"https://updated-url.com:9000/metrics",
+					"scrape_interval_seconds":120,
+					"flavor":"default"
 				}
 			}`))
 		}))


### PR DESCRIPTION
This PR corrects the expected response from Connections API in the client used to create metrics endpoint scrape jobs.

It should be like `{"data":{"name":"test_job","authentication_method":"basic","url":"https://dev.my-metrics-endpoint-url.com:9000/metrics","scrape_interval_seconds":60,"flavor":"default","enabled":true}`.

* Adds the "name" field which depends on: https://github.com/grafana/cloud-onboarding/pull/7778
* Updates the ErrNotFound message which can be a little misleading for any 404.