### PR TITLE
oncall: show warning about switching to irm perms/roles

### DIFF
--- a/internal/resources/grafana/data_source_role.go
+++ b/internal/resources/grafana/data_source_role.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grafana/grafana-openapi-client-go/client/access_control"
 	"github.com/grafana/terraform-provider-grafana/v3/internal/common"
@@ -23,6 +24,13 @@ func datasourceRole() *common.DataSource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of the role",
+				ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+					name := i.(string)
+					if strings.HasPrefix(strings.ToLower(name), "plugins:grafana-oncall-app:") {
+						warnings = append(warnings, "Roles from 'grafana-oncall-app' are deprecated and should be migrated to 'grafana-irm-app' roles instead.")
+					}
+					return warnings, nil
+				},
 			},
 			"auto_increment_version": nil,
 		}),

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -94,6 +95,13 @@ func resourceRole() *common.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "Specific action users granted with the role will be allowed to perform (for example: `users:read`)",
+							ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+								action := i.(string)
+								if strings.HasPrefix(action, "grafana-oncall-app.") {
+									warnings = append(warnings, "'grafana-oncall-app' permissions are deprecated. Permissions from 'grafana-oncall-app' should be migrated to the corresponding 'grafana-irm-app' permissions.")
+								}
+								return warnings, nil
+							},
 						},
 						"scope": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
Grafana OnCall permissions and roles should be migrated to their corresponding IRM versions.

Related to https://github.com/grafana/irm/issues/1463