### PR TITLE
fix(catalog): use full backstage ref

### DIFF
--- a/internal/resources/appplatform/catalog-resource.yaml
+++ b/internal/resources/appplatform/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_apps_dashboard_dashboard_v1beta1` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-app-platform
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_apps_playlist_playlist_v0alpha1` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-app-platform
   lifecycle: production

--- a/internal/resources/cloud/catalog-data-source.yaml
+++ b/internal/resources/cloud/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_cloud_access_policies` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/identity-squad
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_cloud_ips` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: 
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_cloud_organization` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/access-squad
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_cloud_private_data_source_connect_networks` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/partner-datasources
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_cloud_stack` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-com-maintainers
   lifecycle: production

--- a/internal/resources/cloud/catalog-resource.yaml
+++ b/internal/resources/cloud/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_cloud_access_policy` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_cloud_access_policy_token` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_cloud_org_member` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_cloud_plugin_installation` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/plugins-platform-backend
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_cloud_private_data_source_connect_network` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/partner-datasources
   lifecycle: production
@@ -72,7 +72,7 @@ metadata:
   description: |
     resource `grafana_cloud_private_data_source_connect_network_token` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/partner-datasources
   lifecycle: production
@@ -85,7 +85,7 @@ metadata:
   description: |
     resource `grafana_cloud_stack` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-com-maintainers
   lifecycle: production
@@ -98,7 +98,7 @@ metadata:
   description: |
     resource `grafana_cloud_stack_service_account` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -111,7 +111,7 @@ metadata:
   description: |
     resource `grafana_cloud_stack_service_account_token` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -124,7 +124,7 @@ metadata:
   description: |
     resource `grafana_k6_installation` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -137,7 +137,7 @@ metadata:
   description: |
     resource `grafana_synthetic_monitoring_installation` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/synthetic-monitoring-dev
   lifecycle: production

--- a/internal/resources/cloudprovider/catalog-data-source.yaml
+++ b/internal/resources/cloudprovider/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/middleware-apps
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/middleware-apps
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_aws_cloudwatch_scrape_jobs` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/middleware-apps
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/middleware-apps
   lifecycle: production

--- a/internal/resources/cloudprovider/catalog-resource.yaml
+++ b/internal/resources/cloudprovider/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/middleware-apps
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/middleware-apps
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_aws_resource_metadata_scrape_job` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/middleware-apps
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/middleware-apps
   lifecycle: production

--- a/internal/resources/connections/catalog-data-source.yaml
+++ b/internal/resources/connections/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/middleware-apps
   lifecycle: production

--- a/internal/resources/connections/catalog-resource.yaml
+++ b/internal/resources/connections/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/middleware-apps
   lifecycle: production

--- a/internal/resources/fleetmanagement/catalog-data-source.yaml
+++ b/internal/resources/fleetmanagement/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/fleet-management-backend
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_fleet_management_collectors` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/fleet-management-backend
   lifecycle: production

--- a/internal/resources/fleetmanagement/catalog-resource.yaml
+++ b/internal/resources/fleetmanagement/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/fleet-management-backend
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_fleet_management_pipeline` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/fleet-management-backend
   lifecycle: production

--- a/internal/resources/frontendo11y/catalog-data-source.yaml
+++ b/internal/resources/frontendo11y/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/frontend-o11y
   lifecycle: production

--- a/internal/resources/frontendo11y/catalog-resource.yaml
+++ b/internal/resources/frontendo11y/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/frontend-o11y
   lifecycle: production

--- a/internal/resources/grafana/catalog-data-source.yaml
+++ b/internal/resources/grafana/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_dashboard` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/dashboards-squad
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_dashboards` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/dashboards-squad
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_data_source` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/partner-datasources
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_folder` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-search-and-storage
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_folders` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-search-and-storage
   lifecycle: production
@@ -72,7 +72,7 @@ metadata:
   description: |
     resource `grafana_library_panel` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/dataviz-squad
   lifecycle: production
@@ -85,7 +85,7 @@ metadata:
   description: |
     resource `grafana_library_panels` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/dataviz-squad
   lifecycle: production
@@ -98,7 +98,7 @@ metadata:
   description: |
     resource `grafana_organization` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/access-squad
   lifecycle: production
@@ -111,7 +111,7 @@ metadata:
   description: |
     resource `grafana_organization_preferences` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/access-squad
   lifecycle: production
@@ -124,7 +124,7 @@ metadata:
   description: |
     resource `grafana_organization_user` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/access-squad
   lifecycle: production
@@ -137,7 +137,7 @@ metadata:
   description: |
     resource `grafana_role` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/access-squad
   lifecycle: production
@@ -150,7 +150,7 @@ metadata:
   description: |
     resource `grafana_service_account` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/identity-squad
   lifecycle: production
@@ -163,7 +163,7 @@ metadata:
   description: |
     resource `grafana_team` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/access-squad
   lifecycle: production
@@ -176,7 +176,7 @@ metadata:
   description: |
     resource `grafana_user` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/identity-squad
   lifecycle: production
@@ -189,7 +189,7 @@ metadata:
   description: |
     resource `grafana_users` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/identity-squad
   lifecycle: production

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_annotation` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-search-and-storage
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_contact_point` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/alerting-backend
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_dashboard` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/dashboards-squad
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_dashboard_permission` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_dashboard_permission_item` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -72,7 +72,7 @@ metadata:
   description: |
     resource `grafana_dashboard_public` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/sharing-squad
   lifecycle: production
@@ -85,7 +85,7 @@ metadata:
   description: |
     resource `grafana_data_source` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/partner-datasources
   lifecycle: production
@@ -98,7 +98,7 @@ metadata:
   description: |
     resource `grafana_data_source_config` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/partner-datasources
   lifecycle: production
@@ -111,7 +111,7 @@ metadata:
   description: |
     resource `grafana_data_source_config_lbac_rules` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -124,7 +124,7 @@ metadata:
   description: |
     resource `grafana_data_source_permission` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -137,7 +137,7 @@ metadata:
   description: |
     resource `grafana_data_source_permission_item` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -150,7 +150,7 @@ metadata:
   description: |
     resource `grafana_folder` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-search-and-storage
   lifecycle: production
@@ -163,7 +163,7 @@ metadata:
   description: |
     resource `grafana_folder_permission` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -176,7 +176,7 @@ metadata:
   description: |
     resource `grafana_folder_permission_item` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -189,7 +189,7 @@ metadata:
   description: |
     resource `grafana_library_panel` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/dataviz-squad
   lifecycle: production
@@ -202,7 +202,7 @@ metadata:
   description: |
     resource `grafana_message_template` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/alerting-backend
   lifecycle: production
@@ -215,7 +215,7 @@ metadata:
   description: |
     resource `grafana_mute_timing` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/alerting-backend
   lifecycle: production
@@ -228,7 +228,7 @@ metadata:
   description: |
     resource `grafana_notification_policy` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/alerting-backend
   lifecycle: production
@@ -241,7 +241,7 @@ metadata:
   description: |
     resource `grafana_organization` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -254,7 +254,7 @@ metadata:
   description: |
     resource `grafana_organization_preferences` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -267,7 +267,7 @@ metadata:
   description: |
     resource `grafana_playlist` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/sharing-squad
   lifecycle: production
@@ -280,7 +280,7 @@ metadata:
   description: |
     resource `grafana_report` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/sharing-squad
   lifecycle: production
@@ -293,7 +293,7 @@ metadata:
   description: |
     resource `grafana_role` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -306,7 +306,7 @@ metadata:
   description: |
     resource `grafana_role_assignment` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -319,7 +319,7 @@ metadata:
   description: |
     resource `grafana_role_assignment_item` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -332,7 +332,7 @@ metadata:
   description: |
     resource `grafana_rule_group` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/alerting-backend
   lifecycle: production
@@ -345,7 +345,7 @@ metadata:
   description: |
     resource `grafana_service_account` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -358,7 +358,7 @@ metadata:
   description: |
     resource `grafana_service_account_permission` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -371,7 +371,7 @@ metadata:
   description: |
     resource `grafana_service_account_permission_item` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -384,7 +384,7 @@ metadata:
   description: |
     resource `grafana_service_account_token` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -397,7 +397,7 @@ metadata:
   description: |
     resource `grafana_sso_settings` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production
@@ -410,7 +410,7 @@ metadata:
   description: |
     resource `grafana_team` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -423,7 +423,7 @@ metadata:
   description: |
     resource `grafana_team_external_group` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/access-squad
   lifecycle: production
@@ -436,7 +436,7 @@ metadata:
   description: |
     resource `grafana_user` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/identity-squad
   lifecycle: production

--- a/internal/resources/k6/catalog-data-source.yaml
+++ b/internal/resources/k6/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_k6_load_test` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_k6_load_tests` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_k6_project` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_k6_projects` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/k6-cloud-provisioning
   lifecycle: production

--- a/internal/resources/k6/catalog-resource.yaml
+++ b/internal/resources/k6/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_k6_load_test` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_k6_project` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/k6-cloud-provisioning
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/k6-cloud-provisioning
   lifecycle: production

--- a/internal/resources/machinelearning/catalog-resource.yaml
+++ b/internal/resources/machinelearning/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_machine_learning_alert` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/machine-learning
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_machine_learning_holiday` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/machine-learning
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_machine_learning_job` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/machine-learning
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_machine_learning_outlier_detector` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/machine-learning
   lifecycle: production

--- a/internal/resources/oncall/catalog-data-source.yaml
+++ b/internal/resources/oncall/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_oncall_integration` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_oncall_label` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -72,7 +72,7 @@ metadata:
   description: |
     resource `grafana_oncall_slack_channel` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -85,7 +85,7 @@ metadata:
   description: |
     resource `grafana_oncall_team` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -98,7 +98,7 @@ metadata:
   description: |
     resource `grafana_oncall_user` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -111,7 +111,7 @@ metadata:
   description: |
     resource `grafana_oncall_user_group` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -124,7 +124,7 @@ metadata:
   description: |
     resource `grafana_oncall_users` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/grafana-irm-backend
   lifecycle: production

--- a/internal/resources/oncall/catalog-resource.yaml
+++ b/internal/resources/oncall/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_oncall_escalation` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_oncall_integration` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -46,7 +46,7 @@ metadata:
   description: |
     resource `grafana_oncall_on_call_shift` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -59,7 +59,7 @@ metadata:
   description: |
     resource `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -72,7 +72,7 @@ metadata:
   description: |
     resource `grafana_oncall_route` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -85,7 +85,7 @@ metadata:
   description: |
     resource `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production
@@ -98,7 +98,7 @@ metadata:
   description: |
     resource `grafana_oncall_user_notification_rule` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/grafana-irm-backend
   lifecycle: production

--- a/internal/resources/slo/catalog-data-source.yaml
+++ b/internal/resources/slo/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_slos` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/slo-squad
   lifecycle: production

--- a/internal/resources/slo/catalog-resource.yaml
+++ b/internal/resources/slo/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_slo` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/slo-squad
   lifecycle: production

--- a/internal/resources/syntheticmonitoring/catalog-data-source.yaml
+++ b/internal/resources/syntheticmonitoring/catalog-data-source.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/synthetic-monitoring-dev
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_synthetic_monitoring_probes` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
   owner: group:default/synthetic-monitoring-dev
   lifecycle: production

--- a/internal/resources/syntheticmonitoring/catalog-resource.yaml
+++ b/internal/resources/syntheticmonitoring/catalog-resource.yaml
@@ -7,7 +7,7 @@ metadata:
   description: |
     resource `grafana_synthetic_monitoring_check` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/synthetic-monitoring-dev
   lifecycle: production
@@ -20,7 +20,7 @@ metadata:
   description: |
     resource `grafana_synthetic_monitoring_check_alerts` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/synthetic-monitoring-dev
   lifecycle: production
@@ -33,7 +33,7 @@ metadata:
   description: |
     resource `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
 spec:
-  subComponentOf: terraform-provider-grafana
+  subComponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
   owner: group:default/synthetic-monitoring-dev
   lifecycle: production


### PR DESCRIPTION
I'm not 100% sure if this is needed, [docs](https://backstage.io/docs/features/software-catalog/references#string-references) say it is optional.
