### PR TITLE
Teams: `resource_team` Add UID to teams for reads

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -52,6 +52,7 @@ to the team. Note: users specified here must already exist in Grafana.
 - `team_sync` (List of Object) Sync external auth provider groups with this Grafana team. Only available in Grafana Enterprise.
 	* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/)
 	* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team_sync/) (see [below for nested schema](#nestedatt--team_sync))
+- `team_uid` (String) The team uid assigned to this team by Grafana.
 
 <a id="nestedatt--preferences"></a>
 ### Nested Schema for `preferences`

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -55,6 +55,7 @@ to the team. Note: users specified here must already exist in Grafana.
 
 - `id` (String) The ID of this resource.
 - `team_id` (Number) The team id assigned to this team by Grafana.
+- `team_uid` (String) The team uid assigned to this team by Grafana.
 
 <a id="nestedblock--preferences"></a>
 ### Nested Schema for `preferences`

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -55,6 +55,11 @@ func resourceTeam() *common.Resource {
 				Computed:    true,
 				Description: "The team id assigned to this team by Grafana.",
 			},
+			"team_uid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The team uid assigned to this team by Grafana.",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -234,6 +239,7 @@ func readTeamFromID(client *goapi.GrafanaHTTPAPI, teamID int64, d *schema.Resour
 
 	d.SetId(MakeOrgResourceID(team.OrgID, teamID))
 	d.Set("team_id", teamID)
+	d.Set("team_uid", team.UID)
 	d.Set("name", team.Name)
 	d.Set("org_id", strconv.FormatInt(team.OrgID, 10))
 	if team.Email != "" {


### PR DESCRIPTION
Adds the UID to be read from the resource
This enables lbac_rules to read the UIDs from teams.

Enables adding the resource `data_source_config_lbac_rules` - https://github.com/grafana/grafana-enterprise/pull/7469