### PR TITLE
cloudprovider: update docs with defaults

### DIFF
--- a/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -83,8 +83,8 @@ resource "grafana_cloud_provider_aws_cloudwatch_scrape_job" "test" {
 ### Optional
 
 - `custom_namespace` (Block List) Zero or more configuration blocks to configure custom namespaces for the AWS CloudWatch Scrape Job to scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--custom_namespace))
-- `enabled` (Boolean) Whether the AWS CloudWatch Scrape Job is enabled or not.
-- `export_tags` (Boolean) When enabled, AWS resource tags are exported as Prometheus labels to metrics formatted as `aws_<service_name>_info`.
+- `enabled` (Boolean) Whether the AWS CloudWatch Scrape Job is enabled or not. Defaults to `true`.
+- `export_tags` (Boolean) When enabled, AWS resource tags are exported as Prometheus labels to metrics formatted as `aws_<service_name>_info`. Defaults to `true`.
 - `regions_subset_override` (Set of String) A subset of the regions that are configured in the associated AWS Account resource to apply to this scrape job. If not set or empty, all of the Account resource's regions are scraped.
 - `service` (Block List) One or more configuration blocks to configure AWS services for the AWS CloudWatch Scrape Job to scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--service))
 - `static_labels` (Map of String) A set of static labels to add to all metrics exported by this scrape job.
@@ -104,7 +104,7 @@ Required:
 Optional:
 
 - `metric` (Block List) One or more configuration blocks to configure metrics and their statistics to scrape. Each block must represent a distinct metric name. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--custom_namespace--metric))
-- `scrape_interval_seconds` (Number) The interval in seconds to scrape the custom namespace.
+- `scrape_interval_seconds` (Number) The interval in seconds to scrape the custom namespace. Defaults to `300`.
 
 <a id="nestedblock--custom_namespace--metric"></a>
 ### Nested Schema for `custom_namespace.metric`
@@ -127,7 +127,7 @@ Optional:
 
 - `metric` (Block List) One or more configuration blocks to configure metrics and their statistics to scrape. Please note that AWS metric names must be supplied, and not their PromQL counterparts. Each block must represent a distinct metric name. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--service--metric))
 - `resource_discovery_tag_filter` (Block List) One or more configuration blocks to configure tag filters applied to discovery of resource entities in the associated AWS account. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--service--resource_discovery_tag_filter))
-- `scrape_interval_seconds` (Number) The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals.
+- `scrape_interval_seconds` (Number) The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals. Defaults to `300`.
 - `tags_to_add_to_metrics` (Set of String) A set of tags to add to all metrics exported by this scrape job, for use in PromQL queries.
 
 <a id="nestedblock--service--metric"></a>

--- a/docs/resources/cloud_provider_aws_resource_metadata_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_resource_metadata_scrape_job.md
@@ -63,7 +63,7 @@ resource "grafana_cloud_provider_aws_resource_metadata_scrape_job" "test" {
 
 ### Optional
 
-- `enabled` (Boolean) Whether the AWS Resource Metadata Scrape Job is enabled or not.
+- `enabled` (Boolean) Whether the AWS Resource Metadata Scrape Job is enabled or not. Defaults to `true`.
 - `regions_subset_override` (Set of String) A subset of the regions that are configured in the associated AWS Account resource to apply to this scrape job. If not set or empty, all of the Account resource's regions are scraped.
 - `service` (Block List) One or more configuration blocks to configure AWS services for the Resource Metadata Scrape Job to scrape. Each block must have a distinct `name` attribute. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--service))
 - `static_labels` (Map of String) A set of static labels to add to all metrics exported by this scrape job.
@@ -83,7 +83,7 @@ Required:
 Optional:
 
 - `resource_discovery_tag_filter` (Block List) One or more configuration blocks to configure tag filters applied to discovery of resource entities in the associated AWS account. When accessing this as an attribute reference, it is a list of objects. (see [below for nested schema](#nestedblock--service--resource_discovery_tag_filter))
-- `scrape_interval_seconds` (Number) The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals.
+- `scrape_interval_seconds` (Number) The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals. Defaults to `300`.
 
 <a id="nestedblock--service--resource_discovery_tag_filter"></a>
 ### Nested Schema for `service.resource_discovery_tag_filter`

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
@@ -87,7 +87,7 @@ func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource
 				},
 			},
 			"enabled": schema.BoolAttribute{
-				Description: "Whether the AWS CloudWatch Scrape Job is enabled or not.",
+				Description: "Whether the AWS CloudWatch Scrape Job is enabled or not. Defaults to `true`.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
@@ -104,7 +104,7 @@ func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource
 				Default:     setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 			},
 			"export_tags": schema.BoolAttribute{
-				Description: "When enabled, AWS resource tags are exported as Prometheus labels to metrics formatted as `aws_<service_name>_info`.",
+				Description: "When enabled, AWS resource tags are exported as Prometheus labels to metrics formatted as `aws_<service_name>_info`. Defaults to `true`.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
@@ -135,7 +135,7 @@ func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource
 							Required:    true,
 						},
 						"scrape_interval_seconds": schema.Int64Attribute{
-							Description: "The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals.",
+							Description: "The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals. Defaults to `300`.",
 							Optional:    true,
 							Computed:    true,
 							Default:     int64default.StaticInt64(300),
@@ -202,7 +202,7 @@ func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource
 							Required:    true,
 						},
 						"scrape_interval_seconds": schema.Int64Attribute{
-							Description: "The interval in seconds to scrape the custom namespace.",
+							Description: "The interval in seconds to scrape the custom namespace. Defaults to `300`.",
 							Optional:    true,
 							Computed:    true,
 							Default:     int64default.StaticInt64(300),

--- a/internal/resources/cloudprovider/resource_aws_resource_metadata_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_resource_metadata_scrape_job.go
@@ -86,7 +86,7 @@ func (r resourceAWSResourceMetadataScrapeJob) Schema(ctx context.Context, req re
 				},
 			},
 			"enabled": schema.BoolAttribute{
-				Description: "Whether the AWS Resource Metadata Scrape Job is enabled or not.",
+				Description: "Whether the AWS Resource Metadata Scrape Job is enabled or not. Defaults to `true`.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
@@ -128,7 +128,7 @@ func (r resourceAWSResourceMetadataScrapeJob) Schema(ctx context.Context, req re
 							Required:    true,
 						},
 						"scrape_interval_seconds": schema.Int64Attribute{
-							Description: "The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals.",
+							Description: "The interval in seconds to scrape the service. See https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/cloudwatch-metrics/services/ for supported scrape intervals. Defaults to `300`.",
 							Optional:    true,
 							Computed:    true,
 							Default:     int64default.StaticInt64(300),


### PR DESCRIPTION
fixes https://github.com/grafana/grafana-csp-app/issues/586

This adds default values to relevant field descriptions in CloudProvider resource schemas. 

Default values aren't being automatically added to docs by tfplugindocs.  This appears to be because we use the newer [terraform-plugin-framework](https://developer.hashicorp.com/terraform/plugin/framework), which requires fields with Default values to be Computed, but tfplugindocs won't list Computed fields as having default values (since Computed means the providing service (Cloud Provider API) can provide its own value).