### PR TITLE
Alerting: use `notification template group` naming

### DIFF
--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -3,17 +3,17 @@
 page_title: "grafana_message_template Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
-  Manages Grafana Alerting message templates.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#templates
+  Manages Grafana Alerting notification template groups, including notification templates.
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-template-groups
   This resource requires Grafana 9.1.0 or later.
 ---
 
 # grafana_message_template (Resource)
 
-Manages Grafana Alerting message templates.
+Manages Grafana Alerting notification template groups, including notification templates.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#templates)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-template-groups)
 
 This resource requires Grafana 9.1.0 or later.
 
@@ -21,8 +21,8 @@ This resource requires Grafana 9.1.0 or later.
 
 ```terraform
 resource "grafana_message_template" "my_template" {
-  name     = "My Reusable Template"
-  template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+  name     = "My Notification Template Group"
+  template = "{{define \"custom.message\" }}\n template content\n{{ end }}"
 }
 ```
 
@@ -31,8 +31,8 @@ resource "grafana_message_template" "my_template" {
 
 ### Required
 
-- `name` (String) The name of the message template.
-- `template` (String) The content of the message template.
+- `name` (String) The name of the notification template group.
+- `template` (String) The content of the notification template group.
 
 ### Optional
 

--- a/examples/resources/grafana_message_template/resource.tf
+++ b/examples/resources/grafana_message_template/resource.tf
@@ -1,4 +1,4 @@
 resource "grafana_message_template" "my_template" {
-  name     = "My Reusable Template"
-  template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+  name     = "My Notification Template Group"
+  template = "{{define \"custom.message\" }}\n template content\n{{ end }}"
 }

--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -19,10 +19,10 @@ import (
 func resourceMessageTemplate() *common.Resource {
 	schema := &schema.Resource{
 		Description: `
-Manages Grafana Alerting message templates.
+Manages Grafana Alerting notification template groups, including notification templates.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#templates)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-template-groups)
 
 This resource requires Grafana 9.1.0 or later.
 `,
@@ -41,12 +41,12 @@ This resource requires Grafana 9.1.0 or later.
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The name of the message template.",
+				Description: "The name of the notification template group.",
 			},
 			"template": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The content of the message template.",
+				Description: "The content of the notification template group.",
 				StateFunc: func(v interface{}) string {
 					return strings.TrimSpace(v.(string))
 				},

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -25,8 +25,8 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 				Config: testutils.TestAccExample(t, "resources/grafana_message_template/resource.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					alertingMessageTemplateCheckExists.exists("grafana_message_template.my_template", &tmpl),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Reusable Template"),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Notification Template Group"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}"),
 					testutils.CheckLister("grafana_message_template.my_template"),
 				),
 			},
@@ -40,16 +40,16 @@ func TestAccMessageTemplate_basic(t *testing.T) {
 			// Test update with heredoc template doesn't change
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
-					`template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"`: `template = <<-EOT
-{{define "My Reusable Template" }}
+					`template = "{{define \"custom.message\" }}\n template content\n{{ end }}"`: `template = <<-EOT
+{{define "custom.message" }}
  template content
 {{ end }}
 EOT`,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					alertingMessageTemplateCheckExists.exists("grafana_message_template.my_template", &tmpl),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Reusable Template"),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Notification Template Group"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}"),
 				),
 			},
 			// Test update content.
@@ -59,20 +59,20 @@ EOT`,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					alertingMessageTemplateCheckExists.exists("grafana_message_template.my_template", &tmpl),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Reusable Template"),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"My Reusable Template\" }}\n different content\n{{ end }}"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "My Notification Template Group"),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"custom.message\" }}\n different content\n{{ end }}"),
 				),
 			},
 			// Test rename.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/resource.tf", map[string]string{
-					"My Reusable Template": "A Different Template",
+					"My Notification Template Group": "A Different Template",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					alertingMessageTemplateCheckExists.exists("grafana_message_template.my_template", &tmpl),
 					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "A Different Template"),
-					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"A Different Template\" }}\n template content\n{{ end }}"),
-					alertingMessageTemplateCheckExists.destroyed(&models.NotificationTemplate{Name: "My Reusable Template"}, nil),
+					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}"),
+					alertingMessageTemplateCheckExists.destroyed(&models.NotificationTemplate{Name: "My Notification Template Group"}, nil),
 				),
 			},
 		},
@@ -128,7 +128,7 @@ func testAccMessageTemplate_inOrg(name string) string {
 	resource "grafana_message_template" "my_template" {
 		org_id = grafana_organization.test.id
 		name = "my-template"
-		template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+		template = "{{define \"custom.message\" }}\n template content\n{{ end }}"
 	}
 	`, name)
 }

--- a/pkg/generate/testdata/generate/alerting-in-org.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org.tf
@@ -35,8 +35,8 @@ resource "grafana_mute_timing" "my_mute_timing" {
 
 resource "grafana_message_template" "my_template" {
   org_id   = grafana_organization.test.id
-  name     = "My Reusable Template"
-  template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+  name     = "My Notification Template Group"
+  template = "{{define \"custom.message\" }}\n template content\n{{ end }}"
 }
 
 resource "grafana_folder" "rule_folder" {

--- a/pkg/generate/testdata/generate/alerting-in-org/imports.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/imports.tf
@@ -19,8 +19,8 @@ import {
 }
 
 import {
-  to = grafana_message_template._2_My_Reusable_Template
-  id = "2:My Reusable Template"
+  to = grafana_message_template._2_My_Notification_Template_Group
+  id = "2:My Notification Template Group"
 }
 
 import {

--- a/pkg/generate/testdata/generate/alerting-in-org/resources.tf
+++ b/pkg/generate/testdata/generate/alerting-in-org/resources.tf
@@ -43,11 +43,11 @@ resource "grafana_folder" "_2_alert-rule-folder" {
   uid    = "alert-rule-folder"
 }
 
-# __generated__ by Terraform from "2:My Reusable Template"
-resource "grafana_message_template" "_2_My_Reusable_Template" {
-  name     = "My Reusable Template"
+# __generated__ by Terraform from "2:My Notification Template Group"
+resource "grafana_message_template" "_2_My_Notification_Template_Group" {
+  name     = "My Notification Template Group"
   org_id   = grafana_organization.alerting-org.id
-  template = "{{define \"My Reusable Template\" }}\n template content\n{{ end }}"
+  template = "{{define \"custom.message\" }}\n template content\n{{ end }}"
 }
 
 # __generated__ by Terraform from "2:My Mute Timing"


### PR DESCRIPTION
Update Terraform docs and examples to specify the usage of the new `notification template group` element, which was introduced by https://github.com/grafana/grafana/pull/96447.

This PR should be merged after Grafana 11.5 is released. Then, the `https://grafana.com/docs/grafana/latest/` docs will be updated with the necessary changes for this PR.