### PR TITLE
fix(catalog): prefix catalog entry names with type

### DIFF
--- a/.github/actions/validate-catalog/validate.jsonnet
+++ b/.github/actions/validate-catalog/validate.jsonnet
@@ -6,7 +6,11 @@ function(catalog, schema)
     std.sort(
       std.filterMap(
         function(obj) obj.spec.type == 'terraform-resource',
-        function(obj) obj.metadata.name,
+        function(obj)
+          // Strip 'resource-' prefix to match schema names
+          if std.startsWith(obj.metadata.name, 'resource-')
+          then std.substr(obj.metadata.name, 9, std.length(obj.metadata.name) - 9)
+          else obj.metadata.name,
         components
       )
     );

--- a/internal/resources/appplatform/catalog-resource.yaml
+++ b/internal/resources/appplatform/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_apps_dashboard_dashboard_v1beta1
-  title: grafana_apps_dashboard_dashboard_v1beta1
+  name: resource-grafana_apps_dashboard_dashboard_v1beta1
+  title: grafana_apps_dashboard_dashboard_v1beta1 (resource)
   description: |
     resource `grafana_apps_dashboard_dashboard_v1beta1` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_apps_playlist_playlist_v0alpha1
-  title: grafana_apps_playlist_playlist_v0alpha1
+  name: resource-grafana_apps_playlist_playlist_v0alpha1
+  title: grafana_apps_playlist_playlist_v0alpha1 (resource)
   description: |
     resource `grafana_apps_playlist_playlist_v0alpha1` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/cloud/catalog-data-source.yaml
+++ b/internal/resources/cloud/catalog-data-source.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/platform-monitoring
+  owner:
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/cloud/catalog-data-source.yaml
+++ b/internal/resources/cloud/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_access_policies
-  title: grafana_cloud_access_policies
+  name: datasource-grafana_cloud_access_policies
+  title: grafana_cloud_access_policies (data source)
   description: |
-    resource `grafana_cloud_access_policies` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_access_policies` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,23 +15,23 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_ips
-  title: grafana_cloud_ips
+  name: datasource-grafana_cloud_ips
+  title: grafana_cloud_ips (data source)
   description: |
-    resource `grafana_cloud_ips` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_ips` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: 
+  owner: group:default/platform-monitoring
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_organization
-  title: grafana_cloud_organization
+  name: datasource-grafana_cloud_organization
+  title: grafana_cloud_organization (data source)
   description: |
-    resource `grafana_cloud_organization` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_organization` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -41,10 +41,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_private_data_source_connect_networks
-  title: grafana_cloud_private_data_source_connect_networks
+  name: datasource-grafana_cloud_private_data_source_connect_networks
+  title: grafana_cloud_private_data_source_connect_networks (data source)
   description: |
-    resource `grafana_cloud_private_data_source_connect_networks` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_private_data_source_connect_networks` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -54,10 +54,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_stack
-  title: grafana_cloud_stack
+  name: datasource-grafana_cloud_stack
+  title: grafana_cloud_stack (data source)
   description: |
-    resource `grafana_cloud_stack` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_stack` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/cloud/catalog-resource.yaml
+++ b/internal/resources/cloud/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_access_policy
-  title: grafana_cloud_access_policy
+  name: resource-grafana_cloud_access_policy
+  title: grafana_cloud_access_policy (resource)
   description: |
     resource `grafana_cloud_access_policy` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_access_policy_token
-  title: grafana_cloud_access_policy_token
+  name: resource-grafana_cloud_access_policy_token
+  title: grafana_cloud_access_policy_token (resource)
   description: |
     resource `grafana_cloud_access_policy_token` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_org_member
-  title: grafana_cloud_org_member
+  name: resource-grafana_cloud_org_member
+  title: grafana_cloud_org_member (resource)
   description: |
     resource `grafana_cloud_org_member` in Grafana Labs' Terraform Provider
 spec:
@@ -41,8 +41,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_plugin_installation
-  title: grafana_cloud_plugin_installation
+  name: resource-grafana_cloud_plugin_installation
+  title: grafana_cloud_plugin_installation (resource)
   description: |
     resource `grafana_cloud_plugin_installation` in Grafana Labs' Terraform Provider
 spec:
@@ -54,8 +54,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_private_data_source_connect_network
-  title: grafana_cloud_private_data_source_connect_network
+  name: resource-grafana_cloud_private_data_source_connect_network
+  title: grafana_cloud_private_data_source_connect_network (resource)
   description: |
     resource `grafana_cloud_private_data_source_connect_network` in Grafana Labs' Terraform Provider
 spec:
@@ -67,8 +67,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_private_data_source_connect_network_token
-  title: grafana_cloud_private_data_source_connect_network_token
+  name: resource-grafana_cloud_private_data_source_connect_network_token
+  title: grafana_cloud_private_data_source_connect_network_token (resource)
   description: |
     resource `grafana_cloud_private_data_source_connect_network_token` in Grafana Labs' Terraform Provider
 spec:
@@ -80,8 +80,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_stack
-  title: grafana_cloud_stack
+  name: resource-grafana_cloud_stack
+  title: grafana_cloud_stack (resource)
   description: |
     resource `grafana_cloud_stack` in Grafana Labs' Terraform Provider
 spec:
@@ -93,8 +93,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_stack_service_account
-  title: grafana_cloud_stack_service_account
+  name: resource-grafana_cloud_stack_service_account
+  title: grafana_cloud_stack_service_account (resource)
   description: |
     resource `grafana_cloud_stack_service_account` in Grafana Labs' Terraform Provider
 spec:
@@ -106,8 +106,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_stack_service_account_token
-  title: grafana_cloud_stack_service_account_token
+  name: resource-grafana_cloud_stack_service_account_token
+  title: grafana_cloud_stack_service_account_token (resource)
   description: |
     resource `grafana_cloud_stack_service_account_token` in Grafana Labs' Terraform Provider
 spec:
@@ -119,8 +119,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_installation
-  title: grafana_k6_installation
+  name: resource-grafana_k6_installation
+  title: grafana_k6_installation (resource)
   description: |
     resource `grafana_k6_installation` in Grafana Labs' Terraform Provider
 spec:
@@ -132,8 +132,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_synthetic_monitoring_installation
-  title: grafana_synthetic_monitoring_installation
+  name: resource-grafana_synthetic_monitoring_installation
+  title: grafana_synthetic_monitoring_installation (resource)
   description: |
     resource `grafana_synthetic_monitoring_installation` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/cloudprovider/catalog-data-source.yaml
+++ b/internal/resources/cloudprovider/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_aws_account
-  title: grafana_cloud_provider_aws_account
+  name: datasource-grafana_cloud_provider_aws_account
+  title: grafana_cloud_provider_aws_account (data source)
   description: |
-    resource `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,10 +15,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_aws_cloudwatch_scrape_job
-  title: grafana_cloud_provider_aws_cloudwatch_scrape_job
+  name: datasource-grafana_cloud_provider_aws_cloudwatch_scrape_job
+  title: grafana_cloud_provider_aws_cloudwatch_scrape_job (data source)
   description: |
-    resource `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -28,10 +28,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_aws_cloudwatch_scrape_jobs
-  title: grafana_cloud_provider_aws_cloudwatch_scrape_jobs
+  name: datasource-grafana_cloud_provider_aws_cloudwatch_scrape_jobs
+  title: grafana_cloud_provider_aws_cloudwatch_scrape_jobs (data source)
   description: |
-    resource `grafana_cloud_provider_aws_cloudwatch_scrape_jobs` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_provider_aws_cloudwatch_scrape_jobs` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -41,10 +41,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_azure_credential
-  title: grafana_cloud_provider_azure_credential
+  name: datasource-grafana_cloud_provider_azure_credential
+  title: grafana_cloud_provider_azure_credential (data source)
   description: |
-    resource `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
+    data source `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/cloudprovider/catalog-resource.yaml
+++ b/internal/resources/cloudprovider/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_aws_account
-  title: grafana_cloud_provider_aws_account
+  name: resource-grafana_cloud_provider_aws_account
+  title: grafana_cloud_provider_aws_account (resource)
   description: |
     resource `grafana_cloud_provider_aws_account` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_aws_cloudwatch_scrape_job
-  title: grafana_cloud_provider_aws_cloudwatch_scrape_job
+  name: resource-grafana_cloud_provider_aws_cloudwatch_scrape_job
+  title: grafana_cloud_provider_aws_cloudwatch_scrape_job (resource)
   description: |
     resource `grafana_cloud_provider_aws_cloudwatch_scrape_job` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_aws_resource_metadata_scrape_job
-  title: grafana_cloud_provider_aws_resource_metadata_scrape_job
+  name: resource-grafana_cloud_provider_aws_resource_metadata_scrape_job
+  title: grafana_cloud_provider_aws_resource_metadata_scrape_job (resource)
   description: |
     resource `grafana_cloud_provider_aws_resource_metadata_scrape_job` in Grafana Labs' Terraform Provider
 spec:
@@ -41,8 +41,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_cloud_provider_azure_credential
-  title: grafana_cloud_provider_azure_credential
+  name: resource-grafana_cloud_provider_azure_credential
+  title: grafana_cloud_provider_azure_credential (resource)
   description: |
     resource `grafana_cloud_provider_azure_credential` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/connections/catalog-data-source.yaml
+++ b/internal/resources/connections/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_connections_metrics_endpoint_scrape_job
-  title: grafana_connections_metrics_endpoint_scrape_job
+  name: datasource-grafana_connections_metrics_endpoint_scrape_job
+  title: grafana_connections_metrics_endpoint_scrape_job (data source)
   description: |
-    resource `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
+    data source `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/connections/catalog-resource.yaml
+++ b/internal/resources/connections/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_connections_metrics_endpoint_scrape_job
-  title: grafana_connections_metrics_endpoint_scrape_job
+  name: resource-grafana_connections_metrics_endpoint_scrape_job
+  title: grafana_connections_metrics_endpoint_scrape_job (resource)
   description: |
     resource `grafana_connections_metrics_endpoint_scrape_job` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/fleetmanagement/catalog-data-source.yaml
+++ b/internal/resources/fleetmanagement/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_fleet_management_collector
-  title: grafana_fleet_management_collector
+  name: datasource-grafana_fleet_management_collector
+  title: grafana_fleet_management_collector (data source)
   description: |
-    resource `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
+    data source `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,10 +15,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_fleet_management_collectors
-  title: grafana_fleet_management_collectors
+  name: datasource-grafana_fleet_management_collectors
+  title: grafana_fleet_management_collectors (data source)
   description: |
-    resource `grafana_fleet_management_collectors` in Grafana Labs' Terraform Provider
+    data source `grafana_fleet_management_collectors` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/fleetmanagement/catalog-resource.yaml
+++ b/internal/resources/fleetmanagement/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_fleet_management_collector
-  title: grafana_fleet_management_collector
+  name: resource-grafana_fleet_management_collector
+  title: grafana_fleet_management_collector (resource)
   description: |
     resource `grafana_fleet_management_collector` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_fleet_management_pipeline
-  title: grafana_fleet_management_pipeline
+  name: resource-grafana_fleet_management_pipeline
+  title: grafana_fleet_management_pipeline (resource)
   description: |
     resource `grafana_fleet_management_pipeline` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/frontendo11y/catalog-data-source.yaml
+++ b/internal/resources/frontendo11y/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_frontend_o11y_app
-  title: grafana_frontend_o11y_app
+  name: datasource-grafana_frontend_o11y_app
+  title: grafana_frontend_o11y_app (data source)
   description: |
-    resource `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
+    data source `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/frontendo11y/catalog-resource.yaml
+++ b/internal/resources/frontendo11y/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_frontend_o11y_app
-  title: grafana_frontend_o11y_app
+  name: resource-grafana_frontend_o11y_app
+  title: grafana_frontend_o11y_app (resource)
   description: |
     resource `grafana_frontend_o11y_app` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/grafana/catalog-data-source.yaml
+++ b/internal/resources/grafana/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_dashboard
-  title: grafana_dashboard
+  name: datasource-grafana_dashboard
+  title: grafana_dashboard (data source)
   description: |
-    resource `grafana_dashboard` in Grafana Labs' Terraform Provider
+    data source `grafana_dashboard` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,10 +15,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_dashboards
-  title: grafana_dashboards
+  name: datasource-grafana_dashboards
+  title: grafana_dashboards (data source)
   description: |
-    resource `grafana_dashboards` in Grafana Labs' Terraform Provider
+    data source `grafana_dashboards` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -28,10 +28,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_data_source
-  title: grafana_data_source
+  name: datasource-grafana_data_source
+  title: grafana_data_source (data source)
   description: |
-    resource `grafana_data_source` in Grafana Labs' Terraform Provider
+    data source `grafana_data_source` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -41,10 +41,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_folder
-  title: grafana_folder
+  name: datasource-grafana_folder
+  title: grafana_folder (data source)
   description: |
-    resource `grafana_folder` in Grafana Labs' Terraform Provider
+    data source `grafana_folder` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -54,10 +54,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_folders
-  title: grafana_folders
+  name: datasource-grafana_folders
+  title: grafana_folders (data source)
   description: |
-    resource `grafana_folders` in Grafana Labs' Terraform Provider
+    data source `grafana_folders` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -67,10 +67,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_library_panel
-  title: grafana_library_panel
+  name: datasource-grafana_library_panel
+  title: grafana_library_panel (data source)
   description: |
-    resource `grafana_library_panel` in Grafana Labs' Terraform Provider
+    data source `grafana_library_panel` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -80,10 +80,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_library_panels
-  title: grafana_library_panels
+  name: datasource-grafana_library_panels
+  title: grafana_library_panels (data source)
   description: |
-    resource `grafana_library_panels` in Grafana Labs' Terraform Provider
+    data source `grafana_library_panels` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -93,10 +93,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_organization
-  title: grafana_organization
+  name: datasource-grafana_organization
+  title: grafana_organization (data source)
   description: |
-    resource `grafana_organization` in Grafana Labs' Terraform Provider
+    data source `grafana_organization` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -106,10 +106,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_organization_preferences
-  title: grafana_organization_preferences
+  name: datasource-grafana_organization_preferences
+  title: grafana_organization_preferences (data source)
   description: |
-    resource `grafana_organization_preferences` in Grafana Labs' Terraform Provider
+    data source `grafana_organization_preferences` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -119,10 +119,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_organization_user
-  title: grafana_organization_user
+  name: datasource-grafana_organization_user
+  title: grafana_organization_user (data source)
   description: |
-    resource `grafana_organization_user` in Grafana Labs' Terraform Provider
+    data source `grafana_organization_user` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -132,10 +132,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_role
-  title: grafana_role
+  name: datasource-grafana_role
+  title: grafana_role (data source)
   description: |
-    resource `grafana_role` in Grafana Labs' Terraform Provider
+    data source `grafana_role` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -145,10 +145,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_service_account
-  title: grafana_service_account
+  name: datasource-grafana_service_account
+  title: grafana_service_account (data source)
   description: |
-    resource `grafana_service_account` in Grafana Labs' Terraform Provider
+    data source `grafana_service_account` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -158,10 +158,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_team
-  title: grafana_team
+  name: datasource-grafana_team
+  title: grafana_team (data source)
   description: |
-    resource `grafana_team` in Grafana Labs' Terraform Provider
+    data source `grafana_team` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -171,10 +171,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_user
-  title: grafana_user
+  name: datasource-grafana_user
+  title: grafana_user (data source)
   description: |
-    resource `grafana_user` in Grafana Labs' Terraform Provider
+    data source `grafana_user` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -184,10 +184,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_users
-  title: grafana_users
+  name: datasource-grafana_users
+  title: grafana_users (data source)
   description: |
-    resource `grafana_users` in Grafana Labs' Terraform Provider
+    data source `grafana_users` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_annotation
-  title: grafana_annotation
+  name: resource-grafana_annotation
+  title: grafana_annotation (resource)
   description: |
     resource `grafana_annotation` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_contact_point
-  title: grafana_contact_point
+  name: resource-grafana_contact_point
+  title: grafana_contact_point (resource)
   description: |
     resource `grafana_contact_point` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_dashboard
-  title: grafana_dashboard
+  name: resource-grafana_dashboard
+  title: grafana_dashboard (resource)
   description: |
     resource `grafana_dashboard` in Grafana Labs' Terraform Provider
 spec:
@@ -41,8 +41,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_dashboard_permission
-  title: grafana_dashboard_permission
+  name: resource-grafana_dashboard_permission
+  title: grafana_dashboard_permission (resource)
   description: |
     resource `grafana_dashboard_permission` in Grafana Labs' Terraform Provider
 spec:
@@ -54,8 +54,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_dashboard_permission_item
-  title: grafana_dashboard_permission_item
+  name: resource-grafana_dashboard_permission_item
+  title: grafana_dashboard_permission_item (resource)
   description: |
     resource `grafana_dashboard_permission_item` in Grafana Labs' Terraform Provider
 spec:
@@ -67,8 +67,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_dashboard_public
-  title: grafana_dashboard_public
+  name: resource-grafana_dashboard_public
+  title: grafana_dashboard_public (resource)
   description: |
     resource `grafana_dashboard_public` in Grafana Labs' Terraform Provider
 spec:
@@ -80,8 +80,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_data_source
-  title: grafana_data_source
+  name: resource-grafana_data_source
+  title: grafana_data_source (resource)
   description: |
     resource `grafana_data_source` in Grafana Labs' Terraform Provider
 spec:
@@ -93,8 +93,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_data_source_config
-  title: grafana_data_source_config
+  name: resource-grafana_data_source_config
+  title: grafana_data_source_config (resource)
   description: |
     resource `grafana_data_source_config` in Grafana Labs' Terraform Provider
 spec:
@@ -106,8 +106,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_data_source_config_lbac_rules
-  title: grafana_data_source_config_lbac_rules
+  name: resource-grafana_data_source_config_lbac_rules
+  title: grafana_data_source_config_lbac_rules (resource)
   description: |
     resource `grafana_data_source_config_lbac_rules` in Grafana Labs' Terraform Provider
 spec:
@@ -119,8 +119,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_data_source_permission
-  title: grafana_data_source_permission
+  name: resource-grafana_data_source_permission
+  title: grafana_data_source_permission (resource)
   description: |
     resource `grafana_data_source_permission` in Grafana Labs' Terraform Provider
 spec:
@@ -132,8 +132,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_data_source_permission_item
-  title: grafana_data_source_permission_item
+  name: resource-grafana_data_source_permission_item
+  title: grafana_data_source_permission_item (resource)
   description: |
     resource `grafana_data_source_permission_item` in Grafana Labs' Terraform Provider
 spec:
@@ -145,8 +145,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_folder
-  title: grafana_folder
+  name: resource-grafana_folder
+  title: grafana_folder (resource)
   description: |
     resource `grafana_folder` in Grafana Labs' Terraform Provider
 spec:
@@ -158,8 +158,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_folder_permission
-  title: grafana_folder_permission
+  name: resource-grafana_folder_permission
+  title: grafana_folder_permission (resource)
   description: |
     resource `grafana_folder_permission` in Grafana Labs' Terraform Provider
 spec:
@@ -171,8 +171,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_folder_permission_item
-  title: grafana_folder_permission_item
+  name: resource-grafana_folder_permission_item
+  title: grafana_folder_permission_item (resource)
   description: |
     resource `grafana_folder_permission_item` in Grafana Labs' Terraform Provider
 spec:
@@ -184,8 +184,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_library_panel
-  title: grafana_library_panel
+  name: resource-grafana_library_panel
+  title: grafana_library_panel (resource)
   description: |
     resource `grafana_library_panel` in Grafana Labs' Terraform Provider
 spec:
@@ -197,8 +197,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_message_template
-  title: grafana_message_template
+  name: resource-grafana_message_template
+  title: grafana_message_template (resource)
   description: |
     resource `grafana_message_template` in Grafana Labs' Terraform Provider
 spec:
@@ -210,8 +210,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_mute_timing
-  title: grafana_mute_timing
+  name: resource-grafana_mute_timing
+  title: grafana_mute_timing (resource)
   description: |
     resource `grafana_mute_timing` in Grafana Labs' Terraform Provider
 spec:
@@ -223,8 +223,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_notification_policy
-  title: grafana_notification_policy
+  name: resource-grafana_notification_policy
+  title: grafana_notification_policy (resource)
   description: |
     resource `grafana_notification_policy` in Grafana Labs' Terraform Provider
 spec:
@@ -236,8 +236,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_organization
-  title: grafana_organization
+  name: resource-grafana_organization
+  title: grafana_organization (resource)
   description: |
     resource `grafana_organization` in Grafana Labs' Terraform Provider
 spec:
@@ -249,8 +249,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_organization_preferences
-  title: grafana_organization_preferences
+  name: resource-grafana_organization_preferences
+  title: grafana_organization_preferences (resource)
   description: |
     resource `grafana_organization_preferences` in Grafana Labs' Terraform Provider
 spec:
@@ -262,8 +262,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_playlist
-  title: grafana_playlist
+  name: resource-grafana_playlist
+  title: grafana_playlist (resource)
   description: |
     resource `grafana_playlist` in Grafana Labs' Terraform Provider
 spec:
@@ -275,8 +275,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_report
-  title: grafana_report
+  name: resource-grafana_report
+  title: grafana_report (resource)
   description: |
     resource `grafana_report` in Grafana Labs' Terraform Provider
 spec:
@@ -288,8 +288,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_role
-  title: grafana_role
+  name: resource-grafana_role
+  title: grafana_role (resource)
   description: |
     resource `grafana_role` in Grafana Labs' Terraform Provider
 spec:
@@ -301,8 +301,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_role_assignment
-  title: grafana_role_assignment
+  name: resource-grafana_role_assignment
+  title: grafana_role_assignment (resource)
   description: |
     resource `grafana_role_assignment` in Grafana Labs' Terraform Provider
 spec:
@@ -314,8 +314,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_role_assignment_item
-  title: grafana_role_assignment_item
+  name: resource-grafana_role_assignment_item
+  title: grafana_role_assignment_item (resource)
   description: |
     resource `grafana_role_assignment_item` in Grafana Labs' Terraform Provider
 spec:
@@ -327,8 +327,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_rule_group
-  title: grafana_rule_group
+  name: resource-grafana_rule_group
+  title: grafana_rule_group (resource)
   description: |
     resource `grafana_rule_group` in Grafana Labs' Terraform Provider
 spec:
@@ -340,8 +340,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_service_account
-  title: grafana_service_account
+  name: resource-grafana_service_account
+  title: grafana_service_account (resource)
   description: |
     resource `grafana_service_account` in Grafana Labs' Terraform Provider
 spec:
@@ -353,8 +353,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_service_account_permission
-  title: grafana_service_account_permission
+  name: resource-grafana_service_account_permission
+  title: grafana_service_account_permission (resource)
   description: |
     resource `grafana_service_account_permission` in Grafana Labs' Terraform Provider
 spec:
@@ -366,8 +366,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_service_account_permission_item
-  title: grafana_service_account_permission_item
+  name: resource-grafana_service_account_permission_item
+  title: grafana_service_account_permission_item (resource)
   description: |
     resource `grafana_service_account_permission_item` in Grafana Labs' Terraform Provider
 spec:
@@ -379,8 +379,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_service_account_token
-  title: grafana_service_account_token
+  name: resource-grafana_service_account_token
+  title: grafana_service_account_token (resource)
   description: |
     resource `grafana_service_account_token` in Grafana Labs' Terraform Provider
 spec:
@@ -392,8 +392,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_sso_settings
-  title: grafana_sso_settings
+  name: resource-grafana_sso_settings
+  title: grafana_sso_settings (resource)
   description: |
     resource `grafana_sso_settings` in Grafana Labs' Terraform Provider
 spec:
@@ -405,8 +405,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_team
-  title: grafana_team
+  name: resource-grafana_team
+  title: grafana_team (resource)
   description: |
     resource `grafana_team` in Grafana Labs' Terraform Provider
 spec:
@@ -418,8 +418,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_team_external_group
-  title: grafana_team_external_group
+  name: resource-grafana_team_external_group
+  title: grafana_team_external_group (resource)
   description: |
     resource `grafana_team_external_group` in Grafana Labs' Terraform Provider
 spec:
@@ -431,8 +431,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_user
-  title: grafana_user
+  name: resource-grafana_user
+  title: grafana_user (resource)
   description: |
     resource `grafana_user` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/k6/catalog-data-source.yaml
+++ b/internal/resources/k6/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_load_test
-  title: grafana_k6_load_test
+  name: datasource-grafana_k6_load_test
+  title: grafana_k6_load_test (data source)
   description: |
-    resource `grafana_k6_load_test` in Grafana Labs' Terraform Provider
+    data source `grafana_k6_load_test` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,10 +15,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_load_tests
-  title: grafana_k6_load_tests
+  name: datasource-grafana_k6_load_tests
+  title: grafana_k6_load_tests (data source)
   description: |
-    resource `grafana_k6_load_tests` in Grafana Labs' Terraform Provider
+    data source `grafana_k6_load_tests` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -28,10 +28,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_project
-  title: grafana_k6_project
+  name: datasource-grafana_k6_project
+  title: grafana_k6_project (data source)
   description: |
-    resource `grafana_k6_project` in Grafana Labs' Terraform Provider
+    data source `grafana_k6_project` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -41,10 +41,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_project_limits
-  title: grafana_k6_project_limits
+  name: datasource-grafana_k6_project_limits
+  title: grafana_k6_project_limits (data source)
   description: |
-    resource `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
+    data source `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -54,10 +54,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_projects
-  title: grafana_k6_projects
+  name: datasource-grafana_k6_projects
+  title: grafana_k6_projects (data source)
   description: |
-    resource `grafana_k6_projects` in Grafana Labs' Terraform Provider
+    data source `grafana_k6_projects` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/k6/catalog-resource.yaml
+++ b/internal/resources/k6/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_load_test
-  title: grafana_k6_load_test
+  name: resource-grafana_k6_load_test
+  title: grafana_k6_load_test (resource)
   description: |
     resource `grafana_k6_load_test` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_project
-  title: grafana_k6_project
+  name: resource-grafana_k6_project
+  title: grafana_k6_project (resource)
   description: |
     resource `grafana_k6_project` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_k6_project_limits
-  title: grafana_k6_project_limits
+  name: resource-grafana_k6_project_limits
+  title: grafana_k6_project_limits (resource)
   description: |
     resource `grafana_k6_project_limits` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/machinelearning/catalog-resource.yaml
+++ b/internal/resources/machinelearning/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_machine_learning_alert
-  title: grafana_machine_learning_alert
+  name: resource-grafana_machine_learning_alert
+  title: grafana_machine_learning_alert (resource)
   description: |
     resource `grafana_machine_learning_alert` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_machine_learning_holiday
-  title: grafana_machine_learning_holiday
+  name: resource-grafana_machine_learning_holiday
+  title: grafana_machine_learning_holiday (resource)
   description: |
     resource `grafana_machine_learning_holiday` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_machine_learning_job
-  title: grafana_machine_learning_job
+  name: resource-grafana_machine_learning_job
+  title: grafana_machine_learning_job (resource)
   description: |
     resource `grafana_machine_learning_job` in Grafana Labs' Terraform Provider
 spec:
@@ -41,8 +41,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_machine_learning_outlier_detector
-  title: grafana_machine_learning_outlier_detector
+  name: resource-grafana_machine_learning_outlier_detector
+  title: grafana_machine_learning_outlier_detector (resource)
   description: |
     resource `grafana_machine_learning_outlier_detector` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/oncall/catalog-data-source.yaml
+++ b/internal/resources/oncall/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_escalation_chain
-  title: grafana_oncall_escalation_chain
+  name: datasource-grafana_oncall_escalation_chain
+  title: grafana_oncall_escalation_chain (data source)
   description: |
-    resource `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,10 +15,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_integration
-  title: grafana_oncall_integration
+  name: datasource-grafana_oncall_integration
+  title: grafana_oncall_integration (data source)
   description: |
-    resource `grafana_oncall_integration` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_integration` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -28,10 +28,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_label
-  title: grafana_oncall_label
+  name: datasource-grafana_oncall_label
+  title: grafana_oncall_label (data source)
   description: |
-    resource `grafana_oncall_label` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_label` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -41,10 +41,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_outgoing_webhook
-  title: grafana_oncall_outgoing_webhook
+  name: datasource-grafana_oncall_outgoing_webhook
+  title: grafana_oncall_outgoing_webhook (data source)
   description: |
-    resource `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -54,10 +54,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_schedule
-  title: grafana_oncall_schedule
+  name: datasource-grafana_oncall_schedule
+  title: grafana_oncall_schedule (data source)
   description: |
-    resource `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -67,10 +67,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_slack_channel
-  title: grafana_oncall_slack_channel
+  name: datasource-grafana_oncall_slack_channel
+  title: grafana_oncall_slack_channel (data source)
   description: |
-    resource `grafana_oncall_slack_channel` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_slack_channel` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -80,10 +80,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_team
-  title: grafana_oncall_team
+  name: datasource-grafana_oncall_team
+  title: grafana_oncall_team (data source)
   description: |
-    resource `grafana_oncall_team` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_team` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -93,10 +93,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_user
-  title: grafana_oncall_user
+  name: datasource-grafana_oncall_user
+  title: grafana_oncall_user (data source)
   description: |
-    resource `grafana_oncall_user` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_user` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -106,10 +106,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_user_group
-  title: grafana_oncall_user_group
+  name: datasource-grafana_oncall_user_group
+  title: grafana_oncall_user_group (data source)
   description: |
-    resource `grafana_oncall_user_group` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_user_group` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -119,10 +119,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_users
-  title: grafana_oncall_users
+  name: datasource-grafana_oncall_users
+  title: grafana_oncall_users (data source)
   description: |
-    resource `grafana_oncall_users` in Grafana Labs' Terraform Provider
+    data source `grafana_oncall_users` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/oncall/catalog-resource.yaml
+++ b/internal/resources/oncall/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_escalation
-  title: grafana_oncall_escalation
+  name: resource-grafana_oncall_escalation
+  title: grafana_oncall_escalation (resource)
   description: |
     resource `grafana_oncall_escalation` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_escalation_chain
-  title: grafana_oncall_escalation_chain
+  name: resource-grafana_oncall_escalation_chain
+  title: grafana_oncall_escalation_chain (resource)
   description: |
     resource `grafana_oncall_escalation_chain` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_integration
-  title: grafana_oncall_integration
+  name: resource-grafana_oncall_integration
+  title: grafana_oncall_integration (resource)
   description: |
     resource `grafana_oncall_integration` in Grafana Labs' Terraform Provider
 spec:
@@ -41,8 +41,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_on_call_shift
-  title: grafana_oncall_on_call_shift
+  name: resource-grafana_oncall_on_call_shift
+  title: grafana_oncall_on_call_shift (resource)
   description: |
     resource `grafana_oncall_on_call_shift` in Grafana Labs' Terraform Provider
 spec:
@@ -54,8 +54,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_outgoing_webhook
-  title: grafana_oncall_outgoing_webhook
+  name: resource-grafana_oncall_outgoing_webhook
+  title: grafana_oncall_outgoing_webhook (resource)
   description: |
     resource `grafana_oncall_outgoing_webhook` in Grafana Labs' Terraform Provider
 spec:
@@ -67,8 +67,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_route
-  title: grafana_oncall_route
+  name: resource-grafana_oncall_route
+  title: grafana_oncall_route (resource)
   description: |
     resource `grafana_oncall_route` in Grafana Labs' Terraform Provider
 spec:
@@ -80,8 +80,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_schedule
-  title: grafana_oncall_schedule
+  name: resource-grafana_oncall_schedule
+  title: grafana_oncall_schedule (resource)
   description: |
     resource `grafana_oncall_schedule` in Grafana Labs' Terraform Provider
 spec:
@@ -93,8 +93,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_oncall_user_notification_rule
-  title: grafana_oncall_user_notification_rule
+  name: resource-grafana_oncall_user_notification_rule
+  title: grafana_oncall_user_notification_rule (resource)
   description: |
     resource `grafana_oncall_user_notification_rule` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/slo/catalog-data-source.yaml
+++ b/internal/resources/slo/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_slos
-  title: grafana_slos
+  name: datasource-grafana_slos
+  title: grafana_slos (data source)
   description: |
-    resource `grafana_slos` in Grafana Labs' Terraform Provider
+    data source `grafana_slos` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/slo/catalog-resource.yaml
+++ b/internal/resources/slo/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_slo
-  title: grafana_slo
+  name: resource-grafana_slo
+  title: grafana_slo (resource)
   description: |
     resource `grafana_slo` in Grafana Labs' Terraform Provider
 spec:

--- a/internal/resources/syntheticmonitoring/catalog-data-source.yaml
+++ b/internal/resources/syntheticmonitoring/catalog-data-source.yaml
@@ -2,10 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_synthetic_monitoring_probe
-  title: grafana_synthetic_monitoring_probe
+  name: datasource-grafana_synthetic_monitoring_probe
+  title: grafana_synthetic_monitoring_probe (data source)
   description: |
-    resource `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
+    data source `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
@@ -15,10 +15,10 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_synthetic_monitoring_probes
-  title: grafana_synthetic_monitoring_probes
+  name: datasource-grafana_synthetic_monitoring_probes
+  title: grafana_synthetic_monitoring_probes (data source)
   description: |
-    resource `grafana_synthetic_monitoring_probes` in Grafana Labs' Terraform Provider
+    data source `grafana_synthetic_monitoring_probes` in Grafana Labs' Terraform Provider
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source

--- a/internal/resources/syntheticmonitoring/catalog-resource.yaml
+++ b/internal/resources/syntheticmonitoring/catalog-resource.yaml
@@ -2,8 +2,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_synthetic_monitoring_check
-  title: grafana_synthetic_monitoring_check
+  name: resource-grafana_synthetic_monitoring_check
+  title: grafana_synthetic_monitoring_check (resource)
   description: |
     resource `grafana_synthetic_monitoring_check` in Grafana Labs' Terraform Provider
 spec:
@@ -15,8 +15,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_synthetic_monitoring_check_alerts
-  title: grafana_synthetic_monitoring_check_alerts
+  name: resource-grafana_synthetic_monitoring_check_alerts
+  title: grafana_synthetic_monitoring_check_alerts (resource)
   description: |
     resource `grafana_synthetic_monitoring_check_alerts` in Grafana Labs' Terraform Provider
 spec:
@@ -28,8 +28,8 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: grafana_synthetic_monitoring_probe
-  title: grafana_synthetic_monitoring_probe
+  name: resource-grafana_synthetic_monitoring_probe
+  title: grafana_synthetic_monitoring_probe (resource)
   description: |
     resource `grafana_synthetic_monitoring_probe` in Grafana Labs' Terraform Provider
 spec:


### PR DESCRIPTION
Follow up to https://github.com/grafana/terraform-provider-grafana/pull/2228.

Fixes an issue we were running into where resources that share names with data sources aren't being loaded into the Backstage (EngHub) catalog. The fix simply prefixes each resource or datasource name with its given type. 