### PR TITLE
test(acceptance): replace deprecated probes for sm-check tests

### DIFF
--- a/docs/data-sources/synthetic_monitoring_probe.md
+++ b/docs/data-sources/synthetic_monitoring_probe.md
@@ -13,8 +13,8 @@ Data source for retrieving a single probe by name.
 ## Example Usage
 
 ```terraform
-data "grafana_synthetic_monitoring_probe" "atlanta" {
-  name = "Atlanta"
+data "grafana_synthetic_monitoring_probe" "Ohio" {
+  name = "Ohio"
 }
 ```
 

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -33,7 +33,7 @@ resource "grafana_synthetic_monitoring_check" "dns" {
   target  = "grafana.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"
@@ -110,7 +110,7 @@ resource "grafana_synthetic_monitoring_check" "http" {
   target  = "https://grafana.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"
@@ -231,7 +231,7 @@ resource "grafana_synthetic_monitoring_check" "ping" {
   target  = "grafana.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"
@@ -278,7 +278,7 @@ resource "grafana_synthetic_monitoring_check" "tcp" {
   target  = "grafana.com:80"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"
@@ -370,7 +370,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
   frequency = 120000
   timeout   = 30000
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"
@@ -928,7 +928,7 @@ resource "grafana_synthetic_monitoring_check" "grpc" {
   target  = "host.docker.internal:50051"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -131,7 +131,7 @@ resource "grafana_synthetic_monitoring_check" "http" {
   target  = "https://grafana.org"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Bangalore,
+    data.grafana_synthetic_monitoring_probes.main.probes.Mumbai,
     data.grafana_synthetic_monitoring_probes.main.probes.Mumbai,
   ]
   labels = {

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -762,7 +762,7 @@ resource "grafana_synthetic_monitoring_check" "multihttp" {
   target  = "https://www.grafana-dev.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Amsterdam,
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
   ]
   labels = {
     foo = "bar"
@@ -790,7 +790,7 @@ resource "grafana_synthetic_monitoring_check" "multihttp" {
   target  = "https://www.an-auth-endpoint.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Amsterdam,
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
   ]
   labels = {
     foo = "bar"

--- a/examples/data-sources/grafana_synthetic_monitoring_probe/data-source.tf
+++ b/examples/data-sources/grafana_synthetic_monitoring_probe/data-source.tf
@@ -1,3 +1,3 @@
-data "grafana_synthetic_monitoring_probe" "atlanta" {
-  name = "Atlanta"
+data "grafana_synthetic_monitoring_probe" "Ohio" {
+  name = "Ohio"
 }

--- a/examples/resources/grafana_synthetic_monitoring_check/dns_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/dns_basic.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "dns" {
   target  = "grafana.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/grpc_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/grpc_basic.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "grpc" {
   target  = "host.docker.internal:50051"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/http_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/http_basic.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "http" {
   target  = "https://grafana.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/http_complex.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/http_complex.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "http" {
   target  = "https://grafana.org"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Bangalore,
+    data.grafana_synthetic_monitoring_probes.main.probes.Mumbai,
     data.grafana_synthetic_monitoring_probes.main.probes.Mumbai,
   ]
   labels = {

--- a/examples/resources/grafana_synthetic_monitoring_check/multihttp_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/multihttp_basic.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "multihttp" {
   target  = "https://www.grafana-dev.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Amsterdam,
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/multihttp_complex.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/multihttp_complex.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "multihttp" {
   target  = "https://www.an-auth-endpoint.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Amsterdam,
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/ping_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/ping_basic.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "ping" {
   target  = "grafana.com"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/tcp_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/tcp_basic.tf
@@ -5,7 +5,7 @@ resource "grafana_synthetic_monitoring_check" "tcp" {
   target  = "grafana.com:80"
   enabled = false
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/examples/resources/grafana_synthetic_monitoring_check/traceroute_basic.tf
+++ b/examples/resources/grafana_synthetic_monitoring_check/traceroute_basic.tf
@@ -7,7 +7,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
   frequency = 120000
   timeout   = 30000
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/internal/resources/syntheticmonitoring/data_source_probe_test.go
+++ b/internal/resources/syntheticmonitoring/data_source_probe_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceProbe(t *testing.T) {
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probe/data-source.tf"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probe.atlanta", "name", "Atlanta"),
+					resource.TestCheckResourceAttr("data.grafana_synthetic_monitoring_probe.Ohio", "name", "Ohio"),
 				),
 			},
 		},

--- a/internal/resources/syntheticmonitoring/data_source_probes_test.go
+++ b/internal/resources/syntheticmonitoring/data_source_probes_test.go
@@ -16,12 +16,12 @@ func TestAccDataSourceProbes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/data-source.tf"),
-				Check:  resource.TestCheckResourceAttrSet("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta"),
+				Check:  resource.TestCheckResourceAttrSet("data.grafana_synthetic_monitoring_probes.main", "probes.Ohio"),
 			},
 			{
 				Config: testutils.TestAccExample(t, "data-sources/grafana_synthetic_monitoring_probes/with-deprecated.tf"),
 				// We're not checking for deprecated probes here because there may not be any, causing tests to fail.
-				Check: resource.TestCheckResourceAttrSet("data.grafana_synthetic_monitoring_probes.main", "probes.Atlanta"),
+				Check: resource.TestCheckResourceAttrSet("data.grafana_synthetic_monitoring_probes.main", "probes.Ohio"),
 			},
 		},
 	})

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -611,7 +611,7 @@ resource "grafana_synthetic_monitoring_check" "no_settings" {
   frequency = 120000
   timeout   = 30000
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"
@@ -631,7 +631,7 @@ resource "grafana_synthetic_monitoring_check" "multiple" {
   frequency = 120000
   timeout   = 30000
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Atlanta,
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
   ]
   labels = {
     foo = "bar"

--- a/pkg/generate/testdata/generate/sm-check/resources.tf.tmpl
+++ b/pkg/generate/testdata/generate/sm-check/resources.tf.tmpl
@@ -11,7 +11,7 @@ resource "grafana_synthetic_monitoring_check" "{{ .Job }}" {
   labels = {
     foo = "bar"
   }
-  probes  = [7]
+  probes  = [19]
   target  = "https://grafana.com"
   timeout = 3000
   settings {


### PR DESCRIPTION
Several probes have been [deprecated and will be removed](https://grafana.com/docs/grafana-cloud/whats-new/2025-01-14-launch-and-shutdown-dates-for-synthetics-probes-in-february-2025/), these were failing the cloudinstance acceptance tests. This PR replaces those probes with others that will stick around for a while.