### PR TITLE
Cloud: Check if cloud configuration exists

### DIFF
--- a/internal/resources/cloud/common.go
+++ b/internal/resources/cloud/common.go
@@ -71,6 +71,15 @@ func (r *basePluginFrameworkDataSource) Configure(ctx context.Context, req datas
 		return
 	}
 
+	if client.GrafanaCloudAPI == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the Grafana Cloud API.",
+			"Please ensure that cloud_api_url and cloud_access_policy_token are set in the provider configuration.",
+		)
+
+		return
+	}
+
 	r.client = client.GrafanaCloudAPI
 }
 

--- a/internal/resources/cloud/data_source_cloud_access_policies.go
+++ b/internal/resources/cloud/data_source_cloud_access_policies.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var _ datasource.DataSource = &AccessPoliciesDataSource{}
+var _ datasource.DataSourceWithConfigure = &AccessPoliciesDataSource{}
+
 var dataSourceAccessPoliciesName = "grafana_cloud_access_policies"
 
 func datasourceAccessPolicies() *common.DataSource {

--- a/internal/resources/cloud/data_source_private_data_source_connect_network.go
+++ b/internal/resources/cloud/data_source_private_data_source_connect_network.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var _ datasource.DataSource = &PDCNetworksDataSource{}
+var _ datasource.DataSourceWithConfigure = &PDCNetworksDataSource{}
+
 var dataSourcePrivateDataSourceConnectNetworksName = "grafana_cloud_private_data_source_connect_networks"
 
 func datasourcePrivateDataSourceConnectNetworks() *common.DataSource {


### PR DESCRIPTION
It adds a check if the `GrafanaCloudAPI` configuration is set to early fail and avoid to panic if its nil.

Also it adds checks to ensure that the datasource implements the necessary configuration. Information [here](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-data-source-read#implement-data-source-client-functionality).