### PR TITLE
Add `linkcheck` option to ignore httpredirect warnings

### DIFF
--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -3,6 +3,7 @@ checkextern=1
 ignore=
   # https://regex101.com/r/Pl0jCn/1
   \/\*\!sc\*\/
+ignorewarnings=http-redirected
 
 [MarkdownCheck]
 filename_re=.*\.md


### PR DESCRIPTION
The `make linkcheck` command in the `unit tests / docs CI` job was failing because some URLs were redirected:

```
That's it. 186 links in 188 URLs checked. 2 warnings found. 0 errors found.
Stopped checking at 2025-02-10 11:10:04+000 (22 seconds)
make: *** [linkcheck] Error 1


Exit Code: 2
```

Since redirects shouldn’t be considered failures, this PR adds the `ignorewarnings=http-redirected` option to suppress httpredirect failures.

With this change, the `make linkcheck` output now displays:

```
That's it. 186 links in 188 URLs checked. 0 warnings found. 0 errors found.
Stopped checking at 2025-02-10 11:11:12+000 (28 seconds)

Exit Code: 0
```