### PR TITLE
feat: include oncall_api_url in cloud stack resource

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -65,6 +65,7 @@ available at “https://<stack_slug>.grafana.net".
 - `logs_url` (String)
 - `logs_user_id` (Number)
 - `name` (String) Name of stack. Conventionally matches the url of the instance (e.g. `<stack_slug>.grafana.net`).
+- `oncall_api_url` (String) Base URL of the OnCall API instance configured for this stack.
 - `org_id` (Number) Organization id to assign to this stack.
 - `org_name` (String) Organization name to assign to this stack.
 - `org_slug` (String) Organization slug to assign to this stack.

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,6 +163,11 @@ data "grafana_synthetic_monitoring_probes" "main" {
 
 ### Managing Grafana OnCall
 
+Note that you may need to set the `oncall_api_url` in the provider block
+depending on your region, of if you are using Grafana OnCall OSS.
+When using the cloud API client, you can get the OnCall API URL from the
+stack resource (`oncall_api_url`)
+
 ```terraform
 // Step 1: Configure provider block.
 // You may need to set oncall_url too, depending on your region or if you are using Grafana OnCall OSS. You can get it in OnCall -> settings -> API URL.
@@ -241,6 +246,7 @@ resource "grafana_oncall_escalation" "example_notify_step" {
   position = 0
 }
 ```
+
 
 ### Managing Frontend Observability
 

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -75,6 +75,7 @@ resource "grafana_cloud_stack" "test" {
 - `logs_status` (String)
 - `logs_url` (String)
 - `logs_user_id` (Number)
+- `oncall_api_url` (String) Base URL of the OnCall API instance configured for this stack.
 - `org_id` (Number) Organization id to assign to this stack.
 - `org_name` (String) Organization name to assign to this stack.
 - `org_slug` (String) Organization slug to assign to this stack.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437
 	github.com/grafana/fleet-management-api v1.0.0
 	github.com/grafana/grafana-app-sdk v0.35.2-0.20250408075831-c2a87bde0849
-	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250214150112-a52892176c26
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250225152211-076f0759931d
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250516123951-83fcd32d7bbe
 	github.com/grafana/grafana/apps/dashboard v0.0.0-20250424064802-2fbb2d6f5d27
 	github.com/grafana/grafana/apps/playlist v0.0.0-20250424064802-2fbb2d6f5d27

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/grafana/grafana-app-sdk/logging v0.35.1 h1:taVpl+RoixTYl0JBJGhH+fPVmw
 github.com/grafana/grafana-app-sdk/logging v0.35.1/go.mod h1:Y/bvbDhBiV/tkIle9RW49pgfSPIPSON8Q4qjx3pyqDk=
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250214150112-a52892176c26 h1:7NMB6/x0CcfH/zKQ5D+3Ffb2DbYMJBx0QdJ1GGdw8z4=
 github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250214150112-a52892176c26/go.mod h1:sYWkB3NhyirQJfy3wtNQ29UYjoHbRlJlYhqN1jNsC5g=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250225152211-076f0759931d h1:CS04cUrE9ke/S5sbaH01gW4JcEy3joLKMJO5Vu3T2/4=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20250225152211-076f0759931d/go.mod h1:sYWkB3NhyirQJfy3wtNQ29UYjoHbRlJlYhqN1jNsC5g=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250424142317-beadd3136e10 h1:RznghhbjMUEvGJD0p9AOCjnVOTq0MiINDt98BscNcdw=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250424142317-beadd3136e10/go.mod h1:hiZnMmXc9KXNUlvkV2BKFsiWuIFF/fF4wGgYWEjBitI=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250516123951-83fcd32d7bbe h1:OdLLQKwEBVVhe9wHAncGp+Ff1N5aDl7erDIBdO9xBmA=

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -176,6 +176,9 @@ Required access policy scopes:
 			"alertmanager_status":              common.ComputedStringWithDescription("Status of the Alertmanager instance configured for this stack."),
 			"alertmanager_ip_allow_list_cname": ipAllowListCNAMEDescription("the Alertmanager instances"),
 
+			// OnCall
+			"oncall_api_url": common.ComputedStringWithDescription("Base URL of the OnCall API instance configured for this stack."),
+
 			// Logs (Loki)
 			"logs_user_id": common.ComputedInt(),
 			"logs_name":    common.ComputedString(),
@@ -472,6 +475,10 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 		addPrivateConnectivityInfoIfPresent(d, "alertmanager", tenant)
 		addIPAllowListIfPresent(d, "alertmanager", tenant)
 	})
+
+	if oncallURL := connections.OncallApiUrl; oncallURL.IsSet() {
+		d.Set("oncall_api_url", oncallURL.Get())
+	}
 
 	d.Set("traces_user_id", stack.HtInstanceId)
 	d.Set("traces_name", stack.HtInstanceName)

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -79,6 +79,7 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "pdc_api_private_connectivity_info_service_name"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "pdc_gateway_private_connectivity_info_private_dns"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "pdc_gateway_private_connectivity_info_service_name"),
+		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "oncall_api_url"),
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -28,12 +28,18 @@ The changelog for this provider can be found here: <https://github.com/grafana/t
 
 ### Managing Grafana OnCall
 
+Note that you may need to set the `oncall_api_url` in the provider block
+depending on your region, of if you are using Grafana OnCall OSS.
+When using the cloud API client, you can get the OnCall API URL from the
+stack resource (`oncall_api_url`)
+
 {{ tffile "examples/provider/provider-oncall-sa.tf" }}
 
 Alternatively, you can also configure the provider block by setting
 an specific `oncall_access_token` instead, that you can create in the web UI:
 
 {{ tffile "examples/provider/provider-oncall.tf" }}
+
 
 ### Managing Frontend Observability
 


### PR DESCRIPTION
This will enable to set the `oncall_url` in the provider via the stack obtained value (which changes depending on the region), something like:

```
provider "grafana" {
  alias = "cloud"
  cloud_access_policy_token = "the-token"
}

data "grafana_cloud_stack" "mystack" {
  provider = grafana.cloud
  slug = "mystack"
}

provider "grafana" {
    alias = "oncall"
    url = "https://mystack.grafana.net"
    auth = "service-account-token"
    oncall_url = data.grafana_cloud_stack.mystack.oncall_api_url
}

resource "grafana_oncall_integration" "prod_alertmanager" {
  provider = grafana.oncall
  name     = "Created via terraform"
  type     = "alertmanager"
  default_route {
  }
}

```