### PR TITLE
Cloud: ensure region is a non-empty string on access policies and tokens

### DIFF
--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -74,10 +74,11 @@ Required access policy scopes:
 
 		Schema: map[string]*schema.Schema{
 			"region": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Region where the API is deployed. Generally where the stack is deployed. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Region where the API is deployed. Generally where the stack is deployed. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -49,10 +49,11 @@ Required access policy scopes:
 				Description: "ID of the access policy for which to create a token.",
 			},
 			"region": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Region of the access policy. Should be set to the same region as the access policy. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Region of the access policy. Should be set to the same region as the access policy. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -140,19 +140,16 @@ func updateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, c
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	id := split[1].(string)
-	region := d.Get("region").(string)
+	region, id := split[0], split[1]
 
 	displayName := d.Get("display_name").(string)
 	if displayName == "" {
 		displayName = d.Get("name").(string)
 	}
 
-	tokenInput := gcom.PostTokenRequest{
+	req := client.TokensAPI.PostToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).PostTokenRequest(gcom.PostTokenRequest{
 		DisplayName: &displayName,
-	}
-
-	req := client.TokensAPI.PostToken(ctx, id).Region(region).XRequestId(ClientRequestID()).PostTokenRequest(tokenInput)
+	})
 	if _, _, err := req.Execute(); err != nil {
 		return apiError(err)
 	}

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -140,16 +140,19 @@ func updateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, c
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	region, id := split[0], split[1]
+	id := split[1].(string)
+	region := d.Get("region").(string)
 
 	displayName := d.Get("display_name").(string)
 	if displayName == "" {
 		displayName = d.Get("name").(string)
 	}
 
-	req := client.TokensAPI.PostToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).PostTokenRequest(gcom.PostTokenRequest{
+	tokenInput := gcom.PostTokenRequest{
 		DisplayName: &displayName,
-	})
+	}
+
+	req := client.TokensAPI.PostToken(ctx, id).Region(region).XRequestId(ClientRequestID()).PostTokenRequest(tokenInput)
 	if _, _, err := req.Execute(); err != nil {
 		return apiError(err)
 	}


### PR DESCRIPTION
In Crossplane I'm observing an update request where the `region` field is missing, the API then returns a 409 Conflict.

The Crossplane provider does this on replacing a token:

1. DELETE - deleteCloudAccessPolicyToken - 204
2. POST - createCloudAccessPolicyToken - 409
3. GET - readCloudAccessPolicyToken - 404
4. POST - createCloudAccessPolicyToken - 200
5. GET - readCloudAccessPolicyToken - 200


The 409 response looks like this:

```
409 Conflict
{
  "code": "InvalidArgument",
  "message": "Field is required: region",
  "requestId": "effc73b1-7c5c-430d-96b0-b0c4764eb7a6"
}
```

Screenshot (logs in reverse order):

![2024-11-05_103524_922x222_scrot](https://github.com/user-attachments/assets/ea894b31-d730-4e1d-bb09-5bb5e2570b9e)


Related: https://github.com/grafana/crossplane-provider-grafana/issues/178