### PR TITLE
Alerting: Add missing_series_evals_to_resolve to alert rule

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -144,6 +144,7 @@ Optional:
 - `is_paused` (Boolean) Sets whether the alert should be paused or not. Defaults to `false`.
 - `keep_firing_for` (String) The amount of time for which the rule will considered to be Recovering after initially Firing. Before this time has elapsed, the rule will continue to fire once it's been triggered.
 - `labels` (Map of String) Key-value pairs to attach to the alert rule that can be used in matching, grouping, and routing. Defaults to `map[]`.
+- `missing_series_evals_to_resolve` (Number) The number of missing series evaluations that must occur before the rule is considered to be resolved.
 - `no_data_state` (String) Describes what state to enter when the rule's query returns No Data. Options are OK, NoData, KeepLast, and Alerting. Defaults to NoData if not set.
 - `notification_settings` (Block List, Max: 1) Notification settings for the rule. If specified, it overrides the notification policies. Available since Grafana 10.4, requires feature flag 'alertingSimplifiedRouting' to be enabled. (see [below for nested schema](#nestedblock--rule--notification_settings))
 - `record` (Block List, Max: 1) Settings for a recording rule. Available since Grafana 11.2, requires feature flag 'grafanaManagedRecordingRules' to be enabled. (see [below for nested schema](#nestedblock--rule--record))

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -577,8 +577,8 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 
 	var missingSeriesEvalsToResolve int64
 	if val, ok := json["missing_series_evals_to_resolve"]; ok && val != nil {
-		intVal := val.(int)
-		if intVal >= 1 {
+		intVal, ok := val.(int)
+		if ok && intVal >= 1 {
 			missingSeriesEvalsToResolve = int64(intVal)
 		}
 	}

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -115,6 +115,11 @@ This resource requires Grafana 9.1.0 or later.
 								return oldDuration == newDuration
 							},
 						},
+						"missing_series_evals_to_resolve": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The number of missing series evaluations that must occur before the rule is considered to be resolved.",
+						},
 						"no_data_state": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -538,6 +543,9 @@ func packAlertRule(r *models.ProvisionedAlertRule) (interface{}, error) {
 	if r.KeepFiringFor != 0 {
 		json["keep_firing_for"] = r.KeepFiringFor.String()
 	}
+	if r.MissingSeriesEvalsToResolve >= 1 {
+		json["missing_series_evals_to_resolve"] = r.MissingSeriesEvalsToResolve
+	}
 
 	return json, nil
 }
@@ -567,6 +575,14 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 		return nil, err
 	}
 
+	var missingSeriesEvalsToResolve int64
+	if val, ok := json["missing_series_evals_to_resolve"]; ok && val != nil {
+		intVal := val.(int)
+		if intVal >= 1 {
+			missingSeriesEvalsToResolve = int64(intVal)
+		}
+	}
+
 	ns, err := unpackNotificationSettings(json["notification_settings"])
 	if err != nil {
 		return nil, err
@@ -586,6 +602,9 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 		}
 		if keepFiringForDuration != 0 {
 			return nil, fmt.Errorf(incompatFieldMsgFmt, "keep_firing_for")
+		}
+		if missingSeriesEvalsToResolve != 0 {
+			return nil, fmt.Errorf(incompatFieldMsgFmt, "missing_series_evals_to_resolve")
 		}
 		if noDataState != "" {
 			return nil, fmt.Errorf(incompatFieldMsgFmt, "no_data_state")
@@ -612,22 +631,23 @@ func unpackAlertRule(raw interface{}, groupName string, folderUID string, orgID 
 	}
 
 	rule := models.ProvisionedAlertRule{
-		UID:                  json["uid"].(string),
-		Title:                common.Ref(json["name"].(string)),
-		FolderUID:            common.Ref(folderUID),
-		RuleGroup:            common.Ref(groupName),
-		OrgID:                common.Ref(orgID),
-		ExecErrState:         common.Ref(errState),
-		NoDataState:          common.Ref(noDataState),
-		For:                  common.Ref(strfmt.Duration(forDuration)),
-		KeepFiringFor:        strfmt.Duration(keepFiringForDuration),
-		Data:                 data,
-		Condition:            common.Ref(condition),
-		Labels:               unpackMap(json["labels"]),
-		Annotations:          unpackMap(json["annotations"]),
-		IsPaused:             json["is_paused"].(bool),
-		NotificationSettings: ns,
-		Record:               unpackRecord(json["record"]),
+		UID:                         json["uid"].(string),
+		Title:                       common.Ref(json["name"].(string)),
+		FolderUID:                   common.Ref(folderUID),
+		RuleGroup:                   common.Ref(groupName),
+		OrgID:                       common.Ref(orgID),
+		ExecErrState:                common.Ref(errState),
+		NoDataState:                 common.Ref(noDataState),
+		For:                         common.Ref(strfmt.Duration(forDuration)),
+		KeepFiringFor:               strfmt.Duration(keepFiringForDuration),
+		Data:                        data,
+		Condition:                   common.Ref(condition),
+		Labels:                      unpackMap(json["labels"]),
+		Annotations:                 unpackMap(json["annotations"]),
+		IsPaused:                    json["is_paused"].(bool),
+		NotificationSettings:        ns,
+		Record:                      unpackRecord(json["record"]),
+		MissingSeriesEvalsToResolve: missingSeriesEvalsToResolve,
 	}
 
 	return &rule, nil

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -739,7 +739,7 @@ func TestAccAlertRule_keepFiringFor(t *testing.T) {
 					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.#", "1"),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Keep Firing Test"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Alert"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.keep_firing_for", "5m0s"),
 				),
 			},
@@ -749,8 +749,49 @@ func TestAccAlertRule_keepFiringFor(t *testing.T) {
 					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.#", "1"),
-					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Keep Firing Test"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Alert"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.keep_firing_for", "10m0s"),
+				),
+			},
+			{
+				ResourceName:      "grafana_rule_group.my_rule_group",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAlertRule_MissingSeriesEvalsToResolve(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=12.0.0")
+
+	var group models.AlertRuleGroup
+	name := acctest.RandString(10)
+	missingEvalsToResolve1 := "3"
+	missingEvalsToResolve2 := "5"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingRuleGroupCheckExists.destroyed(&group, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertRuleMissingEvalsToResolve(name, missingEvalsToResolve1),
+				Check: resource.ComposeTestCheckFunc(
+					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Alert"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.missing_series_evals_to_resolve", missingEvalsToResolve1),
+				),
+			},
+			{
+				Config: testAccAlertRuleMissingEvalsToResolve(name, missingEvalsToResolve2),
+				Check: resource.ComposeTestCheckFunc(
+					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", "My Alert"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.missing_series_evals_to_resolve", missingEvalsToResolve2),
 				),
 			},
 			{
@@ -1157,7 +1198,7 @@ resource "grafana_rule_group" "my_rule_group" {
 }`, name, metric, refID)
 }
 
-func testAccAlertRuleKeepFiringFor(name string, keepFiringFor string) string {
+func testAccAlertRuleWithField(name, fieldName, fieldValue string) string {
 	return fmt.Sprintf(`
 resource "grafana_folder" "rule_folder" {
 	title = "%[1]s"
@@ -1176,14 +1217,14 @@ resource "grafana_rule_group" "my_rule_group" {
 	org_id           = 1
 
 	rule {
-		name           = "My Keep Firing Test"
+		name           = "My Alert"
 		for            = "1m"
-		keep_firing_for = "%[2]s"
+		%[2]s = %[3]s
 		condition      = "C"
 		no_data_state  = "NoData"
 		exec_err_state = "Alerting"
 		is_paused = false
-		
+
 		// Query the datasource.
 		data {
 			ref_id = "A"
@@ -1198,7 +1239,7 @@ resource "grafana_rule_group" "my_rule_group" {
 				refId         = "A"
 			})
 		}
-		
+
 		data {
 			ref_id     = "B"
 			query_type = ""
@@ -1242,7 +1283,7 @@ resource "grafana_rule_group" "my_rule_group" {
 				type = "classic_conditions"
 			})
 		}
-		
+
 		data {
 			ref_id     = "C"
 			query_type = ""
@@ -1287,5 +1328,13 @@ resource "grafana_rule_group" "my_rule_group" {
 			})
 		}
 	}
-}`, name, keepFiringFor)
+}`, name, fieldName, fieldValue)
+}
+
+func testAccAlertRuleKeepFiringFor(name string, keepFiringFor string) string {
+	return testAccAlertRuleWithField(name, "keep_firing_for", fmt.Sprintf(`"%s"`, keepFiringFor))
+}
+
+func testAccAlertRuleMissingEvalsToResolve(name string, missingEvalsToResolve string) string {
+	return testAccAlertRuleWithField(name, "missing_series_evals_to_resolve", missingEvalsToResolve)
 }

--- a/pkg/generate/grafana.go
+++ b/pkg/generate/grafana.go
@@ -90,6 +90,7 @@ func generateGrafanaResources(ctx context.Context, cfg *Config, stack stack, gen
 	} else {
 		stripDefaultsExtraFields["org_id"] = `"1"` // Remove org_id if it's the default
 	}
+	stripDefaultsExtraFields["missing_series_evals_to_resolve"] = "0" // Remove missing_series_evals_to_resolve if it's the default
 
 	plannedState, err := getPlannedState(ctx, cfg)
 	if err != nil {

--- a/pkg/generate/postprocessing/strip_defaults.go
+++ b/pkg/generate/postprocessing/strip_defaults.go
@@ -36,14 +36,20 @@ func stripDefaultsFromBlock(block *hclwrite.Block, extraFieldsToRemove map[strin
 			if name == key {
 				toRemove := false
 				fieldValue := strings.TrimSpace(string(attribute.Expr().BuildTokens(nil).Bytes()))
-				fieldValue, err := extractJSONEncode(fieldValue)
+				extractedValue, err := extractJSONEncode(fieldValue)
 				if err != nil {
 					continue
 				}
 
+				// Use extracted value if it's not empty (for jsonencode fields), otherwise use original
+				compareValue := fieldValue
+				if extractedValue != "" {
+					compareValue = extractedValue
+				}
+
 				if v, ok := valueToRemove.(bool); ok && v {
 					toRemove = true
-				} else if v, ok := valueToRemove.(string); ok && v == fieldValue {
+				} else if v, ok := valueToRemove.(string); ok && v == compareValue {
 					toRemove = true
 				}
 				if toRemove {


### PR DESCRIPTION
Adding `missing_series_evals_to_resolve` option to the `grafana_rule_group.rule` resource.

`missing_series_evals_to_resolve` was added to the API in https://github.com/grafana/grafana/pull/102150

Tested locally with Grafana 12:

```
=== RUN   TestAccAlertRule_MissingSeriesEvalsToResolve
=== PAUSE TestAccAlertRule_MissingSeriesEvalsToResolve
=== CONT  TestAccAlertRule_MissingSeriesEvalsToResolve
--- PASS: TestAccAlertRule_MissingSeriesEvalsToResolve (3.25s)
```