### PR TITLE
RBAC: Allow resetting role fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/fleet-management-api v1.0.0
 	github.com/grafana/grafana-app-sdk v0.35.2-0.20250408075831-c2a87bde0849
 	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250214150112-a52892176c26
-	github.com/grafana/grafana-openapi-client-go v0.0.0-20250424142317-beadd3136e10
+	github.com/grafana/grafana-openapi-client-go v0.0.0-20250516123951-83fcd32d7bbe
 	github.com/grafana/grafana/apps/dashboard v0.0.0-20250424064802-2fbb2d6f5d27
 	github.com/grafana/grafana/apps/playlist v0.0.0-20250424064802-2fbb2d6f5d27
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250424064802-2fbb2d6f5d27

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250214150112-a528
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250214150112-a52892176c26/go.mod h1:sYWkB3NhyirQJfy3wtNQ29UYjoHbRlJlYhqN1jNsC5g=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250424142317-beadd3136e10 h1:RznghhbjMUEvGJD0p9AOCjnVOTq0MiINDt98BscNcdw=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250424142317-beadd3136e10/go.mod h1:hiZnMmXc9KXNUlvkV2BKFsiWuIFF/fF4wGgYWEjBitI=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20250516123951-83fcd32d7bbe h1:OdLLQKwEBVVhe9wHAncGp+Ff1N5aDl7erDIBdO9xBmA=
+github.com/grafana/grafana-openapi-client-go v0.0.0-20250516123951-83fcd32d7bbe/go.mod h1:hiZnMmXc9KXNUlvkV2BKFsiWuIFF/fF4wGgYWEjBitI=
 github.com/grafana/grafana-plugin-sdk-go v0.275.0 h1:icGmZG91lVqIo79w/pSki6N44d3IjOjTfsfQPfu4THU=
 github.com/grafana/grafana-plugin-sdk-go v0.275.0/go.mod h1:mO9LJqdXDh5JpO/xIdPAeg5LdThgQ06Y/SLpXDWKw2c=
 github.com/grafana/grafana/apps/dashboard v0.0.0-20250424064802-2fbb2d6f5d27 h1:UAv+x7lwteJR4pPMpIZ9hzngzAT1oiOQ55pq2GS4YCE=

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -246,12 +246,16 @@ func UpdateRole(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 			version += 1
 		}
 
+		description := d.Get("description").(string)
+		displayName := d.Get("display_name").(string)
+		group := d.Get("group").(string)
+
 		r := models.UpdateRoleCommand{
 			Name:        d.Get("name").(string),
 			Global:      d.Get("global").(bool),
-			Description: d.Get("description").(string),
-			DisplayName: d.Get("display_name").(string),
-			Group:       d.Get("group").(string),
+			Description: &description,
+			DisplayName: &displayName,
+			Group:       &group,
 			Hidden:      d.Get("hidden").(bool),
 			Version:     int64(version),
 			Permissions: permissions(d),


### PR DESCRIPTION
This PR:
* updates the API client version
* allows resetting group, display name and description fields of role