### PR TITLE
oncall: trim whitespace for route routing_regex

### DIFF
--- a/internal/resources/oncall/resource_route.go
+++ b/internal/resources/oncall/resource_route.go
@@ -63,9 +63,7 @@ func resourceRoute() *common.Resource {
 				Required:    true,
 				Description: "Python Regex query. Route is chosen for an alert if there is a match inside the alert payload.",
 				StateFunc: func(v interface{}) string {
-					input := v.(string)
-					trimmed := strings.TrimSpace(input)
-					return trimmed
+					return strings.TrimSpace(v.(string))
 				},
 			},
 			"slack": {

--- a/internal/resources/oncall/resource_route.go
+++ b/internal/resources/oncall/resource_route.go
@@ -62,6 +62,11 @@ func resourceRoute() *common.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Python Regex query. Route is chosen for an alert if there is a match inside the alert payload.",
+				StateFunc: func(v interface{}) string {
+					input := v.(string)
+					trimmed := strings.TrimSpace(input)
+					return trimmed
+				},
 			},
 			"slack": {
 				Type:     schema.TypeList,

--- a/internal/resources/oncall/resource_route_test.go
+++ b/internal/resources/oncall/resource_route_test.go
@@ -33,6 +33,29 @@ func TestAccOnCallRoute_basic(t *testing.T) {
 	})
 }
 
+func TestAccOnCallRoute_routingRegexWhitespace(t *testing.T) {
+	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	riName := fmt.Sprintf("integration-%s", acctest.RandString(8))
+	rrRegex := fmt.Sprintf("regex-%s", acctest.RandString(8))
+	rrRegexWithWhitespace := fmt.Sprintf("  \n\t%s\n  \t", rrRegex) // Add leading/trailing whitespace including newlines and tabs
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallRouteResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnCallRouteConfig(riName, rrRegexWithWhitespace),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallRouteResourceExists("grafana_oncall_route.test-acc-route"),
+					// Verify that the whitespace (including newlines) is trimmed in the state
+					resource.TestCheckResourceAttr("grafana_oncall_route.test-acc-route", "routing_regex", rrRegex),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckOnCallRouteResourceDestroy(s *terraform.State) error {
 	client := testutils.Provider.Meta().(*common.Client).OnCallClient
 	for _, r := range s.RootModule().Resources {

--- a/internal/resources/oncall/resource_route_test.go
+++ b/internal/resources/oncall/resource_route_test.go
@@ -38,7 +38,7 @@ func TestAccOnCallRoute_routingRegexWhitespace(t *testing.T) {
 
 	riName := fmt.Sprintf("integration-%s", acctest.RandString(8))
 	rrRegex := fmt.Sprintf("regex-%s", acctest.RandString(8))
-	rrRegexWithWhitespace := fmt.Sprintf("  \n\t%s\n  \t", rrRegex) // Add leading/trailing whitespace including newlines and tabs
+	rrRegexWithWhitespace := fmt.Sprintf("  \\n\\t%s\\n  \\t", rrRegex) // Add leading/trailing whitespace including newlines and tabs
 
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,


### PR DESCRIPTION
Trim whitespace for oncall resource route `routing_regex` so it stops showing as changed when it has not changed.