### PR TITLE
Data source: Add delete `teamHttpHeaders` in the json read path for data source

### DIFF
--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -418,6 +418,8 @@ func removeHeadersFromJSONData(input map[string]interface{}) (map[string]interfa
 			jsonData[dataName] = dataValue
 		}
 	}
+	// for teamhttpheaders, we do not set it in the state and we do not want to return it in the diff
+	delete(jsonData, "teamHttpHeaders")
 
 	return jsonData, headers
 }


### PR DESCRIPTION
We are working on making `data_source_config_lbac_rules` as a separate resource.

This ensures the read path of a data source will not pick up `teamHttpHeaders`


Even if we had lbac rules in the datasource we do not get anything of the updates in the jsonData

### Prior to this change
```hcl

Terraform will perform the following actions:

  # grafana_data_source.test will be updated in-place
  ~ resource "grafana_data_source" "test" {
        id                  = "1:ee1r381l9fk00c"
      ~ json_data_encoded   = jsonencode(
          ~ {
              ~ teamHttpHeaders    = {
                  - headers        = {
                      - "1" = [
                          - {
                              - header = "X-Prom-Label-Policy"
                              - value  = "username:{ app=\"app\" }"
                            },
                        ]
                    }
                  - restrictAccess = false
                # (4 unchanged attributes hidden)
            }
        )
```