### PR TITLE
CI: Update mysql healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-grafana}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-grafana}
     healthcheck:
-      test: mysqladmin ping -h localhost
+      test: ["CMD", "mysqladmin", "ping", "-p$$MYSQL_ROOT_PASSWORD", "--protocol", "tcp"]
       interval: 10s
       retries: 10
       start_period: 10s


### PR DESCRIPTION
Something changed (probably) in `ubuntu-latest` and current health check command is setting the service as healthy when it is not. 

It's creating a temporal service to setup service to setup and grafana tries to connect before it finishes, so it was continuing failing.