### PR TITLE
Skip enterprise tests when the PR comes from a fork

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -104,6 +104,12 @@ jobs:
     name: ${{ matrix.version }} - ${{ matrix.type }} - ${{ matrix.subset }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check if fork
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" || "${{ matrix.type }}" == "enterprise" ]]; then
+            echo "Skipping enterprise tests for forks"
+            exit 1
+          fi
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with: 

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -113,7 +113,7 @@ jobs:
           fi
       - name: Comment PR in forks
         if: env.IS_FORK == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Check if fork
         run: |
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" || "${{ matrix.type }}" == "enterprise" ]]; then
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" && "${{ matrix.type }}" == "enterprise" ]]; then
             echo "Skipping enterprise tests for forks"
             exit 1
           fi

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -107,9 +107,23 @@ jobs:
       - name: Check if fork
         run: |
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" && "${{ matrix.type }}" == "enterprise" ]]; then
-            echo "Skipping enterprise tests for forks"
-            exit 1
+            echo "IS_FORK=true" >> $GITHUB_ENV
+          else
+            echo "IS_FORK=false" >> $GITHUB_ENV
           fi
+      - name: Comment PR in forks
+        if: env.IS_FORK == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ⚠️ Enterprise tests skipped for fork PRs.
+      - name: Skip job if fork
+        if: env.IS_FORK == 'true'
+        run: |
+          echo "Skipping job because PR is from a fork"
+          exit 0
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with: 


### PR DESCRIPTION
We saw that some PR fails trying to retrieve sensitive information to setup enterprise environment. 

It adds a step to check if the PR comes from a fork, skipping these tests. The tests will pass in the main branch when they merge.