### PR TITLE
OnCall - allow more wait time options for escalation steps

### DIFF
--- a/docs/resources/oncall_escalation.md
+++ b/docs/resources/oncall_escalation.md
@@ -65,7 +65,7 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 ### Optional
 
 - `action_to_trigger` (String) The ID of an Action for trigger_webhook type step.
-- `duration` (Number) The duration of delay for wait type step.
+- `duration` (Number) The duration of delay for wait type step in seconds (60-86400).
 - `group_to_notify` (String) The ID of a User Group for notify_user_group type step.
 - `important` (Boolean) Will activate "important" personal notification rules. Actual for steps: notify_persons, notify_on_call_from_schedule and notify_user_group,notify_team_members
 - `notify_if_time_from` (String) The beginning of the time interval for notify_if_time_from_to type step in UTC (for example 08:00:00Z).

--- a/docs/resources/oncall_escalation.md
+++ b/docs/resources/oncall_escalation.md
@@ -65,7 +65,7 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 ### Optional
 
 - `action_to_trigger` (String) The ID of an Action for trigger_webhook type step.
-- `duration` (Number) The duration of delay for wait type step in seconds (60-86400).
+- `duration` (Number) The duration of delay for wait type step. (60-86400) seconds
 - `group_to_notify` (String) The ID of a User Group for notify_user_group type step.
 - `important` (Boolean) Will activate "important" personal notification rules. Actual for steps: notify_persons, notify_on_call_from_schedule and notify_user_group,notify_team_members
 - `notify_if_time_from` (String) The beginning of the time interval for notify_if_time_from_to type step in UTC (for example 08:00:00Z).

--- a/internal/resources/oncall/resource_escalation.go
+++ b/internal/resources/oncall/resource_escalation.go
@@ -30,14 +30,6 @@ var escalationOptions = []string{
 
 var escalationOptionsVerbal = strings.Join(escalationOptions, ", ")
 
-var durationOptions = []int{
-	60,
-	300,
-	900,
-	1800,
-	3600,
-}
-
 func resourceEscalation() *common.Resource {
 	schema := &schema.Resource{
 		Description: `
@@ -88,7 +80,7 @@ func resourceEscalation() *common.Resource {
 					"notify_if_time_from",
 					"notify_if_time_to",
 				},
-				ValidateFunc: validation.IntInSlice(durationOptions),
+				ValidateFunc: validation.IntBetween(60, 86400),
 				Description:  "The duration of delay for wait type step.",
 			},
 			"notify_on_call_from_schedule": {

--- a/internal/resources/oncall/resource_escalation.go
+++ b/internal/resources/oncall/resource_escalation.go
@@ -81,7 +81,7 @@ func resourceEscalation() *common.Resource {
 					"notify_if_time_to",
 				},
 				ValidateFunc: validation.IntBetween(60, 86400),
-				Description:  "The duration of delay for wait type step.",
+				Description:  "The duration of delay for wait type step. (60-86400) seconds",
 			},
 			"notify_on_call_from_schedule": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Removes restrictions on wait times so any number can be entered 60-86400 seconds.

https://github.com/grafana/oncall/pull/5201 must be released before this can be used.