### PR TITLE
Convert k6 resource IDs to string

### DIFF
--- a/docs/data-sources/k6_load_test.md
+++ b/docs/data-sources/k6_load_test.md
@@ -37,13 +37,13 @@ data "grafana_k6_load_test" "from_id" {
 
 ### Required
 
-- `id` (Number) Numeric identifier of the load test.
+- `id` (String) Numeric identifier of the load test.
 
 ### Read-Only
 
-- `baseline_test_run_id` (Number) Identifier of a baseline test run used for results comparison.
+- `baseline_test_run_id` (String) Identifier of a baseline test run used for results comparison.
 - `created` (String) The date when the load test was created.
 - `name` (String) Human-friendly identifier of the load test.
-- `project_id` (Number) The identifier of the project this load test belongs to.
+- `project_id` (String) The identifier of the project this load test belongs to.
 - `script` (String) The k6 test script content.
 - `updated` (String) The date when the load test was last updated.

--- a/docs/data-sources/k6_load_tests.md
+++ b/docs/data-sources/k6_load_tests.md
@@ -69,7 +69,7 @@ data "grafana_k6_load_tests" "filter_by_name" {
 
 ### Required
 
-- `project_id` (Number) The identifier of the project the load tests belong to.
+- `project_id` (String) The identifier of the project the load tests belong to.
 
 ### Optional
 
@@ -77,7 +77,7 @@ data "grafana_k6_load_tests" "filter_by_name" {
 
 ### Read-Only
 
-- `id` (Number) The identifier of the project the load tests belong to. This is set to the same as the project_id.
+- `id` (String) The identifier of the project the load tests belong to. This is set to the same as the project_id.
 - `load_tests` (List of Object) (see [below for nested schema](#nestedatt--load_tests))
 
 <a id="nestedatt--load_tests"></a>
@@ -85,10 +85,10 @@ data "grafana_k6_load_tests" "filter_by_name" {
 
 Read-Only:
 
-- `baseline_test_run_id` (Number)
+- `baseline_test_run_id` (String)
 - `created` (String)
-- `id` (Number)
+- `id` (String)
 - `name` (String)
-- `project_id` (Number)
+- `project_id` (String)
 - `script` (String)
 - `updated` (String)

--- a/docs/data-sources/k6_project.md
+++ b/docs/data-sources/k6_project.md
@@ -30,7 +30,7 @@ data "grafana_k6_project" "from_id" {
 
 ### Required
 
-- `id` (Number) Numeric identifier of the project.
+- `id` (String) Numeric identifier of the project.
 
 ### Read-Only
 

--- a/docs/data-sources/k6_project_limits.md
+++ b/docs/data-sources/k6_project_limits.md
@@ -27,12 +27,12 @@ data "grafana_k6_project_limits" "from_project_id" {
 
 ### Required
 
-- `project_id` (Number) The identifier of the project to get limits for.
+- `project_id` (String) The identifier of the project to get limits for.
 
 ### Read-Only
 
 - `duration_max_per_test` (Number) Maximum duration of a test in seconds.
-- `id` (Number) The identifier of the project limits. This is set to the same as the project_id.
+- `id` (String) The identifier of the project limits. This is set to the same as the project_id.
 - `vu_browser_max_per_test` (Number) Maximum number of concurrent browser virtual users (VUs) used in one test.
 - `vu_max_per_test` (Number) Maximum number of concurrent virtual users (VUs) used in one test.
 - `vuh_max_per_month` (Number) Maximum amount of virtual user hours (VU/h) used per one calendar month.

--- a/docs/data-sources/k6_projects.md
+++ b/docs/data-sources/k6_projects.md
@@ -45,7 +45,7 @@ Read-Only:
 
 - `created` (String)
 - `grafana_folder_uid` (String)
-- `id` (Number)
+- `id` (String)
 - `is_default` (Boolean)
 - `name` (String)
 - `updated` (String)

--- a/docs/resources/k6_load_test.md
+++ b/docs/resources/k6_load_test.md
@@ -34,17 +34,17 @@ resource "grafana_k6_load_test" "test_load_test" {
 ### Required
 
 - `name` (String) Human-friendly identifier of the load test.
-- `project_id` (Number) The identifier of the project this load test belongs to.
+- `project_id` (String) The identifier of the project this load test belongs to.
 - `script` (String) The k6 test script content. Can be provided inline or via the `file()` function.
 
 ### Optional
 
-- `baseline_test_run_id` (Number) Identifier of a baseline test run used for results comparison.
+- `baseline_test_run_id` (String) Identifier of a baseline test run used for results comparison.
 
 ### Read-Only
 
 - `created` (String) The date when the load test was created.
-- `id` (Number) Numeric identifier of the load test.
+- `id` (String) Numeric identifier of the load test.
 - `updated` (String) The date when the load test was last updated.
 
 ## Import

--- a/docs/resources/k6_project.md
+++ b/docs/resources/k6_project.md
@@ -29,7 +29,7 @@ resource "grafana_k6_project" "test_project" {
 
 - `created` (String) The date when the project was created.
 - `grafana_folder_uid` (String) The Grafana folder uid.
-- `id` (Number) Numeric identifier of the project.
+- `id` (String) Numeric identifier of the project.
 - `is_default` (Boolean) Use this project as default for running tests when no explicit project identifier is provided.
 - `updated` (String) The date when the project was last updated.
 

--- a/docs/resources/k6_project_limits.md
+++ b/docs/resources/k6_project_limits.md
@@ -31,7 +31,7 @@ resource "grafana_k6_project_limits" "test_limits" {
 
 ### Required
 
-- `project_id` (Number) The identifier of the project to manage limits for.
+- `project_id` (String) The identifier of the project to manage limits for.
 
 ### Optional
 
@@ -42,7 +42,7 @@ resource "grafana_k6_project_limits" "test_limits" {
 
 ### Read-Only
 
-- `id` (Number) The identifier of the project limits. This is the same as the project_id.
+- `id` (String) The identifier of the project limits. This is the same as the project_id.
 
 ## Import
 

--- a/internal/resources/k6/data_source_k6_project.go
+++ b/internal/resources/k6/data_source_k6_project.go
@@ -33,7 +33,7 @@ func dataSourceProject() *common.DataSource {
 
 // projectDataSourceModel maps the data source schema data.
 type projectDataSourceModel struct {
-	ID               types.Int32  `tfsdk:"id"`
+	ID               types.String  `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
 	IsDefault        types.Bool   `tfsdk:"is_default"`
 	GrafanaFolderUID types.String `tfsdk:"grafana_folder_uid"`
@@ -56,7 +56,7 @@ func (d *projectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 	resp.Schema = schema.Schema{
 		Description: "Retrieves a k6 project.",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.Int32Attribute{
+			"id": schema.StringAttribute{
 				Description: "Numeric identifier of the project.",
 				Required:    true,
 			},
@@ -93,15 +93,25 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
+	intID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing project ID",
+			"Could not parse project ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+	projectID := int32(intID)
+
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, d.config.Token)
-	k6Req := d.client.ProjectsAPI.ProjectsRetrieve(ctx, state.ID.ValueInt32()).
+	k6Req := d.client.ProjectsAPI.ProjectsRetrieve(ctx, projectID).
 		XStackId(d.config.StackID)
 
 	p, _, err := k6Req.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 project",
-			"Could not read k6 project with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 project with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/resources/k6/data_source_k6_project.go
+++ b/internal/resources/k6/data_source_k6_project.go
@@ -33,7 +33,7 @@ func dataSourceProject() *common.DataSource {
 
 // projectDataSourceModel maps the data source schema data.
 type projectDataSourceModel struct {
-	ID               types.String  `tfsdk:"id"`
+	ID               types.String `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
 	IsDefault        types.Bool   `tfsdk:"is_default"`
 	GrafanaFolderUID types.String `tfsdk:"grafana_folder_uid"`

--- a/internal/resources/k6/data_source_k6_projects.go
+++ b/internal/resources/k6/data_source_k6_projects.go
@@ -3,6 +3,7 @@ package k6
 import (
 	"context"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -66,7 +67,7 @@ func (d *projectsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Computed: true,
 				ElementType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
-						"id":                 types.Int32Type,
+						"id":                 types.StringType,
 						"name":               types.StringType,
 						"is_default":         types.BoolType,
 						"grafana_folder_uid": types.StringType,
@@ -113,7 +114,7 @@ func (d *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	})
 	for _, pj := range pjs.Value {
 		pjState := projectDataSourceModel{
-			ID:               types.Int32Value(pj.GetId()),
+			ID:               types.StringValue(strconv.Itoa(int(pj.GetId()))),
 			Name:             types.StringValue(pj.GetName()),
 			IsDefault:        types.BoolValue(pj.GetIsDefault()),
 			GrafanaFolderUID: handleGrafanaFolderUID(pj.GrafanaFolderUid),

--- a/internal/resources/k6/resource_loadtest.go
+++ b/internal/resources/k6/resource_loadtest.go
@@ -21,8 +21,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.ResourceWithConfigure   = (*loadTestResource)(nil)
-	_ resource.ResourceWithImportState = (*loadTestResource)(nil)
+	_ resource.ResourceWithConfigure    = (*loadTestResource)(nil)
+	_ resource.ResourceWithImportState  = (*loadTestResource)(nil)
+	_ resource.ResourceWithUpgradeState = (*loadTestResource)(nil)
 )
 
 var (
@@ -40,12 +41,22 @@ func resourceLoadTest() *common.Resource {
 }
 
 // loadTestResourceModel maps the resource schema data.
-type loadTestResourceModel struct {
+type loadTestResourceModelV0 struct {
 	ID                types.Int32  `tfsdk:"id"`
 	ProjectID         types.Int32  `tfsdk:"project_id"`
 	Name              types.String `tfsdk:"name"`
 	Script            types.String `tfsdk:"script"`
 	BaselineTestRunID types.Int32  `tfsdk:"baseline_test_run_id"`
+	Created           types.String `tfsdk:"created"`
+	Updated           types.String `tfsdk:"updated"`
+}
+
+type loadTestResourceModelV1 struct {
+	ID                types.String `tfsdk:"id"`
+	ProjectID         types.String `tfsdk:"project_id"`
+	Name              types.String `tfsdk:"name"`
+	Script            types.String `tfsdk:"script"`
+	BaselineTestRunID types.String `tfsdk:"baseline_test_run_id"`
 	Created           types.String `tfsdk:"created"`
 	Updated           types.String `tfsdk:"updated"`
 }
@@ -65,11 +76,11 @@ func (r *loadTestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Description: "Manages a k6 load test.",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.Int32Attribute{
+			"id": schema.StringAttribute{
 				Description: "Numeric identifier of the load test.",
 				Computed:    true,
 			},
-			"project_id": schema.Int32Attribute{
+			"project_id": schema.StringAttribute{
 				Description: "The identifier of the project this load test belongs to.",
 				Required:    true,
 			},
@@ -81,7 +92,7 @@ func (r *loadTestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "The k6 test script content. Can be provided inline or via the `file()` function.",
 				Required:    true,
 			},
-			"baseline_test_run_id": schema.Int32Attribute{
+			"baseline_test_run_id": schema.StringAttribute{
 				Description: "Identifier of a baseline test run used for results comparison.",
 				Optional:    true,
 			},
@@ -97,18 +108,88 @@ func (r *loadTestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+func (r *loadTestResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.Int32Attribute{
+						Description: "Numeric identifier of the load test.",
+						Computed:    true,
+					},
+					"project_id": schema.Int32Attribute{
+						Description: "The identifier of the project this load test belongs to.",
+						Required:    true,
+					},
+					"name": schema.StringAttribute{
+						Description: "Human-friendly identifier of the load test.",
+						Required:    true,
+					},
+					"script": schema.StringAttribute{
+						Description: "The k6 test script content. Can be provided inline or via the `file()` function.",
+						Required:    true,
+					},
+					"baseline_test_run_id": schema.Int32Attribute{
+						Description: "Identifier of a baseline test run used for results comparison.",
+						Optional:    true,
+					},
+					"created": schema.StringAttribute{
+						Description: "The date when the load test was created.",
+						Computed:    true,
+					},
+					"updated": schema.StringAttribute{
+						Description: "The date when the load test was last updated.",
+						Computed:    true,
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				// Convert int32 ID to string ID
+				var priorStateData loadTestResourceModelV0
+				diags := req.State.Get(ctx, &priorStateData)
+				resp.Diagnostics.Append(diags...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgradedStateData := loadTestResourceModelV1{
+					ID:                types.StringValue(strconv.Itoa(int(priorStateData.ID.ValueInt32()))),
+					ProjectID:         types.StringValue(strconv.Itoa(int(priorStateData.ProjectID.ValueInt32()))),
+					Name:              priorStateData.Name,
+					Script:            priorStateData.Script,
+					BaselineTestRunID: types.StringValue(strconv.Itoa(int(priorStateData.BaselineTestRunID.ValueInt32()))),
+					Created:           priorStateData.Created,
+					Updated:           priorStateData.Updated,
+				}
+
+				diags = resp.State.Set(ctx, upgradedStateData)
+				resp.Diagnostics.Append(diags...)
+			},
+		},
+	}
+}
+
 // Create creates the resource and sets the Terraform state on success.
 func (r *loadTestResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Retrieve values from plan
-	var plan loadTestResourceModel
+	var plan loadTestResourceModelV1
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	projectID, err := strconv.ParseInt(plan.ProjectID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing project ID",
+			"Could not parse project ID '"+plan.ProjectID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	k6Req := r.client.LoadTestsAPI.ProjectsLoadTestsCreate(ctx, plan.ProjectID.ValueInt32()).
+	k6Req := r.client.LoadTestsAPI.ProjectsLoadTestsCreate(ctx, int32(projectID)).
 		Name(plan.Name.ValueString()).
 		Script(io.NopCloser(strings.NewReader(plan.Script.ValueString()))).
 		XStackId(r.config.StackID)
@@ -124,9 +205,9 @@ func (r *loadTestResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Map response body to schema and populate Computed attribute values
-	plan.ID = types.Int32Value(lt.GetId())
+	plan.ID = types.StringValue(strconv.Itoa(int(lt.GetId())))
 	plan.Name = types.StringValue(lt.GetName())
-	plan.ProjectID = types.Int32Value(lt.GetProjectId())
+	plan.ProjectID = types.StringValue(strconv.Itoa(int(lt.GetProjectId())))
 	plan.BaselineTestRunID = handleBaselineTestRunID(lt.GetBaselineTestRunId())
 	plan.Created = types.StringValue(lt.GetCreated().Format(time.RFC3339Nano))
 	plan.Updated = types.StringValue(lt.GetUpdated().Format(time.RFC3339Nano))
@@ -142,16 +223,33 @@ func (r *loadTestResource) Create(ctx context.Context, req resource.CreateReques
 // Read retrieves the resource information.
 func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Get current state
-	var state loadTestResourceModel
+	var state loadTestResourceModelV1
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// If the ID is empty, we cannot read the resource.
+	// This is required for crossplane to work, but it never happens in Terraform in practice.
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	intID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing load test ID",
+			"Could not parse load test ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+	loadTestID := int32(intID)
+
 	// Retrieve the load test attributes
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	k6Req := r.client.LoadTestsAPI.LoadTestsRetrieve(ctx, state.ID.ValueInt32()).
+	k6Req := r.client.LoadTestsAPI.LoadTestsRetrieve(ctx, loadTestID).
 		XStackId(r.config.StackID)
 
 	lt, httpResp, err := k6Req.Execute()
@@ -162,13 +260,13 @@ func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 load test",
-			"Could not read k6 load test with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 load test with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Retrieve the load test script content
-	scriptReq := r.client.LoadTestsAPI.LoadTestsScriptRetrieve(ctx, state.ID.ValueInt32()).
+	scriptReq := r.client.LoadTestsAPI.LoadTestsScriptRetrieve(ctx, loadTestID).
 		XStackId(r.config.StackID)
 
 	script, httpResp, err := scriptReq.Execute()
@@ -179,15 +277,15 @@ func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, r
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 load test script",
-			"Could not read k6 load test script with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 load test script with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Overwrite items with refreshed state
-	state.ID = types.Int32Value(lt.GetId())
+	state.ID = types.StringValue(strconv.Itoa(int(lt.GetId())))
 	state.Name = types.StringValue(lt.GetName())
-	state.ProjectID = types.Int32Value(lt.GetProjectId())
+	state.ProjectID = types.StringValue(strconv.Itoa(int(lt.GetProjectId())))
 	state.BaselineTestRunID = handleBaselineTestRunID(lt.GetBaselineTestRunId())
 	state.Script = types.StringValue(script)
 	state.Created = types.StringValue(lt.GetCreated().Format(time.RFC3339Nano))
@@ -204,7 +302,7 @@ func (r *loadTestResource) Read(ctx context.Context, req resource.ReadRequest, r
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *loadTestResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Retrieve values from plan
-	var plan loadTestResourceModel
+	var plan loadTestResourceModelV1
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -212,12 +310,22 @@ func (r *loadTestResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	// Get current state to retrieve the ID
-	var state loadTestResourceModel
+	var state loadTestResourceModelV1
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	intID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing load test ID",
+			"Could not parse load test ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+	loadTestID := int32(intID)
 
 	// Generate API request body from plan
 	toUpdate := k6.NewPatchLoadTestApiModel()
@@ -225,27 +333,35 @@ func (r *loadTestResource) Update(ctx context.Context, req resource.UpdateReques
 	if plan.BaselineTestRunID.IsNull() {
 		toUpdate.SetBaselineTestRunIdNil()
 	} else {
-		toUpdate.SetBaselineTestRunId(plan.BaselineTestRunID.ValueInt32())
+		intID, err := strconv.ParseInt(plan.BaselineTestRunID.ValueString(), 10, 32)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error parsing baseline test run ID",
+				"Could not parse baseline test run ID '"+state.BaselineTestRunID.ValueString()+"': "+err.Error(),
+			)
+			return
+		}
+		toUpdate.SetBaselineTestRunId(int32(intID))
 	}
 
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	updateReq := r.client.LoadTestsAPI.LoadTestsPartialUpdate(ctx, state.ID.ValueInt32()).
+	updateReq := r.client.LoadTestsAPI.LoadTestsPartialUpdate(ctx, loadTestID).
 		PatchLoadTestApiModel(toUpdate).
 		XStackId(r.config.StackID)
 
 	// Update the load test
-	_, err := updateReq.Execute()
+	_, err = updateReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating k6 load test",
-			"Could not update k6 load test with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not update k6 load test with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Update the script if it has changed
 	if !plan.Script.Equal(state.Script) {
-		scriptReq := r.client.LoadTestsAPI.LoadTestsScriptUpdate(ctx, state.ID.ValueInt32()).
+		scriptReq := r.client.LoadTestsAPI.LoadTestsScriptUpdate(ctx, loadTestID).
 			Body(io.NopCloser(strings.NewReader(plan.Script.ValueString()))).
 			XStackId(r.config.StackID)
 
@@ -253,42 +369,42 @@ func (r *loadTestResource) Update(ctx context.Context, req resource.UpdateReques
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error updating k6 load test script",
-				"Could not update k6 load test script with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+				"Could not update k6 load test script with id "+state.ID.ValueString()+": "+err.Error(),
 			)
 			return
 		}
 	}
 
 	// Update resource state with updated items and timestamp
-	fetchReq := r.client.LoadTestsAPI.LoadTestsRetrieve(ctx, state.ID.ValueInt32()).
+	fetchReq := r.client.LoadTestsAPI.LoadTestsRetrieve(ctx, loadTestID).
 		XStackId(r.config.StackID)
 
 	lt, _, err := fetchReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 load test",
-			"Could not read k6 load test with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 load test with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Retrieve the updated script content
-	scriptReq := r.client.LoadTestsAPI.LoadTestsScriptRetrieve(ctx, state.ID.ValueInt32()).
+	scriptReq := r.client.LoadTestsAPI.LoadTestsScriptRetrieve(ctx, loadTestID).
 		XStackId(r.config.StackID)
 
 	script, _, err := scriptReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 load test script",
-			"Could not read k6 load test script with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 load test script with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Overwrite items with refreshed state
-	plan.ID = types.Int32Value(lt.GetId())
+	plan.ID = types.StringValue(strconv.Itoa(int(lt.GetId())))
 	plan.Name = types.StringValue(lt.GetName())
-	plan.ProjectID = types.Int32Value(lt.GetProjectId())
+	plan.ProjectID = types.StringValue(strconv.Itoa(int(lt.GetProjectId())))
 	plan.BaselineTestRunID = handleBaselineTestRunID(lt.GetBaselineTestRunId())
 	plan.Script = types.StringValue(script)
 	plan.Created = types.StringValue(lt.GetCreated().Format(time.RFC3339Nano))
@@ -304,44 +420,39 @@ func (r *loadTestResource) Update(ctx context.Context, req resource.UpdateReques
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *loadTestResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Retrieve values from state
-	var state loadTestResourceModel
+	var state loadTestResourceModelV1
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	intID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing load test ID",
+			"Could not parse load test ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+	loadTestID := int32(intID)
+
 	// Delete existing load test
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	deleteReq := r.client.LoadTestsAPI.LoadTestsDestroy(ctx, state.ID.ValueInt32()).
+	deleteReq := r.client.LoadTestsAPI.LoadTestsDestroy(ctx, loadTestID).
 		XStackId(r.config.StackID)
 
-	_, err := deleteReq.Execute()
+	_, err = deleteReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting k6 load test",
-			"Could not delete k6 load test with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not delete k6 load test with id "+strconv.Itoa(int(loadTestID))+": "+err.Error(),
 		)
 	}
 }
 
 func (r *loadTestResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id, err := strconv.ParseInt(req.ID, 10, 32)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error importing k6 load test",
-			"Could not parse k6 load test id "+req.ID+": "+err.Error(),
-		)
-		return
-	}
-
-	resp.State.SetAttribute(ctx, path.Root("id"), types.Int32Value(int32(id)))
-
-	readReq := resource.ReadRequest{State: resp.State}
-	readResp := resource.ReadResponse{State: resp.State}
-
-	r.Read(ctx, readReq, &readResp)
-	resp.Diagnostics.Append(readResp.Diagnostics...)
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // listLoadTests retrieves the list ids of all the existing load tests.

--- a/internal/resources/k6/resource_loadtest.go
+++ b/internal/resources/k6/resource_loadtest.go
@@ -105,6 +105,7 @@ func (r *loadTestResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:    true,
 			},
 		},
+		Version: 1,
 	}
 }
 

--- a/internal/resources/k6/resource_loadtest_test.go
+++ b/internal/resources/k6/resource_loadtest_test.go
@@ -130,20 +130,14 @@ func TestAccLoadTest_StateUpgrade(t *testing.T) {
 					loadTestCheckExists.exists("grafana_k6_load_test.test_load_test", &loadTest),
 				),
 			},
-			// Test apply updates the TF state to the latest schema but the resource is unchanged
+			// Test upgrading the provider version does not create a diff
 			{
 				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_load_test/resource.tf", map[string]string{
 					"Terraform Load Test Project": projectName,
 				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccLoadTestUnchangedAttr("grafana_k6_load_test.test_load_test", "id", func() string { return strconv.Itoa(int(loadTest.GetId())) }),
-					testAccLoadTestUnchangedAttr("grafana_k6_load_test.test_load_test", "project_id", func() string { return strconv.Itoa(int(loadTest.GetProjectId())) }),
-					testAccLoadTestUnchangedAttr("grafana_k6_load_test.test_load_test", "name", func() string { return "Terraform Test Load Test" }),
-					testAccLoadTestUnchangedAttr("grafana_k6_load_test.test_load_test", "script", func() string { return "export default function() {\n  console.log('Hello from k6!');\n}\n" }),
-					testAccLoadTestUnchangedAttr("grafana_k6_load_test.test_load_test", "created", func() string { return loadTest.GetCreated().Truncate(time.Microsecond).Format(time.RFC3339Nano) }),
-					testAccLoadTestUnchangedAttr("grafana_k6_load_test.test_load_test", "updated", func() string { return loadTest.GetUpdated().Truncate(time.Microsecond).Format(time.RFC3339Nano) }),
-				),
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
 			},
 		},
 	})

--- a/internal/resources/k6/resource_project.go
+++ b/internal/resources/k6/resource_project.go
@@ -19,13 +19,14 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.ResourceWithConfigure   = (*projectResource)(nil)
-	_ resource.ResourceWithImportState = (*projectResource)(nil)
+	_ resource.ResourceWithConfigure    = (*projectResource)(nil)
+	_ resource.ResourceWithImportState  = (*projectResource)(nil)
+	_ resource.ResourceWithUpgradeState = (*projectResource)(nil)
 )
 
 var (
 	resourceProjectName = "grafana_k6_project"
-	resourceProjectID   = common.NewResourceID(common.IntIDField("id"))
+	resourceProjectID   = common.NewResourceID(common.StringIDField("id"))
 )
 
 func resourceProject() *common.Resource {
@@ -38,8 +39,17 @@ func resourceProject() *common.Resource {
 }
 
 // projectResourceModel maps the resource schema data.
-type projectResourceModel struct {
+type projectResourceModelV0 struct {
 	ID               types.Int32  `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	IsDefault        types.Bool   `tfsdk:"is_default"`
+	GrafanaFolderUID types.String `tfsdk:"grafana_folder_uid"`
+	Created          types.String `tfsdk:"created"`
+	Updated          types.String `tfsdk:"updated"`
+}
+
+type projectResourceModelV1 struct {
+	ID               types.String `tfsdk:"id"`
 	Name             types.String `tfsdk:"name"`
 	IsDefault        types.Bool   `tfsdk:"is_default"`
 	GrafanaFolderUID types.String `tfsdk:"grafana_folder_uid"`
@@ -62,7 +72,7 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 	resp.Schema = schema.Schema{
 		Description: "Manages a k6 project.",
 		Attributes: map[string]schema.Attribute{
-			"id": schema.Int32Attribute{
+			"id": schema.StringAttribute{
 				Description: "Numeric identifier of the project.",
 				Computed:    true,
 			},
@@ -87,13 +97,64 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:    true,
 			},
 		},
+		Version: 1,
+	}
+}
+
+func (r *projectResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": schema.Int32Attribute{
+						Computed: true,
+					},
+					"name": schema.StringAttribute{
+						Required: true,
+					},
+					"is_default": schema.BoolAttribute{
+						Computed: true,
+					},
+					"grafana_folder_uid": schema.StringAttribute{
+						Computed: true,
+					},
+					"created": schema.StringAttribute{
+						Computed: true,
+					},
+					"updated": schema.StringAttribute{
+						Computed: true,
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				// Convert int32 ID to string ID
+				var priorStateData projectResourceModelV0
+				diags := req.State.Get(ctx, &priorStateData)
+				resp.Diagnostics.Append(diags...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				upgradedStateData := projectResourceModelV1{
+					ID:               types.StringValue(strconv.Itoa(int(priorStateData.ID.ValueInt32()))),
+					Name:             priorStateData.Name,
+					IsDefault:        priorStateData.IsDefault,
+					GrafanaFolderUID: priorStateData.GrafanaFolderUID,
+					Created:          priorStateData.Created,
+					Updated:          priorStateData.Updated,
+				}
+
+				diags = resp.State.Set(ctx, upgradedStateData)
+				resp.Diagnostics.Append(diags...)
+			},
+		},
 	}
 }
 
 // Create creates the resource and sets the Terraform state on success.
 func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// Retrieve values from plan
-	var plan projectResourceModel
+	var plan projectResourceModelV1
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -119,7 +180,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Map response body to schema and populate Computed attribute values
-	plan.ID = types.Int32Value(p.GetId())
+	plan.ID = types.StringValue(strconv.Itoa(int(p.GetId())))
 	plan.Name = types.StringValue(p.GetName())
 	plan.IsDefault = types.BoolValue(p.GetIsDefault())
 	plan.GrafanaFolderUID = handleGrafanaFolderUID(p.GrafanaFolderUid)
@@ -137,15 +198,31 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 // Read retrieves the resource information.
 func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Get current state
-	var state projectResourceModel
+	var state projectResourceModelV1
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// If the ID is empty, than it must be a call from crossplane during reconciliation of a new resource.
+	// This is required for crossplane to work when Read is called before Create, but it never happens in Terraform in practice.
+	if state.ID.ValueString() == "" {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	k6Req := r.client.ProjectsAPI.ProjectsRetrieve(ctx, state.ID.ValueInt32()).
+	projectID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing project ID",
+			"Could not parse project ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+
+	k6Req := r.client.ProjectsAPI.ProjectsRetrieve(ctx, int32(projectID)).
 		XStackId(r.config.StackID)
 
 	p, httpResp, err := k6Req.Execute()
@@ -158,13 +235,13 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 project",
-			"Could not read k6 project with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 project with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Overwrite items with refreshed state
-	state.ID = types.Int32Value(p.GetId())
+	state.ID = types.StringValue(strconv.Itoa(int(p.GetId())))
 	state.Name = types.StringValue(p.GetName())
 	state.IsDefault = types.BoolValue(p.GetIsDefault())
 	state.GrafanaFolderUID = handleGrafanaFolderUID(p.GrafanaFolderUid)
@@ -182,7 +259,7 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Retrieve values from plan
-	var plan projectResourceModel
+	var plan projectResourceModelV1
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -190,46 +267,56 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Get current state to retrieve the ID
-	var state projectResourceModel
+	var state projectResourceModelV1
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	intID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing project ID",
+			"Could not parse project ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+	projectID := int32(intID)
+
 	// Generate API request body from plan
 	toUpdate := k6.NewPatchProjectApiModel(plan.Name.ValueString())
 
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	updateReq := r.client.ProjectsAPI.ProjectsPartialUpdate(ctx, state.ID.ValueInt32()).
+	updateReq := r.client.ProjectsAPI.ProjectsPartialUpdate(ctx, projectID).
 		PatchProjectApiModel(toUpdate).
 		XStackId(r.config.StackID)
 
 	// Update the project
-	_, err := updateReq.Execute()
+	_, err = updateReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating k6 project",
-			"Could not update k6 project with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not update k6 project with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Update resource state with updated items and timestamp
-	fetchReq := r.client.ProjectsAPI.ProjectsRetrieve(ctx, state.ID.ValueInt32()).
+	fetchReq := r.client.ProjectsAPI.ProjectsRetrieve(ctx, projectID).
 		XStackId(r.config.StackID)
 
 	p, _, err := fetchReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading k6 project",
-			"Could not read k6 project with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not read k6 project with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
 	// Overwrite items with refreshed state
-	plan.ID = types.Int32Value(p.GetId())
+	plan.ID = types.StringValue(strconv.Itoa(int(p.GetId())))
 	plan.Name = types.StringValue(p.GetName())
 	plan.IsDefault = types.BoolValue(p.GetIsDefault())
 	plan.GrafanaFolderUID = handleGrafanaFolderUID(p.GrafanaFolderUid)
@@ -246,44 +333,39 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Retrieve values from state
-	var state projectResourceModel
+	var state projectResourceModelV1
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	intID, err := strconv.ParseInt(state.ID.ValueString(), 10, 32)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error parsing project ID",
+			"Could not parse project ID '"+state.ID.ValueString()+"': "+err.Error(),
+		)
+		return
+	}
+	projectID := int32(intID)
+
 	// Delete existing project
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
-	deleteReq := r.client.ProjectsAPI.ProjectsDestroy(ctx, state.ID.ValueInt32()).
+	deleteReq := r.client.ProjectsAPI.ProjectsDestroy(ctx, projectID).
 		XStackId(r.config.StackID)
 
-	_, err := deleteReq.Execute()
+	_, err = deleteReq.Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting k6 project",
-			"Could not delete k6 project with id "+strconv.Itoa(int(state.ID.ValueInt32()))+": "+err.Error(),
+			"Could not delete k6 project with id "+state.ID.ValueString()+": "+err.Error(),
 		)
 	}
 }
 
 func (r *projectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id, err := strconv.ParseInt(req.ID, 10, 32)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error importing k6 project",
-			"Could not parse k6 project id "+req.ID+": "+err.Error(),
-		)
-		return
-	}
-
-	resp.State.SetAttribute(ctx, path.Root("id"), types.Int32Value(int32(id)))
-
-	readReq := resource.ReadRequest{State: resp.State}
-	readResp := resource.ReadResponse{State: resp.State}
-
-	r.Read(ctx, readReq, &readResp)
-	resp.Diagnostics.Append(readResp.Diagnostics...)
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // listProjects retrieves the list ids of all the existing projects.

--- a/internal/resources/k6/resource_project_test.go
+++ b/internal/resources/k6/resource_project_test.go
@@ -121,23 +121,19 @@ func TestAccProject_StateUpgrade(t *testing.T) {
 				},
 				Check: projectCheckExists.exists("grafana_k6_project.test_project", &project),
 			},
-			// Test apply updates the TF state to the latest schema but the resource is unchanged
+			// Test upgrading the provider version does not create a diff
 			{
 				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_k6_project/resource.tf", map[string]string{
 					"Terraform Test Project": projectName,
 				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "id", func() string { return strconv.Itoa(int(project.GetId())) }),
-					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "name", func() string { return projectName }),
-					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "grafana_folder_uid", project.GetGrafanaFolderUid),
-					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "created", func() string { return project.GetCreated().Truncate(time.Microsecond).Format(time.RFC3339Nano) }),
-					testAccProjectUnchangedAttr("grafana_k6_project.test_project", "updated", func() string { return project.GetUpdated().Truncate(time.Microsecond).Format(time.RFC3339Nano) }),
-				),
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
 			},
 		},
 	})
 }
+
 func testAccProjectUnchangedAttr(resName, attrName string, oldValueGetter func() string) resource.TestCheckFunc {
 	return resource.TestCheckResourceAttrWith(resName, attrName, func(newVal string) error {
 		if oldValue := oldValueGetter(); oldValue != newVal {


### PR DESCRIPTION

* Convert k6 resource IDs from int32 to string to work correctly in the crossplane provider when generated with upjet.
* Upgrade resource schema versions and implement the `UpgradeState` methods to migrate the existing states. This makes the change backward compatible.
* Add a check for empty ID in the `Read` methods to prevent errors when called from crossplane `Observe()` method for the first time before the resource is created. 
* Add tests to verify empty plans when upgrading to the new schemas. 