### PR TITLE
Fix ID used to reference `grafana_cloud_provider_aws_account`

### DIFF
--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -83,7 +83,7 @@ data "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 
 ### Read-Only
 
-- `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `id` attribute of the `grafana_cloud_provider_aws_account` resource.
+- `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `resource_id` attribute of the `grafana_cloud_provider_aws_account` resource.
 - `custom_namespace` (Block List) Zero or more configuration blocks to configure custom namespaces for the CloudWatch Scrape Job to scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--custom_namespace))
 - `disabled_reason` (String) When the CloudWatch Scrape Job is disabled, this will show the reason that it is in that state.
 - `enabled` (Boolean) Whether the CloudWatch Scrape Job is enabled or not.

--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
@@ -39,7 +39,7 @@ data "grafana_cloud_provider_aws_cloudwatch_scrape_jobs" "test" {
 
 Read-Only:
 
-- `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `id` attribute of the `grafana_cloud_provider_aws_account` resource.
+- `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `resource_id` attribute of the `grafana_cloud_provider_aws_account` resource.
 - `custom_namespace` (Block List) Zero or more configuration blocks to configure custom namespaces for the CloudWatch Scrape Job to scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--scrape_job--custom_namespace))
 - `disabled_reason` (String) When the CloudWatch Scrape Job is disabled, this will show the reason that it is in that state.
 - `enabled` (Boolean) Whether the CloudWatch Scrape Job is enabled or not.

--- a/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -71,7 +71,7 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 
 ### Required
 
-- `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `id` attribute of the `grafana_cloud_provider_aws_account` resource.
+- `aws_account_resource_id` (String) The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `resource_id` attribute of the `grafana_cloud_provider_aws_account` resource.
 - `name` (String) The name of the CloudWatch Scrape Job. Part of the Terraform Resource ID.
 - `stack_id` (String) The Stack ID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
@@ -32,7 +32,7 @@ var (
 				Computed:    true,
 			},
 			"aws_account_resource_id": schema.StringAttribute{
-				Description: "The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `id` attribute of the `grafana_cloud_provider_aws_account` resource.",
+				Description: "The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `resource_id` attribute of the `grafana_cloud_provider_aws_account` resource.",
 				Computed:    true,
 			},
 			"role_arn": schema.StringAttribute{

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
@@ -92,7 +92,7 @@ func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource
 				Default:     booldefault.StaticBool(true),
 			},
 			"aws_account_resource_id": schema.StringAttribute{
-				Description: "The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `id` attribute of the `grafana_cloud_provider_aws_account` resource.",
+				Description: "The ID assigned by the Grafana Cloud Provider API to an AWS Account resource that should be associated with this CloudWatch Scrape Job. This can be provided by the `resource_id` attribute of the `grafana_cloud_provider_aws_account` resource.",
 				Required:    true,
 			},
 			"regions_subset_override": schema.SetAttribute{


### PR DESCRIPTION
This PR does a tiny fix to change the id that's used to reference a `grafana_cloud_provider_aws_account` resource created in the same snippet as a `grafana_cloud_provider_aws_cloudwatch_scrape_job`.
