### PR TITLE
Add active-timings to rule's notification settings

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -183,6 +183,7 @@ Required:
 
 Optional:
 
+- `active_timings` (List of String) A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
 - `group_by` (List of String) A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
 - `group_wait` (String) Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -255,6 +255,14 @@ This resource requires Grafana 9.1.0 or later.
 											Type: schema.TypeString,
 										},
 									},
+									"active_timings": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later",
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
 									"group_wait": {
 										Type:        schema.TypeString,
 										Optional:    true,
@@ -789,6 +797,13 @@ func packNotificationSettings(settings *models.AlertRuleNotificationSettings) (i
 		}
 		result["mute_timings"] = g
 	}
+	if len(settings.ActiveTimeIntervals) > 0 {
+		g := make([]interface{}, 0, len(settings.ActiveTimeIntervals))
+		for _, s := range settings.ActiveTimeIntervals {
+			g = append(g, s)
+		}
+		result["active_timings"] = g
+	}
 	if settings.GroupWait != "" {
 		result["group_wait"] = settings.GroupWait
 	}
@@ -826,6 +841,9 @@ func unpackNotificationSettings(p interface{}) (*models.AlertRuleNotificationSet
 
 	if v, ok := jsonData["mute_timings"]; ok && v != nil {
 		result.MuteTimeIntervals = common.ListToStringSlice(v.([]interface{}))
+	}
+	if v, ok := jsonData["active_timings"]; ok && v != nil {
+		result.ActiveTimeIntervals = common.ListToStringSlice(v.([]interface{}))
 	}
 	if v, ok := jsonData["group_wait"]; ok && v != nil {
 		result.GroupWait = v.(string)

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -843,7 +843,7 @@ func TestAccAlertRule_NotificationSettings(t *testing.T) {
 		CheckDestroy:             alertingRuleGroupCheckExists.destroyed(&group, nil),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAlertRuleWithNotificationSettings(name, []string{"alertname", "grafana_folder", "test"}),
+				Config: testAccAlertRuleWithNotificationSettings(name, []string{"alertname", "grafana_folder", "test"}, false),
 				Check: resource.ComposeTestCheckFunc(
 					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
@@ -855,6 +855,40 @@ func TestAccAlertRule_NotificationSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.repeat_interval", "3h"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.mute_timings.#", "1"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.mute_timings.0", fmt.Sprintf("%s-mute-timing", name)),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.#", "3"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.0", "alertname"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.1", "grafana_folder"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.2", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlertRule_NotificationSettings_ActiveTimings(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=12.1.0")
+
+	var group models.AlertRuleGroup
+	var name = acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             alertingRuleGroupCheckExists.destroyed(&group, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertRuleWithNotificationSettings(name, []string{"alertname", "grafana_folder", "test"}, true),
+				Check: resource.ComposeTestCheckFunc(
+					alertingRuleGroupCheckExists.exists("grafana_rule_group.my_rule_group", &group),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "name", name),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.name", fmt.Sprintf("%s-alertrule", name)),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.contact_point", fmt.Sprintf("%s-receiver", name)),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_wait", "45s"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_interval", "6m"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.repeat_interval", "3h"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.mute_timings.#", "1"),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.mute_timings.0", fmt.Sprintf("%s-mute-timing", name)),
+					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.active_timings.0", fmt.Sprintf("%s-mute-timing", name)),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.#", "3"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.0", "alertname"),
 					resource.TestCheckResourceAttr("grafana_rule_group.my_rule_group", "rule.0.notification_settings.0.group_by.1", "grafana_folder"),
@@ -999,11 +1033,15 @@ resource "grafana_rule_group" "my_rule_group" {
 }`, name)
 }
 
-func testAccAlertRuleWithNotificationSettings(name string, groupBy []string) string {
+func testAccAlertRuleWithNotificationSettings(name string, groupBy []string, hasActiveTimings bool) string {
 	gr := ""
 	if len(groupBy) > 0 {
 		b, _ := json.Marshal(groupBy)
 		gr = "group_by = " + string(b)
+	}
+	activeTimings := ""
+	if hasActiveTimings {
+		activeTimings = "active_timings = [grafana_mute_timing.my_mute_timing.name]"
 	}
 	return fmt.Sprintf(`
 resource "grafana_folder" "rule_folder" {
@@ -1060,9 +1098,10 @@ resource "grafana_rule_group" "my_rule_group" {
             group_interval  = "6m"
             repeat_interval = "3h"
 			mute_timings = [grafana_mute_timing.my_mute_timing.name]
+			%[3]s
 		}
 	}
-}`, name, gr)
+}`, name, gr, activeTimings)
 }
 
 func testAccRecordingRule(name string, metric string, refID string) string {


### PR DESCRIPTION
Adds a new field active timings to alert rule's notification settings object. This field is available since Grafana 12.1.0 
Related to https://github.com/grafana/grafana/pull/104252 and https://github.com/grafana/terraform-provider-grafana/pull/2249