### PR TITLE
Fix typos in the azure_credentials resources descriptions

### DIFF
--- a/docs/data-sources/cloud_provider_azure_credential.md
+++ b/docs/data-sources/cloud_provider_azure_credential.md
@@ -78,7 +78,7 @@ data "grafana_cloud_provider_azure_credential" "test" {
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".
 - `name` (String) The name of the Azure Credential.
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
-- `resource_tags_to_add_to_metrics` (Set of String) A set of regions that this AWS Account resource applies to.
+- `resource_tags_to_add_to_metrics` (Set of String) The list of resource tags to add to metrics.
 - `tenant_id` (String) The tenant ID of the Azure Credential.
 
 <a id="nestedblock--auto_discovery_configuration"></a>

--- a/docs/resources/cloud_provider_azure_credential.md
+++ b/docs/resources/cloud_provider_azure_credential.md
@@ -72,12 +72,12 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 
 - `auto_discovery_configuration` (Block List) The list of auto discovery configurations. (see [below for nested schema](#nestedblock--auto_discovery_configuration))
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
-- `resource_tags_to_add_to_metrics` (Set of String) A set of regions that this AWS Account resource applies to.
+- `resource_tags_to_add_to_metrics` (Set of String) The list of resource tags to add to metrics.
 
 ### Read-Only
 
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".
-- `resource_id` (String) The ID given by the Grafana Cloud Provider API to this AWS Account resource.
+- `resource_id` (String) The ID given by the Grafana Cloud Provider API to this Azure Credential resource.
 
 <a id="nestedblock--auto_discovery_configuration"></a>
 ### Nested Schema for `auto_discovery_configuration`

--- a/internal/resources/cloudprovider/data_source_azure_credential.go
+++ b/internal/resources/cloudprovider/data_source_azure_credential.go
@@ -76,7 +76,7 @@ func (r *datasourceAzureCredential) Schema(ctx context.Context, req datasource.S
 				Sensitive:   true,
 			},
 			"resource_tags_to_add_to_metrics": schema.SetAttribute{
-				Description: "A set of regions that this AWS Account resource applies to.",
+				Description: "The list of resource tags to add to metrics.",
 				Computed:    true,
 				ElementType: types.StringType,
 			},

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -147,7 +147,7 @@ func (r *resourceAzureCredential) Schema(ctx context.Context, req resource.Schem
 				},
 			},
 			"resource_id": schema.StringAttribute{
-				Description: "The ID given by the Grafana Cloud Provider API to this AWS Account resource.",
+				Description: "The ID given by the Grafana Cloud Provider API to this Azure Credential resource.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					// See https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#usestateforunknown
@@ -173,7 +173,7 @@ func (r *resourceAzureCredential) Schema(ctx context.Context, req resource.Schem
 				Sensitive:   true,
 			},
 			"resource_tags_to_add_to_metrics": schema.SetAttribute{
-				Description: "A set of regions that this AWS Account resource applies to.",
+				Description: "The list of resource tags to add to metrics.",
 				Optional:    true,
 				ElementType: types.StringType,
 			},


### PR DESCRIPTION
This PR fixes typos in the azure_credentials resources descriptions