### PR TITLE
Mark password and bearer token as sensitive

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -519,7 +519,7 @@ Optional:
 Optional:
 
 - `basic_auth` (Block Set, Max: 1) Basic auth settings. (see [below for nested schema](#nestedblock--settings--http--basic_auth))
-- `bearer_token` (String) Token for use with bearer authorization header.
+- `bearer_token` (String, Sensitive) Token for use with bearer authorization header.
 - `body` (String) The body of the HTTP request used in probe.
 - `cache_busting_query_param_name` (String) The name of the query parameter used to prevent the server from using a cached response. Each probe will assign a random value to this parameter each time a request is made.
 - `fail_if_body_matches_regexp` (Set of String) List of regexes. If any match the response body, the check will fail.
@@ -543,7 +543,7 @@ Optional:
 
 Required:
 
-- `password` (String) Basic auth password.
+- `password` (String, Sensitive) Basic auth password.
 - `username` (String) Basic auth username.
 
 

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -270,6 +270,7 @@ var (
 				Description: "Token for use with bearer authorization header.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Sensitive:   true,
 			},
 			"proxy_url": {
 				Description: "Proxy URL.",
@@ -359,6 +360,7 @@ var (
 				Description: "Basic auth password.",
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 			},
 		},
 	}


### PR DESCRIPTION
These two fields can contain sensitive information and should be classified as such. In addition, I believe this will allow the use of secret refs when creating a check from Crossplane.