### PR TITLE
Recreate deleted k6 resources

### DIFF
--- a/docs/data-sources/k6_projects.md
+++ b/docs/data-sources/k6_projects.md
@@ -17,18 +17,12 @@ resource "grafana_k6_project" "project" {
   name = "Terraform Test Project"
 }
 
-resource "grafana_k6_project" "project_2" {
-  name = "Terraform Test Project"
-}
-
 data "grafana_k6_projects" "from_name" {
   name = "Terraform Test Project"
 
   depends_on = [
     grafana_k6_project.project,
-    grafana_k6_project.project_2
   ]
-
 }
 ```
 

--- a/examples/data-sources/grafana_k6_projects/data-source.tf
+++ b/examples/data-sources/grafana_k6_projects/data-source.tf
@@ -2,18 +2,12 @@ resource "grafana_k6_project" "project" {
   name = "Terraform Test Project"
 }
 
-resource "grafana_k6_project" "project_2" {
-  name = "Terraform Test Project"
-}
-
 data "grafana_k6_projects" "from_name" {
   name = "Terraform Test Project"
 
   depends_on = [
     grafana_k6_project.project,
-    grafana_k6_project.project_2
   ]
-
 }
 
 

--- a/internal/resources/k6/data_source_k6_loadtest_test.go
+++ b/internal/resources/k6/data_source_k6_loadtest_test.go
@@ -3,6 +3,7 @@ package k6_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
@@ -11,11 +12,15 @@ import (
 func TestAccDataSourceK6LoadTest_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	projectName := "Terraform Load Test Project " + acctest.RandString(8)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_k6_load_test/data-source.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_k6_load_test/data-source.tf", map[string]string{
+					"Terraform Load Test Project": projectName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.grafana_k6_load_test.from_id", "id"),
 					resource.TestCheckResourceAttr("data.grafana_k6_load_test.from_id", "name", "Terraform Test Load Test"),

--- a/internal/resources/k6/data_source_k6_loadtests_test.go
+++ b/internal/resources/k6/data_source_k6_loadtests_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceK6LoadTests_basic(t *testing.T) {
 
 	var project k6.ProjectApiModel
 
-    projectName := "Terraform Load Test Project " + acctest.RandString(8)
+	projectName := "Terraform Load Test Project " + acctest.RandString(8)
 
 	checkProjectIDMatch := func(value string) error {
 		if value != strconv.Itoa(int(project.GetId())) {

--- a/internal/resources/k6/data_source_k6_loadtests_test.go
+++ b/internal/resources/k6/data_source_k6_loadtests_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/grafana/k6-cloud-openapi-client-go/k6"
@@ -17,6 +18,8 @@ func TestAccDataSourceK6LoadTests_basic(t *testing.T) {
 
 	var project k6.ProjectApiModel
 
+    projectName := "Terraform Load Test Project " + acctest.RandString(8)
+
 	checkProjectIDMatch := func(value string) error {
 		if value != strconv.Itoa(int(project.GetId())) {
 			return fmt.Errorf("project_id does not match the expected value: %s", value)
@@ -28,7 +31,9 @@ func TestAccDataSourceK6LoadTests_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_k6_load_tests/data-source.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_k6_load_tests/data-source.tf", map[string]string{
+					"Terraform Load Test Project": projectName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.load_test_project", &project),
 					// from_project_id.0

--- a/internal/resources/k6/data_source_k6_project_limits_test.go
+++ b/internal/resources/k6/data_source_k6_project_limits_test.go
@@ -3,6 +3,7 @@ package k6_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
@@ -11,11 +12,15 @@ import (
 func TestAccDataSourceK6ProjectLimits_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	projectName := "Terraform Project Test Limits " + acctest.RandString(8)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_k6_project_limits/data-source.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_k6_project_limits/data-source.tf", map[string]string{
+					"Terraform Project Test Limits": projectName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					// project_id
 					resource.TestCheckResourceAttr("data.grafana_k6_project_limits.from_project_id", "vuh_max_per_month", "10000"),

--- a/internal/resources/k6/data_source_k6_project_test.go
+++ b/internal/resources/k6/data_source_k6_project_test.go
@@ -3,6 +3,7 @@ package k6_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/grafana/terraform-provider-grafana/v3/internal/testutils"
@@ -11,11 +12,15 @@ import (
 func TestAccDataSourceK6Project_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
+	projectName := "Terraform Test Project " + acctest.RandString(8)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_k6_project/data-source.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_k6_project/data-source.tf", map[string]string{
+					"Terraform Test Project": projectName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.grafana_k6_project.from_id", "id"),
 					resource.TestCheckResourceAttr("data.grafana_k6_project.from_id", "name", "Terraform Test Project"),

--- a/internal/resources/k6/data_source_k6_project_test.go
+++ b/internal/resources/k6/data_source_k6_project_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceK6Project_basic(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.grafana_k6_project.from_id", "id"),
-					resource.TestCheckResourceAttr("data.grafana_k6_project.from_id", "name", "Terraform Test Project"),
+					resource.TestCheckResourceAttr("data.grafana_k6_project.from_id", "name", projectName),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_project.from_id", "is_default"),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_project.from_id", "grafana_folder_uid"),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_project.from_id", "created"),

--- a/internal/resources/k6/data_source_k6_projects_test.go
+++ b/internal/resources/k6/data_source_k6_projects_test.go
@@ -14,8 +14,8 @@ import (
 func TestAccDataSourceK6Projects_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	var project  k6.ProjectApiModel
-	
+	var project k6.ProjectApiModel
+
 	projectName := "Terraform Test Project " + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/resources/k6/data_source_k6_projects_test.go
+++ b/internal/resources/k6/data_source_k6_projects_test.go
@@ -3,6 +3,7 @@ package k6_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/grafana/k6-cloud-openapi-client-go/k6"
@@ -13,33 +14,25 @@ import (
 func TestAccDataSourceK6Projects_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	var (
-		project  k6.ProjectApiModel
-		project2 k6.ProjectApiModel
-	)
+	var project  k6.ProjectApiModel
+	
+	projectName := "Terraform Test Project " + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "data-sources/grafana_k6_projects/data-source.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "data-sources/grafana_k6_projects/data-source.tf", map[string]string{
+					"Terraform Test Project": projectName,
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.project", &project),
-					projectCheckExists.exists("grafana_k6_project.project_2", &project2),
-					// from_name.0
 					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.0.id"),
-					resource.TestCheckResourceAttr("data.grafana_k6_projects.from_name", "projects.0.name", "Terraform Test Project"),
+					resource.TestCheckResourceAttr("data.grafana_k6_projects.from_name", "projects.0.name", projectName),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.0.is_default"),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.0.grafana_folder_uid"),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.0.created"),
 					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.0.updated"),
-					// from_name.1
-					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.1.id"),
-					resource.TestCheckResourceAttr("data.grafana_k6_projects.from_name", "projects.1.name", "Terraform Test Project"),
-					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.1.is_default"),
-					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.1.grafana_folder_uid"),
-					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.1.created"),
-					resource.TestCheckResourceAttrSet("data.grafana_k6_projects.from_name", "projects.1.updated"),
 				),
 			},
 		},

--- a/internal/resources/k6/resource_loadtest.go
+++ b/internal/resources/k6/resource_loadtest.go
@@ -154,8 +154,12 @@ func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	k6Req := r.client.LoadTestsAPI.LoadTestsRetrieve(ctx, state.ID.ValueInt32()).
 		XStackId(r.config.StackID)
 
-	lt, _, err := k6Req.Execute()
-	if err != nil {
+	lt, httpResp, err := k6Req.Execute()
+
+	if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 load test",
 			"Could not read k6 load test with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
@@ -170,11 +174,9 @@ func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	script, httpResp, err := scriptReq.Execute()
 
 	if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	if err != nil {
+		// 404 response from the script endpoin for an existing test means that the script is undefined
+		script = ""
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 load test script",
 			"Could not read k6 load test script with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),

--- a/internal/resources/k6/resource_loadtest.go
+++ b/internal/resources/k6/resource_loadtest.go
@@ -174,7 +174,7 @@ func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	script, httpResp, err := scriptReq.Execute()
 
 	if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-		// 404 response from the script endpoin for an existing test means that the script is undefined
+		// 404 response from the script endpoint for an existing test means that the script is undefined
 		script = ""
 	} else if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/resources/k6/resource_loadtest_test.go
+++ b/internal/resources/k6/resource_loadtest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 

--- a/internal/resources/k6/resource_loadtest_test.go
+++ b/internal/resources/k6/resource_loadtest_test.go
@@ -24,6 +24,8 @@ func TestAccLoadTest_basic(t *testing.T) {
 		loadTest k6.LoadTestApiModel
 	)
 
+    projectName := "Terraform Load Test Project " + acctest.RandString(8)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -32,7 +34,9 @@ func TestAccLoadTest_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_k6_load_test/resource.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf" map[string]string{
+				    "Terraform Load Test Project": projectName
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.load_test_project", &project),
 					loadTestCheckExists.exists("grafana_k6_load_test.test_load_test", &loadTest),
@@ -67,7 +71,9 @@ func TestAccLoadTest_basic(t *testing.T) {
 			},
 			// Recreate the test
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_k6_load_test/resource.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf" map[string]string{
+				    "Terraform Load Test Project": projectName
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					loadTestCheckExists.exists("grafana_k6_load_test.test_load_test", &loadTest),
 					resource.TestCheckResourceAttr("grafana_k6_load_test.test_load_test", "name", "Terraform Test Load Test"),
@@ -76,6 +82,7 @@ func TestAccLoadTest_basic(t *testing.T) {
 			// Change the name and script of a load test. This shouldn't recreate the load test.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{
+                    "Terraform Load Test Project": projectName
 					"Terraform Test Load Test":      "Terraform Test Load Test Updated",
 					"console.log('Hello from k6!')": "console.log('Hello from updated k6!')",
 				}),

--- a/internal/resources/k6/resource_loadtest_test.go
+++ b/internal/resources/k6/resource_loadtest_test.go
@@ -47,32 +47,6 @@ func TestAccLoadTest_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Delete the load test and check that TF sees a difference
-			{
-				PreConfig: func() {
-					commonClient := testutils.Provider.Meta().(*common.Client)
-					client := commonClient.K6APIClient
-					config := commonClient.K6APIConfig
-
-					ctx := context.WithValue(context.Background(), k6.ContextAccessToken, config.Token)
-					deleteReq := client.LoadTestsAPI.LoadTestsDestroy(ctx, loadTest.Id).XStackId(config.StackID)
-
-					_, err := deleteReq.Execute()
-					if err != nil {
-						t.Fatalf("error deleting load test: %s", err)
-					}
-				},
-				RefreshState:       true,
-				ExpectNonEmptyPlan: true,
-			},
-			// Recreate the test
-			{
-				Config: testutils.TestAccExample(t, "resources/grafana_k6_load_test/resource.tf"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					loadTestCheckExists.exists("grafana_k6_load_test.test_load_test", &loadTest),
-					resource.TestCheckResourceAttr("grafana_k6_load_test.test_load_test", "name", "Terraform Test Load Test"),
-				),
-			},
 			// Change the name and script of a load test. This shouldn't recreate the load test.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{

--- a/internal/resources/k6/resource_loadtest_test.go
+++ b/internal/resources/k6/resource_loadtest_test.go
@@ -47,6 +47,32 @@ func TestAccLoadTest_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Delete the load test and check that TF sees a difference
+			{
+				PreConfig: func() {
+					commonClient := testutils.Provider.Meta().(*common.Client)
+					client := commonClient.K6APIClient
+					config := commonClient.K6APIConfig
+
+					ctx := context.WithValue(context.Background(), k6.ContextAccessToken, config.Token)
+					deleteReq := client.LoadTestsAPI.LoadTestsDestroy(ctx, loadTest.Id).XStackId(config.StackID)
+
+					_, err := deleteReq.Execute()
+					if err != nil {
+						t.Fatalf("error deleting load test: %s", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Recreate the test
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_k6_load_test/resource.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					loadTestCheckExists.exists("grafana_k6_load_test.test_load_test", &loadTest),
+					resource.TestCheckResourceAttr("grafana_k6_load_test.test_load_test", "name", "Terraform Test Load Test"),
+				),
+			},
 			// Change the name and script of a load test. This shouldn't recreate the load test.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{

--- a/internal/resources/k6/resource_loadtest_test.go
+++ b/internal/resources/k6/resource_loadtest_test.go
@@ -24,7 +24,7 @@ func TestAccLoadTest_basic(t *testing.T) {
 		loadTest k6.LoadTestApiModel
 	)
 
-    projectName := "Terraform Load Test Project " + acctest.RandString(8)
+	projectName := "Terraform Load Test Project " + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
@@ -34,8 +34,8 @@ func TestAccLoadTest_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf" map[string]string{
-				    "Terraform Load Test Project": projectName
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{
+					"Terraform Load Test Project": projectName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.load_test_project", &project),
@@ -71,8 +71,8 @@ func TestAccLoadTest_basic(t *testing.T) {
 			},
 			// Recreate the test
 			{
-				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf" map[string]string{
-				    "Terraform Load Test Project": projectName
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{
+					"Terraform Load Test Project": projectName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					loadTestCheckExists.exists("grafana_k6_load_test.test_load_test", &loadTest),
@@ -82,7 +82,7 @@ func TestAccLoadTest_basic(t *testing.T) {
 			// Change the name and script of a load test. This shouldn't recreate the load test.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{
-                    "Terraform Load Test Project": projectName
+					"Terraform Load Test Project":   projectName,
 					"Terraform Test Load Test":      "Terraform Test Load Test Updated",
 					"console.log('Hello from k6!')": "console.log('Hello from updated k6!')",
 				}),

--- a/internal/resources/k6/resource_project_limits_test.go
+++ b/internal/resources/k6/resource_project_limits_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 

--- a/internal/resources/k6/resource_project_limits_test.go
+++ b/internal/resources/k6/resource_project_limits_test.go
@@ -18,6 +18,8 @@ func TestAccProjectLimits_basic(t *testing.T) {
 	var project k6.ProjectApiModel
 	var projectLimits k6.ProjectLimitsApiModel
 
+    projectName := "Terraform Project Test Limits " + acctest.RandString(8)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeTestCheckFunc(
@@ -26,7 +28,9 @@ func TestAccProjectLimits_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testutils.TestAccExample(t, "resources/grafana_k6_project_limits/resource.tf"),
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project_limits/resource.tf", map[string]string{
+				    "Terraform Project Test Limits": projectName
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.test_project_limits", &project),
 					projectLimitsCheckExists.exists("grafana_k6_project_limits.test_limits", &projectLimits),
@@ -38,6 +42,7 @@ func TestAccProjectLimits_basic(t *testing.T) {
 			},
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project_limits/resource.tf", map[string]string{
+                    "Terraform Project Test Limits": projectName
 					"vuh_max_per_month       = 1000": "vuh_max_per_month       = 2000",
 				}),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/resources/k6/resource_project_limits_test.go
+++ b/internal/resources/k6/resource_project_limits_test.go
@@ -18,7 +18,7 @@ func TestAccProjectLimits_basic(t *testing.T) {
 	var project k6.ProjectApiModel
 	var projectLimits k6.ProjectLimitsApiModel
 
-    projectName := "Terraform Project Test Limits " + acctest.RandString(8)
+	projectName := "Terraform Project Test Limits " + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
@@ -29,7 +29,7 @@ func TestAccProjectLimits_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project_limits/resource.tf", map[string]string{
-				    "Terraform Project Test Limits": projectName
+					"Terraform Project Test Limits": projectName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.test_project_limits", &project),
@@ -42,7 +42,7 @@ func TestAccProjectLimits_basic(t *testing.T) {
 			},
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project_limits/resource.tf", map[string]string{
-                    "Terraform Project Test Limits": projectName
+					"Terraform Project Test Limits":  projectName,
 					"vuh_max_per_month       = 1000": "vuh_max_per_month       = 2000",
 				}),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/resources/k6/resource_project_test.go
+++ b/internal/resources/k6/resource_project_test.go
@@ -47,32 +47,6 @@ func TestAccProject_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"grafana_folder_uid"},
 			},
-			// Delete the project and check that TF sees a difference
-			{
-				PreConfig: func() {
-					commonClient := testutils.Provider.Meta().(*common.Client)
-					client := commonClient.K6APIClient
-					config := commonClient.K6APIConfig
-
-					ctx := context.WithValue(context.Background(), k6.ContextAccessToken, config.Token)
-					deleteReq := client.ProjectsAPI.ProjectsDestroy(ctx, project.Id).XStackId(config.StackID)
-
-					_, err := deleteReq.Execute()
-					if err != nil {
-						t.Fatalf("error deleting project: %s", err)
-					}
-				},
-				RefreshState:       true,
-				ExpectNonEmptyPlan: true,
-			},
-			// Recreate the project
-			{
-				Config: testutils.TestAccExample(t, "resources/grafana_k6_project/resource.tf"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					projectCheckExists.exists("grafana_k6_project.test_project", &project),
-					resource.TestCheckResourceAttr("grafana_k6_project.test_project", "name", "Terraform Test Project"),
-				),
-			},
 			// Change the title of a project. This shouldn't recreate the project.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{

--- a/internal/resources/k6/resource_project_test.go
+++ b/internal/resources/k6/resource_project_test.go
@@ -47,6 +47,32 @@ func TestAccProject_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"grafana_folder_uid"},
 			},
+			// Delete the project and check that TF sees a difference
+			{
+				PreConfig: func() {
+					commonClient := testutils.Provider.Meta().(*common.Client)
+					client := commonClient.K6APIClient
+					config := commonClient.K6APIConfig
+
+					ctx := context.WithValue(context.Background(), k6.ContextAccessToken, config.Token)
+					deleteReq := client.ProjectsAPI.ProjectsDestroy(ctx, project.Id).XStackId(config.StackID)
+
+					_, err := deleteReq.Execute()
+					if err != nil {
+						t.Fatalf("error deleting project: %s", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Recreate the project
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_k6_project/resource.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					projectCheckExists.exists("grafana_k6_project.test_project", &project),
+					resource.TestCheckResourceAttr("grafana_k6_project.test_project", "name", "Terraform Test Project"),
+				),
+			},
 			// Change the title of a project. This shouldn't recreate the project.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{

--- a/internal/resources/k6/resource_project_test.go
+++ b/internal/resources/k6/resource_project_test.go
@@ -24,7 +24,7 @@ func TestAccProject_basic(t *testing.T) {
 
 	var project k6.ProjectApiModel
 
-    projectName := "Terraform Test Project " + acctest.RandString(8)
+	projectName := "Terraform Test Project " + acctest.RandString(8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
@@ -34,7 +34,7 @@ func TestAccProject_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{
-				    "Terraform Test Project": projectName
+					"Terraform Test Project": projectName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.test_project", &project),
@@ -72,7 +72,7 @@ func TestAccProject_basic(t *testing.T) {
 			// Recreate the project
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{
-				    "Terraform Test Project": projectName
+					"Terraform Test Project": projectName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					projectCheckExists.exists("grafana_k6_project.test_project", &project),
@@ -82,12 +82,12 @@ func TestAccProject_basic(t *testing.T) {
 			// Change the title of a project. This shouldn't recreate the project.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{
-                    projectName: projectName + " Updated"
+					projectName: projectName + " Updated",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccProjectWasntRecreated("grafana_k6_project.test_project", &project),
 					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "id", func() string { return strconv.Itoa(int(project.GetId())) }),
-					resource.TestCheckResourceAttr("grafana_k6_project.test_project", "name", projectName + " Updated"),
+					resource.TestCheckResourceAttr("grafana_k6_project.test_project", "name", projectName+" Updated"),
 					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "grafana_folder_uid", project.GetGrafanaFolderUid),
 					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "created", func() string { return project.GetCreated().Truncate(time.Microsecond).Format(time.RFC3339Nano) }),
 				),

--- a/internal/resources/k6/resource_project_test.go
+++ b/internal/resources/k6/resource_project_test.go
@@ -83,7 +83,7 @@ func TestAccProject_basic(t *testing.T) {
 			// Change the title of a project. This shouldn't recreate the project.
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{
-					projectName: projectName + " Updated",
+					"Terraform Test Project": projectName + " Updated",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccProjectWasntRecreated("grafana_k6_project.test_project", &project),

--- a/internal/resources/k6/resource_project_test.go
+++ b/internal/resources/k6/resource_project_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 


### PR DESCRIPTION
* Ensure that k6 resources (Projects, Load Tests) create a Terraform drift instead of raising an error when deleted outside of Terraform.
* Add tests to verify the resources are removed from the state when not found on the backend.
* Update existing tests to generate unique k6 project names.