### PR TITLE
Docs: Fix order on Connections (Metrics Endpoint) docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -355,6 +355,22 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 
 ### Managing Connections
 
+#### Obtaining Connections access token
+
+Before using the Terraform Provider to manage Grafana Connections resources, such as metrics endpoint scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Connections API.
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
+an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
+
+Also, by default the Access Policies UI will not show those scopes, instead, search for it using the `Add Scope` textbox, as shown in the following image:
+
+<img src="https://grafana.com/media/docs/grafana-cloud/connections/connections-terraform-access-policy-create.png" width="700"/>
+
+1. Use the `Add Scope` textbox to search for the permissions you need to add to the access policy: `integration-management:read`, `integration-management:write` and `stacks:read`.
+1. Once done, you should see the scopes selected with checkboxes.
+
+Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Connections API. You can do so just after creating the access policy, following
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+
 #### Obtaining Connections API hostname
 
 Having created the token, we can find the correct Connections API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
@@ -376,22 +392,6 @@ For example, in the following response, the correct hostname for the `examplesta
   }
 ]
 ```
-
-#### Obtaining Connections access token
-
-Before using the Terraform Provider to manage Grafana Connections resources, such as metrics endpoint scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Connections API.
-[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
-an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
-
-Also, by default the Access Policies UI will not show those scopes, instead, search for it using the `Add Scope` textbox, as shown in the following image:
-
-<img src="https://grafana.com/media/docs/grafana-cloud/connections/connections-terraform-access-policy-create.png" width="700"/>
-
-1. Use the `Add Scope` textbox (1) to search for the permissions you need to add to the access policy.
-1. Make sure that you configure the three required scopes. Once done, you'll see the selected scopes as in (2).
-
-Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Connections API. You can do so just after creating the access policy, following
-the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
 
 #### Configuring the Provider to use the Connections API
 
@@ -436,4 +436,4 @@ To create one, follow the instructions in the [obtaining cloud provider access t
 
 An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/) to manage
 connections resources, such as Metrics Endpoint jobs.
-For guidance on creating one, see section [obtaining connections access token](#obtaining-connections-access-token)
+For guidance on creating one, see section [obtaining connections access token](#obtaining-connections-access-token).

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -89,6 +89,22 @@ The following are examples on how the *Account* and *Scrape Job* resources can b
 
 ### Managing Connections
 
+#### Obtaining Connections access token
+
+Before using the Terraform Provider to manage Grafana Connections resources, such as metrics endpoint scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Connections API.
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
+an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
+
+Also, by default the Access Policies UI will not show those scopes, instead, search for it using the `Add Scope` textbox, as shown in the following image:
+
+<img src="https://grafana.com/media/docs/grafana-cloud/connections/connections-terraform-access-policy-create.png" width="700"/>
+
+1. Use the `Add Scope` textbox to search for the permissions you need to add to the access policy: `integration-management:read`, `integration-management:write` and `stacks:read`.
+1. Once done, you should see the scopes selected with checkboxes.
+
+Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Connections API. You can do so just after creating the access policy, following
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+
 #### Obtaining Connections API hostname
 
 Having created the token, we can find the correct Connections API hostname by running the following script, that requires `curl` and [`jq`](https://jqlang.github.io/jq/) installed:
@@ -110,22 +126,6 @@ For example, in the following response, the correct hostname for the `examplesta
   }
 ]
 ```
-
-#### Obtaining Connections access token
-
-Before using the Terraform Provider to manage Grafana Connections resources, such as metrics endpoint scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Connections API.
-[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
-an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
-
-Also, by default the Access Policies UI will not show those scopes, instead, search for it using the `Add Scope` textbox, as shown in the following image:
-
-<img src="https://grafana.com/media/docs/grafana-cloud/connections/connections-terraform-access-policy-create.png" width="700"/>
-
-1. Use the `Add Scope` textbox (1) to search for the permissions you need to add to the access policy.
-1. Make sure that you configure the three required scopes. Once done, you'll see the selected scopes as in (2).
-
-Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Connections API. You can do so just after creating the access policy, following
-the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
 
 #### Configuring the Provider to use the Connections API
 
@@ -170,4 +170,4 @@ To create one, follow the instructions in the [obtaining cloud provider access t
 
 An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/) to manage
 connections resources, such as Metrics Endpoint jobs.
-For guidance on creating one, see section [obtaining connections access token](#obtaining-connections-access-token)
+For guidance on creating one, see section [obtaining connections access token](#obtaining-connections-access-token).


### PR DESCRIPTION
I noticed that "getting a token" section should come before using said token to "get the hostname."
I've also updated a couple of lines to better match our screenshot and added a missing period.

Let me know if there is anything else I can touch up while we're here.