### PR TITLE
Add assertion attribute for external user ID in SSO settings

### DIFF
--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -255,6 +255,7 @@ Optional:
 - `allow_sign_up` (Boolean) Whether to allow new Grafana user creation through SAML login. If set to false, then only existing Grafana users can log in with SAML.
 - `allowed_organizations` (String) List of comma- or space-separated organizations. User should be a member of at least one organization to log in.
 - `assertion_attribute_email` (String) Friendly name or name of the attribute within the SAML assertion to use as the user email.
+- `assertion_attribute_external_uid` (String) Friendly name of the attribute within the SAML assertion to use as the external user ID. Only used for SCIM provisioned users.
 - `assertion_attribute_groups` (String) Friendly name or name of the attribute within the SAML assertion to use as the user groups.
 - `assertion_attribute_login` (String) Friendly name or name of the attribute within the SAML assertion to use as the user login handle.
 - `assertion_attribute_name` (String) Friendly name or name of the attribute within the SAML assertion to use as the user name. Alternatively, this can be a template with variables that match the names of attributes within the SAML assertion.

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -428,6 +428,11 @@ var samlSettingsSchema = &schema.Resource{
 			Optional:    true,
 			Description: "Friendly name or name of the attribute within the SAML assertion to use as the user organization.",
 		},
+		"assertion_attribute_external_uid": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Friendly name of the attribute within the SAML assertion to use as the external user ID. Only used for SCIM provisioned users.",
+		},
 		"allowed_organizations": {
 			Type:        schema.TypeString,
 			Optional:    true,


### PR DESCRIPTION
Resolves #2229 by adding an `assertion_attribute_external_uid` to the `grafana_sso_settings` resource, which is required for SCIM provisioning via SAML ([docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/)).