### PR TITLE
fix(syntheticmonitoring): Update timeout documentation

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -426,7 +426,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
 - `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.
 - `labels` (Map of String) Custom labels to be included with collected metrics and logs. The maximum number of labels that can be specified per check is 5. These are applied, along with the probe-specific labels, to the outgoing metrics. The names and values of the labels cannot be empty, and the maximum length is 32 bytes.
-- `timeout` (Number) Specifies the maximum running time for the check in milliseconds. The minimum acceptable value is 1 second (1000 ms), and the maximum 10 seconds (10000 ms). Defaults to `3000`.
+- `timeout` (Number) Specifies the maximum running time for the check in milliseconds. The minimum acceptable value is 1 second (1000 ms), and the maximum 180 seconds (180000 ms). Defaults to `3000`.
 
 ### Read-Only
 

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -747,7 +747,7 @@ multiple checks for a single endpoint to check different capabilities.
 			},
 			"timeout": {
 				Description: "Specifies the maximum running time for the check in milliseconds. " +
-					"The minimum acceptable value is 1 second (1000 ms), and the maximum 10 seconds (10000 ms).",
+					"The minimum acceptable value is 1 second (1000 ms), and the maximum 180 seconds (180000 ms).",
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  checkDefaultTimeout,


### PR DESCRIPTION
Set the timeout for checks to 180 seconds(180000ms) to align with the existing api.

A potential improvement would be to also include a ValidateFunc that ensures the values are in between the documented minimum and maximum.