### PR TITLE
Reject recording rules with incompatible fields

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -139,11 +139,11 @@ Optional:
 
 - `annotations` (Map of String) Key-value pairs of metadata to attach to the alert rule. They add additional information, such as a `summary` or `runbook_url`, to help identify and investigate alerts. The `dashboardUId` and `panelId` annotations, which link alerts to a panel, must be set together. Defaults to `map[]`.
 - `condition` (String) The `ref_id` of the query node in the `data` field to use as the alert condition.
-- `exec_err_state` (String) Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are OK, Error, KeepLast, and Alerting. Defaults to `Alerting`.
+- `exec_err_state` (String) Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are OK, Error, KeepLast, and Alerting.  Defaults to Alerting if not set.
 - `for` (String) The amount of time for which the rule must be breached for the rule to be considered to be Firing. Before this time has elapsed, the rule is only considered to be Pending. Defaults to `0`.
 - `is_paused` (Boolean) Sets whether the alert should be paused or not. Defaults to `false`.
 - `labels` (Map of String) Key-value pairs to attach to the alert rule that can be used in matching, grouping, and routing. Defaults to `map[]`.
-- `no_data_state` (String) Describes what state to enter when the rule's query returns No Data. Options are OK, NoData, KeepLast, and Alerting. Defaults to `NoData`.
+- `no_data_state` (String) Describes what state to enter when the rule's query returns No Data. Options are OK, NoData, KeepLast, and Alerting. Defaults to NoData if not set.
 - `notification_settings` (Block List, Max: 1) Notification settings for the rule. If specified, it overrides the notification policies. Available since Grafana 10.4, requires feature flag 'alertingSimplifiedRouting' to be enabled. (see [below for nested schema](#nestedblock--rule--notification_settings))
 - `record` (Block List, Max: 1) Settings for a recording rule. Available since Grafana 11.2, requires feature flag 'grafanaManagedRecordingRules' to be enabled. (see [below for nested schema](#nestedblock--rule--record))
 

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -132,13 +132,13 @@ EOT
 
 Required:
 
-- `condition` (String) The `ref_id` of the query node in the `data` field to use as the alert condition.
 - `data` (Block List, Min: 1) A sequence of stages that describe the contents of the rule. (see [below for nested schema](#nestedblock--rule--data))
 - `name` (String) The name of the alert rule.
 
 Optional:
 
 - `annotations` (Map of String) Key-value pairs of metadata to attach to the alert rule. They add additional information, such as a `summary` or `runbook_url`, to help identify and investigate alerts. The `dashboardUId` and `panelId` annotations, which link alerts to a panel, must be set together. Defaults to `map[]`.
+- `condition` (String) The `ref_id` of the query node in the `data` field to use as the alert condition.
 - `exec_err_state` (String) Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are OK, Error, KeepLast, and Alerting. Defaults to `Alerting`.
 - `for` (String) The amount of time for which the rule must be breached for the rule to be considered to be Firing. Before this time has elapsed, the rule is only considered to be Pending. Defaults to `0`.
 - `is_paused` (Boolean) Sets whether the alert should be paused or not. Defaults to `false`.

--- a/internal/resources/grafana/resource_alerting_mute_timing_test.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing_test.go
@@ -118,11 +118,11 @@ func TestAccMuteTiming_RemoveInUse(t *testing.T) {
 		locals {
 			use_mute = %t
 		}
-		
+
 		resource "grafana_organization" "my_org" {
 			name = "mute-timing-test"
 		}
-		
+
 		resource "grafana_contact_point" "default_policy" {
 			org_id = grafana_organization.my_org.id
 			name   = "default-policy"
@@ -130,7 +130,7 @@ func TestAccMuteTiming_RemoveInUse(t *testing.T) {
 				addresses = ["test@example.com"]
 			}
 		}
-		
+
 		resource "grafana_notification_policy" "org_policy" {
 			org_id             = grafana_organization.my_org.id
 			group_by           = ["..."]
@@ -138,9 +138,9 @@ func TestAccMuteTiming_RemoveInUse(t *testing.T) {
 			group_interval     = "6m"
 			repeat_interval    = "3h"
 			contact_point      = grafana_contact_point.default_policy.name
-			
+
 			policy {
-				mute_timings = local.use_mute ? [grafana_mute_timing.test[0].name] : [] 
+				mute_timings = local.use_mute ? [grafana_mute_timing.test[0].name] : []
 				contact_point = grafana_contact_point.default_policy.name
 			}
 		}
@@ -167,7 +167,7 @@ func TestAccMuteTiming_RemoveInUse(t *testing.T) {
 }
 
 func TestAccMuteTiming_RemoveInUseInAlertRule(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t) // TODO: Switch to OSS when this is released: https://github.com/grafana/grafana/pull/90500
+	testutils.CheckOSSTestsEnabled(t, ">=11.2.0")
 
 	randomStr := acctest.RandString(6)
 
@@ -176,11 +176,11 @@ func TestAccMuteTiming_RemoveInUseInAlertRule(t *testing.T) {
 		locals {
 			use_mute = %[2]t
 		}
-		
+
 		resource "grafana_folder" "rule_folder" {
 			title  = "%[1]s"
 		}
-		
+
 		resource "grafana_contact_point" "default_policy" {
 			name   = "%[1]s"
 			email {
@@ -219,7 +219,7 @@ func TestAccMuteTiming_RemoveInUseInAlertRule(t *testing.T) {
 			}
 		}
 
-		
+
 		resource "grafana_mute_timing" "test" {
 			count = local.use_mute ? 1 : 0
 			name = "%[1]s"

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -795,7 +795,3 @@ func unpackRecord(p interface{}) *models.Record {
 	}
 	return res
 }
-
-func isValidRecordRule(rule *models.ProvisionedAlertRule) {
-
-}

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -624,11 +624,11 @@ func checkFields(rule *models.ProvisionedAlertRule) error {
 		if rule.Condition != nil {
 			return fmt.Errorf(incompatFieldMsgFmt, "condition")
 		}
-	} else {
-		// condition is required if the rule is not a recording rule
-		if rule.Condition == nil {
-			return fmt.Errorf(`"condition" is required`)
-		}
+	}
+
+	// condition is required if the rule is not a recording rule
+	if rule.Condition == nil {
+		return fmt.Errorf(`"condition" is required`)
 	}
 	return nil
 }

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -107,11 +107,25 @@ This resource requires Grafana 9.1.0 or later.
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Describes what state to enter when the rule's query returns No Data. Options are OK, NoData, KeepLast, and Alerting. Defaults to NoData if not set.",
+							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+								// We default to this value later in the pipeline, so we need to account for that here.
+								if newValue == "" {
+									return oldValue == "NoData"
+								}
+								return oldValue == newValue
+							},
 						},
 						"exec_err_state": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Describes what state to enter when the rule's query is invalid and the rule cannot be executed. Options are OK, Error, KeepLast, and Alerting.  Defaults to Alerting if not set.",
+							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+								// We default to this value later in the pipeline, so we need to account for that here.
+								if newValue == "" {
+									return oldValue == "Alerting"
+								}
+								return oldValue == newValue
+							},
 						},
 						"condition": {
 							Type:        schema.TypeString,

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -676,7 +676,7 @@ func TestAccAlertRule_NotificationSettings(t *testing.T) {
 }
 
 func TestAccRecordingRule(t *testing.T) {
-	testutils.CheckCloudInstanceTestsEnabled(t) // TODO: change to 11.3.1 when available
+	testutils.CheckOSSTestsEnabled(t, ">=11.4.0")
 
 	var group models.AlertRuleGroup
 	var name = acctest.RandString(10)
@@ -697,15 +697,28 @@ func TestAccRecordingRule(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.record.0.metric", metric),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.record.0.from", "A"),
 					// ensure fields are empty as expected
-					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.for", "0"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.for", "0s"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.condition", ""),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.no_data_state", ""),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.exec_err_state", ""),
 				),
 			},
+		},
+	})
+}
+
+func TestAccRecordingRule_incompatibleSettings(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=11.4.0")
+
+	var name = acctest.RandString(10)
+	var metric = "valid_metric"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
 			{
 				Config:      testAccRecordingRuleInvalid(name, metric, "A"),
-				ExpectError: regexp.MustCompile(`rule with name "My Random Walk Alert" contains incompatible fields: "record" and "for" cannot be set together`),
+				ExpectError: regexp.MustCompile(`conflicting fields "record" and "for"`),
 			},
 		},
 	})


### PR DESCRIPTION
This PR introduces logic to validate that conflicting fields are not used for recording rules, since these values are stripped by Grafana and will cause plans to always show diffs for these fields.

Note: Due to limitations in the SDK this PR moves some validation out of the schema into `CreateContext` in order to allow for us to check for conflicting fields, which is not possible on a `ListType`