### PR TITLE
Add cluster slug to stack

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -39,6 +39,7 @@ available at “https://<stack_slug>.grafana.net".
 - `alertmanager_status` (String) Status of the Alertmanager instance configured for this stack.
 - `alertmanager_url` (String) Base URL of the Alertmanager instance configured for this stack.
 - `alertmanager_user_id` (Number) User ID of the Alertmanager instance configured for this stack.
+- `cluster_slug` (String) Slug of the cluster where this stack resides.
 - `description` (String) Description of stack.
 - `graphite_name` (String)
 - `graphite_status` (String)

--- a/docs/index.md
+++ b/docs/index.md
@@ -274,7 +274,7 @@ resource "grafana_oncall_escalation" "example_notify_step" {
 #### Obtaining Cloud Provider access token
 
 Before using the Terraform Provider to manage Grafana Cloud Provider Observability resources, such as AWS CloudWatch scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Cloud Provider API.
-[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-an-access-policy-for-a-stack) will guide you on how to create
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
 
 Also, by default the Access Policies UI will not show those scopes, to find name you need to use the `Add Scope` textbox, as shown in the following image:
@@ -282,7 +282,7 @@ Also, by default the Access Policies UI will not show those scopes, to find name
 <img src="https://grafana.com/media/docs/grafana-cloud/aws/cloud-provider-terraform-access-policy-creation.png" width="700"/>
 
 Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Cloud Provider API. You can do so just after creating the access policy, following
-the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-one-or-more-access-policy-tokens).
 
 #### Obtaining Cloud Provider API hostname
 
@@ -399,7 +399,7 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 #### Obtaining Connections access token
 
 Before using the Terraform Provider to manage Grafana Connections resources, such as metrics endpoint scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Connections API.
-[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-an-access-policy-for-a-stack) will guide you on how to create
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
 
 Also, by default the Access Policies UI will not show those scopes, instead, search for it using the `Add Scope` textbox, as shown in the following image:
@@ -410,7 +410,7 @@ Also, by default the Access Policies UI will not show those scopes, instead, sea
 1. Once done, you should see the scopes selected with checkboxes.
 
 Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Connections API. You can do so just after creating the access policy, following
-the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-one-or-more-access-policy-tokens).
 
 #### Obtaining Connections API hostname
 
@@ -456,7 +456,7 @@ This can be a Grafana API key, basic auth `username:password`, or a
 
 ### `cloud_access_policy_token`
 
-An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/).
+An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/).
 
 ### `sm_access_token`
 
@@ -475,6 +475,6 @@ To create one, follow the instructions in the [obtaining cloud provider access t
 
 ### `connections_api_access_token`
 
-An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/) to manage
+An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/) to manage
 connections resources, such as Metrics Endpoint jobs.
 For guidance on creating one, see section [obtaining connections access token](#obtaining-connections-access-token).

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -52,6 +52,7 @@ resource "grafana_cloud_stack" "test" {
 - `alertmanager_status` (String) Status of the Alertmanager instance configured for this stack.
 - `alertmanager_url` (String) Base URL of the Alertmanager instance configured for this stack.
 - `alertmanager_user_id` (Number) User ID of the Alertmanager instance configured for this stack.
+- `cluster_slug` (String) Slug of the cluster where this stack resides.
 - `graphite_name` (String)
 - `graphite_status` (String)
 - `graphite_url` (String)

--- a/internal/resources/cloud/data_source_cloud_stack_test.go
+++ b/internal/resources/cloud/data_source_cloud_stack_test.go
@@ -35,6 +35,7 @@ func TestAccDataSourceStack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "prometheus_url"),
 					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "prometheus_user_id"),
 					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "alertmanager_user_id"),
+					resource.TestCheckResourceAttrSet("data.grafana_cloud_stack.test", "cluster_slug"),
 				),
 			},
 		},

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -83,6 +83,7 @@ Required access policy scopes:
 					return oldValue == newValue || newValue == "" // Ignore default region
 				},
 			},
+			"cluster_slug": common.ComputedStringWithDescription("Slug of the cluster where this stack resides."),
 			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -369,6 +370,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("url", stack.Url)
 	d.Set("status", stack.Status)
 	d.Set("region_slug", stack.RegionSlug)
+	d.Set("cluster_slug", stack.ClusterSlug)
 	d.Set("description", stack.Description)
 	d.Set("labels", stack.Labels)
 

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -52,6 +52,7 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "profiles_status"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "otlp_url"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "influx_url"),
+		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "cluster_slug"),
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -42,7 +42,7 @@ an specific `oncall_access_token` instead, that you can create in the web UI:
 #### Obtaining Cloud Provider access token
 
 Before using the Terraform Provider to manage Grafana Cloud Provider Observability resources, such as AWS CloudWatch scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Cloud Provider API.
-[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-an-access-policy-for-a-stack) will guide you on how to create
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
 
 Also, by default the Access Policies UI will not show those scopes, to find name you need to use the `Add Scope` textbox, as shown in the following image:
@@ -50,7 +50,7 @@ Also, by default the Access Policies UI will not show those scopes, to find name
 <img src="https://grafana.com/media/docs/grafana-cloud/aws/cloud-provider-terraform-access-policy-creation.png" width="700"/>
 
 Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Cloud Provider API. You can do so just after creating the access policy, following
-the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-one-or-more-access-policy-tokens).
 
 #### Obtaining Cloud Provider API hostname
 
@@ -97,7 +97,7 @@ The following are examples on how the *Account* and *Scrape Job* resources can b
 #### Obtaining Connections access token
 
 Before using the Terraform Provider to manage Grafana Connections resources, such as metrics endpoint scrape jobs, you need to create an access policy token on the Grafana Cloud Portal. This token is used to authenticate the provider to the Grafana Connections API.
-[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-an-access-policy-for-a-stack) will guide you on how to create
+[These docs](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-an-access-policy-for-a-stack) will guide you on how to create
 an access policy. The required permissions, or scopes, are `integration-management:read`, `integration-management:write` and `stacks:read`.
 
 Also, by default the Access Policies UI will not show those scopes, instead, search for it using the `Add Scope` textbox, as shown in the following image:
@@ -108,7 +108,7 @@ Also, by default the Access Policies UI will not show those scopes, instead, sea
 1. Once done, you should see the scopes selected with checkboxes.
 
 Having created an Access Policy, you can now create a token that will be used to authenticate the provider to the Connections API. You can do so just after creating the access policy, following
-the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/#create-one-or-more-access-policy-tokens).
+the in-screen instructions, of following [this guide](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/#create-one-or-more-access-policy-tokens).
 
 #### Obtaining Connections API hostname
 
@@ -154,7 +154,7 @@ This can be a Grafana API key, basic auth `username:password`, or a
 
 ### `cloud_access_policy_token`
 
-An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/).
+An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/).
 
 ### `sm_access_token`
 
@@ -173,6 +173,6 @@ To create one, follow the instructions in the [obtaining cloud provider access t
 
 ### `connections_api_access_token`
 
-An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/authorize-services/) to manage
+An access policy token created on the [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/using-an-access-policy-token/) to manage
 connections resources, such as Metrics Endpoint jobs.
 For guidance on creating one, see section [obtaining connections access token](#obtaining-connections-access-token).


### PR DESCRIPTION
I was attempting to simplify some extra setup we have for the cloud provider fields by being able to programmatically build it using two providers. The problem is that we only expose the `region_slug` which cannot be used to build the URL. We have customers pull their `clusterSlug` to generate the URL today and with `cluster_slug` we could simplify it to be all through terraform like,

```HCL
provider "grafana" {
}

data "grafana_cloud_organization" "current" {
  slug = "my-org"
}

data "grafana_cloud_stack" "current" {
  slug = "my-stack"
}

resource "grafana_cloud_access_policy" "cloud_provider_policy" {
  region       = data.grafana_cloud_stack.current.region_slug
  name         = "cloud-provider-terraform"
  display_name = "Access policy used for Cloud Provider o11y setup"

  scopes = ["integration-management:read", "integration-management:write", "stacks:read"]

  realm {
    type       = "org"
    identifier = data.grafana_cloud_organization.current.id
  }
}

resource "grafana_cloud_access_policy_token" "cloud_provider_token" {
  region           = data.grafana_cloud_stack.current.region_slug
  access_policy_id = grafana_cloud_access_policy.cloud_provider_policy.policy_id
  name             = "cloud-provider-terraform"
  display_name     = "Token used for Cloud Provider o11y setup"
}

provider "grafana" {
  alias                       = "cloud_provider"
  cloud_provider_url          = format("https://cloud-provider-api-%s.grafana.net", data.grafana_cloud_stack.current.cluster_slug)
  cloud_provider_access_token = grafana_cloud_access_policy_token.cloud_provider_token.token
}
```