### PR TITLE
Add new assertions for no_data_state in ML tests

### DIFF
--- a/docs/resources/machine_learning_alert.md
+++ b/docs/resources/machine_learning_alert.md
@@ -33,6 +33,7 @@ resource "grafana_machine_learning_alert" "test_job_alert" {
   anomaly_condition = "any"
   threshold         = ">0.8"
   window            = "15m"
+  no_data_state     = "OK"
 }
 ```
 

--- a/examples/resources/grafana_machine_learning_alert/forecast_alert.tf
+++ b/examples/resources/grafana_machine_learning_alert/forecast_alert.tf
@@ -14,4 +14,5 @@ resource "grafana_machine_learning_alert" "test_job_alert" {
   anomaly_condition = "any"
   threshold         = ">0.8"
   window            = "15m"
+  no_data_state     = "OK"
 }

--- a/internal/resources/machinelearning/resource_alert_test.go
+++ b/internal/resources/machinelearning/resource_alert_test.go
@@ -42,6 +42,7 @@ func TestAccResourceJobAlert(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "anomaly_condition", "any"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "threshold", ">0.8"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "window", "15m"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "no_data_state", "OK"),
 				),
 			},
 			// Update the alert with a new anomaly condition.
@@ -59,6 +60,7 @@ func TestAccResourceJobAlert(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "anomaly_condition", "low"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "threshold", ">0.8"),
 					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "window", "15m"),
+					resource.TestCheckResourceAttr("grafana_machine_learning_alert.test_job_alert", "no_data_state", "OK"),
 				),
 			},
 			{


### PR DESCRIPTION
We've fixed the spelling of the `noDataCondition` field in our API and client so I want to double check everything works as expected here.