### PR TITLE
SLO tests: make less flaky.

### DIFF
--- a/internal/resources/slo/data_source_slo_test.go
+++ b/internal/resources/slo/data_source_slo_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceSlo(t *testing.T) {
 	randomName := acctest.RandomWithPrefix("SLO Terraform Testing")
 
 	var slo slo.SloV00Slo
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccSloCheckDestroy(&slo),
 		Steps: []resource.TestStep{

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/slo-openapi-client/go/slo"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
@@ -23,7 +24,7 @@ func TestAccResourceSlo(t *testing.T) {
 	randomName := acctest.RandomWithPrefix("SLO Terraform Testing")
 
 	var slo slo.SloV00Slo
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		// Implicitly tests destroy
 		CheckDestroy: testAccSloCheckDestroy(&slo),
@@ -146,7 +147,7 @@ func TestAccSLO_recreate(t *testing.T) {
 	config := testutils.TestAccExampleWithReplace(t, "resources/grafana_slo/resource.tf", map[string]string{
 		"Terraform Testing": randomName,
 	})
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 
 		// Implicitly tests destroy
@@ -175,6 +176,8 @@ func TestAccSLO_recreate(t *testing.T) {
 					req := client.DefaultAPI.V1SloIdDelete(context.Background(), slo.Uuid)
 					_, err := req.Execute()
 					require.NoError(t, err)
+					// A short delay while background tasks clean up the SLO. After this, the plan should be non-empty again.
+					time.Sleep(5 * time.Second)
 				},
 				Config:             config,
 				PlanOnly:           true,
@@ -395,7 +398,7 @@ resource "grafana_slo" "no_alert" {
 func TestAccResourceInvalidSlo(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
* Runs SLO tests serially, making plan interference less likely.
* Adds a short delay after an out-of-band SLO delete, to allow background workers to clean up the resources. This should reduce flakiness when planning after the deletion.