### PR TITLE
SSO: Add feature toggles for LDAP and SAML tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,8 +29,10 @@ testacc-oss-docker:
 	docker compose down
 
 testacc-enterprise-docker:
+	export DOCKER_USER_UID="$(shell id -u)" && \
 	export GRAFANA_URL=http://0.0.0.0:3000 && \
 	export GRAFANA_VERSION=$(GRAFANA_VERSION) && \
+	make -C testdata generate && \
 	GRAFANA_IMAGE=grafana/grafana-enterprise docker compose up $(DOCKER_COMPOSE_ARGS) && \
 	make testacc-enterprise && \
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     ports:
       - 3000:3000
     image: ${GRAFANA_IMAGE:-grafana/grafana}:${GRAFANA_VERSION}
+    user: ${DOCKER_USER_UID:-}
     environment:
       - GF_DATABASE_TYPE=mysql
       - GF_DATABASE_HOST=mysql
@@ -36,6 +37,8 @@ services:
       interval: 10s
       retries: 10
       start_period: 10s
+    volumes:
+      - ./testdata:/certs
   mtls-proxy:
     profiles:
       - "tls"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   mysql:
     ports:
@@ -30,7 +30,7 @@ services:
       - GF_SERVER_ROOT_URL=${GRAFANA_URL}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
       - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
-      - GF_FEATURE_TOGGLES_ENABLE=nestedFolders
+      - GF_FEATURE_TOGGLES_ENABLE=nestedFolders,ssoSettingsApi,ssoSettingsSAML,ssoSettingsLDAP
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s

--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -56,8 +56,8 @@ resource "grafana_sso_settings" "saml_sso_settings" {
   provider_name = "saml"
   saml_settings {
     allow_sign_up             = true
-    certificate_path          = "devenv/docker/blocks/auth/saml-enterprise/cert.crt"
-    private_key_path          = "devenv/docker/blocks/auth/saml-enterprise/key.pem"
+    certificate_path          = "/certs/saml.crt"
+    private_key_path          = "/certs/saml.key"
     idp_metadata_url          = "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"
     signature_algorithm       = "rsa-sha256"
     assertion_attribute_login = "login"

--- a/examples/resources/grafana_sso_settings/resource.tf
+++ b/examples/resources/grafana_sso_settings/resource.tf
@@ -37,8 +37,8 @@ resource "grafana_sso_settings" "saml_sso_settings" {
   provider_name = "saml"
   saml_settings {
     allow_sign_up             = true
-    certificate_path          = "devenv/docker/blocks/auth/saml-enterprise/cert.crt"
-    private_key_path          = "devenv/docker/blocks/auth/saml-enterprise/key.pem"
+    certificate_path          = "/certs/saml.crt"
+    private_key_path          = "/certs/saml.key"
     idp_metadata_url          = "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"
     signature_algorithm       = "rsa-sha256"
     assertion_attribute_login = "login"

--- a/internal/resources/grafana/resource_sso_settings_test.go
+++ b/internal/resources/grafana/resource_sso_settings_test.go
@@ -86,8 +86,8 @@ func TestSSOSettings_basic_saml(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "provider_name", provider),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.certificate_path", "devenv/docker/blocks/auth/saml-enterprise/cert.crt"),
-					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.private_key_path", "devenv/docker/blocks/auth/saml-enterprise/key.pem"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.certificate_path", "/certs/saml.crt"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.private_key_path", "/certs/saml.key"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.idp_metadata_url", "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.signature_algorithm", "rsa-sha256"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.metadata_valid_duration", "24h"),
@@ -99,8 +99,8 @@ func TestSSOSettings_basic_saml(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "provider_name", provider),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.certificate_path", "devenv/docker/blocks/auth/saml-enterprise/cert.crt"),
-					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.private_key_path", "devenv/docker/blocks/auth/saml-enterprise/key.pem"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.certificate_path", "/certs/saml.crt"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.private_key_path", "/certs/saml.key"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.idp_metadata_url", "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.signature_algorithm", "rsa-sha512"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.metadata_valid_duration", "48h"),
@@ -113,8 +113,8 @@ func TestSSOSettings_basic_saml(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "provider_name", provider),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.certificate_path", "devenv/docker/blocks/auth/saml-enterprise/cert.crt"),
-					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.private_key_path", "devenv/docker/blocks/auth/saml-enterprise/key.pem"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.certificate_path", "/certs/saml.crt"),
+					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.private_key_path", "/certs/saml.key"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.idp_metadata_url", "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.signature_algorithm", "rsa-sha256"),
 					resource.TestCheckResourceAttr(resourceName, "saml_settings.0.metadata_valid_duration", "24h"),
@@ -442,8 +442,8 @@ func testConfigForOAuth2Provider(provider string, prefix string) string {
 const testConfigForSamlProvider = `resource "grafana_sso_settings" "saml_sso_settings" {
   provider_name = "saml"
   saml_settings {
-    certificate_path        = "devenv/docker/blocks/auth/saml-enterprise/cert.crt"
-    private_key_path        = "devenv/docker/blocks/auth/saml-enterprise/key.pem"
+    certificate_path        = "/certs/saml.crt"
+    private_key_path        = "/certs/saml.key"
     idp_metadata_url        = "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"
     signature_algorithm     = "rsa-sha256"
     metadata_valid_duration = "24h"
@@ -454,8 +454,8 @@ const testConfigForSamlProvider = `resource "grafana_sso_settings" "saml_sso_set
 const testConfigForSamlProviderUpdated = `resource "grafana_sso_settings" "saml_sso_settings" {
   provider_name = "saml"
   saml_settings {
-    certificate_path          = "devenv/docker/blocks/auth/saml-enterprise/cert.crt"
-    private_key_path          = "devenv/docker/blocks/auth/saml-enterprise/key.pem"
+    certificate_path          = "/certs/saml.crt"
+    private_key_path          = "/certs/saml.key"
     idp_metadata_url          = "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"
     allow_sign_up             = true
     signature_algorithm       = "rsa-sha512"
@@ -467,8 +467,8 @@ const testConfigForSamlProviderUpdated = `resource "grafana_sso_settings" "saml_
 const testConfigForSAMLProviderWithAzureAD = `resource "grafana_sso_settings" "saml_sso_settings" {
 	provider_name = "saml"
 	saml_settings {
-		certificate_path          = "devenv/docker/blocks/auth/saml-enterprise/cert.crt"
-		private_key_path          = "devenv/docker/blocks/auth/saml-enterprise/key.pem"
+		certificate_path          = "/certs/saml.crt"
+		private_key_path          = "/certs/saml.key"
 		idp_metadata_url          = "https://nexus.microsoftonline-p.com/federationmetadata/saml20/federationmetadata.xml"
 		signature_algorithm       = "rsa-sha256"
 		metadata_valid_duration   = "24h"


### PR DESCRIPTION
Related to the Grafana version upgrade in the CI: https://github.com/grafana/terraform-provider-grafana/pull/2121.

~~The tests started failing because they couldn't fetch the provider settings, for example LDAP: `failed to fetch the default settings for provider ldap`. Probably some additional configuration is needed? I changed the required versions for now, to avoid blocking the version upgrade.~~

Added the feature toggles for the tests that @dmihai suggested.

Also added certificates generation for the SAML provider. I cherry-picked the commits to test on [11.6.0 with GitHub Actions](https://github.com/grafana/terraform-provider-grafana/pull/2121) and the tests passed.