### PR TITLE
Add support for defining aws account name

### DIFF
--- a/docs/data-sources/cloud_provider_aws_account.md
+++ b/docs/data-sources/cloud_provider_aws_account.md
@@ -40,6 +40,10 @@ data "grafana_cloud_provider_aws_account" "test" {
 - `resource_id` (String) The ID given by the Grafana Cloud Provider API to this AWS Account resource.
 - `stack_id` (String) The StackID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 
+### Optional
+
+- `name` (String) An optional human-readable name for this AWS Account resource.
+
 ### Read-Only
 
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".

--- a/docs/data-sources/cloud_provider_aws_account.md
+++ b/docs/data-sources/cloud_provider_aws_account.md
@@ -40,12 +40,9 @@ data "grafana_cloud_provider_aws_account" "test" {
 - `resource_id` (String) The ID given by the Grafana Cloud Provider API to this AWS Account resource.
 - `stack_id` (String) The StackID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 
-### Optional
-
-- `name` (String) An optional human-readable name for this AWS Account resource.
-
 ### Read-Only
 
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".
+- `name` (String) An optional human-readable name for this AWS Account resource.
 - `regions` (Set of String) A set of regions that this AWS Account resource applies to.
 - `role_arn` (String) An IAM Role ARN string to represent with this AWS Account resource.

--- a/docs/resources/cloud_provider_aws_account.md
+++ b/docs/resources/cloud_provider_aws_account.md
@@ -41,6 +41,10 @@ resource "grafana_cloud_provider_aws_account" "test" {
 - `role_arn` (String) An IAM Role ARN string to represent with this AWS Account resource.
 - `stack_id` (String) The StackID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 
+### Optional
+
+- `name` (String) An optional human-readable name for this AWS Account resource.
+
 ### Read-Only
 
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".

--- a/internal/common/cloudproviderapi/client.go
+++ b/internal/common/cloudproviderapi/client.go
@@ -59,6 +59,9 @@ type AWSAccount struct {
 
 	// Regions is the list of AWS regions in use for the AWS Account.
 	Regions []string `json:"regions"`
+
+	// Name is an optional user-defined name for the AWS account.
+	Name string `json:"name"`
 }
 
 func (c *Client) CreateAWSAccount(ctx context.Context, stackID string, accountData AWSAccount) (AWSAccount, error) {

--- a/internal/resources/cloudprovider/data_source_aws_account.go
+++ b/internal/resources/cloudprovider/data_source_aws_account.go
@@ -58,7 +58,6 @@ func (r datasourceAWSAccount) Schema(ctx context.Context, req datasource.SchemaR
 			},
 			"name": schema.StringAttribute{
 				Description: "An optional human-readable name for this AWS Account resource.",
-				Optional:    true,
 				Computed:    true,
 			},
 			"role_arn": schema.StringAttribute{
@@ -98,6 +97,11 @@ func (r datasourceAWSAccount) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 	diags = resp.State.SetAttribute(ctx, path.Root("role_arn"), account.RoleARN)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = resp.State.SetAttribute(ctx, path.Root("name"), account.Name)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/cloudprovider/data_source_aws_account.go
+++ b/internal/resources/cloudprovider/data_source_aws_account.go
@@ -56,6 +56,11 @@ func (r datasourceAWSAccount) Schema(ctx context.Context, req datasource.SchemaR
 				Description: "The ID given by the Grafana Cloud Provider API to this AWS Account resource.",
 				Required:    true,
 			},
+			"name": schema.StringAttribute{
+				Description: "An optional human-readable name for this AWS Account resource.",
+				Optional:    true,
+				Computed:    true,
+			},
 			"role_arn": schema.StringAttribute{
 				Description: "An IAM Role ARN string to represent with this AWS Account resource.",
 				Computed:    true,

--- a/internal/resources/cloudprovider/data_source_aws_account_test.go
+++ b/internal/resources/cloudprovider/data_source_aws_account_test.go
@@ -17,6 +17,7 @@ func TestAccDataSourceAWSAccount(t *testing.T) {
 
 	account := cloudproviderapi.AWSAccount{
 		ID:      testCfg.accountID,
+		Name:    testCfg.accountName,
 		RoleARN: testCfg.roleARN,
 		Regions: []string{"us-east-1", "us-east-2", "us-west-1"},
 	}
@@ -29,6 +30,7 @@ func TestAccDataSourceAWSAccount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "stack_id", testCfg.stackID),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "resource_id", account.ID),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "name", account.Name),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "role_arn", account.RoleARN),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "regions.#", strconv.Itoa(len(account.Regions))),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_aws_account.test", "regions.0", account.Regions[0]),

--- a/internal/resources/cloudprovider/resource_aws_account.go
+++ b/internal/resources/cloudprovider/resource_aws_account.go
@@ -27,6 +27,7 @@ type resourceAWSAccountModel struct {
 	ID         types.String `tfsdk:"id"`
 	StackID    types.String `tfsdk:"stack_id"`
 	ResourceID types.String `tfsdk:"resource_id"`
+	Name       types.String `tfsdk:"name"`
 	RoleARN    types.String `tfsdk:"role_arn"`
 	Regions    types.Set    `tfsdk:"regions"`
 }
@@ -90,6 +91,13 @@ func (r resourceAWSAccount) Schema(ctx context.Context, req resource.SchemaReque
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"name": schema.StringAttribute{
+				Description: "An optional human-readable name for this AWS Account resource.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"role_arn": schema.StringAttribute{
 				Description: "An IAM Role ARN string to represent with this AWS Account resource.",
 				Required:    true,
@@ -134,6 +142,7 @@ func (r resourceAWSAccount) ImportState(ctx context.Context, req resource.Import
 		ID:         types.StringValue(req.ID),
 		StackID:    types.StringValue(stackID),
 		ResourceID: types.StringValue(resourceID),
+		Name:       types.StringValue(account.Name),
 		RoleARN:    types.StringValue(account.RoleARN),
 		Regions:    regions,
 	})
@@ -149,6 +158,7 @@ func (r resourceAWSAccount) Create(ctx context.Context, req resource.CreateReque
 
 	accountData := cloudproviderapi.AWSAccount{}
 	accountData.RoleARN = data.RoleARN.ValueString()
+	accountData.Name = data.Name.ValueString()
 	diags = data.Regions.ElementsAs(ctx, &accountData.Regions, false)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -168,6 +178,7 @@ func (r resourceAWSAccount) Create(ctx context.Context, req resource.CreateReque
 		ID:         types.StringValue(resourceAWSAccountTerraformID.Make(data.StackID.ValueString(), account.ID)),
 		StackID:    data.StackID,
 		ResourceID: types.StringValue(account.ID),
+		Name:       data.Name,
 		RoleARN:    data.RoleARN,
 		Regions:    data.Regions,
 	})
@@ -196,6 +207,11 @@ func (r resourceAWSAccount) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	diags = resp.State.SetAttribute(ctx, path.Root("name"), account.Name)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	diags = resp.State.SetAttribute(ctx, path.Root("regions"), account.Regions)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -213,6 +229,7 @@ func (r *resourceAWSAccount) Update(ctx context.Context, req resource.UpdateRequ
 
 	accountData := cloudproviderapi.AWSAccount{}
 	accountData.RoleARN = planData.RoleARN.ValueString()
+	accountData.Name = planData.Name.ValueString()
 	diags = planData.Regions.ElementsAs(ctx, &accountData.Regions, false)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -230,6 +247,11 @@ func (r *resourceAWSAccount) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	diags = resp.State.SetAttribute(ctx, path.Root("role_arn"), account.RoleARN)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = resp.State.SetAttribute(ctx, path.Root("name"), account.Name)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/cloudprovider/resource_aws_account.go
+++ b/internal/resources/cloudprovider/resource_aws_account.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -94,9 +95,8 @@ func (r resourceAWSAccount) Schema(ctx context.Context, req resource.SchemaReque
 			"name": schema.StringAttribute{
 				Description: "An optional human-readable name for this AWS Account resource.",
 				Optional:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:    true, // used to complete the default "" if the resource existed before this field was introduced
+				Default:     stringdefault.StaticString(""),
 			},
 			"role_arn": schema.StringAttribute{
 				Description: "An IAM Role ARN string to represent with this AWS Account resource.",

--- a/internal/resources/cloudprovider/resource_aws_account_test.go
+++ b/internal/resources/cloudprovider/resource_aws_account_test.go
@@ -34,6 +34,7 @@ func TestAccResourceAWSAccount(t *testing.T) {
 					checkAWSAccountResourceExists("grafana_cloud_provider_aws_account.test", testCfg.stackID, &gotAccount),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "stack_id", testCfg.stackID),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "role_arn", account.RoleARN),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "name", account.Name),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.#", strconv.Itoa(len(account.Regions))),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.0", account.Regions[0]),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_aws_account.test", "regions.1", account.Regions[1]),
@@ -107,10 +108,12 @@ resource "grafana_cloud_provider_aws_account" "test" {
 	stack_id = "%[1]s"
 	role_arn = "%[2]s"
 	regions = [%[3]s]
+	name = [%[4]s]
 }
 `,
 		stackID,
 		account.RoleARN,
 		regionsString(account.Regions),
+		account.Name,
 	)
 }

--- a/internal/resources/cloudprovider/resource_aws_account_test.go
+++ b/internal/resources/cloudprovider/resource_aws_account_test.go
@@ -108,8 +108,8 @@ func awsAccountResourceData(stackID string, account cloudproviderapi.AWSAccount)
 resource "grafana_cloud_provider_aws_account" "test" {
 	stack_id = "%[1]s"
 	role_arn = "%[2]s"
+	name = "%[4]s"
 	regions = [%[3]s]
-	name = [%[4]s]
 }
 `,
 		stackID,

--- a/internal/resources/cloudprovider/resource_aws_account_test.go
+++ b/internal/resources/cloudprovider/resource_aws_account_test.go
@@ -21,6 +21,7 @@ func TestAccResourceAWSAccount(t *testing.T) {
 
 	account := cloudproviderapi.AWSAccount{
 		RoleARN: testCfg.roleARN,
+		Name:    testCfg.accountName,
 		Regions: []string{"us-east-1", "us-east-2", "us-west-1"},
 	}
 	var gotAccount cloudproviderapi.AWSAccount

--- a/internal/resources/cloudprovider/utils_test.go
+++ b/internal/resources/cloudprovider/utils_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type testConfig struct {
-	stackID   string
-	accountID string
-	roleARN   string
+	stackID     string
+	accountID   string
+	accountName string
+	roleARN     string
 }
 
 func makeTestConfig(t require.TestingT) testConfig {
@@ -36,9 +37,10 @@ func makeTestConfig(t require.TestingT) testConfig {
 	require.Equal(t, roleARN, gotAccount.RoleARN)
 
 	return testConfig{
-		stackID:   stackID,
-		accountID: accountID,
-		roleARN:   roleARN,
+		stackID:     stackID,
+		accountID:   accountID,
+		accountName: gotAccount.Name,
+		roleARN:     roleARN,
 	}
 }
 


### PR DESCRIPTION
This PR adds support in the cloud-provider section of the provider, to define an optional `name` for a `grafana_cloud_provider_aws_account` resouce, which will help users keep a human readable name in the accounts.

Part of https://github.com/grafana/grafana-csp-app/issues/296