### PR TITLE
Add support for the additional tags for the Azure metrics

### DIFF
--- a/docs/data-sources/cloud_provider_azure_credential.md
+++ b/docs/data-sources/cloud_provider_azure_credential.md
@@ -20,6 +20,8 @@ resource "grafana_cloud_provider_azure_credential" "test" {
   client_secret = "my-client-secret"
   tenant_id     = "my-tenant-id"
 
+  resource_tags_to_add_to_metrics = ["tag1", "tag2"]
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"
@@ -76,6 +78,7 @@ data "grafana_cloud_provider_azure_credential" "test" {
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".
 - `name` (String) The name of the Azure Credential.
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
+- `resource_tags_to_add_to_metrics` (Set of String) A set of regions that this AWS Account resource applies to.
 - `tenant_id` (String) The tenant ID of the Azure Credential.
 
 <a id="nestedblock--auto_discovery_configuration"></a>

--- a/docs/resources/cloud_provider_azure_credential.md
+++ b/docs/resources/cloud_provider_azure_credential.md
@@ -20,6 +20,8 @@ resource "grafana_cloud_provider_azure_credential" "test" {
   client_secret = "my-client-secret"
   tenant_id     = "my-tenant-id"
 
+  resource_tags_to_add_to_metrics = ["tag1", "tag2"]
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"
@@ -70,6 +72,7 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 
 - `auto_discovery_configuration` (Block List) The list of auto discovery configurations. (see [below for nested schema](#nestedblock--auto_discovery_configuration))
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
+- `resource_tags_to_add_to_metrics` (Set of String) A set of regions that this AWS Account resource applies to.
 
 ### Read-Only
 

--- a/examples/data-sources/grafana_cloud_provider_azure_credential/data-source.tf
+++ b/examples/data-sources/grafana_cloud_provider_azure_credential/data-source.tf
@@ -5,6 +5,8 @@ resource "grafana_cloud_provider_azure_credential" "test" {
   client_secret = "my-client-secret"
   tenant_id     = "my-tenant-id"
 
+  resource_tags_to_add_to_metrics = ["tag1", "tag2"]
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"

--- a/examples/resources/grafana_cloud_provider_azure_credential/resource.tf
+++ b/examples/resources/grafana_cloud_provider_azure_credential/resource.tf
@@ -5,6 +5,8 @@ resource "grafana_cloud_provider_azure_credential" "test" {
   client_secret = "my-client-secret"
   tenant_id     = "my-tenant-id"
 
+  resource_tags_to_add_to_metrics = ["tag1", "tag2"]
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"

--- a/internal/common/cloudproviderapi/client.go
+++ b/internal/common/cloudproviderapi/client.go
@@ -220,6 +220,9 @@ type AzureCredential struct {
 
 	// AutoDiscoveryConfiguration is the configuration for auto-discovery of Azure resources.
 	AutoDiscoveryConfiguration []AutoDiscoveryConfiguration `json:"auto_discovery_configuration"`
+
+	// ResourceTagsToAddToMetrics is the list of Azure resource tags to add to metrics.
+	ResourceTagsToAddToMetrics []string `json:"resource_tags_to_add_to_metrics"`
 }
 
 type AutoDiscoveryConfiguration struct {

--- a/internal/resources/cloudprovider/azure_credential_test.go
+++ b/internal/resources/cloudprovider/azure_credential_test.go
@@ -37,6 +37,7 @@ func TestAcc_AzureCredential(t *testing.T) {
         "value": "value-2"
       }
     ],
+	"resource_tags_to_add_to_metrics" : ["tag1", "tag2"],
     "auto_discovery_configuration": [
       {
         "subscription_id": "my-subscription_id",
@@ -94,6 +95,7 @@ func TestAcc_AzureCredential(t *testing.T) {
         "value": "value-2"
       }
     ],
+	"resource_tags_to_add_to_metrics" : ["tag1", "tag2"],
 	"auto_discovery_configuration": [
       {
         "subscription_id": "my-subscription_id",
@@ -146,6 +148,7 @@ func TestAcc_AzureCredential(t *testing.T) {
         "value": "value-2"
       }
     ],
+	"resource_tags_to_add_to_metrics" : ["tag1", "tag2"],
 	"auto_discovery_configuration": [
       {
         "subscription_id": "my-subscription_id",
@@ -218,6 +221,8 @@ func TestAcc_AzureCredential(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.dimensions.0", "GeoType"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.dimensions.1", "ApiName"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.aggregations.0", "Average"),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.0", "tag1"),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.1", "tag2"),
 				),
 			},
 			{
@@ -243,6 +248,8 @@ func TestAcc_AzureCredential(t *testing.T) {
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.dimensions.0", "GeoType"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.dimensions.1", "ApiName"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.aggregations.0", "Average"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.0", "tag1"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.1", "tag2"),
 				),
 			},
 		},

--- a/internal/resources/cloudprovider/data_source_azure_credential.go
+++ b/internal/resources/cloudprovider/data_source_azure_credential.go
@@ -75,6 +75,11 @@ func (r *datasourceAzureCredential) Schema(ctx context.Context, req datasource.S
 				Computed:    true,
 				Sensitive:   true,
 			},
+			"resource_tags_to_add_to_metrics": schema.SetAttribute{
+				Description: "A set of regions that this AWS Account resource applies to.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"resource_discovery_tag_filter": schema.ListNestedBlock{
@@ -175,6 +180,12 @@ func (r *datasourceAzureCredential) Read(ctx context.Context, req datasource.Rea
 	}
 	diags = resp.State.SetAttribute(ctx, path.Root("auto_discovery_configuration"), convertedAutoDiscoveryConfigurations)
 	resp.Diagnostics.Append(diags...)
+
+	diags = resp.State.SetAttribute(ctx, path.Root("resource_tags_to_add_to_metrics"), credential.ResourceTagsToAddToMetrics)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -3,6 +3,7 @@ package cloudprovider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -34,6 +35,7 @@ type resourceAzureCredentialModel struct {
 	ResourceID                 types.String `tfsdk:"resource_id"`
 	ResourceTagFilters         types.List   `tfsdk:"resource_discovery_tag_filter"`
 	AutoDiscoveryConfiguration types.List   `tfsdk:"auto_discovery_configuration"`
+	ResourceTagsToAddToMetrics types.Set    `tfsdk:"resource_tags_to_add_to_metrics"`
 }
 
 type TagFilter struct {
@@ -170,6 +172,11 @@ func (r *resourceAzureCredential) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 				Sensitive:   true,
 			},
+			"resource_tags_to_add_to_metrics": schema.SetAttribute{
+				Description: "A set of regions that this AWS Account resource applies to.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"resource_discovery_tag_filter": schema.ListNestedBlock{
@@ -238,6 +245,12 @@ func (r *resourceAzureCredential) ImportState(ctx context.Context, req resource.
 		return
 	}
 
+	resourceTagsToAddToMetrics, diags := types.SetValueFrom(ctx, basetypes.StringType{}, credentials.ResourceTagsToAddToMetrics)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.State.Set(ctx, &resourceAzureCredentialModel{
 		ID:                         types.StringValue(req.ID),
 		Name:                       types.StringValue(credentials.Name),
@@ -248,6 +261,7 @@ func (r *resourceAzureCredential) ImportState(ctx context.Context, req resource.
 		ClientSecret:               types.StringValue(""), // We don't import the client secret
 		ResourceTagFilters:         tagFilters,
 		AutoDiscoveryConfiguration: autoconfiguration,
+		ResourceTagsToAddToMetrics: resourceTagsToAddToMetrics,
 	})
 }
 
@@ -292,6 +306,12 @@ func (r *resourceAzureCredential) Create(ctx context.Context, req resource.Creat
 		AutoDiscoveryConfiguration: requestAutoDiscoveryConfiguration,
 	}
 
+	diags = data.ResourceTagsToAddToMetrics.ElementsAs(ctx, &azureCredential.ResourceTagsToAddToMetrics, false)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	credential, err := r.client.CreateAzureCredential(
 		ctx,
 		data.StackID.ValueString(),
@@ -312,6 +332,7 @@ func (r *resourceAzureCredential) Create(ctx context.Context, req resource.Creat
 		ResourceID:                 types.StringValue(credential.ID),
 		ResourceTagFilters:         data.ResourceTagFilters,
 		AutoDiscoveryConfiguration: data.AutoDiscoveryConfiguration,
+		ResourceTagsToAddToMetrics: data.ResourceTagsToAddToMetrics,
 	})
 }
 
@@ -386,6 +407,12 @@ func (r *resourceAzureCredential) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("resource_tags_to_add_to_metrics"), credential.ResourceTagsToAddToMetrics)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 func (r *resourceAzureCredential) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -425,6 +452,12 @@ func (r *resourceAzureCredential) Update(ctx context.Context, req resource.Updat
 	}
 
 	credential.AutoDiscoveryConfiguration = autoDiscoveryConfigurations
+
+	diags = planData.ResourceTagsToAddToMetrics.ElementsAs(ctx, &credential.ResourceTagsToAddToMetrics, false)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	credentialResponse, err := r.client.UpdateAzureCredential(
 		ctx,
@@ -478,6 +511,12 @@ func (r *resourceAzureCredential) Update(ctx context.Context, req resource.Updat
 		return
 	}
 	diags = resp.State.SetAttribute(ctx, path.Root("auto_discovery_configuration"), convertedAutoDiscoveryConfigurations)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("resource_tags_to_add_to_metrics"), planData.ResourceTagsToAddToMetrics)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -3,7 +3,6 @@ package cloudprovider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common/cloudproviderapi"


### PR DESCRIPTION
This PR adds one more field to the Azure credentials configuration. `resource_tags_to_add_to_metrics` allows the addition of some existing tags on the resources to the metrics.