### PR TITLE
Alerting: Fix retryable errors

### DIFF
--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -76,7 +76,7 @@ func listMessageTemplate(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgI
 	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		resp, err := client.Provisioning.GetTemplates()
 		if err != nil {
-			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(403) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)
@@ -127,7 +127,7 @@ func putMessageTemplate(ctx context.Context, data *schema.ResourceData, meta int
 			params.SetXDisableProvenance(&provenanceDisabled)
 		}
 		if _, err := client.Provisioning.PutTemplate(params); err != nil {
-			if orgID > 1 && err.(*runtime.APIError).IsCode(500) {
+			if err.(runtime.ClientResponseStatus).IsCode(500) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -143,7 +143,7 @@ func listMuteTimings(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID in
 	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		resp, err := client.Provisioning.GetMuteTimings()
 		if err != nil {
-			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(403) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)
@@ -194,12 +194,10 @@ func createMuteTiming(ctx context.Context, data *schema.ResourceData, meta inter
 	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		var postErr error
 		resp, postErr = client.Provisioning.PostMuteTiming(params)
-		if orgID > 1 && postErr != nil {
-			if apiError, ok := postErr.(*runtime.APIError); ok && (apiError.IsCode(500) || apiError.IsCode(404)) {
+		if postErr != nil {
+			if postErr.(runtime.ClientResponseStatus).IsCode(500) || postErr.(runtime.ClientResponseStatus).IsCode(403) {
 				return retry.RetryableError(postErr)
 			}
-		}
-		if postErr != nil {
 			return retry.NonRetryableError(postErr)
 		}
 		return nil

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -206,7 +206,7 @@ func listNotificationPolicies(ctx context.Context, client *goapi.GrafanaHTTPAPI,
 	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		_, err := client.Provisioning.GetPolicyTree()
 		if err != nil {
-			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(403) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)
@@ -251,12 +251,10 @@ func putNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta 
 
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		_, err := client.Provisioning.PutPolicyTree(putParams)
-		if orgID > 1 && err != nil {
-			if apiError, ok := err.(*runtime.APIError); ok && (apiError.IsCode(500) || apiError.IsCode(404)) {
+		if err != nil {
+			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(404) {
 				return retry.RetryableError(err)
 			}
-		}
-		if err != nil {
 			return retry.NonRetryableError(err)
 		}
 		return nil

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -327,7 +327,7 @@ func listRuleGroups(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int
 	if err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		resp, err := client.Provisioning.GetAlertRules()
 		if err != nil {
-			if orgID > 1 && (err.(*runtime.APIError).IsCode(500) || err.(*runtime.APIError).IsCode(403)) {
+			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(403) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)


### PR DESCRIPTION
Remove the `orgID = 1` restriction for `RetryableError` in all Alerting resource `RetryContexts`.
Except for the "Alertmanager Not Ready" error, limiting retryability to non-default orgs doesn’t make sense. Even for the default `orgID = 1`, retries on "Alertmanager Not Ready" remain valid.

Previously, this restriction caused sporadic failures in alerting unit tests, as conflicts between parallel tests for the default org were not retried.

Also switched from the specific `*runtime.APIError` struct to the more general `runtime.ClientResponseStatus` interface to accommodate other error types, such as `PostContactpointsBadRequest`.