### PR TITLE
Handle non 200 error codes from connections API specifically

### DIFF
--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -103,7 +103,10 @@ func (c *Client) DeleteMetricsEndpointScrapeJob(ctx context.Context, stackID, jo
 	return nil
 }
 
-var ErrNotFound = fmt.Errorf("not found")
+var (
+	ErrNotFound     = fmt.Errorf("not found")
+	ErrUnauthorized = fmt.Errorf("request not authorized for stack")
+)
 
 func (c *Client) doAPIRequest(ctx context.Context, method string, path string, body any, responseData any) error {
 	var reqBodyBytes io.Reader
@@ -141,6 +144,9 @@ func (c *Client) doAPIRequest(ctx context.Context, method string, path string, b
 	if !(resp.StatusCode >= 200 && resp.StatusCode <= 299) {
 		if resp.StatusCode == 404 {
 			return ErrNotFound
+		}
+		if resp.StatusCode == 401 {
+			return ErrUnauthorized
 		}
 		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
 	}

--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -148,7 +148,7 @@ func (c *Client) doAPIRequest(ctx context.Context, method string, path string, b
 		if resp.StatusCode == 401 {
 			return ErrUnauthorized
 		}
-		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
+		return fmt.Errorf("status: %d", resp.StatusCode)
 	}
 	if responseData != nil && resp.StatusCode != http.StatusNoContent {
 		err = json.Unmarshal(bodyContents, &responseData)

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -118,7 +118,7 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 		_, err = c.CreateMetricsEndpointScrapeJob(context.Background(), "some-stack-id", "test_job", connectionsapi.MetricsEndpointScrapeJob{})
 
 		assert.Error(t, err)
-		assert.Equal(t, `failed to create metrics endpoint scrape job "test_job": status: 500, body: {"some error"}`, err.Error())
+		assert.Equal(t, `failed to create metrics endpoint scrape job "test_job": status: 500`, err.Error())
 	})
 
 	t.Run("returns ErrUnauthorized when connections API responds 401", func(t *testing.T) {
@@ -245,7 +245,7 @@ func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {
 		_, err = c.GetMetricsEndpointScrapeJob(context.Background(), "some-stack-id", "job-name")
 
 		assert.Error(t, err)
-		assert.Equal(t, `failed to get metrics endpoint scrape job "job-name": status: 500, body: {"some error"}`, err.Error())
+		assert.Equal(t, `failed to get metrics endpoint scrape job "job-name": status: 500`, err.Error())
 	})
 
 	t.Run("returns error when client fails to Do request", func(t *testing.T) {
@@ -372,7 +372,7 @@ func TestClient_UpdateMetricsEndpointScrapeJob(t *testing.T) {
 		_, err = c.UpdateMetricsEndpointScrapeJob(context.Background(), "some-stack-id", "job-name", connectionsapi.MetricsEndpointScrapeJob{})
 
 		assert.Error(t, err)
-		assert.Equal(t, `failed to update metrics endpoint scrape job "job-name": status: 500, body: {"some error"}`, err.Error())
+		assert.Equal(t, `failed to update metrics endpoint scrape job "job-name": status: 500`, err.Error())
 	})
 
 	t.Run("returns error when client fails to Do request", func(t *testing.T) {
@@ -462,7 +462,7 @@ func TestClient_DeleteMetricsEndpointScrapeJob(t *testing.T) {
 		err = c.DeleteMetricsEndpointScrapeJob(context.Background(), "some-stack-id", "job-name")
 
 		assert.Error(t, err)
-		assert.Equal(t, `failed to delete metrics endpoint scrape job "job-name": status: 500, body: {"some error"}`, err.Error())
+		assert.Equal(t, `failed to delete metrics endpoint scrape job "job-name": status: 500`, err.Error())
 	})
 
 	t.Run("returns error when client fails to Do request", func(t *testing.T) {


### PR DESCRIPTION
This change introduces explicit handling of 401 http response codes from the connections API. The result is more human readable errors that still indicate the issue.

**Before:**
```
│ Error: failed to create metrics endpoint scrape job
│
│   with grafana_connections_metrics_endpoint_scrape_job.test,
│   on main.tf line 6, in resource "grafana_connections_metrics_endpoint_scrape_job" "test":
│    6: resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
│
│ failed to create metrics endpoint scrape job "my_scrape_job": status: 401, body: {"status":"error","message":"unauthorized access to
│ /api/v1/stacks/5223/metrics-endpoint/jobs/my_scrape_job","error":{"message":"unauthorized access to
│ /api/v1/stacks/5223/metrics-endpoint/jobs/my_scrape_job"}}
```

**After**:
```
│ Error: failed to create metrics endpoint scrape job
│
│   with grafana_connections_metrics_endpoint_scrape_job.test,
│   on main.tf line 6, in resource "grafana_connections_metrics_endpoint_scrape_job" "test":
│    6: resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
│
│ failed to create metrics endpoint scrape job "my_scrape_job": request not authorized for stack
```



It also removes error bodies for unhandled errors, which were proving to be very verbose and unhelpful.