### PR TITLE
SSO: Add entity_id to SAML provider settings

### DIFF
--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -265,6 +265,7 @@ Optional:
 - `client_id` (String) The client Id of your OAuth2 app.
 - `client_secret` (String) The client secret of your OAuth2 app.
 - `enabled` (Boolean) Define whether this configuration is enabled for SAML. Defaults to `true`.
+- `entity_id` (String) The entity ID is a globally unique identifier for the service provider. It is used to identify the service provider to the identity provider. Defaults to the URL of the Grafana instance if not set.
 - `force_use_graph_api` (Boolean) If enabled, Grafana will fetch groups from Microsoft Graph API instead of using the groups claim from the ID token.
 - `idp_metadata` (String) Base64-encoded string for the IdP SAML metadata XML.
 - `idp_metadata_path` (String) Path for the IdP SAML metadata XML.

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -309,6 +309,11 @@ var samlSettingsSchema = &schema.Resource{
 			Optional:    true,
 			Description: "Name used to refer to the SAML authentication.",
 		},
+		"entity_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The entity ID is a globally unique identifier for the service provider. It is used to identify the service provider to the identity provider. Defaults to the URL of the Grafana instance if not set.",
+		},
 		"single_logout": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/internal/resources/grafana/resource_sso_settings_test.go
+++ b/internal/resources/grafana/resource_sso_settings_test.go
@@ -91,6 +91,7 @@ func TestSSOSettings_basic_saml(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.idp_metadata_url", "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.signature_algorithm", "rsa-sha256"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.metadata_valid_duration", "24h"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.entity_id", "https://custom-entity-id.com"),
 				),
 			},
 			{
@@ -446,6 +447,7 @@ const testConfigForSamlProvider = `resource "grafana_sso_settings" "saml_sso_set
     idp_metadata_url        = "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"
     signature_algorithm     = "rsa-sha256"
     metadata_valid_duration = "24h"
+	entity_id               = "https://custom-entity-id.com"
   }
 }`
 


### PR DESCRIPTION
Add `entity_id` to SAML provider settings.