### PR TITLE
Dashboards: ForceNew for Dashboard UIDs

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -49,7 +49,7 @@ resource "grafana_dashboard" "test" {
 
 - `dashboard_id` (Number) The numeric ID of the dashboard computed by Grafana.
 - `id` (String) The ID of this resource.
-- `uid` (String) The unique identifier of a dashboard. This is used to construct its URL. It's automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs.
+- `uid` (String) The unique identifier of a dashboard. This is used to construct its URL. It's automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs. This field cannot be updated after creation.
 - `url` (String) The full URL of the dashboard.
 - `version` (Number) Whenever you save a version of your dashboard, a copy of that version is saved so that previous versions of your dashboard are not lost.
 

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -43,9 +43,11 @@ Manages Grafana dashboards.
 			"uid": {
 				Type:     schema.TypeString,
 				Computed: true,
+				ForceNew: true,
 				Description: "The unique identifier of a dashboard. This is used to construct its URL. " +
 					"It's automatically generated if not provided when creating a dashboard. " +
-					"The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs. ",
+					"The uid allows having consistent URLs for accessing dashboards and when syncing dashboards between multiple Grafana installs. " +
+					"This field cannot be updated after creation.",
 			},
 			"dashboard_id": {
 				Type:        schema.TypeInt,

--- a/test_immutable_uid.tf
+++ b/test_immutable_uid.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    grafana = {
+      source = "grafana/grafana"
+    }
+  }
+}
+
+provider "grafana" {
+  url  = "http://localhost:3000"
+  auth = "admin:admin"
+}
+
+# Step 1: Create a dashboard with initial UID
+resource "grafana_dashboard" "test" {
+  config_json = jsonencode({
+    title = "Test Dashboard"
+    uid   = "test-dashboard-1"
+  })
+}
+
+output "dashboard_uid" {
+  value = grafana_dashboard.test.uid
+} 


### PR DESCRIPTION
This PR updates the terraform provider to require a destroy & create in dashboards if you try to update the uid