### PR TITLE
Modify Connections API path for metrics endpoint scrape jobs

### DIFF
--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -22,7 +22,7 @@ type Client struct {
 const (
 	defaultRetries = 3
 	defaultTimeout = 90 * time.Second
-	pathPrefix     = "/api/v1/metrics-endpoint/stacks"
+	pathPrefix     = "/api/v1/stacks"
 )
 
 func NewClient(authToken string, rawURL string, client *http.Client) (*Client, error) {
@@ -62,7 +62,7 @@ type MetricsEndpointScrapeJob struct {
 }
 
 func (c *Client) CreateMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobData MetricsEndpointScrapeJob) (MetricsEndpointScrapeJob, error) {
-	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobData.Name)
+	path := fmt.Sprintf("%s/%s/metrics-endpoint/jobs/%s", pathPrefix, stackID, jobData.Name)
 	respData := apiResponseWrapper[MetricsEndpointScrapeJob]{}
 	err := c.doAPIRequest(ctx, http.MethodPost, path, &jobData, &respData)
 	if err != nil {
@@ -72,7 +72,7 @@ func (c *Client) CreateMetricsEndpointScrapeJob(ctx context.Context, stackID str
 }
 
 func (c *Client) GetMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobName string) (MetricsEndpointScrapeJob, error) {
-	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobName)
+	path := fmt.Sprintf("%s/%s/metrics-endpoint/jobs/%s", pathPrefix, stackID, jobName)
 	respData := apiResponseWrapper[MetricsEndpointScrapeJob]{}
 	err := c.doAPIRequest(ctx, http.MethodGet, path, nil, &respData)
 	if err != nil {
@@ -82,7 +82,7 @@ func (c *Client) GetMetricsEndpointScrapeJob(ctx context.Context, stackID string
 }
 
 func (c *Client) UpdateMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobName string, jobData MetricsEndpointScrapeJob) (MetricsEndpointScrapeJob, error) {
-	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobName)
+	path := fmt.Sprintf("%s/%s/metrics-endpoint/jobs/%s", pathPrefix, stackID, jobName)
 	respData := apiResponseWrapper[MetricsEndpointScrapeJob]{}
 	err := c.doAPIRequest(ctx, http.MethodPut, path, &jobData, &respData)
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *Client) UpdateMetricsEndpointScrapeJob(ctx context.Context, stackID str
 }
 
 func (c *Client) DeleteMetricsEndpointScrapeJob(ctx context.Context, stackID string, jobName string) error {
-	path := fmt.Sprintf("%s/%s/jobs/%s", pathPrefix, stackID, jobName)
+	path := fmt.Sprintf("%s/%s/metrics-endpoint/jobs/%s", pathPrefix, stackID, jobName)
 	err := c.doAPIRequest(ctx, http.MethodDelete, path, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete metrics endpoint scrape job: %w", err)

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -31,7 +31,7 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/stacks/some-stack-id/metrics-endpoint/jobs/test_job", r.URL.Path)
 			requestBody, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.JSONEq(t, `
@@ -107,7 +107,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/stacks/some-stack-id/metrics-endpoint/jobs/test_job", r.URL.Path)
 
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`
@@ -178,7 +178,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodPut, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/stacks/some-stack-id/metrics-endpoint/jobs/test_job", r.URL.Path)
 			requestBody, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.JSONEq(t, `
@@ -267,7 +267,7 @@ func TestClient_DeleteMetricsEndpointScrapeJob(t *testing.T) {
 	t.Run("successfully sends request and receives response", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodDelete, r.Method)
-			assert.Equal(t, "/api/v1/metrics-endpoint/stacks/some-stack-id/jobs/test_job", r.URL.Path)
+			assert.Equal(t, "/api/v1/stacks/some-stack-id/metrics-endpoint/jobs/test_job", r.URL.Path)
 
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/internal/resources/connections/metrics_endpoint_scrape_job_test.go
+++ b/internal/resources/connections/metrics_endpoint_scrape_job_test.go
@@ -22,7 +22,7 @@ import (
 func TestAcc_MetricsEndpointScrapeJob(t *testing.T) {
 	// Mock the Connections API response for Create, Get, and Delete
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/metrics-endpoint/stacks/1/jobs/scrape-job-name", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/stacks/1/metrics-endpoint/jobs/scrape-job-name", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
 			w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
Going from `/api/v1/metrics-endpoint/stacks/{stack-id}/jobs/{job-name}` to `/api/v1/stacks/{stack-id}/metrics-endpoint/jobs/{job-name}`.

See https://github.com/grafana/cloud-onboarding/pull/7851