### PR TITLE
Alerting: Allow duplicated alert rule names

### DIFF
--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -427,23 +427,8 @@ func putAlertRuleGroup(ctx context.Context, data *schema.ResourceData, meta inte
 
 			// Check if a rule with the same name or uid already exists within the same rule group
 			for _, r := range rules {
-				if *r.Title == *ruleToApply.Title {
-					return retry.NonRetryableError(fmt.Errorf("rule with name %q is defined more than once", *ruleToApply.Title))
-				}
 				if ruleToApply.UID != "" && r.UID == ruleToApply.UID {
 					return retry.NonRetryableError(fmt.Errorf("rule with UID %q is defined more than once. Rules with name %q and %q have the same uid", ruleToApply.UID, *r.Title, *ruleToApply.Title))
-				}
-			}
-
-			// Check if a rule with the same name already exists within the same folder (changing the ordering is allowed within the same rule group)
-			for _, existingRule := range respAlertRules.Payload {
-				if *existingRule.Title == *ruleToApply.Title && *existingRule.FolderUID == *ruleToApply.FolderUID {
-					if *ruleToApply.RuleGroup == *existingRule.RuleGroup {
-						break
-					}
-
-					// Retry so that if the user is moving a rule from one group to another, it will pass on the next iteration.
-					return retry.RetryableError(fmt.Errorf("rule with name %q already exists in the folder", *ruleToApply.Title))
 				}
 			}
 

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -381,7 +381,7 @@ resource "grafana_rule_group" "second" {
 }
 
 func TestAccAlertRule_ruleNameConflict(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+	testutils.CheckOSSTestsEnabled(t, ">=11.6.0")
 
 	name := acctest.RandString(10)
 

--- a/internal/resources/grafana/resource_alerting_rule_group_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_test.go
@@ -452,7 +452,11 @@ resource "grafana_rule_group" "first" {
 	}
 }
 				`, name),
-				ExpectError: regexp.MustCompile(`rule with name "My Alert Rule" is defined more than once`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.#", "2"),
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.0.name", "My Alert Rule"),
+					resource.TestCheckResourceAttr("grafana_rule_group.first", "rule.1.name", "My Alert Rule"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
When creating alert rules using the UI, we allow for repeated alert rule names.
The Terraform provider should also allow users to define multiple alert rules with the same name. 

Fixes https://github.com/grafana/terraform-provider-grafana/issues/2275