### PR TITLE
Revert "ci(dependabot): group GitHub Actions updates (#1932)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      github-actions:
-        patterns:
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
This reverts commit 8645a1c3b04405974bcb97674abd873e3e6611ce.

Apparently this doesn't work. :shrug:
