### PR TITLE
feat: make plugin version optional - installs latest version

### DIFF
--- a/docs/resources/cloud_plugin_installation.md
+++ b/docs/resources/cloud_plugin_installation.md
@@ -41,7 +41,7 @@ resource "grafana_cloud_plugin_installation" "test" {
 
 ### Optional
 
-- `version` (String) Version of the plugin to be installed, latest version is installed when omitted.
+- `version` (String) Version of the plugin to be installed. When omitted, installs the latest available version at the time of creation. Will not auto-update to newer versions. If you already have a plugin installed and want to upgrade, specify the target version explicitly.
 
 ### Read-Only
 

--- a/docs/resources/cloud_plugin_installation.md
+++ b/docs/resources/cloud_plugin_installation.md
@@ -38,7 +38,10 @@ resource "grafana_cloud_plugin_installation" "test" {
 
 - `slug` (String) Slug of the plugin to be installed.
 - `stack_slug` (String) The stack id to which the plugin should be installed.
-- `version` (String) Version of the plugin to be installed.
+
+### Optional
+
+- `version` (String) Version of the plugin to be installed, latest version is installed when omitted.
 
 ### Read-Only
 

--- a/docs/resources/cloud_plugin_installation.md
+++ b/docs/resources/cloud_plugin_installation.md
@@ -41,7 +41,7 @@ resource "grafana_cloud_plugin_installation" "test" {
 
 ### Optional
 
-- `version` (String) Version of the plugin to be installed. When omitted, installs the latest available version at the time of creation. Will not auto-update to newer versions. If you already have a plugin installed and want to upgrade, specify the target version explicitly.
+- `version` (String) Version of the plugin to be installed. Defaults to 'latest' and installs the most recent version. Terraform will detect new version as drift for plan/apply. Defaults to `latest`.
 
 ### Read-Only
 

--- a/internal/resources/cloud/resource_cloud_plugin_installation.go
+++ b/internal/resources/cloud/resource_cloud_plugin_installation.go
@@ -46,7 +46,7 @@ Required access policy scopes:
 				ForceNew:    true,
 			},
 			"version": {
-				Description: "Version of the plugin to be installed, latest version is installed when omitted.",
+				Description: "Version of the plugin to be installed. When omitted, installs the latest available version at the time of creation. Will not auto-update to newer versions. If you already have a plugin installed and want to upgrade, specify the target version explicitly.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,

--- a/internal/resources/cloud/resource_cloud_plugin_test.go
+++ b/internal/resources/cloud/resource_cloud_plugin_test.go
@@ -37,14 +37,14 @@ func TestAccResourcePluginInstallation(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_plugin_installation.test-installation", "version", "1.2.5")),
 			},
 			{
-				Config: testAccGrafanaCloudPluginInstallationNoVersion(stackSlug, pluginSlug),
+				Config: testAccGrafanaCloudPluginInstallationLatest(stackSlug, "grafana-clock-panel"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
-					testAccCloudPluginInstallationCheckExists(stackSlug, pluginSlug),
+					testAccCloudPluginInstallationCheckExists(stackSlug, "grafana-clock-panel"),
 					resource.TestCheckResourceAttrSet("grafana_cloud_plugin_installation.test-installation-no-version", "id"),
 					resource.TestCheckResourceAttr("grafana_cloud_plugin_installation.test-installation-no-version", "stack_slug", stackSlug),
 					resource.TestCheckResourceAttr("grafana_cloud_plugin_installation.test-installation-no-version", "slug", pluginSlug),
-					// Don't check version attribute since it's not specified in config
+					resource.TestCheckResourceAttr("grafana_cloud_plugin_installation.test-installation-no-version", "version", "latest"),
 				),
 			},
 			{
@@ -106,6 +106,7 @@ func testAccGrafanaCloudPluginInstallation(stackSlug, name, version string) stri
 		resource "grafana_cloud_stack" "test" {
 			name  = "%[1]s"
 			slug  = "%[1]s"
+			delete_protection = false
 			wait_for_readiness = false
 		}
 
@@ -117,17 +118,17 @@ func testAccGrafanaCloudPluginInstallation(stackSlug, name, version string) stri
 	`, stackSlug, name, version)
 }
 
-func testAccGrafanaCloudPluginInstallationNoVersion(stackSlug, name string) string {
+func testAccGrafanaCloudPluginInstallationLatest(stackSlug, name string) string {
 	return fmt.Sprintf(`
-        resource "grafana_cloud_stack" "test" {
-            name  = "%[1]s"
-            slug  = "%[1]s"
-            wait_for_readiness = false
-        }
+		resource "grafana_cloud_stack" "test" {
+			name  = "%[1]s"
+			slug  = "%[1]s"
+			delete_protection = false
+			wait_for_readiness = false
+		}
         resource "grafana_cloud_plugin_installation" "test-installation-no-version" {
             stack_slug = grafana_cloud_stack.test.slug
             slug       = "%[2]s"
-            # version omitted - should install latest
         }
     `, stackSlug, name)
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/terraform-provider-grafana/issues/2312
Tested with dev instance on local using locally built provider.
**resource.tf**
```
terraform {
  required_providers {
    grafana = {
      source = "registry.terraform.io/grafana/grafana"
    }
  }
}
provider "grafana" {
  cloud_api_url             = "https://grafana-dev.com/api"
  cloud_access_policy_token = "dev token"
}
resource "grafana_cloud_plugin_installation" "test" {
  stack_slug = "skh3"
  slug       = "axiomhq-axiom-datasource"
}
```