### PR TITLE
fixing the description for the link

### DIFF
--- a/docs/data-sources/oncall_integration.md
+++ b/docs/data-sources/oncall_integration.md
@@ -27,5 +27,5 @@ data "grafana_oncall_integration" "example_integration" {
 
 ### Read-Only
 
-- `link` (String) The webhook link for the integration.
+- `link` (String) The link for the integration.
 - `name` (String) The integration name.

--- a/internal/resources/oncall/data_source_integration.go
+++ b/internal/resources/oncall/data_source_integration.go
@@ -30,7 +30,7 @@ func dataSourceIntegration() *common.DataSource {
 			"link": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The webhook link for the integration.",
+				Description: "The link for the integration.",
 			},
 		},
 	}


### PR DESCRIPTION
The description was wrong - it's not always a webhook.