### PR TITLE
Alerting: Add support for setting target_datasource_uid for recording rules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - GF_SERVER_ROOT_URL=${GRAFANA_URL}
       - GF_ENTERPRISE_LICENSE_TEXT=${GF_ENTERPRISE_LICENSE_TEXT:-}
       - GF_SERVER_SERVE_FROM_SUB_PATH=${GF_SERVER_SERVE_FROM_SUB_PATH:-}
-      - GF_FEATURE_TOGGLES_ENABLE=nestedFolders,ssoSettingsApi,ssoSettingsSAML,ssoSettingsLDAP
+      - GF_FEATURE_TOGGLES_ENABLE=nestedFolders,ssoSettingsApi,ssoSettingsSAML,ssoSettingsLDAP,grafanaManagedRecordingRulesDatasources
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000/api/health || exit 1 # Use wget because older versions of Grafana don't have curl
       interval: 10s

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -197,6 +197,10 @@ Required:
 - `from` (String) The ref id of the query node in the data field to use as the source of the metric.
 - `metric` (String) The name of the metric to write to.
 
+Optional:
+
+- `target_datasource_uid` (String) The UID of the datasource to write the metric to.
+
 ## Import
 
 Import is supported using the following syntax:

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -285,6 +285,11 @@ This resource requires Grafana 9.1.0 or later.
 										Required:    true,
 										Description: "The ref id of the query node in the data field to use as the source of the metric.",
 									},
+									"target_datasource_uid": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The UID of the datasource to write the metric to.",
+									},
 								},
 							},
 						},
@@ -825,6 +830,9 @@ func packRecord(r *models.Record) interface{} {
 	if r.From != nil {
 		res["from"] = *r.From
 	}
+	if r.TargetDatasourceUID != "" {
+		res["target_datasource_uid"] = r.TargetDatasourceUID
+	}
 	return []interface{}{res}
 }
 
@@ -843,6 +851,9 @@ func unpackRecord(p interface{}) *models.Record {
 	}
 	if v, ok := jsonData["from"]; ok && v != nil {
 		res.From = common.Ref(v.(string))
+	}
+	if v, ok := jsonData["target_datasource_uid"]; ok && v != nil {
+		res.TargetDatasourceUID = v.(string)
 	}
 	return res
 }

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -762,6 +762,35 @@ func TestAccAlertRule_keepFiringFor(t *testing.T) {
 	})
 }
 
+func TestAccAlertRule_RecordingRules_TargetDatasourceUID(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=12.0.0")
+
+	var group models.AlertRuleGroup
+	var name = acctest.RandString(10)
+	var metric = "valid_metric"
+	var targetDatasourceUID = "some_datasource_uid"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingRuleGroupCheckExists.destroyed(&group, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordingRuleWithTargetDatasourceUID(name, metric, "A", targetDatasourceUID),
+				Check: resource.ComposeTestCheckFunc(
+					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Random Walk Alert"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.data.0.model", "{\"refId\":\"A\"}"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.record.0.metric", metric),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.record.0.from", "A"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.record.0.target_datasource_uid", targetDatasourceUID),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAlertRule_NotificationSettings(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=10.4.0")
 
@@ -1035,6 +1064,50 @@ resource "grafana_rule_group" "my_rule_group" {
 		}
 	}
 }`, name, metric, refID)
+}
+
+func testAccRecordingRuleWithTargetDatasourceUID(name, metric, refID, datasourceUID string) string {
+	return fmt.Sprintf(`
+resource "grafana_folder" "rule_folder" {
+	title = "%[1]s"
+}
+
+resource "grafana_data_source" "testdata_datasource" {
+	name = "%[1]s"
+	type = "grafana-testdata-datasource"
+	url  = "http://localhost:3333"
+    uid  = "%[4]s"
+}
+
+resource "grafana_rule_group" "my_rule_group" {
+	name             = "%[1]s"
+	folder_uid       = grafana_folder.rule_folder.uid
+	interval_seconds = 60
+
+	rule {
+		name      = "My Random Walk Alert"
+
+		// Query the datasource.
+		data {
+			ref_id = "A"
+			relative_time_range {
+				from = 600
+				to   = 0
+			}
+			datasource_uid = grafana_data_source.testdata_datasource.uid
+			model = jsonencode({
+				intervalMs    = 1000
+				maxDataPoints = 43200
+				refId         = "A"
+			})
+		}
+		record {
+			metric                = "%[2]s"
+			from                  = "%[3]s"
+			target_datasource_uid = grafana_data_source.testdata_datasource.uid
+		}
+	}
+}`, name, metric, refID, datasourceUID)
 }
 
 func testAccRecordingRuleInvalid(name string, metric string, refID string) string {


### PR DESCRIPTION
Adds support for `target_datasource_uid` for recording rules, that allows to set the datasource to write to. It is currently optional and behind a feature flag.

The tests passed locally, in the CI the Grafana version is not 12 yet.

Part of https://github.com/grafana/alerting-squad/issues/1056