### PR TITLE
Run tests on Grafana 11.6.0

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -76,26 +76,26 @@ jobs:
       fail-fast: false # Let all versions run, even if one fails
       matrix:
         # OSS tests, run on all versions
-        version: ['11.0.0', '10.4.3', '9.5.18']
+        version: ['11.6.0', '10.4.3', '9.5.18']
         type: ['oss']
         subset: ['basic', 'other', 'long']
         include:
-          - version: '11.0.0'
+          - version: '11.6.0'
             type: 'oss'
             subset: examples
           # TLS proxy tests, run only on latest version
-          - version: '11.0.0'
+          - version: '11.6.0'
             type: 'tls'
             subset: 'basic'
           # Sub-path tests. Runs tests on localhost:3000/grafana/
-          - version: '11.0.0'
+          - version: '11.6.0'
             type: 'subpath'
             subset: 'basic'
-          - version: '11.0.0'
+          - version: '11.6.0'
             type: 'subpath'
             subset: 'other'
           # Enterprise tests
-          - version: '11.0.0'
+          - version: '11.6.0'
             type: 'enterprise'
             subset: 'enterprise'
           - version: '10.4.3'
@@ -105,7 +105,7 @@ jobs:
             type: 'enterprise'
             subset: 'enterprise'
           # Generate tests
-          - version: '11.0.0'
+          - version: '11.6.0'
             type: 'enterprise'
             subset: 'generate'
           - version: '10.4.3'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= 11.0.0
+GRAFANA_VERSION ?= 11.6.0
 DOCKER_COMPOSE_ARGS ?= --force-recreate --detach --remove-orphans --wait --renew-anon-volumes
 
 testacc:

--- a/docs/data-sources/library_panel.md
+++ b/docs/data-sources/library_panel.md
@@ -15,7 +15,8 @@ Data source for retrieving a single library panel by name or uid.
 ```terraform
 // create a minimal library panel inside the General folder
 resource "grafana_library_panel" "test" {
-  name = "test name"
+  name       = "test name"
+  folder_uid = "general"
   model_json = jsonencode({
     title   = "test name"
     type    = "text"
@@ -33,7 +34,8 @@ data "grafana_library_panel" "from_uid" {
 
 // create library panels to be added to a dashboard
 resource "grafana_library_panel" "dashboard" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/docs/data-sources/library_panels.md
+++ b/docs/data-sources/library_panels.md
@@ -14,7 +14,8 @@ description: |-
 
 ```terraform
 resource "grafana_library_panel" "test" {
-  name = "panelname"
+  name       = "panelname"
+  folder_uid = "general"
   model_json = jsonencode({
     title       = "test name"
     type        = "text"

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -18,7 +18,8 @@ Manages Grafana library panels.
 
 ```terraform
 resource "grafana_library_panel" "test" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/examples/data-sources/grafana_library_panel/data-source.tf
+++ b/examples/data-sources/grafana_library_panel/data-source.tf
@@ -1,6 +1,7 @@
 // create a minimal library panel inside the General folder
 resource "grafana_library_panel" "test" {
-  name = "test name"
+  name       = "test name"
+  folder_uid = "general"
   model_json = jsonencode({
     title   = "test name"
     type    = "text"
@@ -18,7 +19,8 @@ data "grafana_library_panel" "from_uid" {
 
 // create library panels to be added to a dashboard
 resource "grafana_library_panel" "dashboard" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/examples/data-sources/grafana_library_panels/data-source.tf
+++ b/examples/data-sources/grafana_library_panels/data-source.tf
@@ -1,5 +1,6 @@
 resource "grafana_library_panel" "test" {
-  name = "panelname"
+  name       = "panelname"
+  folder_uid = "general"
   model_json = jsonencode({
     title       = "test name"
     type        = "text"

--- a/examples/resources/grafana_library_panel/resource.tf
+++ b/examples/resources/grafana_library_panel/resource.tf
@@ -1,5 +1,6 @@
 resource "grafana_library_panel" "test" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/internal/resources/examples_test.go
+++ b/internal/resources/examples_test.go
@@ -37,7 +37,7 @@ func TestAccExamples(t *testing.T) {
 				case strings.Contains(filename, "grafana_apps_rules"):
 					t.Skip() // TODO: Enable once the API is no longer behind a feature toggle.
 				default:
-					testutils.CheckOSSTestsEnabled(t, ">=11.0.0") // Only run on latest OSS version. The examples should be updated to reflect their latest working config.
+					testutils.CheckOSSTestsEnabled(t, ">=11.6.0") // Only run on latest OSS version. The examples should be updated to reflect their latest working config.
 				}
 			},
 		},
@@ -94,7 +94,7 @@ func TestAccExamples(t *testing.T) {
 				case strings.Contains(filename, "grafana_scim_config"):
 					testutils.CheckEnterpriseTestsEnabled(t, ">=12.0.0")
 				default:
-					testutils.CheckEnterpriseTestsEnabled(t, ">=11.0.0") // Only run on latest version
+					testutils.CheckEnterpriseTestsEnabled(t, ">=11.6.0") // Only run on latest version
 				}
 			},
 		},

--- a/internal/resources/examples_test.go
+++ b/internal/resources/examples_test.go
@@ -48,13 +48,25 @@ func TestAccExamples(t *testing.T) {
 			},
 		},
 		{
+			category: "Grafana OSS >=10.4.0 <=11.0.0 playlists",
+			testCheck: func(t *testing.T, filename string) {
+				if strings.Contains(filename, "grafana_playlist") {
+					testutils.CheckOSSTestsEnabled(t, ">=10.4.0,<=11.0.0")
+				}
+			},
+		},
+		{
 			category: "Grafana OSS",
 			testCheck: func(t *testing.T, filename string) {
 				if strings.Contains(filename, "sso_settings") {
 					t.Skip() // TODO: Fix the tests to run on local instances
-				} else {
-					testutils.CheckOSSTestsEnabled(t, ">=11.0.0") // Only run on latest OSS version. The examples should be updated to reflect their latest working config.
 				}
+				if strings.Contains(filename, "grafana_playlist") {
+					// Breaks after Grafana 11.0.0
+					t.Skip()
+				}
+
+				testutils.CheckOSSTestsEnabled(t, ">=11.6.0") // Only run on latest OSS version. The examples should be updated to reflect their latest working config.
 			},
 		},
 		{

--- a/internal/resources/grafana/data_source_library_panel_test.go
+++ b/internal/resources/grafana/data_source_library_panel_test.go
@@ -10,35 +10,57 @@ import (
 )
 
 func TestAccDatasourceLibraryPanel_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	var panel models.LibraryElementResponse
-	// var dashboard gapi.Dashboard
-	checks := []resource.TestCheckFunc{
-		libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-		resource.TestCheckResourceAttr(
-			"data.grafana_library_panel.from_name", "name", "test name",
-		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_library_panel.from_name", "uid", common.UIDRegexp,
-		),
-		resource.TestCheckResourceAttr(
-			"data.grafana_library_panel.from_uid", "name", "test name",
-		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_library_panel.from_uid", "uid", common.UIDRegexp,
-		),
-	}
-
-	// TODO: Make parallelizable
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+	testCases := []struct {
+		versionConstraint string
+		replacements      map[string]string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			replacements: map[string]string{
+				`"general"`: "null",
 			},
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			replacements:      map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			var panel models.LibraryElementResponse
+			checks := []resource.TestCheckFunc{
+				libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+				resource.TestCheckResourceAttr(
+					"data.grafana_library_panel.from_name", "name", "test name",
+				),
+				resource.TestMatchResourceAttr(
+					"data.grafana_library_panel.from_name", "uid", common.UIDRegexp,
+				),
+				resource.TestCheckResourceAttr(
+					"data.grafana_library_panel.from_uid", "name", "test name",
+				),
+				resource.TestMatchResourceAttr(
+					"data.grafana_library_panel.from_uid", "uid", common.UIDRegexp,
+				),
+			}
+
+			// TODO: Make parallelizable
+			resource.Test(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						Config: testutils.TestAccExampleWithReplace(t,
+							"data-sources/grafana_library_panel/data-source.tf",
+							tc.replacements,
+						),
+						Check: resource.ComposeTestCheckFunc(checks...),
+					},
+				},
+			})
+		})
+	}
 }

--- a/internal/resources/grafana/data_source_library_panels_test.go
+++ b/internal/resources/grafana/data_source_library_panels_test.go
@@ -9,30 +9,54 @@ import (
 )
 
 func TestAccDatasourceLibraryPanels_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
 	randomName := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_library_panels/data-source.tf", map[string]string{
-					"panelname": randomName,
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
-						"description":   "test description",
-						"folder_uid":    "",
-						"panels.0.name": randomName,
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
-						"description":   "",
-						"folder_uid":    randomName + "-folder",
-						"panels.0.name": randomName + " In Folder",
-					}),
-				),
+	testCases := []struct {
+		versionConstraint string
+		replacements      map[string]string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			replacements: map[string]string{
+				"panelname": randomName,
+				`"general"`: "null",
 			},
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			replacements: map[string]string{
+				"panelname": randomName,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: testutils.TestAccExampleWithReplace(t,
+							"data-sources/grafana_library_panels/data-source.tf",
+							tc.replacements,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
+								"description":   "test description",
+								"folder_uid":    "",
+								"panels.0.name": randomName,
+							}),
+							resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
+								"description":   "",
+								"folder_uid":    randomName + "-folder",
+								"panels.0.name": randomName + " In Folder",
+							}),
+						),
+					},
+				},
+			})
+		})
+	}
 }

--- a/internal/resources/grafana/data_source_role_test.go
+++ b/internal/resources/grafana/data_source_role_test.go
@@ -23,7 +23,7 @@ func TestAccDatasourceRole_basic(t *testing.T) {
 				})
 			}
 
-			resource.ParallelTest(t, resource.TestCase{
+			resource.Test(t, resource.TestCase{
 				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 				CheckDestroy:             roleCheckExists.destroyed(&role, nil),
 				Steps: []resource.TestStep{

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -397,7 +397,8 @@ func TestAccFolder_RapidCreation(t *testing.T) {
 
 // This is a bug in Grafana, not the provider. It was fixed in 9.2.7+ and 9.3.0+, this test will check for regressions
 func TestAccFolder_createFromDifferentRoles(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=9.2.7")
+	// TODO: In Grafana 11.5.0 permissions are checked differently and specific permissions are required: https://github.com/grafana/grafana/pull/98751
+	testutils.CheckOSSTestsEnabled(t, ">=9.2.7,<11.5.0")
 
 	for _, tc := range []struct {
 		role        string

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -12,49 +12,67 @@ import (
 )
 
 func TestAccLibraryPanel_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	name := acctest.RandString(10)
-	var panel models.LibraryElementResponse
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				// Test resource creation.
-				Config: testAccLibraryPanelBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-					resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
-					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "org_id", "1"),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "1"),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"%s","type":""}`, name)),
-					testutils.CheckLister("grafana_library_panel.test"),
-				),
-			},
-			{
-				// Updates title.
-				Config: testAccLibraryPanelBasic("updated " + name),
-				Check: resource.ComposeTestCheckFunc(
-					libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-					resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
-					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "updated "+name),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "2"),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"updated %s","type":""}`, name)),
-				),
-			},
-			{
-				// Importing matches the state of the previous step.
-				ResourceName:      "grafana_library_panel.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+	testCases := []struct {
+		versionConstraint string
+		folder            string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=10.4.3",
+			folder:            "",
 		},
-	})
+		{
+			versionConstraint: ">10.4.3",
+			folder:            "general",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			name := acctest.RandString(10)
+			var panel models.LibraryElementResponse
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						// Test resource creation.
+						Config: testAccLibraryPanelBasic(name, tc.folder),
+						Check: resource.ComposeTestCheckFunc(
+							libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+							resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
+							resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "org_id", "1"),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "name", name),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "1"),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"%s","type":""}`, name)),
+							testutils.CheckLister("grafana_library_panel.test"),
+						),
+					},
+					{
+						// Updates title.
+						Config: testAccLibraryPanelBasic("updated "+name, tc.folder),
+						Check: resource.ComposeTestCheckFunc(
+							libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+							resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
+							resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "updated "+name),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "2"),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"updated %s","type":""}`, name)),
+						),
+					},
+					{
+						// Importing matches the state of the previous step.
+						ResourceName:      "grafana_library_panel.test",
+						ImportState:       true,
+						ImportStateVerify: true,
+					},
+				},
+			})
+		})
+	}
 }
 
 func TestAccLibraryPanel_folder(t *testing.T) {
@@ -91,59 +109,108 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 }
 
 func TestAccLibraryPanel_dashboard(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	var panel models.LibraryElementResponse
-	var dashboard models.DashboardFullWithMeta
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				// Test library panel is connected to dashboard
-				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("grafana_library_panel.dashboard", "id", defaultOrgIDRegexp),
-					libraryPanelCheckExists.exists("grafana_library_panel.dashboard", &panel),
-					dashboardCheckExists.exists("grafana_dashboard.with_library_panel", &dashboard),
-				),
+	testCases := []struct {
+		versionConstraint string
+		replacements      map[string]string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=10.4.3",
+			replacements: map[string]string{
+				`"general"`: "null",
 			},
 		},
-	})
+		{
+			versionConstraint: ">10.4.3",
+			replacements:      map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			var panel models.LibraryElementResponse
+			var dashboard models.DashboardFullWithMeta
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						// Test library panel is connected to dashboard
+						Config: testutils.TestAccExampleWithReplace(t,
+							"data-sources/grafana_library_panel/data-source.tf",
+							tc.replacements,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("grafana_library_panel.dashboard", "id", defaultOrgIDRegexp),
+							libraryPanelCheckExists.exists("grafana_library_panel.dashboard", &panel),
+							dashboardCheckExists.exists("grafana_dashboard.with_library_panel", &dashboard),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
 func TestAccLibraryPanel_inOrg(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	var panel models.LibraryElementResponse
-	orgName := acctest.RandString(10)
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLibraryPanelInOrganization(orgName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", nonDefaultOrgIDRegexp),
-					libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-					checkResourceIsInOrg("grafana_library_panel.test", "grafana_organization.test"),
-				),
-			},
+	testCases := []struct {
+		versionConstraint string
+		folder            string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=10.4.3",
+			folder:            "",
 		},
-	})
+		{
+			versionConstraint: ">10.4.3",
+			folder:            "general",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			var panel models.LibraryElementResponse
+			orgName := acctest.RandString(10)
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccLibraryPanelInOrganization(orgName, tc.folder),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("grafana_library_panel.test", "id", nonDefaultOrgIDRegexp),
+							libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+							checkResourceIsInOrg("grafana_library_panel.test", "grafana_organization.test"),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
-func testAccLibraryPanelBasic(name string) string {
+func testAccLibraryPanelBasic(name, folder string) string {
+	var fuid string
+	if folder == "" {
+		fuid = "null"
+	} else {
+		fuid = fmt.Sprintf(`"%s"`, folder)
+	}
+
 	return fmt.Sprintf(`
 resource "grafana_library_panel" "test" {
-	name      = "%[1]s"
+	name       = "%[1]s"
+	folder_uid = %[2]s
 	model_json = jsonencode({
 		title   = "%[1]s",
 	})
 }
-`, name)
+`, name, fuid)
 }
 
 func testAccLibraryPanelInFolder(name string) string {
@@ -163,17 +230,25 @@ resource "grafana_library_panel" "test_folder" {
 }`, name)
 }
 
-func testAccLibraryPanelInOrganization(orgName string) string {
+func testAccLibraryPanelInOrganization(orgName, folder string) string {
+	var fuid string
+	if folder == "" {
+		fuid = "null"
+	} else {
+		fuid = fmt.Sprintf(`"%s"`, folder)
+	}
+
 	return fmt.Sprintf(`
 resource "grafana_organization" "test" {
 	name = "%[1]s"
 }
 
 resource "grafana_library_panel" "test" {
-	org_id    = grafana_organization.test.id
-	name      = "%[1]s"
+	org_id     = grafana_organization.test.id
+	name       = "%[1]s"
+    folder_uid = %[2]s
 	model_json = jsonencode({
 	  title   = "%[1]s",
 	})
-  }`, orgName)
+  }`, orgName, fuid)
 }

--- a/internal/resources/grafana/resource_playlist_test.go
+++ b/internal/resources/grafana/resource_playlist_test.go
@@ -15,7 +15,7 @@ import (
 const paylistResource = "grafana_playlist.test"
 
 func TestAccPlaylist_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t, "<=11.0.0")
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var playlist models.Playlist
@@ -50,7 +50,7 @@ func TestAccPlaylist_basic(t *testing.T) {
 }
 
 func TestAccPlaylist_update(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t, "<=11.0.0")
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	updatedName := "updated name"
@@ -122,7 +122,7 @@ func TestAccPlaylist_update(t *testing.T) {
 }
 
 func TestAccPlaylist_disappears(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t)
+	testutils.CheckOSSTestsEnabled(t, "<=11.0.0")
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var playlist models.Playlist
@@ -144,7 +144,7 @@ func TestAccPlaylist_disappears(t *testing.T) {
 }
 
 func TestAccPlaylist_inOrg(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=9.0.0") // Querying org-specific playlists is broken pre-9
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0,<=11.0.0") // Querying org-specific playlists is broken pre-9
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	var org models.OrgDetailsDTO


### PR DESCRIPTION
Many tests broke on 11.6.0, listing them per team using [this table](https://docs.google.com/spreadsheets/d/1hBpYQpOq9MBlt1Fbf6A-JDsZmcf7y9BC-zk0hbJVCgo/edit?gid=0#gid=0). Changes are split it separate commits since in this way it's a bit easier to test them in the CI with the newer Grafana version.

### Team-specific changes

#### @grafana/dataviz-squad
- For `grafana_library_panel` resource, `folder_uid` [was populated](https://github.com/grafana/grafana/pull/83819/files#diff-c0834e17513d02874a6a9178dc7e72fca9c965a36ff367af145349e6b2653526) with a migration in Grafana > 11.0.0 so I added it to the TF files with the required versions.

---

#### @grafana/access-squad
- `TestAccDatasourceRole_basic` [failed](https://github.com/grafana/terraform-provider-grafana/actions/runs/14385418657/job/40339510283) with `Failed to create role: role with the provided name already exists`: Changed `ParallelTest` to `Test` to fix role creation conflicts, but it's unclear why it broke after the version upgrade. 

- `TestAccFolder_createFromDifferentRoles`: Skipped for Grafana 11.5.0+ due to permission model changes (ref: https://github.com/grafana/grafana/pull/98751).

@grafana/access-squad Could you please check these and help with a proper fix?

---

#### @grafana/sharing-squad
- `TestAccPlaylist_basic` (`grafana_playlist`) 
  - Changed this test and other playlist APIs the require Grafana <= 11.0.0. The API returns k8s-style responses now and the tests fail. 

@grafana/sharing-squad I added `<= 11.0.0` for now, but I am not sure what is the right fix here.