### PR TITLE
Add ConfigValidators for bearer and basic auth combinations

### DIFF
--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -120,6 +121,23 @@ func (r *resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resou
 				Optional:    true,
 			},
 		},
+	}
+}
+
+func (r *resourceMetricsEndpointScrapeJob) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.Conflicting(
+			path.MatchRoot("authentication_bearer_token"),
+			path.MatchRoot("authentication_basic_username"),
+		),
+		resourcevalidator.Conflicting(
+			path.MatchRoot("authentication_bearer_token"),
+			path.MatchRoot("authentication_basic_password"),
+		),
+		resourcevalidator.RequiredTogether(
+			path.MatchRoot("authentication_basic_username"),
+			path.MatchRoot("authentication_basic_password"),
+		),
 	}
 }
 


### PR DESCRIPTION
The Metrics Endpoint Job type accepts either basic or bearer auth types. 
This change adds validation so that either basic or bearer auth is set on the resource, but not both. 
It also adds a check that if basic username is provided, then basic password must also be set.