### PR TITLE
Alerting: Adding color option to slack contact point

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -358,6 +358,7 @@ Read-Only:
 
 Optional:
 
+- `color` (String) Templated color of the slack message.
 - `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
 - `endpoint_url` (String) Use this to override the Slack API endpoint URL to send requests to.
 - `icon_emoji` (String) The name of a Slack workspace emoji to use as the bot icon.
@@ -372,7 +373,6 @@ Optional:
 - `token` (String, Sensitive) A Slack API token,for sending messages directly without the webhook method.
 - `url` (String, Sensitive) A Slack webhook URL,for sending messages via the webhook method.
 - `username` (String) Username for the bot to use.
-- `color` (String) Templated color of the slack message.
 
 Read-Only:
 

--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -372,6 +372,7 @@ Optional:
 - `token` (String, Sensitive) A Slack API token,for sending messages directly without the webhook method.
 - `url` (String, Sensitive) A Slack webhook URL,for sending messages via the webhook method.
 - `username` (String) Username for the bot to use.
+- `color` (String) Templated color of the slack message.
 
 Read-Only:
 

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -118,6 +118,7 @@ resource "grafana_contact_point" "receiver_types" {
     mention_channel = "here"
     mention_users   = "user"
     mention_groups  = "group"
+    color           = "color"
   }
 
   teams {

--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -1514,6 +1514,11 @@ func (s slackNotifier) schema() *schema.Resource {
 		Optional:    true,
 		Description: "Comma-separated list of groups to mention in the message.",
 	}
+	r.Schema["color"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Templated color of the slack message.",
+	}
 	return r
 }
 
@@ -1533,6 +1538,7 @@ func (s slackNotifier) pack(p *models.EmbeddedContactPoint, data *schema.Resourc
 	packNotifierStringField(&settings, &notifier, "mentionChannel", "mention_channel")
 	packNotifierStringField(&settings, &notifier, "mentionUsers", "mention_users")
 	packNotifierStringField(&settings, &notifier, "mentionGroups", "mention_groups")
+	packNotifierStringField(&settings, &notifier, "color", "color")
 
 	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, s, p.UID), s.meta().secureFields)
 
@@ -1557,6 +1563,7 @@ func (s slackNotifier) unpack(raw interface{}, name string) *models.EmbeddedCont
 	unpackNotifierStringField(&json, &settings, "mention_channel", "mentionChannel")
 	unpackNotifierStringField(&json, &settings, "mention_users", "mentionUsers")
 	unpackNotifierStringField(&json, &settings, "mention_groups", "mentionGroups")
+	unpackNotifierStringField(&json, &settings, "color", "color")
 
 	return &models.EmbeddedContactPoint{
 		UID:                   uid,

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -261,6 +261,7 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_channel", "here"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_users", "user"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.mention_groups", "group"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "slack.0.color", "color"),
 					// teams
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "teams.0.url", "http://teams-webhook"),


### PR DESCRIPTION
Adding the color option when provisioning slack contact point. 

Issue:
https://github.com/grafana/alerting/issues/251

Related PRs:
https://github.com/grafana/grafana/pull/99615
https://github.com/grafana/alerting/pull/270
