### PR TITLE
chore: update catalog files with correct team ownership

### DIFF
--- a/internal/resources/cloud/catalog-data-source.yaml
+++ b/internal/resources/cloud/catalog-data-source.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/partner-datasources
+  owner: group:default/grafana-datasources-core-services
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/cloud/catalog-resource.yaml
+++ b/internal/resources/cloud/catalog-resource.yaml
@@ -61,7 +61,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/partner-datasources
+  owner: group:default/grafana-datasources-core-services
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -74,7 +74,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/partner-datasources
+  owner: group:default/grafana-datasources-core-services
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/grafana/catalog-data-source.yaml
+++ b/internal/resources/grafana/catalog-data-source.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/partner-datasources
+  owner: group:default/data-sources
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -87,7 +87,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/partner-datasources
+  owner: group:default/data-sources
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -100,7 +100,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/partner-datasources
+  owner: group:default/data-sources
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
During Platform Monitoring's weekly sync, the team filters all new issues created in this repository and assigns them based on ownership in a Google sheet. After assigning [this](https://github.com/grafana/terraform-provider-grafana/issues/2219) issue to Partner Data Sources, I was notified via DM about a mistake in the mapping of resource/datasource to team. While the Google sheet has been updated to reflect this change, this serves to update the corresponding `catalog-<resource|datasource>` files of the corresponding resources.