### PR TITLE
Add enabled to metrics endpoint scrape job resource

### DIFF
--- a/docs/data-sources/connections_metrics_endpoint_scrape_job.md
+++ b/docs/data-sources/connections_metrics_endpoint_scrape_job.md
@@ -33,6 +33,7 @@ data "grafana_connections_metrics_endpoint_scrape_job" "ds_test" {
 - `authentication_basic_username` (String) Username for basic authentication.
 - `authentication_bearer_token` (String, Sensitive) Token for authentication bearer.
 - `authentication_method` (String) Method to pass authentication credentials: basic or bearer.
+- `enabled` (Boolean) Whether the metrics endpoint scrape job is enabled or not.
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ name }}".
 - `scrape_interval_seconds` (Number) Frequency for scraping the metrics endpoint: 30, 60, or 120 seconds.
 - `url` (String) The url to scrape metrics.

--- a/docs/resources/connections_metrics_endpoint_scrape_job.md
+++ b/docs/resources/connections_metrics_endpoint_scrape_job.md
@@ -16,6 +16,7 @@ description: |-
 resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
   stack_id                      = "1"
   name                          = "scrape-job-name"
+  enabled                       = true
   authentication_method         = "basic"
   authentication_basic_username = "my-username"
   authentication_basic_password = "my-password"
@@ -39,6 +40,7 @@ resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
 - `authentication_basic_password` (String, Sensitive) Password for basic authentication.
 - `authentication_basic_username` (String) Username for basic authentication.
 - `authentication_bearer_token` (String, Sensitive) Token for authentication bearer.
+- `enabled` (Boolean) Whether the metrics endpoint scrape job is enabled or not.
 - `scrape_interval_seconds` (Number) Frequency for scraping the metrics endpoint: 30, 60, or 120 seconds.
 
 ### Read-Only

--- a/examples/resources/grafana_connections_metrics_endpoint_scrape_job/resource.tf
+++ b/examples/resources/grafana_connections_metrics_endpoint_scrape_job/resource.tf
@@ -1,6 +1,7 @@
 resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
   stack_id                      = "1"
   name                          = "scrape-job-name"
+  enabled                       = true
   authentication_method         = "basic"
   authentication_basic_username = "my-username"
   authentication_basic_password = "my-password"

--- a/internal/resources/connections/data_source_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/data_source_metrics_endpoint_scrape_job.go
@@ -54,6 +54,10 @@ func (r *datasourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req dat
 				Description: "The name of the Metrics Endpoint Scrape Job. Part of the Terraform Resource ID.",
 				Required:    true,
 			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the metrics endpoint scrape job is enabled or not.",
+				Computed:    true,
+			},
 			"authentication_method": schema.StringAttribute{
 				Description: "Method to pass authentication credentials: basic or bearer.",
 				Computed:    true,

--- a/internal/resources/connections/metrics_endpoint_scrape_job_test.go
+++ b/internal/resources/connections/metrics_endpoint_scrape_job_test.go
@@ -86,6 +86,7 @@ func TestAcc_MetricsEndpointScrapeJob(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.grafana_connections_metrics_endpoint_scrape_job.ds_test", "stack_id", "1"),
 					resource.TestCheckResourceAttr("data.grafana_connections_metrics_endpoint_scrape_job.ds_test", "name", "scrape-job-name"),
+					resource.TestCheckResourceAttr("data.grafana_connections_metrics_endpoint_scrape_job.ds_test", "enabled", "true"),
 					resource.TestCheckResourceAttr("data.grafana_connections_metrics_endpoint_scrape_job.ds_test", "authentication_method", "basic"),
 					resource.TestCheckNoResourceAttr("data.grafana_connections_metrics_endpoint_scrape_job.ds_test", "authentication_basic_username"),
 					resource.TestCheckNoResourceAttr("data.grafana_connections_metrics_endpoint_scrape_job.ds_test", "authentication_basic_password"),

--- a/internal/resources/connections/metrics_endpoint_scrape_job_test.go
+++ b/internal/resources/connections/metrics_endpoint_scrape_job_test.go
@@ -72,6 +72,7 @@ func TestAcc_MetricsEndpointScrapeJob(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("grafana_connections_metrics_endpoint_scrape_job.test", "stack_id", "1"),
 					resource.TestCheckResourceAttr("grafana_connections_metrics_endpoint_scrape_job.test", "name", "scrape-job-name"),
+					resource.TestCheckResourceAttr("grafana_connections_metrics_endpoint_scrape_job.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("grafana_connections_metrics_endpoint_scrape_job.test", "authentication_method", "basic"),
 					resource.TestCheckResourceAttr("grafana_connections_metrics_endpoint_scrape_job.test", "authentication_basic_username", "my-username"),
 					resource.TestCheckResourceAttr("grafana_connections_metrics_endpoint_scrape_job.test", "authentication_basic_password", "my-password"),

--- a/internal/resources/connections/models.go
+++ b/internal/resources/connections/models.go
@@ -9,6 +9,7 @@ type metricsEndpointScrapeJobTFModel struct {
 	ID                          types.String `tfsdk:"id"`
 	StackID                     types.String `tfsdk:"stack_id"`
 	Name                        types.String `tfsdk:"name"`
+	Enabled                     types.Bool   `tfsdk:"enabled"`
 	AuthenticationMethod        types.String `tfsdk:"authentication_method"`
 	AuthenticationBearerToken   types.String `tfsdk:"authentication_bearer_token"`
 	AuthenticationBasicUsername types.String `tfsdk:"authentication_basic_username"`
@@ -23,6 +24,7 @@ type metricsEndpointScrapeJobTFModel struct {
 func convertJobTFModelToClientModel(tfData metricsEndpointScrapeJobTFModel) connectionsapi.MetricsEndpointScrapeJob {
 	return connectionsapi.MetricsEndpointScrapeJob{
 		Name:                        tfData.Name.ValueString(),
+		Enabled:                     tfData.Enabled.ValueBool(),
 		AuthenticationMethod:        tfData.AuthenticationMethod.ValueString(),
 		AuthenticationBearerToken:   tfData.AuthenticationBearerToken.ValueString(),
 		AuthenticationBasicUsername: tfData.AuthenticationBasicUsername.ValueString(),
@@ -40,6 +42,7 @@ func convertClientModelToTFModel(stackID string, scrapeJobData connectionsapi.Me
 		ID:                    types.StringValue(resourceMetricsEndpointScrapeJobTerraformID.Make(stackID, scrapeJobData.Name)),
 		StackID:               types.StringValue(stackID),
 		Name:                  types.StringValue(scrapeJobData.Name),
+		Enabled:               types.BoolValue(scrapeJobData.Enabled),
 		AuthenticationMethod:  types.StringValue(scrapeJobData.AuthenticationMethod),
 		URL:                   types.StringValue(scrapeJobData.URL),
 		ScrapeIntervalSeconds: types.Int64Value(scrapeJobData.ScrapeIntervalSeconds),

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -79,6 +80,12 @@ func (r *resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resou
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the metrics endpoint scrape job is enabled or not.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
 			},
 			"authentication_method": schema.StringAttribute{
 				Description: "Method to pass authentication credentials: basic or bearer.",
@@ -158,6 +165,7 @@ func (r *resourceMetricsEndpointScrapeJob) Read(ctx context.Context, req resourc
 	// Set only non-sensitive attributes
 	resp.State.SetAttribute(ctx, path.Root("stack_id"), jobTF.StackID)
 	resp.State.SetAttribute(ctx, path.Root("name"), jobTF.Name)
+	resp.State.SetAttribute(ctx, path.Root("enabled"), jobTF.Enabled)
 	resp.State.SetAttribute(ctx, path.Root("authentication_method"), jobTF.AuthenticationMethod)
 	resp.State.SetAttribute(ctx, path.Root("url"), jobTF.URL)
 	resp.State.SetAttribute(ctx, path.Root("scrape_interval_seconds"), jobTF.ScrapeIntervalSeconds)


### PR DESCRIPTION
Thanks to Tristan's work on https://github.com/grafana/cloud-onboarding/pull/7841, we can make use of the "enabled" field on resource Create and Update.
This PR puts back the ability to define the boolean "enabled" field for metrics endpoint scrape jobs. 

Fixes https://github.com/grafana/cloud-onboarding/issues/7842