### PR TITLE
Data source: Add check for `write` path of `teamHttpHeaders` in the json encoding

### DIFF
--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -187,11 +187,6 @@ func datasourceSecureJSONDataAttribute() *schema.Schema {
 					errors.New("httpHeaderValue{num} is a reserved key and cannot be used in JSON data. Use the http_headers attribute instead"),
 				}
 			}
-			if strings.Contains(i.(string), "teamHttpHeaders") {
-				return nil, []error{
-					errors.New("teamHttpHeaders is a reserved key and cannot be used in JSON data. Use the data_source_config_lbac_rules resource instead"),
-				}
-			}
 			return validation.StringIsJSON(i, s)
 		},
 		StateFunc: func(v interface{}) string {

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -155,6 +155,11 @@ func datasourceJSONDataAttribute() *schema.Schema {
 					errors.New("httpHeaderName{num} is a reserved key and cannot be used in JSON data. Use the http_headers attribute instead"),
 				}
 			}
+			if strings.Contains(i.(string), "teamHttpHeaders") {
+				return nil, []error{
+					errors.New("teamHttpHeaders is a reserved key and cannot be used in JSON data. Use the data_source_config_lbac_rules resource instead"),
+				}
+			}
 			return validation.StringIsJSON(i, s)
 		},
 		StateFunc: func(v interface{}) string {
@@ -180,6 +185,11 @@ func datasourceSecureJSONDataAttribute() *schema.Schema {
 			if strings.Contains(i.(string), "httpHeaderValue") {
 				return nil, []error{
 					errors.New("httpHeaderValue{num} is a reserved key and cannot be used in JSON data. Use the http_headers attribute instead"),
+				}
+			}
+			if strings.Contains(i.(string), "teamHttpHeaders") {
+				return nil, []error{
+					errors.New("teamHttpHeaders is a reserved key and cannot be used in JSON data. Use the data_source_config_lbac_rules resource instead"),
 				}
 			}
 			return validation.StringIsJSON(i, s)


### PR DESCRIPTION
We are working on making `data_source_config_lbac_rules` as a separate resource.

This ensures no terraform provisioning will happen for the `teamHttpHeaders` 


```hcl
terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - grafana/grafana in /Users/eleijonmarck/dev/grafana/terraform-provider-grafana
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
│ published releases.
╵
╷
│ Error: teamHttpHeaders is a reserved key and cannot be used in JSON data. Use the data_source_config_lbac_rules resource instead.
│
│   with grafana_data_source.test,
│   on main.tf line 22, in resource "grafana_data_source" "test":
│   22:   json_data_encoded = jsonencode({
│   23:     "tokenUri"           = "https://oauth2.googleapis.com/token"
│   24:     "authenticationType" = "jwt"
│   25:     "defaultProject"     = "default-project"
│   26:     "clientEmail"        = "client-email@default-project.iam.gserviceaccount.com"
│   27:     "teamHttpHeaders" = {
│   28:       "X-My-Header" = "MyHeaderValue"
│   29:       "1" = {
│   30:         "header" = "Authorization"
│   31:       }
│   32:       "2" = {
│   33:         "header" = "Authorization"
│   34:       }
│   35:     }
│   36:   })
│
╵
```