### PR TITLE
Playlists: Move examples of deprecated dashboard_by_id to dashboard_by_uid

### DIFF
--- a/docs/resources/playlist.md
+++ b/docs/resources/playlist.md
@@ -29,9 +29,9 @@ resource "grafana_playlist" "test" {
 
   item {
     order = 1
-    title = "Terraform Dashboard By ID"
-    type  = "dashboard_by_id"
-    value = "3"
+    title = "Terraform Dashboard By UID"
+    type  = "dashboard_by_uid"
+    value = "cIBgcSjkk"
   }
 }
 ```

--- a/examples/resources/grafana_playlist/resource.tf
+++ b/examples/resources/grafana_playlist/resource.tf
@@ -13,8 +13,8 @@ resource "grafana_playlist" "test" {
 
   item {
     order = 1
-    title = "Terraform Dashboard By ID"
-    type  = "dashboard_by_id"
-    value = "3"
+    title = "Terraform Dashboard By UID"
+    type  = "dashboard_by_uid"
+    value = "cIBgcSjkk"
   }
 }

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -87,13 +87,13 @@ func TestAccPlaylist_update(t *testing.T) {
 						"order": "1",
 						"title": "Terraform Dashboard By UID",
 						"type":  "dashboard_by_uid",
-						"value": "3",
+						"value": "uid-3",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "2",
 						"title": "other",
 						"type":  "dashboard_by_uid",
-						"value": "uid-other",
+						"value": "uid-1",
 					}),
 				),
 			},
@@ -108,13 +108,13 @@ func TestAccPlaylist_update(t *testing.T) {
 						"order": "1",
 						"title": "Terraform Dashboard By UID",
 						"type":  "dashboard_by_uid",
-						"value": "4",
+						"value": "uid-4",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "2",
 						"title": "other",
 						"type":  "dashboard_by_uid",
-						"value": "uid-other",
+						"value": "uid-1",
 					}),
 				),
 			},
@@ -262,7 +262,7 @@ resource "grafana_playlist" "test" {
 		order = 2
 		title = "other"
 		type = "dashboard_by_uid"
-		value = "uid-other"
+		value = "uid-1"
 	}
 	
 	item {

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -37,7 +37,7 @@ func TestAccPlaylist_basic(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "2",
-						"title": "Terraform Dashboard By ID",
+						"title": "Terraform Dashboard By UID",
 					}),
 					testutils.CheckLister(paylistResource),
 				),
@@ -85,15 +85,15 @@ func TestAccPlaylist_update(t *testing.T) {
 					resource.TestCheckResourceAttr(paylistResource, "item.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "1",
-						"title": "Terraform Dashboard By ID",
-						"type":  "dashboard_by_id",
+						"title": "Terraform Dashboard By UID",
+						"type":  "dashboard_by_uid",
 						"value": "3",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "2",
 						"title": "other",
-						"type":  "dashboard_by_id",
-						"value": "1",
+						"type":  "dashboard_by_uid",
+						"value": "uid-other",
 					}),
 				),
 			},
@@ -106,15 +106,15 @@ func TestAccPlaylist_update(t *testing.T) {
 					resource.TestCheckResourceAttr(paylistResource, "item.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "1",
-						"title": "Terraform Dashboard By ID",
-						"type":  "dashboard_by_id",
+						"title": "Terraform Dashboard By UID",
+						"type":  "dashboard_by_uid",
 						"value": "4",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "2",
 						"title": "other",
-						"type":  "dashboard_by_id",
-						"value": "1",
+						"type":  "dashboard_by_uid",
+						"value": "uid-other",
 					}),
 				),
 			},
@@ -177,7 +177,7 @@ func TestAccPlaylist_inOrg(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(paylistResource, "item.*", map[string]string{
 						"order": "2",
-						"title": "Terraform Dashboard By ID",
+						"title": "Terraform Dashboard By UID",
 					}),
 				),
 			},
@@ -215,7 +215,7 @@ resource "grafana_playlist" "test" {
 
 	item {
 		order = 2
-		title = "Terraform Dashboard By ID"
+		title = "Terraform Dashboard By UID"
 	}
 
 	item {
@@ -240,7 +240,7 @@ resource "grafana_playlist" "test" {
 
 	item {
 		order = 2
-		title = "Terraform Dashboard By ID"
+		title = "Terraform Dashboard By UID"
 	}
 
 	item {
@@ -261,15 +261,15 @@ resource "grafana_playlist" "test" {
 	item {
 		order = 2
 		title = "other"
-		type = "dashboard_by_id"
-		value = "1"
+		type = "dashboard_by_uid"
+		value = "uid-other"
 	}
 	
 	item {
 		order = 1
-		title = "Terraform Dashboard By ID"
-		type = "dashboard_by_id"
-		value = "%[2]s"
+		title = "Terraform Dashboard By UID"
+		type = "dashboard_by_uid"
+		value = "uid-%[2]s"
 	}
 }
 `, name, value)


### PR DESCRIPTION
In Grafana 11, we started migrating the use of the playlist item type `dashboard_by_id` to `dashboard_by_uid`. This PR updates the examples in terraform to follow suit with that change.

Note this is not a functionality change, as [the item type can be any arbitrary string](https://github.com/grafana/terraform-provider-grafana/blob/b03e5dba60f06ad392efa790daa16b35af40c574/internal/resources/grafana/resource_playlist.go#L184).

References:
- https://github.com/grafana/grafana/pull/92884
- https://github.com/grafana/grafana/pull/54125

Fixes https://github.com/grafana/app-platform-wg/issues/187