### PR TITLE
Alerting: Fix contact point update and diff logic

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -492,14 +492,17 @@ Read-Only:
 <a id="nestedblock--webex"></a>
 ### Nested Schema for `webex`
 
+Required:
+
+- `room_id` (String) ID of the Webex Teams room where to send the messages.
+- `token` (String, Sensitive) The bearer token used to authorize the client.
+
 Optional:
 
 - `api_url` (String) The URL to send webhook requests to.
 - `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
 - `message` (String) The templated title of the message to send.
-- `room_id` (String) ID of the Webex Teams room where to send the messages.
 - `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
-- `token` (String, Sensitive) The bearer token used to authorize the client.
 
 Read-Only:
 

--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -1444,6 +1444,12 @@ type slackNotifier struct{}
 
 var _ notifier = (*slackNotifier)(nil)
 
+func (s slackNotifier) HasData(data map[string]any) bool {
+	// Slack has no simple required fields as they require mutual exclusivity. We rely on `Required` to test for
+	// deletions on update, so instead we define a custom HasData method.
+	return data["url"] != "" || data["token"] != ""
+}
+
 func (s slackNotifier) meta() notifierMeta {
 	return notifierMeta{
 		field:        "slack",
@@ -2047,7 +2053,7 @@ func (w webexNotifier) schema() *schema.Resource {
 	r := commonNotifierResource()
 	r.Schema["token"] = &schema.Schema{
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		Sensitive:   true,
 		Description: "The bearer token used to authorize the client.",
 	}
@@ -2063,7 +2069,7 @@ func (w webexNotifier) schema() *schema.Resource {
 	}
 	r.Schema["room_id"] = &schema.Schema{
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		Description: "ID of the Webex Teams room where to send the messages.",
 	}
 	return r
@@ -2246,6 +2252,12 @@ func (w webhookNotifier) unpack(raw interface{}, name string) *models.EmbeddedCo
 type wecomNotifier struct{}
 
 var _ notifier = (*wecomNotifier)(nil)
+
+func (w wecomNotifier) HasData(data map[string]any) bool {
+	// WeCom has no simple required fields as they require mutual exclusivity. We rely on `Required` to test for
+	// deletions on update, so instead we define a custom HasData method.
+	return data["url"] != "" || data["secret"] != ""
+}
 
 func (w wecomNotifier) meta() notifierMeta {
 	return notifierMeta{

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -320,6 +320,19 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "wecom.0.to_user", "to_user"),
 				),
 			},
+			// The following test ensures that the plan remains empty for notifiers when updates are made to
+			// other notifiers in the contact point. This is a regression test to catch certain notifiers without
+			// required fields being deleted on update.
+			{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_contact_point/_acc_receiver_types.tf", map[string]string{
+					`victor-ops-url`: `updated-victor-ops-url`, // VictorOps is a "safe" update as it's not being tested.
+				}),
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "victorops.#", "1"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "victorops.0.url", "http://updated-victor-ops-url"),
+				),
+			},
 			// Test blank fields in settings should be omitted.
 			{
 				Config: testutils.TestAccExample(t, "resources/grafana_contact_point/_acc_default_settings.tf"),


### PR DESCRIPTION
This includes two fixes:
- Fixed an issue where notifiers without required fields (WeCom, Webex, Slack) were incorrectly deleted during updates.
- Fixed a state drift issue where, if all notifiers of a given type existed in state but not in the API, the missing notifiers were not synced to state during refresh and did not show up in diff.

The solution is:
- Correctly mark required fields for `webex`, which were previously missing.
- For slack and wecom, required fields are mutually exclusive:
  - `slack` requires either `url` or `token`.
  - `wecom` requires either `url` or `secret`.
  - This is now enforced by defining a custom `HasData` method for these two notifiers.


Minimal Reproduction:

First create:
```hcl
terraform {
  required_providers {
    grafana = {
      source  = "grafana/grafana"
      version = "4.3.0"
    }
  }
}

provider "grafana" {
  url   = "http://localhost:3000"
  auth  = "admin:admin"
}

resource "grafana_organization" "my_org" {
  name     = "BugFix Org"
}

resource "grafana_contact_point" "contacts" {
  name = "No Required Args"
  org_id = grafana_organization.my_org.org_id
  slack {
    url = "http://custom-slack-url"
  }
  webex {
    token   = "token"
    room_id = "room_id"
  }
  wecom {
    url = "http://wecom-url"
  }
}
```

Then update  something unrelated in the contact point (example add a webhook notifier):
```hcl
resource "grafana_contact_point" "contacts" {
  name = "No Required Args"
  org_id = grafana_organization.my_org.org_id
  slack {
    url = "http://custom-slack-url"
  }
  webex {
    token   = "token"
    room_id = "room_id"
  }
  wecom {
    url = "http://wecom-url"
  }
  webhook {
    url  = "http://webhook-url"
  }
}
```

Notice that slack, webex, and wecom notifiers have been deleted and subsequent `terraform apply` calls show no diff.