### PR TITLE
grafana_library_panel: fix tests on Grafana >11.0.0

### DIFF
--- a/docs/data-sources/library_panel.md
+++ b/docs/data-sources/library_panel.md
@@ -15,7 +15,8 @@ Data source for retrieving a single library panel by name or uid.
 ```terraform
 // create a minimal library panel inside the General folder
 resource "grafana_library_panel" "test" {
-  name = "test name"
+  name       = "test name"
+  folder_uid = "general"
   model_json = jsonencode({
     title   = "test name"
     type    = "text"
@@ -33,7 +34,8 @@ data "grafana_library_panel" "from_uid" {
 
 // create library panels to be added to a dashboard
 resource "grafana_library_panel" "dashboard" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/docs/data-sources/library_panels.md
+++ b/docs/data-sources/library_panels.md
@@ -14,7 +14,8 @@ description: |-
 
 ```terraform
 resource "grafana_library_panel" "test" {
-  name = "panelname"
+  name       = "panelname"
+  folder_uid = "general"
   model_json = jsonencode({
     title       = "test name"
     type        = "text"

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -18,7 +18,8 @@ Manages Grafana library panels.
 
 ```terraform
 resource "grafana_library_panel" "test" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/examples/data-sources/grafana_library_panel/data-source.tf
+++ b/examples/data-sources/grafana_library_panel/data-source.tf
@@ -1,6 +1,7 @@
 // create a minimal library panel inside the General folder
 resource "grafana_library_panel" "test" {
-  name = "test name"
+  name       = "test name"
+  folder_uid = "general"
   model_json = jsonencode({
     title   = "test name"
     type    = "text"
@@ -18,7 +19,8 @@ data "grafana_library_panel" "from_uid" {
 
 // create library panels to be added to a dashboard
 resource "grafana_library_panel" "dashboard" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/examples/data-sources/grafana_library_panels/data-source.tf
+++ b/examples/data-sources/grafana_library_panels/data-source.tf
@@ -1,5 +1,6 @@
 resource "grafana_library_panel" "test" {
-  name = "panelname"
+  name       = "panelname"
+  folder_uid = "general"
   model_json = jsonencode({
     title       = "test name"
     type        = "text"

--- a/examples/resources/grafana_library_panel/resource.tf
+++ b/examples/resources/grafana_library_panel/resource.tf
@@ -1,5 +1,6 @@
 resource "grafana_library_panel" "test" {
-  name = "panel"
+  name       = "panel"
+  folder_uid = "general"
   model_json = jsonencode({
     gridPos = {
       x = 0

--- a/internal/resources/grafana/data_source_library_panel_test.go
+++ b/internal/resources/grafana/data_source_library_panel_test.go
@@ -10,35 +10,57 @@ import (
 )
 
 func TestAccDatasourceLibraryPanel_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	var panel models.LibraryElementResponse
-	// var dashboard gapi.Dashboard
-	checks := []resource.TestCheckFunc{
-		libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-		resource.TestCheckResourceAttr(
-			"data.grafana_library_panel.from_name", "name", "test name",
-		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_library_panel.from_name", "uid", common.UIDRegexp,
-		),
-		resource.TestCheckResourceAttr(
-			"data.grafana_library_panel.from_uid", "name", "test name",
-		),
-		resource.TestMatchResourceAttr(
-			"data.grafana_library_panel.from_uid", "uid", common.UIDRegexp,
-		),
-	}
-
-	// TODO: Make parallelizable
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+	testCases := []struct {
+		versionConstraint string
+		replacements      map[string]string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			replacements: map[string]string{
+				`"general"`: "null",
 			},
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			replacements:      map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			var panel models.LibraryElementResponse
+			checks := []resource.TestCheckFunc{
+				libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+				resource.TestCheckResourceAttr(
+					"data.grafana_library_panel.from_name", "name", "test name",
+				),
+				resource.TestMatchResourceAttr(
+					"data.grafana_library_panel.from_name", "uid", common.UIDRegexp,
+				),
+				resource.TestCheckResourceAttr(
+					"data.grafana_library_panel.from_uid", "name", "test name",
+				),
+				resource.TestMatchResourceAttr(
+					"data.grafana_library_panel.from_uid", "uid", common.UIDRegexp,
+				),
+			}
+
+			// TODO: Make parallelizable
+			resource.Test(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						Config: testutils.TestAccExampleWithReplace(t,
+							"data-sources/grafana_library_panel/data-source.tf",
+							tc.replacements,
+						),
+						Check: resource.ComposeTestCheckFunc(checks...),
+					},
+				},
+			})
+		})
+	}
 }

--- a/internal/resources/grafana/data_source_library_panels_test.go
+++ b/internal/resources/grafana/data_source_library_panels_test.go
@@ -9,30 +9,54 @@ import (
 )
 
 func TestAccDatasourceLibraryPanels_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
 	randomName := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_library_panels/data-source.tf", map[string]string{
-					"panelname": randomName,
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
-						"description":   "test description",
-						"folder_uid":    "",
-						"panels.0.name": randomName,
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
-						"description":   "",
-						"folder_uid":    randomName + "-folder",
-						"panels.0.name": randomName + " In Folder",
-					}),
-				),
+	testCases := []struct {
+		versionConstraint string
+		replacements      map[string]string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			replacements: map[string]string{
+				"panelname": randomName,
+				`"general"`: "null",
 			},
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			replacements: map[string]string{
+				"panelname": randomName,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: testutils.TestAccExampleWithReplace(t,
+							"data-sources/grafana_library_panels/data-source.tf",
+							tc.replacements,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
+								"description":   "test description",
+								"folder_uid":    "",
+								"panels.0.name": randomName,
+							}),
+							resource.TestCheckTypeSetElemNestedAttrs("data.grafana_library_panels.all", "panels.*", map[string]string{
+								"description":   "",
+								"folder_uid":    randomName + "-folder",
+								"panels.0.name": randomName + " In Folder",
+							}),
+						),
+					},
+				},
+			})
+		})
+	}
 }

--- a/internal/resources/grafana/resource_library_panel_test.go
+++ b/internal/resources/grafana/resource_library_panel_test.go
@@ -12,49 +12,67 @@ import (
 )
 
 func TestAccLibraryPanel_basic(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	name := acctest.RandString(10)
-	var panel models.LibraryElementResponse
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				// Test resource creation.
-				Config: testAccLibraryPanelBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-					resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
-					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "org_id", "1"),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "1"),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"%s","type":""}`, name)),
-					testutils.CheckLister("grafana_library_panel.test"),
-				),
-			},
-			{
-				// Updates title.
-				Config: testAccLibraryPanelBasic("updated " + name),
-				Check: resource.ComposeTestCheckFunc(
-					libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-					resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
-					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "updated "+name),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "2"),
-					resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"updated %s","type":""}`, name)),
-				),
-			},
-			{
-				// Importing matches the state of the previous step.
-				ResourceName:      "grafana_library_panel.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+	testCases := []struct {
+		versionConstraint string
+		folder            string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			folder:            "",
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			folder:            "general",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			name := acctest.RandString(10)
+			var panel models.LibraryElementResponse
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						// Test resource creation.
+						Config: testAccLibraryPanelBasic(name, tc.folder),
+						Check: resource.ComposeTestCheckFunc(
+							libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+							resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
+							resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "org_id", "1"),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "name", name),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "1"),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"%s","type":""}`, name)),
+							testutils.CheckLister("grafana_library_panel.test"),
+						),
+					},
+					{
+						// Updates title.
+						Config: testAccLibraryPanelBasic("updated "+name, tc.folder),
+						Check: resource.ComposeTestCheckFunc(
+							libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+							resource.TestCheckResourceAttrSet("grafana_library_panel.test", "uid"),
+							resource.TestMatchResourceAttr("grafana_library_panel.test", "id", defaultOrgIDRegexp),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "name", "updated "+name),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "version", "2"),
+							resource.TestCheckResourceAttr("grafana_library_panel.test", "model_json", fmt.Sprintf(`{"description":"","title":"updated %s","type":""}`, name)),
+						),
+					},
+					{
+						// Importing matches the state of the previous step.
+						ResourceName:      "grafana_library_panel.test",
+						ImportState:       true,
+						ImportStateVerify: true,
+					},
+				},
+			})
+		})
+	}
 }
 
 func TestAccLibraryPanel_folder(t *testing.T) {
@@ -91,59 +109,108 @@ func TestAccLibraryPanel_folder(t *testing.T) {
 }
 
 func TestAccLibraryPanel_dashboard(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	var panel models.LibraryElementResponse
-	var dashboard models.DashboardFullWithMeta
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				// Test library panel is connected to dashboard
-				Config: testutils.TestAccExample(t, "data-sources/grafana_library_panel/data-source.tf"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("grafana_library_panel.dashboard", "id", defaultOrgIDRegexp),
-					libraryPanelCheckExists.exists("grafana_library_panel.dashboard", &panel),
-					dashboardCheckExists.exists("grafana_dashboard.with_library_panel", &dashboard),
-				),
+	testCases := []struct {
+		versionConstraint string
+		replacements      map[string]string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			replacements: map[string]string{
+				`"general"`: "null",
 			},
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			replacements:      map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			var panel models.LibraryElementResponse
+			var dashboard models.DashboardFullWithMeta
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						// Test library panel is connected to dashboard
+						Config: testutils.TestAccExampleWithReplace(t,
+							"data-sources/grafana_library_panel/data-source.tf",
+							tc.replacements,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("grafana_library_panel.dashboard", "id", defaultOrgIDRegexp),
+							libraryPanelCheckExists.exists("grafana_library_panel.dashboard", &panel),
+							dashboardCheckExists.exists("grafana_dashboard.with_library_panel", &dashboard),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
 func TestAccLibraryPanel_inOrg(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=8.0.0")
-
-	var panel models.LibraryElementResponse
-	orgName := acctest.RandString(10)
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLibraryPanelInOrganization(orgName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("grafana_library_panel.test", "id", nonDefaultOrgIDRegexp),
-					libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
-					checkResourceIsInOrg("grafana_library_panel.test", "grafana_organization.test"),
-				),
-			},
+	testCases := []struct {
+		versionConstraint string
+		folder            string
+	}{
+		{
+			versionConstraint: ">=8.0.0,<=11.0.0",
+			folder:            "",
 		},
-	})
+		{
+			versionConstraint: ">11.0.0",
+			folder:            "general",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.versionConstraint, func(t *testing.T) {
+			testutils.CheckOSSTestsEnabled(t, tc.versionConstraint)
+
+			var panel models.LibraryElementResponse
+			orgName := acctest.RandString(10)
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				CheckDestroy:             libraryPanelCheckExists.destroyed(&panel, nil),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccLibraryPanelInOrganization(orgName, tc.folder),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("grafana_library_panel.test", "id", nonDefaultOrgIDRegexp),
+							libraryPanelCheckExists.exists("grafana_library_panel.test", &panel),
+							checkResourceIsInOrg("grafana_library_panel.test", "grafana_organization.test"),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
-func testAccLibraryPanelBasic(name string) string {
+func testAccLibraryPanelBasic(name, folder string) string {
+	var fuid string
+	if folder == "" {
+		fuid = "null"
+	} else {
+		fuid = fmt.Sprintf(`"%s"`, folder)
+	}
+
 	return fmt.Sprintf(`
 resource "grafana_library_panel" "test" {
-	name      = "%[1]s"
+	name       = "%[1]s"
+	folder_uid = %[2]s
 	model_json = jsonencode({
 		title   = "%[1]s",
 	})
 }
-`, name)
+`, name, fuid)
 }
 
 func testAccLibraryPanelInFolder(name string) string {
@@ -163,17 +230,25 @@ resource "grafana_library_panel" "test_folder" {
 }`, name)
 }
 
-func testAccLibraryPanelInOrganization(orgName string) string {
+func testAccLibraryPanelInOrganization(orgName, folder string) string {
+	var fuid string
+	if folder == "" {
+		fuid = "null"
+	} else {
+		fuid = fmt.Sprintf(`"%s"`, folder)
+	}
+
 	return fmt.Sprintf(`
 resource "grafana_organization" "test" {
 	name = "%[1]s"
 }
 
 resource "grafana_library_panel" "test" {
-	org_id    = grafana_organization.test.id
-	name      = "%[1]s"
+	org_id     = grafana_organization.test.id
+	name       = "%[1]s"
+    folder_uid = %[2]s
 	model_json = jsonencode({
 	  title   = "%[1]s",
 	})
-  }`, orgName)
+  }`, orgName, fuid)
 }


### PR DESCRIPTION
Related to the Grafana version upgrade in the CI: https://github.com/grafana/terraform-provider-grafana/pull/2121.

Fixes tests in Grafana >11.0.0 for the `grafana_library_panel` resource. The `folder_uid` [was populated](https://github.com/grafana/grafana/pull/83819/files#diff-c0834e17513d02874a6a9178dc7e72fca9c965a36ff367af145349e6b2653526) with a migration in Grafana > 11.0.0 so I added it to the TF files for the corresponding Grafana versions.