### PR TITLE
Add http compression option to synthetic monitoring check resource

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -147,6 +147,7 @@ resource "grafana_synthetic_monitoring_check" "http" {
       proxy_url                      = "https://almost-there"
       fail_if_ssl                    = true
       fail_if_not_ssl                = true
+      compression                    = "deflate"
       cache_busting_query_param_name = "pineapple"
 
       tls_config {
@@ -522,6 +523,7 @@ Optional:
 - `bearer_token` (String, Sensitive) Token for use with bearer authorization header.
 - `body` (String) The body of the HTTP request used in probe.
 - `cache_busting_query_param_name` (String) The name of the query parameter used to prevent the server from using a cached response. Each probe will assign a random value to this parameter each time a request is made.
+- `compression` (String) Check fails if the response body is not compressed using this compression algorithm. One of `none`, `identity`, `br`, `gzip`, `deflate`.
 - `fail_if_body_matches_regexp` (Set of String) List of regexes. If any match the response body, the check will fail.
 - `fail_if_body_not_matches_regexp` (Set of String) List of regexes. If any do not match the response body, the check will fail.
 - `fail_if_header_matches_regexp` (Block Set) Check fails if headers match. (see [below for nested schema](#nestedblock--settings--http--fail_if_header_matches_regexp))

--- a/examples/resources/grafana_synthetic_monitoring_check/http_complex.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/http_complex.tf
@@ -21,6 +21,7 @@ resource "grafana_synthetic_monitoring_check" "http" {
       proxy_url                      = "https://almost-there"
       fail_if_ssl                    = true
       fail_if_not_ssl                = true
+      compression                    = "deflate"
       cache_busting_query_param_name = "pineapple"
 
       tls_config {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -980,7 +980,9 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 			"cache_busting_query_param_name":    chk.Settings.Http.CacheBustingQueryParamName,
 		})
 
-		if chk.Settings.Http.Compression != nil {
+		// The default compression "none" is the same as omitting the value.
+		// Since this value is usually not explicitly set, omit when set to "none"
+		if chk.Settings.Http.Compression != sm.CompressionAlgorithm_none {
 			http.Add(map[string]interface{}{
 				"compression": chk.Settings.Http.Compression.String(),
 			})

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -1482,7 +1482,7 @@ func makeCheckSettings(settings map[string]interface{}) (sm.CheckSettings, error
 			CacheBustingQueryParamName: h["cache_busting_query_param_name"].(string),
 		}
 		compression, ok := h["compression"].(string)
-		if ok {
+		if ok && compression != "" {
 			cs.Http.Compression = sm.CompressionAlgorithm(sm.CompressionAlgorithm_value[compression])
 		}
 		if h["tls_config"].(*schema.Set).Len() > 0 {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -944,10 +944,6 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 				},
 			)
 		}
-		var compression string
-		if chk.Settings.Http.Compression != sm.CompressionAlgorithm_none {
-			compression = chk.Settings.Http.Compression.String()
-		}
 		headerMatch := func(hms []sm.HeaderMatch) *schema.Set {
 			hmSet := schema.NewSet(
 				schema.HashResource(syntheticMonitoringCheckSettingsTCPQueryResponse),
@@ -981,9 +977,14 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 			"fail_if_body_not_matches_regexp":   common.StringSliceToSet(chk.Settings.Http.FailIfBodyNotMatchesRegexp),
 			"fail_if_header_matches_regexp":     headerMatch(chk.Settings.Http.FailIfHeaderMatchesRegexp),
 			"fail_if_header_not_matches_regexp": headerMatch(chk.Settings.Http.FailIfHeaderNotMatchesRegexp),
-			"compression":                       compression,
 			"cache_busting_query_param_name":    chk.Settings.Http.CacheBustingQueryParamName,
 		})
+
+		if chk.Settings.Http.Compression != nil {
+			http.Add(map[string]interface{}{
+				"compression": chk.Settings.Http.Compression.String(),
+			})
+		}
 
 		settings.Add(map[string]interface{}{
 			"http": http,
@@ -1489,7 +1490,7 @@ func makeCheckSettings(settings map[string]interface{}) (sm.CheckSettings, error
 			CacheBustingQueryParamName: h["cache_busting_query_param_name"].(string),
 		}
 		compression, ok := h["compression"].(string)
-		if ok && compression != "" {
+		if ok {
 			cs.Http.Compression = sm.CompressionAlgorithm(sm.CompressionAlgorithm_value[compression])
 		}
 		if h["tls_config"].(*schema.Set).Len() > 0 {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -941,6 +941,10 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 				},
 			)
 		}
+		var compression string
+		if chk.Settings.Http.Compression != sm.CompressionAlgorithm_none {
+			compression = chk.Settings.Http.Compression.String()
+		}
 		headerMatch := func(hms []sm.HeaderMatch) *schema.Set {
 			hmSet := schema.NewSet(
 				schema.HashResource(syntheticMonitoringCheckSettingsTCPQueryResponse),
@@ -974,7 +978,7 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 			"fail_if_body_not_matches_regexp":   common.StringSliceToSet(chk.Settings.Http.FailIfBodyNotMatchesRegexp),
 			"fail_if_header_matches_regexp":     headerMatch(chk.Settings.Http.FailIfHeaderMatchesRegexp),
 			"fail_if_header_not_matches_regexp": headerMatch(chk.Settings.Http.FailIfHeaderNotMatchesRegexp),
-			"compression":                       chk.Settings.Http.Compression.String(),
+			"compression":                       compression,
 			"cache_busting_query_param_name":    chk.Settings.Http.CacheBustingQueryParamName,
 		})
 

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -944,6 +944,12 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 				},
 			)
 		}
+		// The default compression "none" is the same as omitting the value.
+		// Since this value is usually not explicitly set, omit when set to "none"
+		var compression string
+		if chk.Settings.Http.Compression != sm.CompressionAlgorithm_none {
+			compression = chk.Settings.Http.Compression.String()
+		}
 		headerMatch := func(hms []sm.HeaderMatch) *schema.Set {
 			hmSet := schema.NewSet(
 				schema.HashResource(syntheticMonitoringCheckSettingsTCPQueryResponse),
@@ -977,16 +983,9 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 			"fail_if_body_not_matches_regexp":   common.StringSliceToSet(chk.Settings.Http.FailIfBodyNotMatchesRegexp),
 			"fail_if_header_matches_regexp":     headerMatch(chk.Settings.Http.FailIfHeaderMatchesRegexp),
 			"fail_if_header_not_matches_regexp": headerMatch(chk.Settings.Http.FailIfHeaderNotMatchesRegexp),
+			"compression":						 compression,
 			"cache_busting_query_param_name":    chk.Settings.Http.CacheBustingQueryParamName,
 		})
-
-		// The default compression "none" is the same as omitting the value.
-		// Since this value is usually not explicitly set, omit when set to "none"
-		if chk.Settings.Http.Compression != sm.CompressionAlgorithm_none {
-			http.Add(map[string]interface{}{
-				"compression": chk.Settings.Http.Compression.String(),
-			})
-		}
 
 		settings.Add(map[string]interface{}{
 			"http": http,

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -1479,8 +1479,11 @@ func makeCheckSettings(settings map[string]interface{}) (sm.CheckSettings, error
 			ValidHTTPVersions:          common.SetToStringSlice(h["valid_http_versions"].(*schema.Set)),
 			FailIfBodyMatchesRegexp:    common.SetToStringSlice(h["fail_if_body_matches_regexp"].(*schema.Set)),
 			FailIfBodyNotMatchesRegexp: common.SetToStringSlice(h["fail_if_body_not_matches_regexp"].(*schema.Set)),
-			Compression:                sm.CompressionAlgorithm(sm.CompressionAlgorithm_value[h["compression"].(string)]),
 			CacheBustingQueryParamName: h["cache_busting_query_param_name"].(string),
+		}
+		compression, ok := h["compression"].(string)
+		if ok {
+			cs.Http.Compression = sm.CompressionAlgorithm(sm.CompressionAlgorithm_value[compression])
 		}
 		if h["tls_config"].(*schema.Set).Len() > 0 {
 			cs.Http.TlsConfig = tlsConfig(h["tls_config"].(*schema.Set))

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -344,9 +344,9 @@ var (
 				Elem:        syntheticMonitoringCheckSettingsHTTPHeaderMatch,
 			},
 			"compression": {
-				Description: "Check fails if the response body is not compressed using this compression algorithm. One of `none`, `identity`, `br`, `gzip`, `deflate`.",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:  "Check fails if the response body is not compressed using this compression algorithm. One of `none`, `identity`, `br`, `gzip`, `deflate`.",
+				Type:         schema.TypeString,
+				Optional:     true,
 				ValidateFunc: validation.StringInSlice(slices.Collect(maps.Keys(sm.CompressionAlgorithm_value)), false),
 			},
 			"cache_busting_query_param_name": {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -983,7 +983,7 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 			"fail_if_body_not_matches_regexp":   common.StringSliceToSet(chk.Settings.Http.FailIfBodyNotMatchesRegexp),
 			"fail_if_header_matches_regexp":     headerMatch(chk.Settings.Http.FailIfHeaderMatchesRegexp),
 			"fail_if_header_not_matches_regexp": headerMatch(chk.Settings.Http.FailIfHeaderNotMatchesRegexp),
-			"compression":						 compression,
+			"compression":                       compression,
 			"cache_busting_query_param_name":    chk.Settings.Http.CacheBustingQueryParamName,
 		})
 

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -341,6 +341,11 @@ var (
 				Optional:    true,
 				Elem:        syntheticMonitoringCheckSettingsHTTPHeaderMatch,
 			},
+			"compression": {
+				Description: "Check fails if the response body is not compressed using this compression algorithm. One of `none`, `identity`, `br`, `gzip`, `deflate`.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"cache_busting_query_param_name": {
 				Description: "The name of the query parameter used to prevent the server from using a cached response. Each probe will assign a random value to this parameter each time a request is made.",
 				Type:        schema.TypeString,
@@ -969,6 +974,7 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 			"fail_if_body_not_matches_regexp":   common.StringSliceToSet(chk.Settings.Http.FailIfBodyNotMatchesRegexp),
 			"fail_if_header_matches_regexp":     headerMatch(chk.Settings.Http.FailIfHeaderMatchesRegexp),
 			"fail_if_header_not_matches_regexp": headerMatch(chk.Settings.Http.FailIfHeaderNotMatchesRegexp),
+			"compression":                       chk.Settings.Http.Compression.String(),
 			"cache_busting_query_param_name":    chk.Settings.Http.CacheBustingQueryParamName,
 		})
 
@@ -1473,6 +1479,7 @@ func makeCheckSettings(settings map[string]interface{}) (sm.CheckSettings, error
 			ValidHTTPVersions:          common.SetToStringSlice(h["valid_http_versions"].(*schema.Set)),
 			FailIfBodyMatchesRegexp:    common.SetToStringSlice(h["fail_if_body_matches_regexp"].(*schema.Set)),
 			FailIfBodyNotMatchesRegexp: common.SetToStringSlice(h["fail_if_body_not_matches_regexp"].(*schema.Set)),
+			Compression:                sm.CompressionAlgorithm(sm.CompressionAlgorithm_value[h["compression"].(string)]),
 			CacheBustingQueryParamName: h["cache_busting_query_param_name"].(string),
 		}
 		if h["tls_config"].(*schema.Set).Len() > 0 {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -345,6 +347,7 @@ var (
 				Description: "Check fails if the response body is not compressed using this compression algorithm. One of `none`, `identity`, `br`, `gzip`, `deflate`.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ValidateFunc: validation.StringInSlice(slices.Collect(maps.Keys(sm.CompressionAlgorithm_value)), false),
 			},
 			"cache_busting_query_param_name": {
 				Description: "The name of the query parameter used to prevent the server from using a cached response. Each probe will assign a random value to this parameter each time a request is made.",

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -124,6 +124,7 @@ func TestAccResourceCheck_http(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.bearer_token", "asdfjkl;"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.proxy_url", "https://almost-there"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.fail_if_ssl", "true"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.compression", "deflate"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.cache_busting_query_param_name", "pineapple"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.tls_config.0.server_name", "grafana.org"),
 					resource.TestMatchResourceAttr("grafana_synthetic_monitoring_check.http", "settings.0.http.0.tls_config.0.client_cert", regexp.MustCompile((`^-{5}BEGIN CERTIFICATE`))),


### PR DESCRIPTION
This option - which validates check the compression algorithm used in the response - is available in the UI and the API, but was not exposed in the terraform provider. 

Fixes https://github.com/grafana/synthetic-monitoring/issues/184

The absence of a compression value, compression = "", and compression=none mean the same thing: "no compression validation is being done".

But we need to chose one of these representations when reading and writing http check settings.  In this PR I opted for removing the compression value altogether when compression = none.  This preserves the current behaviour if no compression value is specified (and the integration tests fail if we represent it with compression = none ).