### PR TITLE
Mark Grafana apps resources as stable

### DIFF
--- a/docs/resources/apps_dashboard_dashboard_v1beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v1beta1.md
@@ -3,12 +3,16 @@
 page_title: "grafana_apps_dashboard_dashboard_v1beta1 Resource - terraform-provider-grafana"
 subcategory: "Grafana Apps"
 description: |-
-  Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently EXPERIMENTAL and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+  Manages Grafana dashboards using the new Grafana APIs.
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis
 ---
 
 # grafana_apps_dashboard_dashboard_v1beta1 (Resource)
 
-Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+Manages Grafana dashboards using the new Grafana APIs.
+
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
 
 
 

--- a/docs/resources/apps_playlist_playlist_v0alpha1.md
+++ b/docs/resources/apps_playlist_playlist_v0alpha1.md
@@ -3,12 +3,16 @@
 page_title: "grafana_apps_playlist_playlist_v0alpha1 Resource - terraform-provider-grafana"
 subcategory: "Grafana Apps"
 description: |-
-  Manages Grafana playlists via the new Grafana App Platform API. This resource is currently EXPERIMENTAL and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+  Manages Grafana playlists using the new Grafana APIs.
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/apis/
 ---
 
 # grafana_apps_playlist_playlist_v0alpha1 (Resource)
 
-Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+Manages Grafana playlists using the new Grafana APIs.
+
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
 
 
 

--- a/internal/resources/appplatform/dashboard_resource.go
+++ b/internal/resources/appplatform/dashboard_resource.go
@@ -30,9 +30,11 @@ func Dashboard() NamedResource {
 			Schema: ResourceSpecSchema{
 				Description: "Manages Grafana dashboards.",
 				MarkdownDescription: `
-Manages Grafana dashboards via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+Manages Grafana dashboards using the new Grafana APIs.
+
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#new-dashboard-apis)
 	`,
-				DeprecationMessage: "This resource is currently EXPERIMENTAL and may be subject to change.",
 				SpecAttributes: map[string]schema.Attribute{
 					"json": schema.StringAttribute{
 						Required:    true,

--- a/internal/resources/appplatform/playlist_resource.go
+++ b/internal/resources/appplatform/playlist_resource.go
@@ -45,9 +45,11 @@ func Playlist() NamedResource {
 			Schema: ResourceSpecSchema{
 				Description: "Manages Grafana playlists.",
 				MarkdownDescription: `
-Manages Grafana playlists via the new Grafana App Platform API. This resource is currently **EXPERIMENTAL** and may be subject to change. It requires a development build of Grafana with specific feature flags enabled.
+Manages Grafana playlists using the new Grafana APIs.
+
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/apis/)
 `,
-				DeprecationMessage: "This resource is currently EXPERIMENTAL and may be subject to change.",
 				SpecAttributes: map[string]schema.Attribute{
 					"title": schema.StringAttribute{
 						Required:    true,


### PR DESCRIPTION
### What

This change updates the docs for Grafana apps resources and removes deprecation / experimental notices.

### Why

Since Grafana 12 is now released, these resources are GA.