### PR TITLE
synthetic monitoring: add support for browser checks

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -909,8 +909,8 @@ resource "grafana_synthetic_monitoring_check" "browser" {
     environment = "production"
   }
   settings {
-    scripted {
-      // `script.js` is a file in the same directory as this file and contains the
+    browser {
+      // `browser_script.js` is a file in the same directory as this file and contains the
       // script to be executed.
       script = file("${path.module}/browser_script.js")
     }

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -438,6 +438,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 
 Optional:
 
+- `browser` (Block Set, Max: 1) Settings for browser check. See https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/k6-browser/. (see [below for nested schema](#nestedblock--settings--browser))
 - `dns` (Block Set, Max: 1) Settings for DNS check. The target must be a valid hostname (or IP address for `PTR` records). (see [below for nested schema](#nestedblock--settings--dns))
 - `grpc` (Block Set, Max: 1) Settings for gRPC Health check. The target must be of the form `<host>:<port>`, where the host portion must be a valid hostname or IP address. (see [below for nested schema](#nestedblock--settings--grpc))
 - `http` (Block Set, Max: 1) Settings for HTTP check. The target must be a URL (http or https). (see [below for nested schema](#nestedblock--settings--http))
@@ -446,6 +447,14 @@ Optional:
 - `scripted` (Block Set, Max: 1) Settings for scripted check. See https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/k6/. (see [below for nested schema](#nestedblock--settings--scripted))
 - `tcp` (Block Set, Max: 1) Settings for TCP check. The target must be of the form `<host>:<port>`, where the host portion must be a valid hostname or IP address. (see [below for nested schema](#nestedblock--settings--tcp))
 - `traceroute` (Block Set, Max: 1) Settings for traceroute check. The target must be a valid hostname or IP address (see [below for nested schema](#nestedblock--settings--traceroute))
+
+<a id="nestedblock--settings--browser"></a>
+### Nested Schema for `settings.browser`
+
+Required:
+
+- `script` (String)
+
 
 <a id="nestedblock--settings--dns"></a>
 ### Nested Schema for `settings.dns`
@@ -879,6 +888,31 @@ resource "grafana_synthetic_monitoring_check" "scripted" {
       // `script.js` is a file in the same directory as this file and contains the
       // script to be executed.
       script = file("${path.module}/script.js")
+    }
+  }
+}
+```
+
+### Browser Basic
+
+```terraform
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+resource "grafana_synthetic_monitoring_check" "browser" {
+  job     = "Validate login"
+  target  = "https://test.k6.io"
+  enabled = true
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Paris,
+  ]
+  labels = {
+    environment = "production"
+  }
+  settings {
+    scripted {
+      // `script.js` is a file in the same directory as this file and contains the
+      // script to be executed.
+      script = file("${path.module}/browser_script.js")
     }
   }
 }

--- a/examples/resources/grafana_synthetic_monitoring_check/browser_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/browser_basic.tf
@@ -1,0 +1,20 @@
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+resource "grafana_synthetic_monitoring_check" "browser" {
+  job     = "Validate login"
+  target  = "https://test.k6.io"
+  enabled = true
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Paris,
+  ]
+  labels = {
+    environment = "production"
+  }
+  settings {
+    scripted {
+      // `script.js` is a file in the same directory as this file and contains the
+      // script to be executed.
+      script = file("${path.module}/browser_script.js")
+    }
+  }
+}

--- a/examples/resources/grafana_synthetic_monitoring_check/browser_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/browser_basic.tf
@@ -11,8 +11,8 @@ resource "grafana_synthetic_monitoring_check" "browser" {
     environment = "production"
   }
   settings {
-    scripted {
-      // `script.js` is a file in the same directory as this file and contains the
+    browser {
+      // `browser_script.js` is a file in the same directory as this file and contains the
       // script to be executed.
       script = file("${path.module}/browser_script.js")
     }

--- a/examples/resources/grafana_synthetic_monitoring_check/browser_script.js
+++ b/examples/resources/grafana_synthetic_monitoring_check/browser_script.js
@@ -1,0 +1,41 @@
+import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto("https://test.k6.io/my_messages.php");
+
+    await page.locator('input[name="login"]').type("admin");
+    await page.locator('input[name="password"]').type("123");
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('input[type="submit"]').click(),
+    ]);
+
+    await check(page.locator("h2"), {
+      header: async (locator) => (await locator.textContent()) == "Welcome, admin!",
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -854,6 +854,7 @@ func resourceCheckCreate(ctx context.Context, d *schema.ResourceData, c *smapi.C
 	return resourceCheckRead(ctx, d, c)
 }
 
+//nolint:gocyclo
 func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {
 	id, err := resourceCheckID.Single(d.Id())
 	if err != nil {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -1188,7 +1188,6 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 		settings.Add(map[string]any{
 			"browser": browser,
 		})
-
 	}
 
 	d.Set("settings", settings)

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -452,8 +452,8 @@ func TestAccResourceCheck_browser(t *testing.T) {
 	// Inject random job names to avoid conflicts with other tests
 	jobName := acctest.RandomWithPrefix("browser")
 	nameReplaceMap := map[string]string{
-		`"Validate homepage"`: strconv.Quote(jobName),
-		"${path.module}":      scriptFilepathAbs,
+		`"Validate login"`: strconv.Quote(jobName),
+		"${path.module}":   scriptFilepathAbs,
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
@@ -479,7 +479,6 @@ func TestAccResourceCheck_browser(t *testing.T) {
 		},
 	})
 }
-
 
 func TestAccResourceCheck_grpc(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)

--- a/templates/resources/synthetic_monitoring_check.md.tmpl
+++ b/templates/resources/synthetic_monitoring_check.md.tmpl
@@ -66,6 +66,10 @@ description: |-
 
 {{ tffile "examples/resources/grafana_synthetic_monitoring_check/scripted_basic.tf" }}
 
+### Browser Basic
+
+{{ tffile "examples/resources/grafana_synthetic_monitoring_check/browser_basic.tf" }}
+
 ### gRPC Health Check Basic
 
 {{ tffile "examples/resources/grafana_synthetic_monitoring_check/grpc_basic.tf" }}


### PR DESCRIPTION
Synthetics browser checks are currently in public preview, but cannot be managed yet with terraform.  This PR adds support for them.   

Resolves: https://github.com/grafana/synthetic-monitoring/issues/122