### PR TITLE
SCIM: Update logic for determining if a stack is cloud or on-prem

### DIFF
--- a/internal/resources/grafana/resource_scim_config.go
+++ b/internal/resources/grafana/resource_scim_config.go
@@ -90,12 +90,12 @@ func CreateOrUpdateSCIMConfig(ctx context.Context, d *schema.ResourceData, meta 
 	// Determine namespace based on whether this is on-prem or cloud
 	var namespace string
 	switch {
-	case metaClient.GrafanaOrgID > 0:
-		// On-prem Grafana instance - use "default" namespace
-		namespace = "default"
 	case metaClient.GrafanaStackID > 0:
 		// Grafana Cloud instance - use "stacks-{stackId}" namespace
 		namespace = fmt.Sprintf("stacks-%d", metaClient.GrafanaStackID)
+	case metaClient.GrafanaOrgID > 0:
+		// On-prem Grafana instance - use "default" namespace
+		namespace = "default"
 	default:
 		return diag.Errorf("expected either Grafana org ID (for local Grafana) or Grafana stack ID (for Grafana Cloud) to be set")
 	}
@@ -174,12 +174,12 @@ func ReadSCIMConfig(ctx context.Context, d *schema.ResourceData, meta interface{
 	// Determine namespace based on whether this is on-prem or cloud
 	var namespace string
 	switch {
-	case metaClient.GrafanaOrgID > 0:
-		// On-prem Grafana instance - use "default" namespace
-		namespace = "default"
 	case metaClient.GrafanaStackID > 0:
 		// Grafana Cloud instance - use "stacks-{stackId}" namespace
 		namespace = fmt.Sprintf("stacks-%d", metaClient.GrafanaStackID)
+	case metaClient.GrafanaOrgID > 0:
+		// On-prem Grafana instance - use "default" namespace
+		namespace = "default"
 	default:
 		return diag.Errorf("expected either Grafana org ID (for local Grafana) or Grafana stack ID (for Grafana Cloud) to be set")
 	}
@@ -255,12 +255,12 @@ func DeleteSCIMConfig(ctx context.Context, d *schema.ResourceData, meta interfac
 	// Determine namespace based on whether this is on-prem or cloud
 	var namespace string
 	switch {
-	case metaClient.GrafanaOrgID > 0:
-		// On-prem Grafana instance - use "default" namespace
-		namespace = "default"
 	case metaClient.GrafanaStackID > 0:
 		// Grafana Cloud instance - use "stacks-{stackId}" namespace
 		namespace = fmt.Sprintf("stacks-%d", metaClient.GrafanaStackID)
+	case metaClient.GrafanaOrgID > 0:
+		// On-prem Grafana instance - use "default" namespace
+		namespace = "default"
 	default:
 		return diag.Errorf("expected either Grafana org ID (for local Grafana) or Grafana stack ID (for Grafana Cloud) to be set")
 	}


### PR DESCRIPTION
The current logic for determining if the stack being modified is running in cloud versus on-prem/enterprise fails for cloud orgs using service account tokens. Because a service account token is scoped to an org, the provider sees an `org_id` of `1`, and incorrectly assumes it's enterprise. This results in it using the `default` namespace which won't work.

This PR updates the logic to check for a `stack_id` first, before checking for `org_id`. This should correctly account for the cloud use cases.