### PR TITLE
CI: Remove PR comment in forks since permissions issue

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -112,14 +112,6 @@ jobs:
           else
             echo "IS_FORK=false" >> $GITHUB_ENV
           fi
-      - name: Comment PR in forks
-        if: github.event_name == 'pull_request' && env.IS_FORK == 'true'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ⚠️ Enterprise tests skipped for fork PRs.
       - name: Skip job if fork
         if: github.event_name == 'pull_request' && env.IS_FORK == 'true'
         run: |


### PR DESCRIPTION
Adding a comment to notify that enterprise tests aren't executed in forks doesn't work since it needs extra permissions that could expose sensitive information.

It removes this step to avoid to fail in forks but we won't have any feedback 🤷🏼‍♀️ 