### PR TITLE
Alerting: Fix TestAccNotificationPolicy_disableProvenance and TestAccNotificationPolicy_error tests

### DIFF
--- a/internal/resources/grafana/resource_alerting_notification_policy_test.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy_test.go
@@ -125,52 +125,82 @@ func TestAccNotificationPolicy_inheritContactPoint(t *testing.T) {
 }
 
 func TestAccNotificationPolicy_disableProvenance(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+	t.Run("fetch disable_provenance", func(t *testing.T) {
+		testutils.CheckOSSTestsEnabled(t, ">=11.3.0")
 
-	var policy models.Route
+		var policy models.Route
 
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
-		// Implicitly tests deletion.
-		CheckDestroy: alertingNotificationPolicyCheckExists.destroyed(&policy, nil),
-		Steps: []resource.TestStep{
-			// Create
-			{
-				Config: testAccNotificationPolicyDisableProvenance(false),
-				Check: resource.ComposeTestCheckFunc(
-					alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
-					resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "false"),
-				),
+		resource.Test(t, resource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			// Implicitly tests deletion.
+			CheckDestroy: alertingNotificationPolicyCheckExists.destroyed(&policy, nil),
+			Steps: []resource.TestStep{
+				// Create
+				{
+					Config: testAccNotificationPolicyDisableProvenance(false),
+					Check: resource.ComposeTestCheckFunc(
+						alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
+						resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "false"),
+					),
+				},
+				// Import (tests that disable_provenance is fetched from API)
+				{
+					ResourceName:      "grafana_notification_policy.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
-			// Import (tests that disable_provenance is fetched from API)
-			{
-				ResourceName:      "grafana_notification_policy.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+		})
+	})
+
+	t.Run("disable_provenance", func(t *testing.T) {
+		testutils.CheckOSSTestsEnabled(t, ">=9.1.0,<=11.1.0")
+
+		var policy models.Route
+
+		resource.Test(t, resource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			// Implicitly tests deletion.
+			CheckDestroy: alertingNotificationPolicyCheckExists.destroyed(&policy, nil),
+			Steps: []resource.TestStep{
+				// Create
+				{
+					Config: testAccNotificationPolicyDisableProvenance(false),
+					Check: resource.ComposeTestCheckFunc(
+						alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
+						resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "false"),
+					),
+				},
+				// Import (tests that disable_provenance is fetched from API)
+				{
+					ResourceName:      "grafana_notification_policy.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				// Disable provenance
+				{
+					Config: testAccNotificationPolicyDisableProvenance(true),
+					Check: resource.ComposeTestCheckFunc(
+						alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
+						resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "true"),
+					),
+				},
+				// Import (tests that disable_provenance is fetched from API)
+				{
+					ResourceName:      "grafana_notification_policy.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				// Re-enable provenance
+				{
+					Config: testAccNotificationPolicyDisableProvenance(false),
+					Check: resource.ComposeTestCheckFunc(
+						alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
+						resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "false"),
+					),
+				},
 			},
-			// Disable provenance
-			{
-				Config: testAccNotificationPolicyDisableProvenance(true),
-				Check: resource.ComposeTestCheckFunc(
-					alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
-					resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "true"),
-				),
-			},
-			// Import (tests that disable_provenance is fetched from API)
-			{
-				ResourceName:      "grafana_notification_policy.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Re-enable provenance
-			{
-				Config: testAccNotificationPolicyDisableProvenance(false),
-				Check: resource.ComposeTestCheckFunc(
-					alertingNotificationPolicyCheckExists.exists("grafana_notification_policy.test", &policy),
-					resource.TestCheckResourceAttr("grafana_notification_policy.test", "disable_provenance", "false"),
-				),
-			},
-		},
+		})
 	})
 }
 


### PR DESCRIPTION
Is needed to make the CI run tests on a newer Grafana: https://github.com/grafana/terraform-provider-grafana/pull/2121. I cherry-picked the commits there to test on a newer version too.

**TestAccNotificationPolicy_disableProvenance**
In 11.3.0 changing provenance from anything to none was restricted for notification policies: [Alerting: Update notification policy service to check provenance status  grafana#94359](https://github.com/grafana/grafana/pull/94359)

**TestAccNotificationPolicy_error**
Error message was changed: https://github.com/grafana/grafana/pull/91550/files#diff-a7977ade6eee3fe02cdeef82c12fdbfafb3cae5a118aa200a27fe39af76c63f6R32