### PR TITLE
CloudProvider: Allow unhandled values in metrics list validation

### DIFF
--- a/internal/resources/cloudprovider/models.go
+++ b/internal/resources/cloudprovider/models.go
@@ -185,7 +185,7 @@ func (v awsCWScrapeJobNoDuplicateMetricNamesValidator) MarkdownDescription(ctx c
 func (v awsCWScrapeJobNoDuplicateMetricNamesValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
 	seen := map[string]struct{}{}
 	elems := make([]awsCWScrapeJobMetricTFModel, len(req.ConfigValue.Elements()))
-	diags := req.ConfigValue.ElementsAs(ctx, &elems, false)
+	diags := req.ConfigValue.ElementsAs(ctx, &elems, true)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return


### PR DESCRIPTION
We've seen a common use case where customers want to modularize the use of cloud provider observability, into a terraform module, and inject the "service" or "metrics" configuration as variables.

Once such case is the following:

```
resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "main" {
  stack_id                = var.stack_id
  name                    = var.name
  aws_account_resource_id = grafana_cloud_provider_aws_account.main.resource_id

  dynamic "service" {
    for_each = var.services
    content {
      name = service.value.namespace

      dynamic "metric" {
        for_each = service.value.metrics
        content {
          name       = metric.key
          statistics = metric.value
        }
      }

      scrape_interval_seconds = service.value.scrape_interval_seconds
      tags_to_add_to_metrics  = service.value.tags_to_add_to_metrics
    }
  }
}

# fed from 

variable "metrics" {
  description = "The default set of metrics and statics for alb"
  type        = map(list(string))
  default = {
    ActiveConnectionCount          = ["Average", "Sum"]
    ClientTLSNegotiationErrorCount = ["Average", "Sum"]
  }
}
```

When using this in a test module, with the latest version, terraform fails even before planning in the validation stage with:

```
╷
│ Error: Value Conversion Error
│ 
│   with module.lb-monitoring.grafana_cloud_provider_aws_cloudwatch_scrape_job.accountAlb,
│   on modules/loadbalancer-monitoring/main.tf line 17, in resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "accountAlb":
│   17: resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "accountAlb" {
│ 
│ An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the following to the provider developer:
│ 
│ Received unknown value, however the target type cannot handle unknown values. Use the corresponding `types` package type or a custom type that handles unknown values.
│ 
│ Path: 
│ Target Type: []cloudprovider.awsCWScrapeJobMetricTFModel
│ Suggested Type: basetypes.ListValue
```

More details in:

```
Path: 
Target Type: []cloudprovider.awsCWScrapeJobMetricTFModel
Suggested Type: basetypes.ListValue" diagnostic_summary="Value Conversion Error" diagnostic_attribute= diagnostic_severity=ERROR tf_req_id=16f71fe0-ecb7-608c-dc51-a768307e32d2 tf_rpc=ValidateResourceTypeConfig timestamp=2025-01-31T16:10:00.351-0300
2025-01-31T16:10:00.351-0300 [WARN]  provider.terraform-provider-grafana: Response contains warning diagnostic: tf_resource_type=grafana_cloud_provider_aws_cloudwatch_scrape_job @module=sdk.proto diagnostic_detail="list value as string is: <unknown>" diagnostic_severity=WARNING diagnostic_summary="was here" tf_proto_version=5.7 @caller=/Users/pablo/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/internal/diag/diagnostics.go:60 tf_provider_addr=registry.terraform.io/grafana/grafana tf_req_id=16f71fe0-ecb7-608c-dc51-a768307e32d2 tf_rpc=ValidateResourceTypeConfig timestamp=2025-01-31T16:10:00.351-0300
2025-01-31T16:10:00.351-0300 [ERROR] vertex "module.lb-monitoring.grafana_cloud_provider_aws_cloudwatch_scrape_job.accountAlb" error: Value Conversion Error
```

Which indicates in `tf_rpc=ValidateResourceTypeConfig` that this came from [this bit](https://github.com/grafana/terraform-provider-grafana/blob/main/internal/resources/cloudprovider/models.go#L188) of type being mapped to the plan config.

Looking at the difference with the other validators, such as [this](https://github.com/grafana/terraform-provider-grafana/blob/main/internal/resources/cloudprovider/models.go#L158), once can see that the **third** parameter of `ElementsAs`, named `allows unhandled` is used:

```go
diags := req.ConfigValue.ElementsAs(ctx, &customNamespaces, true)
```

[Reading more in depth](https://github.com/hashicorp/terraform/issues/35173#issuecomment-2118243512), this comes from that during the validation stage, which is before planning, variables values injected into `for_each` statements for example, are not resolves until plan, but handled as unknown. That's why allowing this `ElementsAs` to allow unhandled values such as unknowns is the right choice, and a design decision in terraform.

This PR fixes this.