### PR TITLE
Add zendesk on-call integration types

### DIFF
--- a/docs/resources/oncall_integration.md
+++ b/docs/resources/oncall_integration.md
@@ -51,7 +51,7 @@ resource "grafana_oncall_integration" "integration_with_templates" {
 
 - `default_route` (Block List, Min: 1, Max: 1) The Default route for all alerts from the given integration (see [below for nested schema](#nestedblock--default_route))
 - `name` (String) The name of the service integration.
-- `type` (String) The type of integration. Can be grafana, grafana_alerting, webhook, alertmanager, kapacitor, fabric, newrelic, datadog, pagerduty, pingdom, elastalert, amazon_sns, curler, sentry, formatted_webhook, heartbeat, demo, manual, stackdriver, uptimerobot, sentry_platform, zabbix, prtg, slack_channel, inbound_email, direct_paging, jira.
+- `type` (String) The type of integration. Can be grafana, grafana_alerting, webhook, alertmanager, kapacitor, fabric, newrelic, datadog, pagerduty, pingdom, elastalert, amazon_sns, curler, sentry, formatted_webhook, heartbeat, demo, manual, stackdriver, uptimerobot, sentry_platform, zabbix, prtg, slack_channel, inbound_email, direct_paging, jira, zendesk.
 
 ### Optional
 

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -41,6 +41,7 @@ var integrationTypes = []string{
 	"inbound_email",
 	"direct_paging",
 	"jira",
+	"zendesk",
 }
 
 var integrationTypesVerbal = strings.Join(integrationTypes, ", ")


### PR DESCRIPTION
Similar to what was done in https://github.com/grafana/terraform-provider-grafana/pull/1152, add support for the `zendesk` integrationType. I have verified that this is what the state would contain by importing an existing zendesk integration.