### PR TITLE
Modify docs, examples and tests to reference prod-us-east-0 instead of us

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ resource "grafana_cloud_stack" "my_stack" {
 
   name        = "myteststack"
   slug        = "myteststack"
-  region_slug = "us"
+  region_slug = "prod-us-east-0"
 }
 
 // Step 2: Create a service account and key for the stack
@@ -102,7 +102,7 @@ variable "cloud_access_policy_token" {
 }
 variable "stack_slug" {}
 variable "cloud_region" {
-  default = "us"
+  default = "prod-us-east-0"
 }
 
 // Step 1: Create a stack

--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -27,7 +27,7 @@ data "grafana_cloud_organization" "current" {
 }
 
 resource "grafana_cloud_access_policy" "test" {
-  region       = "us"
+  region       = "prod-us-east-0"
   name         = "my-policy"
   display_name = "My Policy"
 
@@ -44,7 +44,7 @@ resource "grafana_cloud_access_policy" "test" {
 }
 
 resource "grafana_cloud_access_policy_token" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   access_policy_id = grafana_cloud_access_policy.test.policy_id
   name             = "my-policy-token"
   display_name     = "My Policy Token"

--- a/docs/resources/cloud_access_policy_token.md
+++ b/docs/resources/cloud_access_policy_token.md
@@ -27,7 +27,7 @@ data "grafana_cloud_organization" "current" {
 }
 
 resource "grafana_cloud_access_policy" "test" {
-  region       = "us"
+  region       = "prod-us-east-0"
   name         = "my-policy"
   display_name = "My Policy"
 
@@ -44,7 +44,7 @@ resource "grafana_cloud_access_policy" "test" {
 }
 
 resource "grafana_cloud_access_policy_token" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   access_policy_id = grafana_cloud_access_policy.test.policy_id
   name             = "my-policy-token"
   display_name     = "My Policy Token"

--- a/docs/resources/cloud_private_data_source_connect_network.md
+++ b/docs/resources/cloud_private_data_source_connect_network.md
@@ -27,7 +27,7 @@ data "grafana_cloud_stack" "current" {
 }
 
 resource "grafana_cloud_private_data_source_connect_network" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   name             = "my-pdc"
   display_name     = "My PDC"
   stack_identifier = data.grafana_cloud_stack.current.id

--- a/docs/resources/cloud_private_data_source_connect_network_token.md
+++ b/docs/resources/cloud_private_data_source_connect_network_token.md
@@ -27,7 +27,7 @@ data "grafana_cloud_stack" "current" {
 }
 
 resource "grafana_cloud_private_data_source_connect_network" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   name             = "my-pdc"
   display_name     = "My PDC"
   stack_identifier = data.grafana_cloud_stack.current.id

--- a/docs/resources/synthetic_monitoring_installation.md
+++ b/docs/resources/synthetic_monitoring_installation.md
@@ -35,7 +35,7 @@ variable "cloud_access_policy_token" {
 }
 variable "stack_slug" {}
 variable "cloud_region" {
-  default = "us"
+  default = "prod-us-east-0"
 }
 
 // Step 1: Create a stack

--- a/examples/provider/provider-cloud.tf
+++ b/examples/provider/provider-cloud.tf
@@ -9,7 +9,7 @@ resource "grafana_cloud_stack" "my_stack" {
 
   name        = "myteststack"
   slug        = "myteststack"
-  region_slug = "us"
+  region_slug = "prod-us-east-0"
 }
 
 // Step 2: Create a service account and key for the stack

--- a/examples/resources/grafana_cloud_access_policy/resource.tf
+++ b/examples/resources/grafana_cloud_access_policy/resource.tf
@@ -3,7 +3,7 @@ data "grafana_cloud_organization" "current" {
 }
 
 resource "grafana_cloud_access_policy" "test" {
-  region       = "us"
+  region       = "prod-us-east-0"
   name         = "my-policy"
   display_name = "My Policy"
 
@@ -20,7 +20,7 @@ resource "grafana_cloud_access_policy" "test" {
 }
 
 resource "grafana_cloud_access_policy_token" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   access_policy_id = grafana_cloud_access_policy.test.policy_id
   name             = "my-policy-token"
   display_name     = "My Policy Token"

--- a/examples/resources/grafana_cloud_access_policy_token/resource.tf
+++ b/examples/resources/grafana_cloud_access_policy_token/resource.tf
@@ -3,7 +3,7 @@ data "grafana_cloud_organization" "current" {
 }
 
 resource "grafana_cloud_access_policy" "test" {
-  region       = "us"
+  region       = "prod-us-east-0"
   name         = "my-policy"
   display_name = "My Policy"
 
@@ -20,7 +20,7 @@ resource "grafana_cloud_access_policy" "test" {
 }
 
 resource "grafana_cloud_access_policy_token" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   access_policy_id = grafana_cloud_access_policy.test.policy_id
   name             = "my-policy-token"
   display_name     = "My Policy Token"

--- a/examples/resources/grafana_cloud_private_data_source_connect_network/resource.tf
+++ b/examples/resources/grafana_cloud_private_data_source_connect_network/resource.tf
@@ -3,7 +3,7 @@ data "grafana_cloud_stack" "current" {
 }
 
 resource "grafana_cloud_private_data_source_connect_network" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   name             = "my-pdc"
   display_name     = "My PDC"
   stack_identifier = data.grafana_cloud_stack.current.id

--- a/examples/resources/grafana_cloud_private_data_source_connect_network_token/resource.tf
+++ b/examples/resources/grafana_cloud_private_data_source_connect_network_token/resource.tf
@@ -3,7 +3,7 @@ data "grafana_cloud_stack" "current" {
 }
 
 resource "grafana_cloud_private_data_source_connect_network" "test" {
-  region           = "us"
+  region           = "prod-us-east-0"
   name             = "my-pdc"
   display_name     = "My PDC"
   stack_identifier = data.grafana_cloud_stack.current.id

--- a/examples/resources/grafana_synthetic_monitoring_installation/resource.tf
+++ b/examples/resources/grafana_synthetic_monitoring_installation/resource.tf
@@ -3,7 +3,7 @@ variable "cloud_access_policy_token" {
 }
 variable "stack_slug" {}
 variable "cloud_region" {
-  default = "us"
+  default = "prod-us-east-0"
 }
 
 // Step 1: Create a stack

--- a/internal/resources/cloud/data_source_cloud_access_policies_test.go
+++ b/internal/resources/cloud/data_source_cloud_access_policies_test.go
@@ -30,11 +30,11 @@ func TestDataSourceAccessPolicy_Basic(t *testing.T) {
 		"datadog:validate",
 	}
 
-	accessPolicyConfig := testAccCloudAccessPolicyTokenConfigBasic(randomName, randomName+"display", "us", scopes, expiresAt)
+	accessPolicyConfig := testAccCloudAccessPolicyTokenConfigBasic(randomName, randomName+"display", "prod-us-east-0", scopes, expiresAt)
 	setItemMatcher := func(s *terraform.State) error {
 		return resource.TestCheckTypeSetElemNestedAttrs("data.grafana_cloud_access_policies.test", "access_policies.*", map[string]string{
 			"id":           *policy.Id,
-			"region":       "us",
+			"region":       "prod-us-east-0",
 			"name":         randomName,
 			"display_name": randomName + "display",
 			"status":       *policy.Status,
@@ -43,7 +43,7 @@ func TestDataSourceAccessPolicy_Basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCloudAccessPolicyCheckDestroy("us", &policy),
+		CheckDestroy:             testAccCloudAccessPolicyCheckDestroy("prod-us-east-0", &policy),
 		Steps: []resource.TestStep{
 			// Test without filters
 			{
@@ -70,23 +70,23 @@ func TestDataSourceAccessPolicy_Basic(t *testing.T) {
 			},
 			// Test with region filter
 			{
-				Config: accessPolicyConfig + testAccDataSourceAccessPoliciesConfigBasic(nil, common.Ref("us")),
+				Config: accessPolicyConfig + testAccDataSourceAccessPoliciesConfigBasic(nil, common.Ref("prod-us-east-0")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 
 					resource.TestCheckNoResourceAttr("data.grafana_cloud_access_policies.test", "name_filter"),
-					resource.TestCheckResourceAttr("data.grafana_cloud_access_policies.test", "region_filter", "us"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_access_policies.test", "region_filter", "prod-us-east-0"),
 					setItemMatcher,
 				),
 			},
 			// Test with name and region filter
 			{
-				Config: accessPolicyConfig + testAccDataSourceAccessPoliciesConfigBasic(&randomName, common.Ref("us")),
+				Config: accessPolicyConfig + testAccDataSourceAccessPoliciesConfigBasic(&randomName, common.Ref("prod-us-east-0")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 
 					resource.TestCheckResourceAttr("data.grafana_cloud_access_policies.test", "name_filter", randomName),
-					resource.TestCheckResourceAttr("data.grafana_cloud_access_policies.test", "region_filter", "us"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_access_policies.test", "region_filter", "prod-us-east-0"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_access_policies.test", "access_policies.#", "1"),
 					setItemMatcher,
 				),

--- a/internal/resources/cloud/resource_cloud_access_policy_token_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token_test.go
@@ -48,12 +48,12 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCloudAccessPolicyCheckDestroy("us", &policy),
-			testAccCloudAccessPolicyTokenCheckDestroy("us", &policyToken),
+			testAccCloudAccessPolicyCheckDestroy("prod-us-east-0", &policy),
+			testAccCloudAccessPolicyTokenCheckDestroy("prod-us-east-0", &policyToken),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "", "us", initialScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "", "prod-us-east-0", initialScopes, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),
@@ -76,7 +76,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "", "us", initialScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "", "prod-us-east-0", initialScopes, expiresAt),
 				PreConfig: func() {
 					orgID, err := strconv.ParseInt(*policy.OrgId, 10, 32)
 					if err != nil {
@@ -84,7 +84,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 					}
 					client := testutils.Provider.Meta().(*common.Client).GrafanaCloudAPI
 					_, _, err = client.TokensAPI.DeleteToken(context.Background(), *policyToken.Id).
-						Region("us").
+						Region("prod-us-east-0").
 						OrgId(int32(orgID)).
 						XRequestId("deleting-token").Execute()
 					if err != nil {
@@ -93,7 +93,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "updated", "us", updatedScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(initialName, "updated", "prod-us-east-0", updatedScopes, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),
@@ -112,7 +112,7 @@ func TestResourceAccessPolicyToken_Basic(t *testing.T) {
 			},
 			// Recreate
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic(updatedName, "updated", "us", updatedScopes, expiresAt),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(updatedName, "updated", "prod-us-east-0", updatedScopes, expiresAt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),
@@ -152,7 +152,7 @@ func TestResourceAccessPolicyToken_NoExpiration(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudAccessPolicyTokenConfigBasic(randomName, "", "us", []string{"metrics:read"}, ""),
+				Config: testAccCloudAccessPolicyTokenConfigBasic(randomName, "", "prod-us-east-0", []string{"metrics:read"}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &policy),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &policyToken),

--- a/internal/resources/cloud/resource_private_data_source_connect_network_token_test.go
+++ b/internal/resources/cloud/resource_private_data_source_connect_network_token_test.go
@@ -27,12 +27,12 @@ func TestResourcePrivateDataSourceConnectNetworkToken_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCloudAccessPolicyCheckDestroy("us", &pdcNetwork),
-			testAccCloudAccessPolicyTokenCheckDestroy("us", &pdcNetworkToken),
+			testAccCloudAccessPolicyCheckDestroy("prod-us-east-0", &pdcNetwork),
+			testAccCloudAccessPolicyTokenCheckDestroy("prod-us-east-0", &pdcNetworkToken),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudPrivateDataSourceConnectNetworkConfigBasic(initialName, "", "us"),
+				Config: testAccCloudPrivateDataSourceConnectNetworkConfigBasic(initialName, "", "prod-us-east-0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudAccessPolicyCheckExists("grafana_cloud_access_policy.test", &pdcNetwork),
 					testAccCloudAccessPolicyTokenCheckExists("grafana_cloud_access_policy_token.test", &pdcNetworkToken),


### PR DESCRIPTION
That region is a region we do not want to have new stacks in, so having it as default for docs and examples seems counterintuitive.