### PR TITLE
Update PDC scopes

### DIFF
--- a/internal/resources/cloud/data_source_private_data_source_connect_network.go
+++ b/internal/resources/cloud/data_source_private_data_source_connect_network.go
@@ -118,7 +118,8 @@ func (r *PDCNetworksDataSource) Read(ctx context.Context, req datasource.ReadReq
 			if data.NameFilter.ValueString() != "" && data.NameFilter.ValueString() != policy.Name {
 				continue
 			}
-			if !slices.Contains(policy.Scopes, "pdc-signing:write") {
+			// Include pdc-signing:write to account for old PDC access policies
+			if !slices.Contains(policy.Scopes, "pdc-signing:write") || !slices.Contains(policy.Scopes, "set:pdc-signing") {
 				continue
 			}
 			data.PrivateDataSourceNetworks = append(data.PrivateDataSourceNetworks, PDCNetworksDataSourcePolicyModel{

--- a/internal/resources/cloud/resource_private_data_source_connect_network.go
+++ b/internal/resources/cloud/resource_private_data_source_connect_network.go
@@ -124,7 +124,8 @@ func listPDCNetworkIds(ctx context.Context, client *gcom.APIClient, data *Lister
 		}
 
 		for _, policy := range resp.Items {
-			if slices.Contains(policy.Scopes, "pdc-signing:write") {
+			// Include pdc-signing:write to account for old PDC access policies
+			if slices.Contains(policy.Scopes, "pdc-signing:write") || slices.Contains(policy.Scopes, "set:pdc-signing") {
 				policies = append(policies, resourceAccessPolicyID.Make(regionSlug, policy.Id))
 			}
 		}
@@ -145,7 +146,7 @@ func createPDCNetwork(ctx context.Context, d *schema.ResourceData, client *gcom.
 		PostAccessPoliciesRequest(gcom.PostAccessPoliciesRequest{
 			Name:        d.Get("name").(string),
 			DisplayName: &displayName,
-			Scopes:      []string{"pdc-signing:write"},
+			Scopes:      []string{"set:pdc-signing"},
 			Realms:      []gcom.PostAccessPoliciesRequestRealmsInner{{Type: "stack", Identifier: d.Get("stack_identifier").(string)}},
 		})
 	result, _, err := req.Execute()

--- a/internal/resources/cloud/resource_private_data_source_connect_network_token_test.go
+++ b/internal/resources/cloud/resource_private_data_source_connect_network_token_test.go
@@ -40,7 +40,7 @@ func TestResourcePrivateDataSourceConnectNetworkToken_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "name", initialName),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "display_name", initialName),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.#", "1"),
-					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "pdc-signing:write"),
+					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "scopes.0", "set:pdc-signing"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.#", "1"),
 					resource.TestCheckResourceAttr("grafana_cloud_access_policy.test", "realm.0.type", "stack"),
 


### PR DESCRIPTION
Accounts for the new PDC scope (`set:pdc-signing`) and keeps the old one for legacy PDC access policies (`pdc-signing:write`).