### PR TITLE
Fix CleanResourceName for IDs starting with a - characted

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ provider_installation {
 Acceptance tests require a running instance of Grafana. You can either handle
 running an instance of Grafana yourself or use `docker-compose`.
 
-If you choose `docker-compose`, run `make testacc-docker`. This is the simplest
+If you choose `docker-compose`, run `make testacc-oss-docker`. This is the simplest
 option, but often not the quickest.
 
 Alternatively you can use the `testacc` target which will use your local `go`

--- a/pkg/generate/postprocessing/preferred_resource_name.go
+++ b/pkg/generate/postprocessing/preferred_resource_name.go
@@ -68,5 +68,8 @@ func CleanResourceName(name string) string {
 	if cleaned[0] >= '0' && cleaned[0] <= '9' {
 		cleaned = "_" + cleaned
 	}
+	if cleaned[0] == '-' {
+		cleaned = "_" + cleaned
+	}
 	return cleaned
 }

--- a/pkg/generate/postprocessing/preferred_resource_name_test.go
+++ b/pkg/generate/postprocessing/preferred_resource_name_test.go
@@ -1,6 +1,9 @@
 package postprocessing
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestUsePreferredResourceNames(t *testing.T) {
 	for _, testFile := range []string{
@@ -8,6 +11,27 @@ func TestUsePreferredResourceNames(t *testing.T) {
 	} {
 		postprocessingTest(t, testFile, func(fpath string) {
 			UsePreferredResourceNames(fpath)
+		})
+	}
+}
+
+func TestCleanResourceName(t *testing.T) {
+	var tests = []struct {
+		before, after string
+	}{
+		{"qwerty", "qwerty"},
+		{"123", "_123"},
+		{"-foo", "_-foo"},
+		{"_bar", "_bar"},
+	}
+
+	for _, tt := range tests {
+		testname := fmt.Sprintf("%s,%s", tt.before, tt.after)
+		t.Run(testname, func(t *testing.T) {
+			cleaned := CleanResourceName(tt.before)
+			if cleaned != tt.after {
+				t.Errorf(`Resource name %q was clean as %q and not %q as expected`, tt.before, cleaned, tt.after)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This should make IDs compatible with Terraform syntax for identifiers:

> Identifiers
> 
> Argument names, block type names, and the names of most Terraform-specific constructs like resources, input variables, etc. are all identifiers.
> 
> Identifiers can contain letters, digits, underscores (_), and hyphens (-). The first character of an identifier must not be a digit, to avoid ambiguity with literal numbers.
> 
> For complete identifier rules, Terraform implements [the Unicode identifier syntax](http://unicode.org/reports/tr31/), extended to include the ASCII hyphen character -.

https://developer.hashicorp.com/terraform/language/syntax/configuration#identifiers 