### PR TITLE
feat: add Backstage catalog files

### DIFF
--- a/.github/actions/validate-catalog/action.yaml
+++ b/.github/actions/validate-catalog/action.yaml
@@ -1,0 +1,35 @@
+name: Validate catalog
+description: Validate Backstage catalog information
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+      with:
+        go-version-file: go.mod
+
+    - name: Setup jsonnet
+      id: setup-jsonnet
+      uses: zendesk/setup-jsonnet@f683a0d16f479db69751bd8d3a49a09e22b45b39 # v12
+
+    - name: Setup terraform
+      id: setup-terraform
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+
+    - name: Generate provider schema
+      id: generate-schema
+      shell: bash
+      run: ./scripts/generate_schema.sh > schema.json
+
+    - name: Validate catalog
+      id: validate-catalog
+      shell: bash
+      run: |
+        jsonnet -S \
+            --tla-str-file "catalog=./catalog-info.yaml" \
+            "./.github/actions/validate-catalog/locations.jsonnet" | xargs cat > catalog.yaml
+
+        jsonnet -S \
+            --tla-str-file catalog=catalog.yaml \
+            --tla-code-file schema=schema.json \
+            "./.github/actions/validate-catalog/validate.jsonnet"

--- a/.github/actions/validate-catalog/locations.jsonnet
+++ b/.github/actions/validate-catalog/locations.jsonnet
@@ -1,0 +1,16 @@
+function(catalog, pathPrefix='')
+  // Get resources from catalog
+  local catalogParsed = std.parseYaml(catalog);
+  local locations = std.filter(function(obj) obj.kind == 'Location', catalogParsed);
+  local targets =
+    std.flatMap(
+      function(obj) obj.spec.targets,
+      locations
+    );
+
+  std.lines(
+    std.map(
+      function(target) pathPrefix + target,
+      targets
+    )
+  )

--- a/.github/actions/validate-catalog/validate.jsonnet
+++ b/.github/actions/validate-catalog/validate.jsonnet
@@ -1,0 +1,22 @@
+function(catalog, schema)
+  // Get resources from catalog
+  local catalogParsed = std.parseYaml(catalog);
+  local components = std.filter(function(obj) obj.kind == 'Component', catalogParsed);
+  local resources =
+    std.sort(
+      std.filterMap(
+        function(obj) obj.spec.type == 'terraform-resource',
+        function(obj) obj.metadata.name,
+        components
+      )
+    );
+
+  // Get resources from provider schema
+  local s = schema.provider_schemas['registry.terraform.io/grafana/grafana'];
+  local resourcesInSchema = std.objectFields(s.resource_schemas);
+
+  // Validate
+  assert resources == resourcesInSchema :
+         '\nMissing in catalog: ' + std.setDiff(resourcesInSchema, resources)
+         + '\nMissing in schema: ' + std.setDiff(resources, resourcesInSchema);
+  'Valid!'

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,0 +1,11 @@
+name: Validate catalog
+on:
+  pull_request: {}
+
+jobs:
+  validate-catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/validate-catalog
+

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
@@ -14,3 +15,41 @@ spec:
   type: tool
   owner: group:default/platform-monitoring
   lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: terraform-resources
+spec:
+  type: file
+  targets:
+    - ./internal/resources/appplatform/catalog-resource.yaml
+    - ./internal/resources/cloud/catalog-resource.yaml
+    - ./internal/resources/cloudprovider/catalog-resource.yaml
+    - ./internal/resources/connections/catalog-resource.yaml
+    - ./internal/resources/fleetmanagement/catalog-resource.yaml
+    - ./internal/resources/frontendo11y/catalog-resource.yaml
+    - ./internal/resources/grafana/catalog-resource.yaml
+    - ./internal/resources/k6/catalog-resource.yaml
+    - ./internal/resources/machinelearning/catalog-resource.yaml
+    - ./internal/resources/oncall/catalog-resource.yaml
+    - ./internal/resources/slo/catalog-resource.yaml
+    - ./internal/resources/syntheticmonitoring/catalog-resource.yaml
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: terraform-data-sources
+spec:
+  type: file
+  targets:
+    - ./internal/resources/cloud/catalog-data-source.yaml
+    - ./internal/resources/cloudprovider/catalog-data-source.yaml
+    - ./internal/resources/connections/catalog-data-source.yaml
+    - ./internal/resources/fleetmanagement/catalog-data-source.yaml
+    - ./internal/resources/frontendo11y/catalog-data-source.yaml
+    - ./internal/resources/grafana/catalog-data-source.yaml
+    - ./internal/resources/k6/catalog-data-source.yaml
+    - ./internal/resources/oncall/catalog-data-source.yaml
+    - ./internal/resources/slo/catalog-data-source.yaml
+    - ./internal/resources/syntheticmonitoring/catalog-data-source.yaml

--- a/internal/resources/appplatform/catalog-resource.yaml
+++ b/internal/resources/appplatform/catalog-resource.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_apps_dashboard_dashboard_v1beta1
+  title: grafana_apps_dashboard_dashboard_v1beta1
+  description: |
+    resource `grafana_apps_dashboard_dashboard_v1beta1` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-app-platform
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_apps_playlist_playlist_v0alpha1
+  title: grafana_apps_playlist_playlist_v0alpha1
+  description: |
+    resource `grafana_apps_playlist_playlist_v0alpha1` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-app-platform
+  lifecycle: production

--- a/internal/resources/cloud/catalog-data-source.yaml
+++ b/internal/resources/cloud/catalog-data-source.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_access_policies
+  title: grafana_cloud_access_policies
+  description: |
+    resource `grafana_cloud_access_policies` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_ips
+  title: grafana_cloud_ips
+  description: |
+    resource `grafana_cloud_ips` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: 
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_organization
+  title: grafana_cloud_organization
+  description: |
+    resource `grafana_cloud_organization` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_private_data_source_connect_networks
+  title: grafana_cloud_private_data_source_connect_networks
+  description: |
+    resource `grafana_cloud_private_data_source_connect_networks` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/partner-datasources
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_stack
+  title: grafana_cloud_stack
+  description: |
+    resource `grafana_cloud_stack` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-com-maintainers
+  lifecycle: production

--- a/internal/resources/cloud/catalog-resource.yaml
+++ b/internal/resources/cloud/catalog-resource.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_access_policy
+  title: grafana_cloud_access_policy
+  description: |
+    resource `grafana_cloud_access_policy` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_access_policy_token
+  title: grafana_cloud_access_policy_token
+  description: |
+    resource `grafana_cloud_access_policy_token` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_org_member
+  title: grafana_cloud_org_member
+  description: |
+    resource `grafana_cloud_org_member` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_plugin_installation
+  title: grafana_cloud_plugin_installation
+  description: |
+    resource `grafana_cloud_plugin_installation` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/plugins-platform-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_private_data_source_connect_network
+  title: grafana_cloud_private_data_source_connect_network
+  description: |
+    resource `grafana_cloud_private_data_source_connect_network` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/partner-datasources
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_private_data_source_connect_network_token
+  title: grafana_cloud_private_data_source_connect_network_token
+  description: |
+    resource `grafana_cloud_private_data_source_connect_network_token` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/partner-datasources
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_stack
+  title: grafana_cloud_stack
+  description: |
+    resource `grafana_cloud_stack` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-com-maintainers
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_stack_service_account
+  title: grafana_cloud_stack_service_account
+  description: |
+    resource `grafana_cloud_stack_service_account` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_stack_service_account_token
+  title: grafana_cloud_stack_service_account_token
+  description: |
+    resource `grafana_cloud_stack_service_account_token` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_installation
+  title: grafana_k6_installation
+  description: |
+    resource `grafana_k6_installation` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_synthetic_monitoring_installation
+  title: grafana_synthetic_monitoring_installation
+  description: |
+    resource `grafana_synthetic_monitoring_installation` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/synthetic-monitoring-dev
+  lifecycle: production

--- a/internal/resources/cloudprovider/catalog-data-source.yaml
+++ b/internal/resources/cloudprovider/catalog-data-source.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_aws_account
+  title: grafana_cloud_provider_aws_account
+  description: |
+    resource `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/middleware-apps
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_aws_cloudwatch_scrape_job
+  title: grafana_cloud_provider_aws_cloudwatch_scrape_job
+  description: |
+    resource `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/middleware-apps
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_aws_cloudwatch_scrape_jobs
+  title: grafana_cloud_provider_aws_cloudwatch_scrape_jobs
+  description: |
+    resource `grafana_cloud_provider_aws_cloudwatch_scrape_jobs` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/middleware-apps
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_azure_credential
+  title: grafana_cloud_provider_azure_credential
+  description: |
+    resource `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/middleware-apps
+  lifecycle: production

--- a/internal/resources/cloudprovider/catalog-resource.yaml
+++ b/internal/resources/cloudprovider/catalog-resource.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_aws_account
+  title: grafana_cloud_provider_aws_account
+  description: |
+    resource `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/middleware-apps
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_aws_cloudwatch_scrape_job
+  title: grafana_cloud_provider_aws_cloudwatch_scrape_job
+  description: |
+    resource `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/middleware-apps
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_aws_resource_metadata_scrape_job
+  title: grafana_cloud_provider_aws_resource_metadata_scrape_job
+  description: |
+    resource `grafana_cloud_provider_aws_resource_metadata_scrape_job` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/middleware-apps
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_cloud_provider_azure_credential
+  title: grafana_cloud_provider_azure_credential
+  description: |
+    resource `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/middleware-apps
+  lifecycle: production

--- a/internal/resources/connections/catalog-data-source.yaml
+++ b/internal/resources/connections/catalog-data-source.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_connections_metrics_endpoint_scrape_job
+  title: grafana_connections_metrics_endpoint_scrape_job
+  description: |
+    resource `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/middleware-apps
+  lifecycle: production

--- a/internal/resources/connections/catalog-resource.yaml
+++ b/internal/resources/connections/catalog-resource.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_connections_metrics_endpoint_scrape_job
+  title: grafana_connections_metrics_endpoint_scrape_job
+  description: |
+    resource `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/middleware-apps
+  lifecycle: production

--- a/internal/resources/fleetmanagement/catalog-data-source.yaml
+++ b/internal/resources/fleetmanagement/catalog-data-source.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_fleet_management_collector
+  title: grafana_fleet_management_collector
+  description: |
+    resource `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/fleet-management-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_fleet_management_collectors
+  title: grafana_fleet_management_collectors
+  description: |
+    resource `grafana_fleet_management_collectors` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/fleet-management-backend
+  lifecycle: production

--- a/internal/resources/fleetmanagement/catalog-resource.yaml
+++ b/internal/resources/fleetmanagement/catalog-resource.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_fleet_management_collector
+  title: grafana_fleet_management_collector
+  description: |
+    resource `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/fleet-management-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_fleet_management_pipeline
+  title: grafana_fleet_management_pipeline
+  description: |
+    resource `grafana_fleet_management_pipeline` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/fleet-management-backend
+  lifecycle: production

--- a/internal/resources/frontendo11y/catalog-data-source.yaml
+++ b/internal/resources/frontendo11y/catalog-data-source.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_frontend_o11y_app
+  title: grafana_frontend_o11y_app
+  description: |
+    resource `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/frontend-o11y
+  lifecycle: production

--- a/internal/resources/frontendo11y/catalog-resource.yaml
+++ b/internal/resources/frontendo11y/catalog-resource.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_frontend_o11y_app
+  title: grafana_frontend_o11y_app
+  description: |
+    resource `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/frontend-o11y
+  lifecycle: production

--- a/internal/resources/grafana/catalog-data-source.yaml
+++ b/internal/resources/grafana/catalog-data-source.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_dashboard
+  title: grafana_dashboard
+  description: |
+    resource `grafana_dashboard` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/dashboards-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_dashboards
+  title: grafana_dashboards
+  description: |
+    resource `grafana_dashboards` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/dashboards-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_data_source
+  title: grafana_data_source
+  description: |
+    resource `grafana_data_source` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/partner-datasources
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_folder
+  title: grafana_folder
+  description: |
+    resource `grafana_folder` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-search-and-storage
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_folders
+  title: grafana_folders
+  description: |
+    resource `grafana_folders` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-search-and-storage
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_library_panel
+  title: grafana_library_panel
+  description: |
+    resource `grafana_library_panel` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/dataviz-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_library_panels
+  title: grafana_library_panels
+  description: |
+    resource `grafana_library_panels` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/dataviz-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_organization
+  title: grafana_organization
+  description: |
+    resource `grafana_organization` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_organization_preferences
+  title: grafana_organization_preferences
+  description: |
+    resource `grafana_organization_preferences` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_organization_user
+  title: grafana_organization_user
+  description: |
+    resource `grafana_organization_user` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_role
+  title: grafana_role
+  description: |
+    resource `grafana_role` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_service_account
+  title: grafana_service_account
+  description: |
+    resource `grafana_service_account` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_team
+  title: grafana_team
+  description: |
+    resource `grafana_team` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_user
+  title: grafana_user
+  description: |
+    resource `grafana_user` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_users
+  title: grafana_users
+  description: |
+    resource `grafana_users` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/identity-squad
+  lifecycle: production

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -1,0 +1,442 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_annotation
+  title: grafana_annotation
+  description: |
+    resource `grafana_annotation` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-search-and-storage
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_contact_point
+  title: grafana_contact_point
+  description: |
+    resource `grafana_contact_point` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/alerting-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_dashboard
+  title: grafana_dashboard
+  description: |
+    resource `grafana_dashboard` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/dashboards-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_dashboard_permission
+  title: grafana_dashboard_permission
+  description: |
+    resource `grafana_dashboard_permission` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_dashboard_permission_item
+  title: grafana_dashboard_permission_item
+  description: |
+    resource `grafana_dashboard_permission_item` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_dashboard_public
+  title: grafana_dashboard_public
+  description: |
+    resource `grafana_dashboard_public` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/sharing-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_data_source
+  title: grafana_data_source
+  description: |
+    resource `grafana_data_source` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/partner-datasources
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_data_source_config
+  title: grafana_data_source_config
+  description: |
+    resource `grafana_data_source_config` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/partner-datasources
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_data_source_config_lbac_rules
+  title: grafana_data_source_config_lbac_rules
+  description: |
+    resource `grafana_data_source_config_lbac_rules` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_data_source_permission
+  title: grafana_data_source_permission
+  description: |
+    resource `grafana_data_source_permission` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_data_source_permission_item
+  title: grafana_data_source_permission_item
+  description: |
+    resource `grafana_data_source_permission_item` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_folder
+  title: grafana_folder
+  description: |
+    resource `grafana_folder` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-search-and-storage
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_folder_permission
+  title: grafana_folder_permission
+  description: |
+    resource `grafana_folder_permission` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_folder_permission_item
+  title: grafana_folder_permission_item
+  description: |
+    resource `grafana_folder_permission_item` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_library_panel
+  title: grafana_library_panel
+  description: |
+    resource `grafana_library_panel` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/dataviz-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_message_template
+  title: grafana_message_template
+  description: |
+    resource `grafana_message_template` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/alerting-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_mute_timing
+  title: grafana_mute_timing
+  description: |
+    resource `grafana_mute_timing` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/alerting-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_notification_policy
+  title: grafana_notification_policy
+  description: |
+    resource `grafana_notification_policy` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/alerting-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_organization
+  title: grafana_organization
+  description: |
+    resource `grafana_organization` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_organization_preferences
+  title: grafana_organization_preferences
+  description: |
+    resource `grafana_organization_preferences` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_playlist
+  title: grafana_playlist
+  description: |
+    resource `grafana_playlist` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/sharing-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_report
+  title: grafana_report
+  description: |
+    resource `grafana_report` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/sharing-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_role
+  title: grafana_role
+  description: |
+    resource `grafana_role` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_role_assignment
+  title: grafana_role_assignment
+  description: |
+    resource `grafana_role_assignment` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_role_assignment_item
+  title: grafana_role_assignment_item
+  description: |
+    resource `grafana_role_assignment_item` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_rule_group
+  title: grafana_rule_group
+  description: |
+    resource `grafana_rule_group` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/alerting-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_service_account
+  title: grafana_service_account
+  description: |
+    resource `grafana_service_account` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_service_account_permission
+  title: grafana_service_account_permission
+  description: |
+    resource `grafana_service_account_permission` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_service_account_permission_item
+  title: grafana_service_account_permission_item
+  description: |
+    resource `grafana_service_account_permission_item` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_service_account_token
+  title: grafana_service_account_token
+  description: |
+    resource `grafana_service_account_token` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_sso_settings
+  title: grafana_sso_settings
+  description: |
+    resource `grafana_sso_settings` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_team
+  title: grafana_team
+  description: |
+    resource `grafana_team` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_team_external_group
+  title: grafana_team_external_group
+  description: |
+    resource `grafana_team_external_group` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/access-squad
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_user
+  title: grafana_user
+  description: |
+    resource `grafana_user` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/identity-squad
+  lifecycle: production

--- a/internal/resources/k6/catalog-data-source.yaml
+++ b/internal/resources/k6/catalog-data-source.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_load_test
+  title: grafana_k6_load_test
+  description: |
+    resource `grafana_k6_load_test` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_load_tests
+  title: grafana_k6_load_tests
+  description: |
+    resource `grafana_k6_load_tests` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_project
+  title: grafana_k6_project
+  description: |
+    resource `grafana_k6_project` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_project_limits
+  title: grafana_k6_project_limits
+  description: |
+    resource `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_projects
+  title: grafana_k6_projects
+  description: |
+    resource `grafana_k6_projects` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production

--- a/internal/resources/k6/catalog-resource.yaml
+++ b/internal/resources/k6/catalog-resource.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_load_test
+  title: grafana_k6_load_test
+  description: |
+    resource `grafana_k6_load_test` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_project
+  title: grafana_k6_project
+  description: |
+    resource `grafana_k6_project` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_k6_project_limits
+  title: grafana_k6_project_limits
+  description: |
+    resource `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/k6-cloud-provisioning
+  lifecycle: production

--- a/internal/resources/machinelearning/catalog-resource.yaml
+++ b/internal/resources/machinelearning/catalog-resource.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_machine_learning_alert
+  title: grafana_machine_learning_alert
+  description: |
+    resource `grafana_machine_learning_alert` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/machine-learning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_machine_learning_holiday
+  title: grafana_machine_learning_holiday
+  description: |
+    resource `grafana_machine_learning_holiday` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/machine-learning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_machine_learning_job
+  title: grafana_machine_learning_job
+  description: |
+    resource `grafana_machine_learning_job` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/machine-learning
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_machine_learning_outlier_detector
+  title: grafana_machine_learning_outlier_detector
+  description: |
+    resource `grafana_machine_learning_outlier_detector` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/machine-learning
+  lifecycle: production

--- a/internal/resources/oncall/catalog-data-source.yaml
+++ b/internal/resources/oncall/catalog-data-source.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_escalation_chain
+  title: grafana_oncall_escalation_chain
+  description: |
+    resource `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_integration
+  title: grafana_oncall_integration
+  description: |
+    resource `grafana_oncall_integration` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_label
+  title: grafana_oncall_label
+  description: |
+    resource `grafana_oncall_label` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_outgoing_webhook
+  title: grafana_oncall_outgoing_webhook
+  description: |
+    resource `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_schedule
+  title: grafana_oncall_schedule
+  description: |
+    resource `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_slack_channel
+  title: grafana_oncall_slack_channel
+  description: |
+    resource `grafana_oncall_slack_channel` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_team
+  title: grafana_oncall_team
+  description: |
+    resource `grafana_oncall_team` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_user
+  title: grafana_oncall_user
+  description: |
+    resource `grafana_oncall_user` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_user_group
+  title: grafana_oncall_user_group
+  description: |
+    resource `grafana_oncall_user_group` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_users
+  title: grafana_oncall_users
+  description: |
+    resource `grafana_oncall_users` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/grafana-irm-backend
+  lifecycle: production

--- a/internal/resources/oncall/catalog-resource.yaml
+++ b/internal/resources/oncall/catalog-resource.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_escalation
+  title: grafana_oncall_escalation
+  description: |
+    resource `grafana_oncall_escalation` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_escalation_chain
+  title: grafana_oncall_escalation_chain
+  description: |
+    resource `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_integration
+  title: grafana_oncall_integration
+  description: |
+    resource `grafana_oncall_integration` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_on_call_shift
+  title: grafana_oncall_on_call_shift
+  description: |
+    resource `grafana_oncall_on_call_shift` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_outgoing_webhook
+  title: grafana_oncall_outgoing_webhook
+  description: |
+    resource `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_route
+  title: grafana_oncall_route
+  description: |
+    resource `grafana_oncall_route` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_schedule
+  title: grafana_oncall_schedule
+  description: |
+    resource `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_oncall_user_notification_rule
+  title: grafana_oncall_user_notification_rule
+  description: |
+    resource `grafana_oncall_user_notification_rule` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/grafana-irm-backend
+  lifecycle: production

--- a/internal/resources/slo/catalog-data-source.yaml
+++ b/internal/resources/slo/catalog-data-source.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_slos
+  title: grafana_slos
+  description: |
+    resource `grafana_slos` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/slo-squad
+  lifecycle: production

--- a/internal/resources/slo/catalog-resource.yaml
+++ b/internal/resources/slo/catalog-resource.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_slo
+  title: grafana_slo
+  description: |
+    resource `grafana_slo` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/slo-squad
+  lifecycle: production

--- a/internal/resources/syntheticmonitoring/catalog-data-source.yaml
+++ b/internal/resources/syntheticmonitoring/catalog-data-source.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_synthetic_monitoring_probe
+  title: grafana_synthetic_monitoring_probe
+  description: |
+    resource `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/synthetic-monitoring-dev
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_synthetic_monitoring_probes
+  title: grafana_synthetic_monitoring_probes
+  description: |
+    resource `grafana_synthetic_monitoring_probes` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-data-source
+  owner: group:default/synthetic-monitoring-dev
+  lifecycle: production

--- a/internal/resources/syntheticmonitoring/catalog-resource.yaml
+++ b/internal/resources/syntheticmonitoring/catalog-resource.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_synthetic_monitoring_check
+  title: grafana_synthetic_monitoring_check
+  description: |
+    resource `grafana_synthetic_monitoring_check` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/synthetic-monitoring-dev
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_synthetic_monitoring_check_alerts
+  title: grafana_synthetic_monitoring_check_alerts
+  description: |
+    resource `grafana_synthetic_monitoring_check_alerts` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/synthetic-monitoring-dev
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana_synthetic_monitoring_probe
+  title: grafana_synthetic_monitoring_probe
+  description: |
+    resource `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
+spec:
+  subComponentOf: terraform-provider-grafana
+  type: terraform-resource
+  owner: group:default/synthetic-monitoring-dev
+  lifecycle: production

--- a/scripts/generate_schema.sh
+++ b/scripts/generate_schema.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+CURRENTDIR=$(realpath $(dirname $0))
+REPODIR="${CURRENTDIR}"/..
+WORKDIR=$(mktemp -d)
+function finish {
+    rm -rf "${WORKDIR}"
+}
+trap finish EXIT
+
+cd "$REPODIR"
+go build .
+
+
+cd "${WORKDIR}"
+
+echo '
+provider_installation {
+   dev_overrides {
+      "grafana/grafana" = "'${REPODIR}'" # this path is the directory where the binary is built
+  }
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}' > terraform.rc
+
+
+echo '{"terraform":[{"required_providers":[{"provider":{"source":"grafana/grafana"}}]}]}' > main.tf.json
+
+export TF_CLI_CONFIG_FILE=terraform.rc
+
+terraform providers schema -json=true


### PR DESCRIPTION
The catalog files are generated from internal Google sheet, the intention is to replace this sheet with entries in Backstage (EngHub) and keep it in sync with the repository.

This commit adds the generated catalog files and a GHA to validate whether the catalog files are in sync with the provider resources.