### PR TITLE
[Connections] Add basic and bearer authentication validations

### DIFF
--- a/internal/resources/connections/metrics_endpoint_scrape_job_test.go
+++ b/internal/resources/connections/metrics_endpoint_scrape_job_test.go
@@ -71,7 +71,19 @@ func TestAcc_MetricsEndpointScrapeJob(t *testing.T) {
 				Config:       invalidScrapeJobMissingBasicPassword,
 				PlanOnly:     true,
 				RefreshState: false,
-				ExpectError:  regexp.MustCompile(`These attributes must be configured together`),
+				ExpectError:  regexp.MustCompile(`Missing Required Field`),
+			},
+			{
+				Config:       invalidScrapeJobMissingBasicUsernameAndPassword,
+				PlanOnly:     true,
+				RefreshState: false,
+				ExpectError:  regexp.MustCompile(`Missing Required Field`),
+			},
+			{
+				Config:       invalidScrapeJobUsingBasicWithToken,
+				PlanOnly:     true,
+				RefreshState: false,
+				ExpectError:  regexp.MustCompile(`Missing Required Field`),
 			},
 			{
 				Config:             resourceWithForEachValidURL,
@@ -116,6 +128,29 @@ func TestAcc_MetricsEndpointScrapeJob(t *testing.T) {
 		},
 	})
 }
+
+var invalidScrapeJobUsingBasicWithToken = `
+resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
+  stack_id                      = "1"
+  name                          = "my-scrape-job"
+  enabled                       = true
+  authentication_method         = "basic"
+  authentication_bearer_token   = "some-token"
+  url                           = "https://grafana.com/metrics"
+  scrape_interval_seconds       = 120
+}
+`
+
+var invalidScrapeJobMissingBasicUsernameAndPassword = `
+resource "grafana_connections_metrics_endpoint_scrape_job" "test" {
+  stack_id                      = "1"
+  name                          = "my-scrape-job"
+  enabled                       = true
+  authentication_method         = "basic"
+  url                           = "https://grafana.com/metrics"
+  scrape_interval_seconds       = 120
+}
+`
 
 var invalidScrapeJobMissingBasicPassword = `
 resource "grafana_connections_metrics_endpoint_scrape_job" "test" {

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -19,6 +19,11 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common/connectionsapi"
 )
 
+const (
+	authBasic  = "basic"
+	authBearer = "bearer"
+)
+
 var (
 	resourceMetricsEndpointScrapeJobTerraformName = "grafana_connections_metrics_endpoint_scrape_job"
 	resourceMetricsEndpointScrapeJobTerraformID   = common.NewResourceID(common.StringIDField("stack_id"), common.StringIDField("name"))
@@ -90,7 +95,7 @@ func (r *resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resou
 			"authentication_method": schema.StringAttribute{
 				Description: "Method to pass authentication credentials: basic or bearer.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("basic", "bearer"),
+					stringvalidator.OneOf(authBasic, authBearer),
 					authBasicValidator{},
 					authBearerValidator{},
 				},
@@ -236,7 +241,7 @@ func (v authBasicValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v authBasicValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() != "basic" {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() != authBasic {
 		return
 	}
 
@@ -273,7 +278,7 @@ func (v authBearerValidator) MarkdownDescription(ctx context.Context) string {
 }
 
 func (v authBearerValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() != "bearer" {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() != authBearer {
 		return
 	}
 

--- a/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
+++ b/internal/resources/connections/resource_metrics_endpoint_scrape_job.go
@@ -91,6 +91,8 @@ func (r *resourceMetricsEndpointScrapeJob) Schema(ctx context.Context, req resou
 				Description: "Method to pass authentication credentials: basic or bearer.",
 				Validators: []validator.String{
 					stringvalidator.OneOf("basic", "bearer"),
+					authBasicValidator{},
+					authBearerValidator{},
 				},
 				Required: true,
 			},
@@ -132,10 +134,6 @@ func (r *resourceMetricsEndpointScrapeJob) ConfigValidators(_ context.Context) [
 		),
 		resourcevalidator.Conflicting(
 			path.MatchRoot("authentication_bearer_token"),
-			path.MatchRoot("authentication_basic_password"),
-		),
-		resourcevalidator.RequiredTogether(
-			path.MatchRoot("authentication_basic_username"),
 			path.MatchRoot("authentication_basic_password"),
 		),
 	}
@@ -225,4 +223,71 @@ func (r *resourceMetricsEndpointScrapeJob) Delete(ctx context.Context, req resou
 	}
 
 	resp.State.Set(ctx, nil)
+}
+
+type authBasicValidator struct{}
+
+func (v authBasicValidator) Description(ctx context.Context) string {
+	return "Validates that both username and password are provided for authentication basic"
+}
+
+func (v authBasicValidator) MarkdownDescription(ctx context.Context) string {
+	return "Validates that both username and password are provided for authentication basic"
+}
+
+func (v authBasicValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() != "basic" {
+		return
+	}
+
+	var data metricsEndpointScrapeJobTFModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.AuthenticationBasicUsername.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Missing Required Field",
+			"authentication_basic_username is required when authentication_method is basic",
+		)
+	}
+	if data.AuthenticationBasicPassword.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Missing Required Field",
+			"authentication_basic_password is required when authentication_method is basic",
+		)
+	}
+}
+
+type authBearerValidator struct{}
+
+func (v authBearerValidator) Description(ctx context.Context) string {
+	return "Validates that bearer token is provided for bearer authentication"
+}
+
+func (v authBearerValidator) MarkdownDescription(ctx context.Context) string {
+	return "Validates that bearer token is provided for bearer authentication"
+}
+
+func (v authBearerValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() != "bearer" {
+		return
+	}
+
+	var data metricsEndpointScrapeJobTFModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.AuthenticationBearerToken.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Missing Required Field",
+			"authentication_bearer_token is required when authentication_method is bearer",
+		)
+	}
 }


### PR DESCRIPTION
This PR reinforces validation that authentication "basic" requires a "username" + "password" while authentication "bearer" requires a "token". Errors are now raised earlier by the provider when an invalid resource is defined.

Previously, invalid resources, e.g. missing username/password while using basic were still able to be planned and applied when they should have been rejected by this provider. 

Fixes: https://github.com/grafana/cloud-onboarding/issues/9057