### PR TITLE
fix: fix listing oncall users when more than 1 page

### DIFF
--- a/internal/resources/oncall/data_source_users.go
+++ b/internal/resources/oncall/data_source_users.go
@@ -91,6 +91,7 @@ func (r *usersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		if usersResponse.PaginatedResponse.Next == nil {
 			break
 		}
+		page++
 	}
 
 	data.ID = basetypes.NewStringValue("oncall_users") // singleton


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/14634 

When public API of OnCall is hit from the TF provider, we always pass page=1. In the datasource code of the provider there's a loop that depends on the presence of `next` in paginated response. And it seems we don't bump the page so the `next` is always there causing infinite chain of requests