### PR TITLE
cloudprovider: aws acceptance tests

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -43,10 +43,10 @@ jobs:
             GRAFANA_SM_ACCESS_TOKEN=cloud-instance-tests:sm-token
             GRAFANA_SM_URL=cloud-instance-tests:sm-url
             GRAFANA_URL=cloud-instance-tests:url
-            GRAFANA_CLOUD_PROVIDER_URL=cloud-instance-tests:cloud-provider-url
-            GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN=cloud-instance-tests:cloud-provider-access-token
-            GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN=cloud-instance-tests:cloud-provider-aws-role-arn
-            GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID=cloud-instance-tests:cloud-provider-test-stack-id
+            GRAFANA_CLOUD_PROVIDER_URL=cloudprovider-tests:url
+            GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN=cloudprovider-tests:access-token
+            GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN=cloudprovider-tests:aws-role-arn
+            GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID=cloudprovider-tests:test-stack-id
       - uses: iFaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866 # v1.2.1
         with:
           resource: ${{ env.GRAFANA_URL }}

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -44,6 +44,7 @@ jobs:
             GRAFANA_SM_URL=cloud-instance-tests:sm-url
             GRAFANA_URL=cloud-instance-tests:url
             GRAFANA_CLOUD_PROVIDER_URL=cloudprovider-tests:url
+            GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID=cloudprovider-tests:test-aws-account-resource-id
             GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN=cloudprovider-tests:access-token
             GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN=cloudprovider-tests:aws-role-arn
             GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID=cloudprovider-tests:test-stack-id

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -43,6 +43,10 @@ jobs:
             GRAFANA_SM_ACCESS_TOKEN=cloud-instance-tests:sm-token
             GRAFANA_SM_URL=cloud-instance-tests:sm-url
             GRAFANA_URL=cloud-instance-tests:url
+            GRAFANA_CLOUD_PROVIDER_URL=cloud-instance-tests:cloud-provider-url
+            GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN=cloud-instance-tests:cloud-provider-access-token
+            GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN=cloud-instance-tests:cloud-provider-aws-role-arn
+            GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID=cloud-instance-tests:cloud-provider-test-stack-id
       - uses: iFaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866 # v1.2.1
         with:
           resource: ${{ env.GRAFANA_URL }}

--- a/internal/resources/cloudprovider/data_source_aws_account_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_account_test.go
@@ -1,41 +1,23 @@
 package cloudprovider_test
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
-	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common/cloudproviderapi"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAccDataSourceAWSAccount(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	// Uses a pre-existing account resource so that we don't need to create a new one for every test run
-	accountID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID")
-	require.NotEmpty(t, accountID, "GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID must be set")
-
-	roleARN := os.Getenv("GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN")
-	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN must be set")
-
-	stackID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID")
-	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID must be set")
-
-	// Make sure the account exists and matches the role ARN we expect for testing
-	client := testutils.Provider.Meta().(*common.Client).CloudProviderAPI
-	gotAccount, err := client.GetAWSAccount(context.Background(), stackID, accountID)
-	require.NoError(t, err)
-	require.Equal(t, roleARN, gotAccount.RoleARN)
+	testCfg := makeTestConfig(t)
 
 	account := cloudproviderapi.AWSAccount{
-		ID:      accountID,
-		RoleARN: roleARN,
+		ID:      testCfg.accountID,
+		RoleARN: testCfg.roleARN,
 		Regions: []string{"us-east-1", "us-east-2", "us-west-1"},
 	}
 
@@ -43,9 +25,9 @@ func TestAccDataSourceAWSAccount(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: awsAccountDataSourceData(stackID, account),
+				Config: awsAccountDataSourceData(testCfg.stackID, account),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "stack_id", stackID),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "stack_id", testCfg.stackID),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "resource_id", account.ID),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "role_arn", account.RoleARN),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "regions.#", strconv.Itoa(len(account.Regions))),

--- a/internal/resources/cloudprovider/data_source_aws_account_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_account_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccDataSourceAWSAccount(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	// Uses a pre-existing account resource so that we don't need to create a new one for every test run.
+	// Uses a pre-existing account resource so that we don't need to create a new one for every test run
 	accountID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID")
 	require.NotEmpty(t, accountID, "GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID must be set")
 

--- a/internal/resources/cloudprovider/data_source_aws_account_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_account_test.go
@@ -55,8 +55,8 @@ resource "grafana_cloud_provider_aws_account" "test" {
 }
 
 data "grafana_cloud_provider_aws_account" "test" {
-	stack_id    = grafana_cloud_stack.test.id
-	resource_id = grafana_cloud_provider_aws_account.test.id
+	stack_id    = "%[1]s"
+	resource_id = grafana_cloud_provider_aws_account.test.resource_id
 }
 `,
 		stackID,

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job_test.go
@@ -1,32 +1,61 @@
 package cloudprovider_test
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common/cloudproviderapi"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccDataSourceAWSCloudWatchScrapeJob(t *testing.T) {
-	t.Skip("Skipping test until we have a valid test case")
 	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	// Uses a pre-existing account resource so that we don't need to create a new account resource for every test run.
+	accountID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID")
+	require.NotEmpty(t, accountID, "GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID must be set")
+
+	roleARN := os.Getenv("GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN")
+	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN must be set")
+
+	stackID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID")
+	require.NotEmpty(t, stackID, "GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID must be set")
+
+	// Make sure the account exists and matches the role ARN we expect for testing
+	client := testutils.Provider.Meta().(*common.Client).CloudProviderAPI
+	gotAccount, err := client.GetAWSAccount(context.Background(), stackID, accountID)
+	require.NoError(t, err)
+	require.Equal(t, roleARN, gotAccount.RoleARN)
+
+	var gotJob cloudproviderapi.AWSCloudWatchScrapeJobResponse
+
+	jobName := "test-job" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy: func() resource.TestCheckFunc {
-			return func(s *terraform.State) error {
-				return nil
-			}
-		}(),
 		Steps: []resource.TestStep{
 			{
-				Config: awsCloudWatchScrapeJobDataSourceData(),
+				Config: awsCloudWatchScrapeJobResourceData(stackID,
+					jobName,
+					false,
+					accountID,
+					regionsString(testAWSCloudWatchScrapeJobData.RegionsSubsetOverride),
+					servicesString(testAWSCloudWatchScrapeJobData.Services),
+					customNamespacesString(testAWSCloudWatchScrapeJobData.CustomNamespaces),
+				) + awsCloudWatchScrapeJobDataSourceData(stackID, jobName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "stack_id", testStackID),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "name", testAWSCloudWatchScrapeJobData.Name),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "aws_account_resource_id", testAWSCloudWatchScrapeJobData.AWSAccountResourceID),
+					checkAWSCloudWatchScrapeJobResourceExists("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", stackID, &gotJob),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "stack_id", stackID),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "name", jobName),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "enabled", "false"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "disabled_reason", "disabled_by_user"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "aws_account_resource_id", accountID),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "regions.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.RegionsSubsetOverride))),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "regions.0", testAWSCloudWatchScrapeJobData.RegionsSubsetOverride[0]),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "regions.1", testAWSCloudWatchScrapeJobData.RegionsSubsetOverride[1]),
@@ -55,18 +84,19 @@ func TestAccDataSourceAWSCloudWatchScrapeJob(t *testing.T) {
 				),
 			},
 		},
+		CheckDestroy: checkAWSCloudWatchScrapeJobResourceDestroy(stackID, &gotJob),
 	})
 }
 
-func awsCloudWatchScrapeJobDataSourceData() string {
+func awsCloudWatchScrapeJobDataSourceData(stackID string, jobName string) string {
 	data := fmt.Sprintf(`
 data "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 	stack_id = "%[1]s"
 	name = "%[2]s"
 }
 `,
-		testStackID,
-		testAWSCloudWatchScrapeJobData.Name,
+		stackID,
+		jobName,
 	)
 
 	return data

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job_test.go
@@ -112,7 +112,7 @@ func awsCloudWatchScrapeJobDataSourceData(stackID string, jobName string) string
 	data := fmt.Sprintf(`
 data "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 	stack_id = "%[1]s"
-	name = "%[2]s"
+	name = grafana_cloud_provider_aws_cloudwatch_scrape_job.test.name
 }
 `,
 		stackID,

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job_test.go
@@ -10,14 +10,11 @@ import (
 )
 
 func TestAccDataSourceAWSCloudWatchScrapeJob(t *testing.T) {
-	// TODO(tristan): switch to CloudInstanceTestsEnabled
-	// as part of https://github.com/grafana/grafana-aws-app/issues/381
-	t.Skip("not yet implemented. see TODO comment.")
-	// testutils.CheckCloudInstanceTestsEnabled(t)
+	t.Skip("Skipping test until we have a valid test case")
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		// TODO(tristan): actually check for resource existence
 		CheckDestroy: func() resource.TestCheckFunc {
 			return func(s *terraform.State) error {
 				return nil

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
@@ -10,14 +10,11 @@ import (
 )
 
 func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
-	// TODO(tristan): switch to CloudInstanceTestsEnabled
-	// as part of https://github.com/grafana/grafana-aws-app/issues/381
-	t.Skip("not yet implemented. see TODO comment.")
-	// testutils.CheckCloudInstanceTestsEnabled(t)
+	t.Skip("Skipping test until we have a valid test case")
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		// TODO(tristan): actually check for resource existence
 		CheckDestroy: func() resource.TestCheckFunc {
 			return func(s *terraform.State) error {
 				return nil

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
@@ -94,6 +94,7 @@ func awsCloudWatchScrapeJobsDataSourceData(stackID string) string {
 	data := fmt.Sprintf(`
 data "grafana_cloud_provider_aws_cloudwatch_scrape_jobs" "test" {
 	stack_id = "%[1]s"
+	depends_on = [grafana_cloud_provider_aws_cloudwatch_scrape_job.test]
 }
 `,
 		stackID,

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	// Uses a pre-existing account resource so that we don't need to create a new one for every test run.
+	// Uses a pre-existing account resource so that we don't need to create a new one for every test run
 	accountID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID")
 	require.NotEmpty(t, accountID, "GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID must be set")
 
@@ -45,7 +45,7 @@ func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 					jobName,
 					false,
 					accountID,
-					regionsString(testAWSCloudWatchScrapeJobData.RegionsSubsetOverride),
+					regionsString(testAWSCloudWatchScrapeJobData.Regions),
 					servicesString(testAWSCloudWatchScrapeJobData.Services),
 					customNamespacesString(testAWSCloudWatchScrapeJobData.CustomNamespaces),
 				) + awsCloudWatchScrapeJobsDataSourceData(stackID),
@@ -58,12 +58,12 @@ func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "scrape_job.0.enabled", "false"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "scrape_job.0.disabled_reason", "disabled_by_user"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.aws_account_resource_id", accountID),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.RegionsSubsetOverride))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.0", testAWSCloudWatchScrapeJobData.RegionsSubsetOverride[0]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.1", testAWSCloudWatchScrapeJobData.RegionsSubsetOverride[1]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.2", testAWSCloudWatchScrapeJobData.RegionsSubsetOverride[2]),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Regions))),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.0", testAWSCloudWatchScrapeJobData.Regions[0]),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.1", testAWSCloudWatchScrapeJobData.Regions[1]),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.2", testAWSCloudWatchScrapeJobData.Regions[2]),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions_subset_override_used", "true"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.export_tags", fmt.Sprintf("%t", testAWSCloudWatchScrapeJobData.ExportTags)),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.disabled_reason", ""),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services))),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.name", testAWSCloudWatchScrapeJobData.Services[0].Name),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.metric.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services[0].Metrics))),

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
@@ -1,38 +1,20 @@
 package cloudprovider_test
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
-	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common/cloudproviderapi"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	// Uses a pre-existing account resource so that we don't need to create a new one for every test run
-	accountID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID")
-	require.NotEmpty(t, accountID, "GRAFANA_CLOUD_PROVIDER_TEST_AWS_ACCOUNT_RESOURCE_ID must be set")
-
-	roleARN := os.Getenv("GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN")
-	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN must be set")
-
-	stackID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID")
-	require.NotEmpty(t, stackID, "GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID must be set")
-
-	// Make sure the account exists and matches the role ARN we expect for testing
-	client := testutils.Provider.Meta().(*common.Client).CloudProviderAPI
-	gotAccount, err := client.GetAWSAccount(context.Background(), stackID, accountID)
-	require.NoError(t, err)
-	require.Equal(t, roleARN, gotAccount.RoleARN)
+	testCfg := makeTestConfig(t)
 
 	var gotJob cloudproviderapi.AWSCloudWatchScrapeJobResponse
 
@@ -42,18 +24,18 @@ func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: awsCloudWatchScrapeJobResourceData(stackID,
+				Config: awsCloudWatchScrapeJobResourceData(testCfg.stackID,
 					jobName,
 					false,
-					accountID,
+					testCfg.accountID,
 					regionsString(testAWSCloudWatchScrapeJobData.Regions),
 					servicesString(testAWSCloudWatchScrapeJobData.Services),
 					customNamespacesString(testAWSCloudWatchScrapeJobData.CustomNamespaces),
-				) + awsCloudWatchScrapeJobsDataSourceData(stackID),
+				) + awsCloudWatchScrapeJobsDataSourceData(testCfg.stackID),
 				Check: resource.ComposeTestCheckFunc(
-					checkAWSCloudWatchScrapeJobResourceExists("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", stackID, &gotJob),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "id", stackID),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "stack_id", stackID),
+					checkAWSCloudWatchScrapeJobResourceExists("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", testCfg.stackID, &gotJob),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "id", testCfg.stackID),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "stack_id", testCfg.stackID),
 					resource.TestCheckResourceAttrWith("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.#", func(v string) error {
 						if got, err := strconv.Atoi(v); err != nil || got == 0 {
 							return fmt.Errorf("expected at least one scrape job")
@@ -63,7 +45,7 @@ func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 				),
 			},
 		},
-		CheckDestroy: checkAWSCloudWatchScrapeJobResourceDestroy(stackID, &gotJob),
+		CheckDestroy: checkAWSCloudWatchScrapeJobResourceDestroy(testCfg.stackID, &gotJob),
 	})
 }
 

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
@@ -50,39 +51,15 @@ func TestAccDataSourceAWSCloudWatchScrapeJobs(t *testing.T) {
 					customNamespacesString(testAWSCloudWatchScrapeJobData.CustomNamespaces),
 				) + awsCloudWatchScrapeJobsDataSourceData(stackID),
 				Check: resource.ComposeTestCheckFunc(
+					checkAWSCloudWatchScrapeJobResourceExists("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", stackID, &gotJob),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "id", stackID),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "stack_id", stackID),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.#", "1"),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.stack_id", stackID),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.name", jobName),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "scrape_job.0.enabled", "false"),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "scrape_job.0.disabled_reason", "disabled_by_user"),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.aws_account_resource_id", accountID),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Regions))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.0", testAWSCloudWatchScrapeJobData.Regions[0]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.1", testAWSCloudWatchScrapeJobData.Regions[1]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions.2", testAWSCloudWatchScrapeJobData.Regions[2]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.regions_subset_override_used", "true"),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.export_tags", fmt.Sprintf("%t", testAWSCloudWatchScrapeJobData.ExportTags)),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.name", testAWSCloudWatchScrapeJobData.Services[0].Name),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.metric.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services[0].Metrics))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.metric.0.name", testAWSCloudWatchScrapeJobData.Services[0].Metrics[0].Name),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.metric.0.statistics.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services[0].Metrics[0].Statistics))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.metric.0.statistics.0", testAWSCloudWatchScrapeJobData.Services[0].Metrics[0].Statistics[0]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.scrape_interval_seconds", fmt.Sprintf("%d", testAWSCloudWatchScrapeJobData.Services[0].ScrapeIntervalSeconds)),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.resource_discovery_tag_filter.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services[0].ResourceDiscoveryTagFilters))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.resource_discovery_tag_filter.0.key", testAWSCloudWatchScrapeJobData.Services[0].ResourceDiscoveryTagFilters[0].Key),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.resource_discovery_tag_filter.0.value", testAWSCloudWatchScrapeJobData.Services[0].ResourceDiscoveryTagFilters[0].Value),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.tags_to_add_to_metrics.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services[0].TagsToAddToMetrics))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.service.0.tags_to_add_to_metrics.0", testAWSCloudWatchScrapeJobData.Services[0].TagsToAddToMetrics[0]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.CustomNamespaces))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.0.name", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Name),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.0.metric.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.0.metric.0.name", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics[0].Name),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.0.metric.0.statistics.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics[0].Statistics))),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.0.metric.0.statistics.0", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics[0].Statistics[0]),
-					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.0.custom_namespace.0.scrape_interval_seconds", fmt.Sprintf("%d", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].ScrapeIntervalSeconds)),
+					resource.TestCheckResourceAttrWith("data.grafana_cloud_provider_aws_cloudwatch_scrape_jobs.test", "scrape_job.#", func(v string) error {
+						if got, err := strconv.Atoi(v); err != nil || got == 0 {
+							return fmt.Errorf("expected at least one scrape job")
+						}
+						return nil
+					}),
 				),
 			},
 		},

--- a/internal/resources/cloudprovider/resource_aws_account_test.go
+++ b/internal/resources/cloudprovider/resource_aws_account_test.go
@@ -1,57 +1,112 @@
 package cloudprovider_test
 
 import (
-	"bytes"
+	"context"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common/cloudproviderapi"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
 )
 
-var testAWSAccountData = struct {
-	StackID string
-	RoleARN string
-	Regions []string
-}{
-	StackID: "001",
-	RoleARN: "arn:aws:iam::123456789012:role/my-role-1a",
-	Regions: []string{"us-east-1", "us-east-2", "us-west-1"},
-}
-
 func TestAccResourceAWSAccount(t *testing.T) {
-	// TODO(tristan): switch to CloudInstanceTestsEnabled
-	// as part of https://github.com/grafana/grafana-aws-app/issues/381
-	t.Skip("not yet implemented. see TODO comment.")
-	// testutils.CheckCloudInstanceTestsEnabled(t)
+	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	roleARN := os.Getenv("GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN")
+	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN must be set")
+
+	stackID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID")
+	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_TEST_STACK_IDmust be set")
+
+	account := cloudproviderapi.AWSAccount{
+		RoleARN: roleARN,
+		Regions: []string{"us-east-1", "us-east-2", "us-west-1"},
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		// TODO(tristan): actually check for resource existence
-		CheckDestroy: func() resource.TestCheckFunc {
-			return func(s *terraform.State) error {
-				return nil
-			}
-		}(),
 		Steps: []resource.TestStep{
 			{
-				Config: awsAccountResourceData(),
+				Config: awsAccountResourceData(stackID, account),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "stack_id", testAWSAccountData.StackID),
-					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "role_arn", testAWSAccountData.RoleARN),
-					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.#", strconv.Itoa(len(testAWSAccountData.Regions))),
-					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.0", testAWSAccountData.Regions[0]),
-					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.1", testAWSAccountData.Regions[1]),
-					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.2", testAWSAccountData.Regions[2]),
+					checkAWSAccountResourceExists("grafana_cloud_provider_aws_account.test", stackID, &account),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "stack_id", stackID),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "role_arn", account.RoleARN),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.#", strconv.Itoa(len(account.Regions))),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.0", account.Regions[0]),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.1", account.Regions[1]),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.2", account.Regions[2]),
 				),
 			},
+			{
+				ResourceName:      "grafana_cloud_provider_aws_account.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
+		CheckDestroy: checkAWSAccountResourceDestroy(stackID, &account),
 	})
 }
 
-func awsAccountResourceData() string {
+func checkAWSAccountResourceExists(rn string, stackID string, account *cloudproviderapi.AWSAccount) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		parts := strings.SplitN(rs.Primary.ID, ":", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("Invalid ID: %s", rs.Primary.ID)
+		}
+		accountID := parts[1]
+
+		if accountID == "" {
+			return fmt.Errorf("account id not set")
+		}
+
+		client := testutils.Provider.Meta().(*common.Client).CloudProviderAPI
+		gotAccount, err := client.GetAWSAccount(context.Background(), stackID, accountID)
+		if err != nil {
+			return fmt.Errorf("error getting account: %s", err)
+		}
+
+		*account = gotAccount
+
+		return nil
+	}
+}
+
+func checkAWSAccountResourceDestroy(stackID string, account *cloudproviderapi.AWSAccount) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if account.ID == "" {
+			return fmt.Errorf("checking deletion of empty account id")
+		}
+
+		client := testutils.Provider.Meta().(*common.Client).CloudProviderAPI
+		_, err := client.GetAWSAccount(context.Background(), stackID, account.ID)
+		if err == nil {
+			return fmt.Errorf("account still exists")
+		} else if !common.IsNotFoundError(err) {
+			return fmt.Errorf("unexpected error retrieving account: %s", err)
+		}
+
+		return nil
+	}
+}
+
+func awsAccountResourceData(stackID string, account cloudproviderapi.AWSAccount) string {
 	return fmt.Sprintf(`
 resource "grafana_cloud_provider_aws_account" "test" {
 	stack_id = "%[1]s"
@@ -59,17 +114,8 @@ resource "grafana_cloud_provider_aws_account" "test" {
 	regions = [%[3]s]
 }
 `,
-		testAWSAccountData.StackID,
-		testAWSAccountData.RoleARN,
-		regionsString(testAWSAccountData.Regions),
+		stackID,
+		account.RoleARN,
+		regionsString(account.Regions),
 	)
-}
-
-func regionsString(regions []string) string {
-	b := new(bytes.Buffer)
-	for _, region := range regions {
-		fmt.Fprintf(b, "\n\t\t\"%s\",", region)
-	}
-	fmt.Fprintf(b, "\n\t")
-	return b.String()
 }

--- a/internal/resources/cloudprovider/resource_aws_account_test.go
+++ b/internal/resources/cloudprovider/resource_aws_account_test.go
@@ -23,12 +23,13 @@ func TestAccResourceAWSAccount(t *testing.T) {
 	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN must be set")
 
 	stackID := os.Getenv("GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID")
-	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_TEST_STACK_IDmust be set")
+	require.NotEmpty(t, roleARN, "GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID must be set")
 
 	account := cloudproviderapi.AWSAccount{
 		RoleARN: roleARN,
 		Regions: []string{"us-east-1", "us-east-2", "us-west-1"},
 	}
+	var gotAccount cloudproviderapi.AWSAccount
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
@@ -36,7 +37,7 @@ func TestAccResourceAWSAccount(t *testing.T) {
 			{
 				Config: awsAccountResourceData(stackID, account),
 				Check: resource.ComposeTestCheckFunc(
-					checkAWSAccountResourceExists("grafana_cloud_provider_aws_account.test", stackID, &account),
+					checkAWSAccountResourceExists("grafana_cloud_provider_aws_account.test", stackID, &gotAccount),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "stack_id", stackID),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "role_arn", account.RoleARN),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.#", strconv.Itoa(len(account.Regions))),
@@ -51,7 +52,7 @@ func TestAccResourceAWSAccount(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		},
-		CheckDestroy: checkAWSAccountResourceDestroy(stackID, &account),
+		CheckDestroy: checkAWSAccountResourceDestroy(stackID, &gotAccount),
 	})
 }
 

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
@@ -1,7 +1,6 @@
 package cloudprovider_test
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,6 @@ const testStackID = "1"
 var testAWSCloudWatchScrapeJobData = cloudproviderapi.AWSCloudWatchScrapeJobRequest{
 	Name:                  "test-scrape-job",
 	Enabled:               true,
-	AWSAccountResourceID:  "2",
 	RegionsSubsetOverride: []string{"eu-west-1", "us-east-1", "us-east-2"},
 	ExportTags:            true,
 	Services: []cloudproviderapi.AWSCloudWatchService{
@@ -57,15 +55,11 @@ var testAWSCloudWatchScrapeJobData = cloudproviderapi.AWSCloudWatchScrapeJobRequ
 }
 
 func TestAccResourceAWSCloudWatchScrapeJob(t *testing.T) {
-	// TODO(tristan): switch to CloudInstanceTestsEnabled
-	// as part of https://github.com/grafana/grafana-aws-app/issues/381
-	t.Skip("not yet implemented. see TODO comment.")
-	// testutils.CheckCloudInstanceTestsEnabled(t)
+	t.Skip("Skipping test until we have a valid test case")
+	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	// TODO(tristan) import an existing account resource and stack to plug into the scrape job for tests
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		// TODO(tristan): actually check for resource existence
 		CheckDestroy: func() resource.TestCheckFunc {
 			return func(s *terraform.State) error {
 				return nil
@@ -241,114 +235,4 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 	)
 
 	return data
-}
-
-func servicesString(svcs []cloudproviderapi.AWSCloudWatchService) string {
-	if len(svcs) == 0 {
-		return ""
-	}
-	b := new(bytes.Buffer)
-	for _, svc := range svcs {
-		fmt.Fprintf(b, "\n\t\t")
-		fmt.Fprintf(b, `{
-			name = "%[1]s",
-			metrics = [%[2]s],
-			scrape_interval_seconds = %[3]d,
-			resource_discovery_tag_filters = [%[4]s],
-			tags_to_add_to_metrics = [%[5]s],
-		},`,
-			svc.Name,
-			metricsString(svc.Metrics),
-			svc.ScrapeIntervalSeconds,
-			tagFiltersString(svc.ResourceDiscoveryTagFilters),
-			tagsString(svc.TagsToAddToMetrics),
-		)
-	}
-	fmt.Fprintf(b, "\n\t\t")
-	return b.String()
-}
-
-func customNamespacesString(customNamespaces []cloudproviderapi.AWSCloudWatchCustomNamespace) string {
-	if len(customNamespaces) == 0 {
-		return ""
-	}
-	b := new(bytes.Buffer)
-	for _, customNamespace := range customNamespaces {
-		fmt.Fprintf(b, "\n\t\t")
-		fmt.Fprintf(b, `{
-			name = "%[1]s",
-			metrics = [%[2]s],
-			scrape_interval_seconds = %[3]d,
-		},`,
-			customNamespace.Name,
-			metricsString(customNamespace.Metrics),
-			customNamespace.ScrapeIntervalSeconds,
-		)
-	}
-	fmt.Fprintf(b, "\n\t\t")
-	return b.String()
-}
-
-func metricsString(metrics []cloudproviderapi.AWSCloudWatchMetric) string {
-	if len(metrics) == 0 {
-		return ""
-	}
-	b := new(bytes.Buffer)
-	for _, metric := range metrics {
-		fmt.Fprintf(b, "\n\t\t\t")
-		fmt.Fprintf(b, `{
-				name = "%[1]s",
-				statistics = [%[2]s],
-			},`,
-			metric.Name,
-			statisticsString(metric.Statistics),
-		)
-	}
-	fmt.Fprintf(b, "\n\t\t\t")
-	return b.String()
-}
-
-func statisticsString(stats []string) string {
-	if len(stats) == 0 {
-		return ""
-	}
-	b := new(bytes.Buffer)
-	fmt.Fprintf(b, "\n\t\t\t\t\t")
-	for _, stat := range stats {
-		fmt.Fprintf(b, "\"%s\",", stat)
-	}
-	fmt.Fprintf(b, "\n\t\t\t\t")
-	return b.String()
-}
-
-func tagFiltersString(filters []cloudproviderapi.AWSCloudWatchTagFilter) string {
-	if len(filters) == 0 {
-		return ""
-	}
-	b := new(bytes.Buffer)
-	fmt.Fprintf(b, "\n\t\t\t")
-	for _, filter := range filters {
-		fmt.Fprintf(b, `{
-				key = "%[1]s",
-				value = "%[2]s",
-			},`,
-			filter.Key,
-			filter.Value,
-		)
-	}
-	fmt.Fprintf(b, "\n\t\t\t")
-	return b.String()
-}
-
-func tagsString(tags []string) string {
-	if len(tags) == 0 {
-		return ""
-	}
-	b := new(bytes.Buffer)
-	fmt.Fprintf(b, "\n\t\t\t\t")
-	for _, tag := range tags {
-		fmt.Fprintf(b, "\"%s\",", tag)
-	}
-	fmt.Fprintf(b, "\n\t\t\t")
-	return b.String()
 }

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
@@ -183,8 +183,16 @@ func TestAccResourceAWSCloudWatchScrapeJob(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					// expect this to be stored in the state as an empty list, not null
-					resource.TestCheckResourceAttrSet("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service%"),
+					resource.TestCheckResourceAttrSet("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.#"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.#", "0"),
+
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.CustomNamespaces))),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.0.name", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Name),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.0.metric.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics))),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.0.metric.0.name", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics[0].Name),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.0.metric.0.statistics.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics[0].Statistics))),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.0.metric.0.statistics.0", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].Metrics[0].Statistics[0]),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.0.scrape_interval_seconds", fmt.Sprintf("%d", testAWSCloudWatchScrapeJobData.CustomNamespaces[0].ScrapeIntervalSeconds)),
 				),
 			},
 			// update to re-add services but unset optional custom namespaces field
@@ -192,14 +200,14 @@ func TestAccResourceAWSCloudWatchScrapeJob(t *testing.T) {
 				Config: awsCloudWatchScrapeJobResourceData(stackID,
 					jobName,
 					false,
-					testAWSCloudWatchScrapeJobData.AWSAccountResourceID,
+					accountID,
 					"",
 					servicesString(testAWSCloudWatchScrapeJobData.Services),
 					"",
 				),
 				Check: resource.ComposeTestCheckFunc(
 					// expect this to be stored in the state as an empty list, not null
-					resource.TestCheckResourceAttrSet("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.%"),
+					resource.TestCheckResourceAttrSet("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.#"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "custom_namespace.#", "0"),
 
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services))),
@@ -234,7 +242,7 @@ func TestAccResourceAWSCloudWatchScrapeJob(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.#", fmt.Sprintf("%d", len(testAWSCloudWatchScrapeJobData.Services))),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.0.name", testAWSCloudWatchScrapeJobData.Services[0].Name),
 					// expect this to be stored in the state as an empty list, not null
-					resource.TestCheckResourceAttrSet("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.0.tags_to_add_to_metrics"),
+					resource.TestCheckResourceAttrSet("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.0.tags_to_add_to_metrics.#"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_cloudwatch_scrape_job.test", "service.0.tags_to_add_to_metrics.#", "0"),
 				),
 			},

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
@@ -255,7 +255,16 @@ func checkAWSCloudWatchScrapeJobResourceExists(rn string, stackID string, job *c
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return fmt.Errorf("Invalid ID: %s", rs.Primary.ID)
 		}
+		gotStackID := parts[0]
 		jobName := parts[1]
+
+		if gotStackID == "" {
+			return fmt.Errorf("stack id not set")
+		}
+
+		if gotStackID != stackID {
+			return fmt.Errorf("stack id mismatch, expected %s, but %s was in the TF state", stackID, gotStackID)
+		}
 
 		if jobName == "" {
 			return fmt.Errorf("jobName not set")

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job_test.go
@@ -305,10 +305,10 @@ func awsCloudWatchScrapeJobResourceData(stackID string, jobName string, enabled 
 resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
   stack_id = "%[1]s"
   name = "%[2]s"
-	enabled = %[3]t
+  enabled = %[3]t
   aws_account_resource_id = "%[4]s"
   regions_subset_override = [%[5]s]
-	export_tags = true
+  export_tags = true
   dynamic "service" {
     for_each = [%[6]s]
     content {

--- a/internal/resources/cloudprovider/utils_test.go
+++ b/internal/resources/cloudprovider/utils_test.go
@@ -1,0 +1,127 @@
+package cloudprovider_test
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/grafana/terraform-provider-grafana/v3/internal/common/cloudproviderapi"
+)
+
+func regionsString(regions []string) string {
+	b := new(bytes.Buffer)
+	for _, region := range regions {
+		fmt.Fprintf(b, "\n\t\t\"%s\",", region)
+	}
+	fmt.Fprintf(b, "\n\t")
+	return b.String()
+}
+
+func servicesString(svcs []cloudproviderapi.AWSCloudWatchService) string {
+	if len(svcs) == 0 {
+		return ""
+	}
+	b := new(bytes.Buffer)
+	for _, svc := range svcs {
+		fmt.Fprintf(b, "\n\t\t")
+		fmt.Fprintf(b, `{
+			name = "%[1]s",
+			metrics = [%[2]s],
+			scrape_interval_seconds = %[3]d,
+			resource_discovery_tag_filters = [%[4]s],
+			tags_to_add_to_metrics = [%[5]s],
+		},`,
+			svc.Name,
+			metricsString(svc.Metrics),
+			svc.ScrapeIntervalSeconds,
+			tagFiltersString(svc.ResourceDiscoveryTagFilters),
+			tagsString(svc.TagsToAddToMetrics),
+		)
+	}
+	fmt.Fprintf(b, "\n\t\t")
+	return b.String()
+}
+
+func customNamespacesString(customNamespaces []cloudproviderapi.AWSCloudWatchCustomNamespace) string {
+	if len(customNamespaces) == 0 {
+		return ""
+	}
+	b := new(bytes.Buffer)
+	for _, customNamespace := range customNamespaces {
+		fmt.Fprintf(b, "\n\t\t")
+		fmt.Fprintf(b, `{
+			name = "%[1]s",
+			metrics = [%[2]s],
+			scrape_interval_seconds = %[3]d,
+		},`,
+			customNamespace.Name,
+			metricsString(customNamespace.Metrics),
+			customNamespace.ScrapeIntervalSeconds,
+		)
+	}
+	fmt.Fprintf(b, "\n\t\t")
+	return b.String()
+}
+
+func metricsString(metrics []cloudproviderapi.AWSCloudWatchMetric) string {
+	if len(metrics) == 0 {
+		return ""
+	}
+	b := new(bytes.Buffer)
+	for _, metric := range metrics {
+		fmt.Fprintf(b, "\n\t\t\t")
+		fmt.Fprintf(b, `{
+				name = "%[1]s",
+				statistics = [%[2]s],
+			},`,
+			metric.Name,
+			statisticsString(metric.Statistics),
+		)
+	}
+	fmt.Fprintf(b, "\n\t\t\t")
+	return b.String()
+}
+
+func statisticsString(stats []string) string {
+	if len(stats) == 0 {
+		return ""
+	}
+	b := new(bytes.Buffer)
+	fmt.Fprintf(b, "\n\t\t\t\t\t")
+	for _, stat := range stats {
+		fmt.Fprintf(b, "\"%s\",", stat)
+	}
+	fmt.Fprintf(b, "\n\t\t\t\t")
+	return b.String()
+}
+
+func tagFiltersString(filters []cloudproviderapi.AWSCloudWatchTagFilter) string {
+	if len(filters) == 0 {
+		return ""
+	}
+	b := new(bytes.Buffer)
+	fmt.Fprintf(b, "\n\t\t\t")
+	for _, filter := range filters {
+		fmt.Fprintf(b, `{
+				key = "%[1]s",
+				value = "%[2]s",
+			},`,
+			filter.Key,
+			filter.Value,
+		)
+	}
+	fmt.Fprintf(b, "\n\t\t\t")
+	return b.String()
+}
+
+func tagsString(tags []string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	b := new(bytes.Buffer)
+	fmt.Fprintf(b, "\n\t\t\t\t")
+	for _, tag := range tags {
+		fmt.Fprintf(b, "\"%s\",", tag)
+	}
+	fmt.Fprintf(b, "\n\t\t\t")
+	return b.String()
+}

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -190,11 +190,10 @@ func CheckCloudInstanceTestsEnabled(t *testing.T) {
 		"GRAFANA_AUTH",
 		"GRAFANA_SM_ACCESS_TOKEN",
 		"GRAFANA_ONCALL_ACCESS_TOKEN",
-		// TODO(tristan): uncomment as part of implementing
-		// cloud acceptance tests.
-		// See https://github.com/grafana/grafana-aws-app/issues/381
-		// "GRAFANA_CLOUD_PROVIDER_URL",
-		// "GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN",
+		"GRAFANA_CLOUD_PROVIDER_URL",
+		"GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN",
+		"GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN",
+		"GRAFANA_CLOUD_PROVIDER_TEST_STACK_ID",
 	)
 }
 


### PR DESCRIPTION
this PR implements https://github.com/grafana/grafana-csp-app/issues/63
it adds acceptance tests for major provider functionality for creating Grafana AWS Account resources and CloudWatch Scrape Jobs for the Grafana Cloud Provider app.