### PR TITLE
Use instance login page for waking up cloud stack

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -574,10 +574,16 @@ func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL 
 	if joinErr != nil {
 		return diag.FromErr(joinErr)
 	}
+	wakePath, joinErr := url.JoinPath(stackURL, "login")
+	if joinErr != nil {
+		return diag.FromErr(joinErr)
+	}
+	wakeURL := wakePath + "?disableAutoLogin=true"
+
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
-		// Query the instance URL directly. This makes the stack wake-up if it has been paused.
+		// Query the instance login page directly. This makes the stack wake-up if it has been paused.
 		// The health endpoint is helpful to check that the stack is ready, but it doesn't wake up the stack.
-		stackReq, err := http.NewRequestWithContext(ctx, http.MethodGet, stackURL, nil)
+		stackReq, err := http.NewRequestWithContext(ctx, http.MethodGet, wakeURL, nil)
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}


### PR DESCRIPTION
The Terraform provider currently tries to confirm a Grafana stack is ready hitting the base URL of the instance since #1727. For stacks with autologin enabled, this wake-up check will ultimately follow an HTTP redirect to the configured identity provider.

In cases where the IdP is unreachable or the SSO is misconfigured (invalid client ID, URL, etc), this can lead to a situation where Terraform can no longer manage the stack resources until the SSO misconfiguration is manually resolved.

This updates the wake-up check to use the stack login URL with the `noAutoLogin` query parameter set to prevent the client from being redirected away from the stack.