### PR TITLE
Add client nil checks to avoid panics

### DIFF
--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -5,7 +5,7 @@ subcategory: "Grafana OSS"
 description: |-
   Manages Grafana public dashboards.
   Note: This resource is available only with Grafana 10.2+.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
 ---
 
 # grafana_dashboard_public (Resource)
@@ -14,7 +14,7 @@ Manages Grafana public dashboards.
 
 **Note:** This resource is available only with Grafana 10.2+.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
 
 ## Example Usage

--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -14,7 +14,7 @@ Manages Grafana public dashboards.
 
 **Note:** This resource is available only with Grafana 10.2+.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
 
 ## Example Usage

--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -14,7 +14,7 @@ Manages Grafana public dashboards.
 
 **Note:** This resource is available only with Grafana 10.2+.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
 
 ## Example Usage

--- a/internal/resources/cloud/common.go
+++ b/internal/resources/cloud/common.go
@@ -104,5 +104,14 @@ func (r *basePluginFrameworkResource) Configure(ctx context.Context, req resourc
 		return
 	}
 
+	if client.GrafanaCloudAPI == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the Grafana Cloud API.",
+			"Please ensure that cloud_api_url and cloud_access_policy_token are set in the provider configuration.",
+		)
+
+		return
+	}
+
 	r.client = client.GrafanaCloudAPI
 }

--- a/internal/resources/grafana/common_plugin_framework.go
+++ b/internal/resources/grafana/common_plugin_framework.go
@@ -38,6 +38,15 @@ func (r *basePluginFrameworkDataSource) Configure(ctx context.Context, req datas
 		return
 	}
 
+	if client.GrafanaAPI == nil || client.GrafanaAPIConfig == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the Grafana API.",
+			"Please ensure that url and auth are set in the provider configuration.",
+		)
+
+		return
+	}
+
 	r.client = client.GrafanaAPI
 	r.config = client.GrafanaAPIConfig
 }
@@ -76,6 +85,15 @@ func (r *basePluginFrameworkResource) Configure(ctx context.Context, req resourc
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *common.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	if client.GrafanaAPI == nil || client.GrafanaAPIConfig == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the Grafana API.",
+			"Please ensure that url and auth are set in the provider configuration.",
 		)
 
 		return

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -27,7 +27,7 @@ Manages Grafana public dashboards.
 
 **Note:** This resource is available only with Grafana 10.2+.
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/)
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
 `,
 

--- a/internal/resources/machinelearning/resource_alert.go
+++ b/internal/resources/machinelearning/resource_alert.go
@@ -76,6 +76,15 @@ func (r *alertResource) Configure(ctx context.Context, req resource.ConfigureReq
 		return
 	}
 
+	if client.MLAPI == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the MLAPI API.",
+			"Please ensure that url and auth are set in the provider configuration.",
+		)
+
+		return
+	}
+
 	r.mlapi = client.MLAPI
 }
 

--- a/internal/resources/oncall/resources.go
+++ b/internal/resources/oncall/resources.go
@@ -36,6 +36,15 @@ func (r *basePluginFrameworkResource) Configure(ctx context.Context, req resourc
 		return
 	}
 
+	if client.OnCallClient == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the OnCall API.",
+			"Please ensure that oncall_url and oncall_access_token/auth are set in the provider configuration.",
+		)
+
+		return
+	}
+
 	r.client = client.OnCallClient
 }
 
@@ -55,6 +64,15 @@ func (r *basePluginFrameworkDataSource) Configure(ctx context.Context, req datas
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *common.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	if client.OnCallClient == nil {
+		resp.Diagnostics.AddError(
+			"The Grafana Provider is missing a configuration for the OnCall API.",
+			"Please ensure that oncall_url and oncall_access_token/auth are set in the provider configuration.",
 		)
 
 		return


### PR DESCRIPTION
Same as: https://github.com/grafana/terraform-provider-grafana/pull/1999 but for the missing clients.

Probably we could do something nicer since it follows the same pattern everywhere. But at the moment we should stop the bleeding.