### PR TITLE
ci(dependabot): group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
Updating GitHub actions with dependabot is cumbersome as each update requires the next to be rebased. This tells dependabot to group the updates so they can be done in a single PR.
