### PR TITLE
Alerting: Contact point schema based packing/unpacking

### DIFF
--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -107,6 +107,21 @@ resource "grafana_contact_point" "receiver_types" {
   }
 
   slack {
+    endpoint_url    = "http://custom-slack-endpoint"
+    url             = "http://custom-slack-url"
+    recipient       = "#channel"
+    text            = "message"
+    title           = "title"
+    username        = "bot"
+    icon_emoji      = ":icon:"
+    icon_url        = "http://domain/icon.png"
+    mention_channel = "here"
+    mention_users   = "user"
+    mention_groups  = "group"
+    color           = "color"
+  }
+
+  slack {
     endpoint_url    = "http://custom-slack-url"
     token           = "xoxb-token"
     recipient       = "#channel"
@@ -169,12 +184,6 @@ resource "grafana_contact_point" "receiver_types" {
     max_alerts          = 100
     message             = "Custom message"
     title               = "Custom title"
-    tls_config = {
-      insecure_skip_verify = true
-      ca_certificate       = "ca.crt"
-      client_certificate   = "client.crt"
-      client_key           = "client.key"
-    }
   }
 
   wecom {

--- a/examples/resources/grafana_contact_point/_acc_receiver_types_11_4.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types_11_4.tf
@@ -1,7 +1,7 @@
 resource "grafana_contact_point" "receiver_types" {
-  name = "Receiver Types since v10.2"
+  name = "Receiver Types since v11.4"
 
-  oncall {
+  webhook {
     url                 = "http://my-url"
     http_method         = "POST"
     basic_auth_user     = "user"
@@ -9,8 +9,15 @@ resource "grafana_contact_point" "receiver_types" {
     max_alerts          = 100
     message             = "Custom message"
     title               = "Custom title"
+    tls_config = {
+      insecure_skip_verify = true
+      ca_certificate       = "ca.crt"
+      client_certificate   = "client.crt"
+      client_key           = "client.key"
+    }
   }
-  oncall {
+
+  webhook {
     url                       = "http://my-url"
     http_method               = "POST"
     authorization_scheme      = "Basic"
@@ -18,5 +25,11 @@ resource "grafana_contact_point" "receiver_types" {
     max_alerts                = 100
     message                   = "Custom message"
     title                     = "Custom title"
+    tls_config = {
+      insecure_skip_verify = true
+      ca_certificate       = "ca.crt"
+      client_certificate   = "client.crt"
+      client_key           = "client.key"
+    }
   }
 }

--- a/examples/resources/grafana_contact_point/_acc_receiver_types_9_3.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types_9_3.tf
@@ -1,0 +1,11 @@
+resource "grafana_contact_point" "receiver_types" {
+  name = "Receiver Types since v9.3"
+
+  victorops {
+    url          = "http://victor-ops-url"
+    message_type = "CRITICAL"
+    title        = "title"
+    description  = "description"
+  }
+
+}

--- a/examples/resources/grafana_contact_point/_acc_receiver_types_minimal.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types_minimal.tf
@@ -1,0 +1,101 @@
+resource "grafana_contact_point" "minimal_receivers" {
+  name = "Minimal Receivers"
+
+  alertmanager {
+    url = "http://my-am"
+  }
+
+  dingding {
+    url = "http://dingding-url"
+  }
+
+  discord {
+    url = "http://discord-url"
+  }
+
+  email {
+    addresses = ["one@company.org", "two@company.org"]
+  }
+
+  googlechat {
+    url = "http://googlechat-url"
+  }
+
+  kafka {
+    rest_proxy_url = "http://kafka-rest-proxy-url"
+    topic          = "mytopic"
+  }
+
+  line {
+    token = "token"
+  }
+
+  oncall {
+    url = "http://oncall-url"
+  }
+
+  opsgenie {
+    api_key = "token"
+  }
+
+  pagerduty {
+    integration_key = "token"
+  }
+
+  pushover {
+    user_key  = "userkey"
+    api_token = "token"
+  }
+
+  sensugo {
+    url     = "http://sensugo-url"
+    api_key = "key"
+  }
+
+  slack {
+    token     = "xoxb-token"
+    recipient = "#channel"
+  }
+
+  slack {
+    url = "http://custom-slack-url"
+  }
+
+  teams {
+    url = "http://teams-webhook"
+  }
+
+  telegram {
+    token   = "token"
+    chat_id = "chat-id"
+  }
+
+  threema {
+    gateway_id   = "*gateway"
+    recipient_id = "*target1"
+    api_secret   = "secret"
+  }
+
+  victorops {
+    url = "http://victor-ops-url"
+  }
+
+  webex {
+    token   = "token"
+    room_id = "room_id"
+  }
+
+  webhook {
+    url = "http://webhook-url"
+  }
+
+  wecom {
+    url = "http://wecom-url"
+  }
+
+  wecom {
+    secret   = "secret"
+    corp_id  = "corp_id"
+    agent_id = "agent_id"
+  }
+}

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -410,6 +410,246 @@ func commonNotifierResource() *schema.Resource {
 	}
 }
 
+// fieldMapper is a helper struct to map fields that differ between Terraform and Grafana schema. Such as field keys or type conversions.
+type fieldMapper struct {
+	newKey        string
+	packValFunc   func(any) any
+	unpackValFunc func(any) any
+}
+
+func newFieldMapper(newKey string, packValFunc, unpackValFunc func(any) any) fieldMapper {
+	return fieldMapper{
+		newKey:        newKey,
+		packValFunc:   packValFunc,
+		unpackValFunc: unpackValFunc,
+	}
+}
+
+// newKeyMapper is a fieldMapper that only changes the key name in the schema.
+func newKeyMapper(newKey string) fieldMapper {
+	return fieldMapper{
+		newKey: newKey,
+	}
+}
+
+// valueAsInt is a fieldMapper function that converts a value to an integer.
+func valueAsInt(value any) any {
+	switch typ := value.(type) {
+	case int:
+		return typ
+	case float64:
+		return int(typ)
+	case string:
+		val, err := strconv.Atoi(typ)
+		if err != nil {
+			panic(fmt.Errorf("failed to parse value to integer: %w", err))
+		}
+		return val
+	default:
+		panic(fmt.Sprintf("unexpected type %T: %v", typ, typ))
+	}
+}
+
+// unpackNotifier takes the Terraform-style settings and unpacks them into the grafana-style settings. It handles:
+//   - Applying any transformation functions defined in fieldMapping to the keys and values in gfSettings. This is necessary
+//     because some field names differ between Terraform and Grafana, and some values need to be transformed (e.g., converting a string to an integer).
+//   - Flattening the "settings" field created by TF when unpacking the resource schema. This contains any unknown fields
+//     not present in the resource schema.
+func unpackNotifier(tfSettings map[string]any, name string, n notifier) *models.EmbeddedContactPoint {
+	gfSettings := unpackFields(tfSettings, "", n.schema().Schema, n.meta().fieldMapper)
+
+	// UID, disable_resolve_message, and leftover "settings" are part of the schema so are currently unpacked into gfSettings.
+	// However, they are not part of the settings schema in Grafana, so we extract them.
+	uid := tfSettings["uid"].(string)
+	delete(gfSettings, "uid")
+
+	disableResolve := tfSettings["disable_resolve_message"].(bool)
+	delete(gfSettings, "disable_resolve_message")
+
+	if settings, ok := gfSettings["settings"].(map[string]any); ok {
+		for k, v := range settings {
+			gfSettings[k] = v
+		}
+	}
+	delete(gfSettings, "settings")
+
+	// Treat settings like `omitempty`. Workaround for versions affected by https://github.com/grafana/grafana/issues/55139
+	for k, v := range gfSettings {
+		if v == "" {
+			delete(gfSettings, k)
+		}
+	}
+
+	return &models.EmbeddedContactPoint{
+		UID:                   uid,
+		Name:                  name,
+		Type:                  common.Ref(n.meta().typeStr),
+		DisableResolveMessage: disableResolve,
+		Settings:              gfSettings,
+	}
+}
+
+// unpackFields is the recursive counterpart to unpackNotifier.
+func unpackFields(tfSettings map[string]any, prefix string, schemas map[string]*schema.Schema, fieldMapping map[string]fieldMapper) map[string]any {
+	gfSettings := make(map[string]any, len(schemas))
+	for tfKey, sch := range schemas {
+		fullTfKey := tfKey
+		if prefix != "" {
+			fullTfKey = fmt.Sprintf("%s.%s", prefix, tfKey)
+		}
+
+		val, ok := tfSettings[tfKey]
+		if !ok {
+			continue // Skip if the key is not present in the resource map
+		}
+
+		gfKey := tfKey
+		if fMap := fieldMapping[fullTfKey]; fMap.newKey != "" {
+			gfKey = fMap.newKey
+		}
+
+		if unpackedVal := unpackedValue(val, fullTfKey, sch, fieldMapping); unpackedVal != nil {
+			// Omit nil values, this is usually from a custom transform function or an empty set.
+			gfSettings[gfKey] = unpackedVal
+		}
+	}
+	return gfSettings
+}
+
+// unpackedValue recursively returns the appropriate Grafana representation of the TF field value based on the schema.
+func unpackedValue(val any, tfKey string, sch *schema.Schema, fieldMapping map[string]fieldMapper) any {
+	// Apply the transformation function if provided
+	if fMap := fieldMapping[tfKey]; fMap.unpackValFunc != nil {
+		val = fMap.unpackValFunc(val)
+	}
+
+	switch sch.Type {
+	case schema.TypeSet:
+		// We use TypeSet with MaxItems=1 to represent nested schemas (map[string]any), but they are technically slices
+		// and need to be unpacked as such. This means extracting the first item in the set.
+		set, ok := val.(*schema.Set)
+		if !ok {
+			log.Printf("[WARN] Unsupported value type '%s' for key '%s'", sch.Type.String(), tfKey)
+			return val
+		}
+
+		items := set.List()
+		if len(items) == 0 {
+			return nil // empty set
+		}
+		if len(items) > 1 {
+			log.Printf("[WARN] Multiple items found in set for path '%s', using the first one", tfKey)
+		}
+		// Use the first item in the set as the child map
+		m, ok := items[0].(map[string]any)
+		if !ok {
+			log.Printf("[WARN] Unsupported value type '%s' for key '%s'", sch.Type.String(), tfKey)
+			return val
+		}
+		return unpackFields(m, tfKey, sch.Elem.(*schema.Resource).Schema, fieldMapping)
+	default:
+		return val
+	}
+}
+
+// packNotifier takes the grafana-style settings and packs them into the Terraform-style settings. It handles:
+//   - Applying any transformation functions defined in fieldMapping to the keys and values in gfSettings. This is necessary
+//     because some field names differ between Terraform and Grafana, and some values need to be transformed (e.g., converting a string to an integer).
+//   - Overriding sensitive fields with the state values if they are present in the Terraform state. This is necessary
+//     because the API returns [REDACTED] for sensitive fields, and we want to preserve the original value in the Terraform state.
+//   - Collecting all remaining fields from the Grafana settings that are not in the resource schema into a "settings" field.
+func packNotifier(p *models.EmbeddedContactPoint, data *schema.ResourceData, n notifier) map[string]any {
+	gfSettings := p.Settings.(map[string]any)
+	tfSettings := packFields(gfSettings, getNotifierConfigFromStateWithUID(data, n, p.UID), "", n.schema().Schema, n.meta().fieldMapper)
+
+	// Add common fields to the Terraform settings as these aren't available in EmbeddedContactPoint settings.
+	for k, v := range packCommonNotifierFields(p) {
+		tfSettings[k] = v
+	}
+
+	// Collect all remaining fields from the Grafana settings that are not in the resource schema.
+	settings := map[string]any{}
+	for k, v := range gfSettings {
+		settings[k] = fmt.Sprintf("%s", v)
+	}
+	tfSettings["settings"] = settings
+
+	return tfSettings
+}
+
+// packFields is the recursive counterpart to packNotifier.
+func packFields(gfSettings, state map[string]any, prefix string, schemas map[string]*schema.Schema, fieldMapping map[string]fieldMapper) map[string]any {
+	settings := make(map[string]any, len(schemas))
+	for tfKey, sch := range schemas {
+		fullTfKey := tfKey
+		if prefix != "" {
+			fullTfKey = fmt.Sprintf("%s.%s", prefix, tfKey)
+		}
+
+		gfKey := tfKey
+		if fMap := fieldMapping[fullTfKey]; fMap.newKey != "" {
+			gfKey = fMap.newKey
+		}
+
+		val, ok := gfSettings[gfKey]
+		if !ok {
+			continue // Skip if the key is not present in the resource map
+		}
+
+		packedVal, remove := packedValue(val, state, fullTfKey, sch, fieldMapping)
+		if packedVal != nil {
+			// Omit nil values, this is usually from a custom transform function or an empty set.
+			settings[tfKey] = packedVal
+		}
+		if remove {
+			delete(gfSettings, gfKey) // Remove the key from the original map to avoid including it in leftover "settings"
+		}
+	}
+	return settings
+}
+
+// packedValue recursively returns the appropriate TF representation of the Grafana field value based on the schema.
+func packedValue(val any, state map[string]any, tfKey string, sch *schema.Schema, fieldMapping map[string]fieldMapper) (any, bool) {
+	stateVal, hasState := state[tfKey]
+	if sch.Sensitive && hasState {
+		val = stateVal // Use the state value for sensitive fields as the API returns [REDACTED] for sensitive fields.
+	}
+
+	// Apply the transformation function if provided
+	if fMap := fieldMapping[tfKey]; fMap.packValFunc != nil {
+		val = fMap.packValFunc(val)
+	}
+
+	switch sch.Type {
+	case schema.TypeSet:
+		// We use TypeSet with MaxItems=1 to represent nested schemas (map[string]any), but they are technically slices
+		// and need to be packed as such.
+		m, ok := val.(map[string]any)
+		if !ok {
+			log.Printf("[WARN] Unsupported value type '%s' for key '%s'", sch.Type.String(), tfKey)
+			return val, true
+		}
+
+		stateValMap := make(map[string]any)
+		switch sv := stateVal.(type) {
+		case map[string]any:
+			stateValMap = sv
+		case *schema.Set:
+			items := sv.List()
+			if len(items) != 0 {
+				if len(items) > 1 {
+					log.Printf("[WARN] Multiple items found in state for path '%s', using the first one", tfKey)
+				}
+				stateValMap = items[0].(map[string]any)
+			}
+		}
+
+		return []any{packFields(m, stateValMap, tfKey, sch.Elem.(*schema.Resource).Schema, fieldMapping)}, len(m) == 0
+	default:
+		return val, true
+	}
+}
+
 type notifier interface {
 	meta() notifierMeta
 	schema() *schema.Resource
@@ -422,6 +662,7 @@ type notifierMeta struct {
 	typeStr      string
 	desc         string
 	secureFields []string
+	fieldMapper  map[string]fieldMapper
 }
 
 type statePair struct {
@@ -464,66 +705,76 @@ func getNotifierConfigFromStateWithUID(data *schema.ResourceData, n notifier, ui
 	return nil
 }
 
-func unpackTLSConfig(tfSettings, gfSettings map[string]any) {
-	tlsConfig, ok := tfSettings["tls_config"].(map[string]any)
-	if !ok || len(tlsConfig) == 0 {
-		return
+// translateTLSConfigPack is necessary to convert the TLS configuration from the Grafana API format to the Terraform format.
+// This is needed because tlsConfig was initially defined without a corresponding schema, so packNotifier cannot handle
+// the field name conversions with fieldMapper.newKey.
+func translateTLSConfigPack(value any) any {
+	m, ok := value.(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("unexpected type for tls_config: %T", value))
 	}
-
-	gfTLSConfig := make(map[string]any)
-
-	if is, ok := tlsConfig["insecure_skip_verify"].(string); ok {
-		if insecureSkipVerify, err := strconv.ParseBool(is); err != nil {
-			log.Printf("[WARN] failed to parse 'insecure_skip_verify': %s", err)
-		} else {
-			gfTLSConfig["insecureSkipVerify"] = insecureSkipVerify
+	if len(m) == 0 {
+		return nil // Return nil if the map is empty, to avoid setting an empty map in the resource
+	}
+	// Convert the keys to the expected format
+	newTLSConfig := make(map[string]any, len(m))
+	for k, v := range m {
+		switch k {
+		case "insecureSkipVerify":
+			if is, ok := v.(string); ok {
+				if insecureSkipVerify, err := strconv.ParseBool(is); err != nil {
+					log.Printf("[WARN] failed to parse 'insecureSkipVerify': %s", err)
+				} else {
+					newTLSConfig["insecure_skip_verify"] = insecureSkipVerify
+				}
+			}
+		case "caCertificate":
+			newTLSConfig["ca_certificate"] = v
+		case "clientCertificate":
+			newTLSConfig["client_certificate"] = v
+		case "clientKey":
+			newTLSConfig["client_key"] = v
+		default:
+			newTLSConfig[k] = v
 		}
 	}
 
-	if caCertificate, ok := tlsConfig["ca_certificate"].(string); ok {
-		gfTLSConfig["caCertificate"] = caCertificate
-	}
-
-	if clientCertificate, ok := tlsConfig["client_certificate"].(string); ok {
-		gfTLSConfig["clientCertificate"] = clientCertificate
-	}
-
-	if clientKey, ok := tlsConfig["client_key"].(string); ok {
-		gfTLSConfig["clientKey"] = clientKey
-	}
-
-	gfSettings["tlsConfig"] = gfTLSConfig
+	return newTLSConfig
 }
 
-func packTLSConfig(gfSettings, tfSettings map[string]any) {
-	tlsConfig, ok := gfSettings["tlsConfig"].(map[string]any)
-	if !ok || len(tlsConfig) == 0 {
-		return
+// translateTLSConfigUnpack is necessary to convert the TLS configuration from the Terraform API format to the Grafana format.
+// This is needed because tlsConfig was initially defined without a corresponding schema, so unpackNotifier cannot handle
+// the field name conversions with fieldMapper.newKey.
+func translateTLSConfigUnpack(value any) any {
+	m, ok := value.(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("unexpected type for tlsConfig: %T", value))
 	}
-
-	tfTLSConfig := make(map[string]any)
-
-	if is, ok := tlsConfig["insecureSkipVerify"].(string); ok {
-		if insecureSkipVerify, err := strconv.ParseBool(is); err != nil {
-			log.Printf("[WARN] failed to parse 'insecure_skip_verify': %s", err)
-		} else {
-			tfTLSConfig["insecure_skip_verify"] = insecureSkipVerify
+	if len(m) == 0 {
+		return nil // Return nil if the map is empty, to avoid setting an empty map in the resource
+	}
+	// Convert the keys to the expected format
+	newTLSConfig := make(map[string]any, len(m))
+	for k, v := range m {
+		switch k {
+		case "insecure_skip_verify":
+			if is, ok := v.(string); ok {
+				if insecureSkipVerify, err := strconv.ParseBool(is); err != nil {
+					log.Printf("[WARN] failed to parse 'insecure_skip_verify': %s", err)
+				} else {
+					newTLSConfig["insecureSkipVerify"] = insecureSkipVerify
+				}
+			}
+		case "ca_certificate":
+			newTLSConfig["caCertificate"] = v
+		case "client_certificate":
+			newTLSConfig["clientCertificate"] = v
+		case "client_key":
+			newTLSConfig["clientKey"] = v
+		default:
+			newTLSConfig[k] = v
 		}
 	}
 
-	if caCertificate, ok := tlsConfig["caCertificate"].(string); ok {
-		tfTLSConfig["ca_certificate"] = caCertificate
-	}
-
-	if clientCertificate, ok := tlsConfig["clientCertificate"].(string); ok {
-		tfTLSConfig["client_certificate"] = clientCertificate
-	}
-
-	if clientKey, ok := tlsConfig["clientKey"].(string); ok {
-		tfTLSConfig["client_key"] = clientKey
-	}
-
-	delete(gfSettings, "tlsConfig")
-
-	tfSettings["tls_config"] = tfTLSConfig
+	return newTLSConfig
 }

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -282,7 +282,7 @@ func unpackContactPoints(data *schema.ResourceData) []statePair {
 			// If it's not deleted, it will either be created or updated
 			result = append(result, statePair{
 				tfState: pointMap,
-				gfState: unpackNotifier(p.(map[string]any), name, n),
+				gfState: unpackNotifier(pointMap, name, n),
 				deleted: deleted,
 			})
 		}

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -442,7 +442,7 @@ func valueAsString(value any) any {
 //   - Flattening the "settings" field created by TF when unpacking the resource schema. This contains any unknown fields
 //     not present in the resource schema.
 func unpackNotifier(tfSettings map[string]any, name string, n notifier) *models.EmbeddedContactPoint {
-	gfSettings := unpackFields(tfSettings, "", n.schema().Schema, n.meta().fieldMapper)
+	gfSettings := unpackFields(tfSettings, n.schema().Schema, n.meta().fieldMapper)
 
 	// UID, disable_resolve_message, and leftover "settings" are part of the schema so are currently unpacked into gfSettings.
 	// However, they are not part of the settings schema in Grafana, so we extract them.
@@ -475,56 +475,32 @@ func unpackNotifier(tfSettings map[string]any, name string, n notifier) *models.
 	}
 }
 
-// unpackFields is the recursive counterpart to unpackNotifier.
-func unpackFields(tfSettings map[string]any, prefix string, schemas map[string]*schema.Schema, fieldMapping map[string]fieldMapper) map[string]any {
+func unpackFields(tfSettings map[string]any, schemas map[string]*schema.Schema, fieldMapping map[string]fieldMapper) map[string]any {
 	gfSettings := make(map[string]any, len(schemas))
-	for tfKey, sch := range schemas {
-		fullTfKey := tfKey
-		if prefix != "" {
-			fullTfKey = fmt.Sprintf("%s.%s", prefix, tfKey)
-		}
-
+	for tfKey := range schemas {
 		val, ok := tfSettings[tfKey]
 		if !ok {
 			continue // Skip if the key is not present in the resource map
 		}
 
 		gfKey := tfKey
-		if fMap := fieldMapping[fullTfKey]; fMap.newKey != "" {
+		fMap := fieldMapping[tfKey]
+		// Apply key mapping to get the grafana-style key if defined.
+		if fMap.newKey != "" {
 			gfKey = fMap.newKey
 		}
 
-		if unpackedVal := unpackedValue(val, fullTfKey, sch, fieldMapping); unpackedVal != nil {
+		// Apply the transformation function if provided.
+		if fMap.unpackValFunc != nil {
+			val = fMap.unpackValFunc(val)
+		}
+
+		if val != nil {
 			// Omit nil values, this is usually from a custom transform function or an empty set.
-			gfSettings[gfKey] = unpackedVal
+			gfSettings[gfKey] = val
 		}
 	}
 	return gfSettings
-}
-
-// unpackedValue recursively returns the appropriate Grafana representation of the TF field value based on the schema.
-func unpackedValue(val any, tfKey string, sch *schema.Schema, fieldMapping map[string]fieldMapper) any {
-	// Apply the transformation function if provided
-	if fMap := fieldMapping[tfKey]; fMap.unpackValFunc != nil {
-		val = fMap.unpackValFunc(val)
-	}
-
-	switch sch.Type {
-	case schema.TypeSet:
-		// This is a nested schema type, so we coerce the nested value into a map to continue the recursion.
-		valAsMap, err := extractMapFromSet(val)
-		if err != nil {
-			log.Printf("[WARN] cannot extract map from set for key '%s': %v", tfKey, err)
-			return val
-		}
-		if len(valAsMap) == 0 {
-			return nil // omit empty sets
-		}
-
-		return unpackFields(valAsMap, tfKey, sch.Elem.(*schema.Resource).Schema, fieldMapping)
-	default:
-		return val
-	}
 }
 
 // packNotifier takes the grafana-style settings and packs them into the Terraform-style settings. It handles:
@@ -535,7 +511,7 @@ func unpackedValue(val any, tfKey string, sch *schema.Schema, fieldMapping map[s
 //   - Collecting all remaining fields from the Grafana settings that are not in the resource schema into a "settings" field.
 func packNotifier(p *models.EmbeddedContactPoint, data *schema.ResourceData, n notifier) map[string]any {
 	gfSettings := p.Settings.(map[string]any)
-	tfSettings := packFields(gfSettings, getNotifierConfigFromStateWithUID(data, n, p.UID), "", n.schema().Schema, n.meta().fieldMapper)
+	tfSettings := packFields(gfSettings, getNotifierConfigFromStateWithUID(data, n, p.UID), n.schema().Schema, n.meta().fieldMapper)
 
 	// Add common fields to the Terraform settings as these aren't available in EmbeddedContactPoint settings.
 	for k, v := range packCommonNotifierFields(p) {
@@ -552,94 +528,38 @@ func packNotifier(p *models.EmbeddedContactPoint, data *schema.ResourceData, n n
 	return tfSettings
 }
 
-// packFields is the recursive counterpart to packNotifier.
-func packFields(gfSettings, state map[string]any, prefix string, schemas map[string]*schema.Schema, fieldMapping map[string]fieldMapper) map[string]any {
+func packFields(gfSettings, state map[string]any, schemas map[string]*schema.Schema, fieldMapping map[string]fieldMapper) map[string]any {
 	settings := make(map[string]any, len(schemas))
 	for tfKey, sch := range schemas {
-		fullTfKey := tfKey
-		if prefix != "" {
-			fullTfKey = fmt.Sprintf("%s.%s", prefix, tfKey)
-		}
-
 		gfKey := tfKey
-		if fMap := fieldMapping[fullTfKey]; fMap.newKey != "" {
+		fMap := fieldMapping[tfKey]
+		// Apply key mapping to get the grafana-style key if defined.
+		if fMap.newKey != "" {
 			gfKey = fMap.newKey
 		}
 
 		val, ok := gfSettings[gfKey]
 		if !ok {
-			continue // Skip if the key is not present in the resource map
+			continue // Skip if the key is not present in the grafana settings
 		}
 
-		packedVal, remove := packedValue(val, state[tfKey], fullTfKey, sch, fieldMapping)
-		if packedVal != nil {
-			// Omit nil values, this is usually from a custom transform function or an empty set.
-			settings[tfKey] = packedVal
+		// Use the state value for sensitive fields as the API returns [REDACTED].
+		if sch.Sensitive {
+			val = state[tfKey]
 		}
-		if remove {
-			delete(gfSettings, gfKey) // Remove the key from the original map to avoid including it in leftover "settings"
+
+		// Apply the transformation function if provided
+		if fMap.packValFunc != nil {
+			val = fMap.packValFunc(val)
 		}
+
+		if val != nil {
+			// Omit nil values.
+			settings[tfKey] = val
+		}
+		delete(gfSettings, gfKey) // Remove the key from the original map to avoid including it in leftover "settings"
 	}
 	return settings
-}
-
-// packedValue recursively returns the appropriate TF representation of the Grafana field value based on the schema.
-func packedValue(val any, stateVal any, tfKey string, sch *schema.Schema, fieldMapping map[string]fieldMapper) (any, bool) {
-	// Use the state value for sensitive fields as the API returns [REDACTED].
-	if sch.Sensitive {
-		// Values in state and already correctly packed, so no need to continue the recursion.
-		return stateVal, true
-	}
-
-	// Apply the transformation function if provided
-	if fMap := fieldMapping[tfKey]; fMap.packValFunc != nil {
-		val = fMap.packValFunc(val)
-	}
-
-	switch sch.Type {
-	case schema.TypeSet:
-		// This is a nested schema type, so we coerce the nested value and state into maps to continue the recursion.
-		valAsMap, ok := val.(map[string]any)
-		if !ok {
-			log.Printf("[WARN] Unsupported value type '%s' for key '%s'", sch.Type.String(), tfKey)
-			return val, true
-		}
-
-		// For nested schemas, the state value should be a schema.Set with MaxItems=1.
-		stateValAsMap, err := extractMapFromSet(stateVal)
-		if err != nil {
-			log.Printf("[WARN] cannot extract map from set for key '%s': %v", tfKey, err)
-		}
-
-		// We use TypeSet with MaxItems=1 to represent nested schemas (map[string]any), but they are technically slices
-		// and need to be packed as such.
-		return []any{packFields(valAsMap, stateValAsMap, tfKey, sch.Elem.(*schema.Resource).Schema, fieldMapping)}, len(valAsMap) == 0
-	default:
-		return val, true
-	}
-}
-
-// extractMapFromSet extracts the first item from a schema.Set and returns it as a map[string]any.
-// We use TypeSet with MaxItems=1 to represent nested schemas (map[string]any), but they are technically slices in TF.
-func extractMapFromSet(val any) (map[string]any, error) {
-	set, ok := val.(*schema.Set)
-	if !ok {
-		return map[string]any{}, fmt.Errorf("unsupported value: %q", val)
-	}
-
-	items := set.List()
-	if len(items) == 0 {
-		return map[string]any{}, nil // empty set
-	}
-	if len(items) > 1 {
-		return map[string]any{}, fmt.Errorf("set contains more than one item: %q", items)
-	}
-	// Use the first item in the set as the child map
-	m, ok := items[0].(map[string]any)
-	if !ok {
-		return map[string]any{}, fmt.Errorf("unsupported value in set: %q", items[0])
-	}
-	return m, nil
 }
 
 type notifier interface {

--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -1,14 +1,11 @@
 package grafana
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 )
 
@@ -18,10 +15,13 @@ var _ notifier = (*alertmanagerNotifier)(nil)
 
 func (a alertmanagerNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "alertmanager",
-		typeStr:      "prometheus-alertmanager",
-		desc:         "A contact point that sends notifications to other Alertmanager instances.",
-		secureFields: []string{"basic_auth_password"},
+		field:   "alertmanager",
+		typeStr: "prometheus-alertmanager",
+		desc:    "A contact point that sends notifications to other Alertmanager instances.",
+		fieldMapper: map[string]fieldMapper{
+			"basic_auth_user":     newKeyMapper("basicAuthUser"),
+			"basic_auth_password": newKeyMapper("basicAuthPassword"),
+		},
 	}
 }
 
@@ -46,58 +46,18 @@ func (a alertmanagerNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (a alertmanagerNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "url")
-	}
-	if v, ok := settings["basicAuthUser"]; ok && v != nil {
-		notifier["basic_auth_user"] = v.(string)
-		delete(settings, "basicAuthUser")
-	}
-	if v, ok := settings["basicAuthPassword"]; ok && v != nil {
-		notifier["basic_auth_password"] = v.(string)
-		delete(settings, "basicAuthPassword")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, a, p.UID), a.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (a alertmanagerNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["url"] = json["url"].(string)
-	if v, ok := json["basic_auth_user"]; ok && v != nil {
-		settings["basicAuthUser"] = v.(string)
-	}
-	if v, ok := json["basic_auth_password"]; ok && v != nil {
-		settings["basicAuthPassword"] = v.(string)
-	}
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(a.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type dingDingNotifier struct{}
 
 var _ notifier = (*dingDingNotifier)(nil)
 
 func (d dingDingNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "dingding",
-		typeStr:      "dingding",
-		desc:         "A contact point that sends notifications to DingDing.",
-		secureFields: []string{"url"},
+		field:   "dingding",
+		typeStr: "dingding",
+		desc:    "A contact point that sends notifications to DingDing.",
+		fieldMapper: map[string]fieldMapper{
+			"message_type": newKeyMapper("msgType"),
+		},
 	}
 }
 
@@ -127,63 +87,16 @@ func (d dingDingNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (d dingDingNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "url")
-	}
-	if v, ok := settings["msgType"]; ok && v != nil {
-		notifier["message_type"] = v.(string)
-		delete(settings, "msgType")
-	}
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-	if v, ok := settings["title"]; ok && v != nil {
-		notifier["title"] = v.(string)
-		delete(settings, "title")
-	}
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, d, p.UID), d.meta().secureFields)
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (d dingDingNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["url"] = json["url"].(string)
-	if v, ok := json["message_type"]; ok && v != nil {
-		settings["msgType"] = v.(string)
-	}
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	if v, ok := json["title"]; ok && v != nil {
-		settings["title"] = v.(string)
-	}
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(d.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type discordNotifier struct{}
 
 var _ notifier = (*discordNotifier)(nil)
 
 func (d discordNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "discord",
-		typeStr:      "discord",
-		desc:         "A contact point that sends notifications as Discord messages",
-		secureFields: []string{"url"},
+		field:       "discord",
+		typeStr:     "discord",
+		desc:        "A contact point that sends notifications as Discord messages",
+		fieldMapper: map[string]fieldMapper{},
 	}
 }
 
@@ -221,58 +134,6 @@ func (d discordNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (d discordNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "url")
-	}
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-	if v, ok := settings["avatar_url"]; ok && v != nil {
-		notifier["avatar_url"] = v.(string)
-		delete(settings, "avatar_url")
-	}
-	if v, ok := settings["use_discord_username"]; ok && v != nil {
-		notifier["use_discord_username"] = v.(bool)
-		delete(settings, "use_discord_username")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, d, p.UID), d.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (d discordNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["url"] = json["url"].(string)
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	if v, ok := json["avatar_url"]; ok && v != nil {
-		settings["avatar_url"] = v.(string)
-	}
-	if v, ok := json["use_discord_username"]; ok && v != nil {
-		settings["use_discord_username"] = v.(bool)
-	}
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(d.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type emailNotifier struct{}
 
 var _ notifier = (*emailNotifier)(nil)
@@ -282,6 +143,10 @@ func (e emailNotifier) meta() notifierMeta {
 		field:   "email",
 		typeStr: "email",
 		desc:    "A contact point that sends notifications to an email address.",
+		fieldMapper: map[string]fieldMapper{
+			"addresses":    newFieldMapper("", packAddrs, unpackAddrs),
+			"single_email": newKeyMapper("singleEmail"),
+		},
 	}
 }
 
@@ -317,58 +182,10 @@ func (e emailNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (e emailNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["addresses"]; ok && v != nil {
-		notifier["addresses"] = packAddrs(v.(string))
-		delete(settings, "addresses")
-	}
-	if v, ok := settings["singleEmail"]; ok && v != nil {
-		notifier["single_email"] = v.(bool)
-		delete(settings, "singleEmail")
-	}
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-	if v, ok := settings["subject"]; ok && v != nil {
-		notifier["subject"] = v.(string)
-		delete(settings, "subject")
-	}
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (e emailNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	addrs := unpackAddrs(json["addresses"].([]any))
-	settings["addresses"] = addrs
-	if v, ok := json["single_email"]; ok && v != nil {
-		settings["singleEmail"] = v.(bool)
-	}
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	if v, ok := json["subject"]; ok && v != nil {
-		settings["subject"] = v.(string)
-	}
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(e.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 const addrSeparator = ';'
 
-func packAddrs(addrs string) []string {
-	return strings.FieldsFunc(addrs, func(r rune) bool {
+func packAddrs(addrs any) any {
+	return strings.FieldsFunc(addrs.(string), func(r rune) bool {
 		switch r {
 		case ',', addrSeparator, '\n':
 			return true
@@ -377,8 +194,8 @@ func packAddrs(addrs string) []string {
 	})
 }
 
-func unpackAddrs(addrs []any) string {
-	strs := common.ListToStringSlice(addrs)
+func unpackAddrs(addrs any) any {
+	strs := common.ListToStringSlice(addrs.([]any))
 	return strings.Join(strs, string(addrSeparator))
 }
 
@@ -388,10 +205,10 @@ var _ notifier = (*googleChatNotifier)(nil)
 
 func (g googleChatNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "googlechat",
-		typeStr:      "googlechat",
-		desc:         "A contact point that sends notifications to Google Chat.",
-		secureFields: []string{"url"},
+		field:       "googlechat",
+		typeStr:     "googlechat",
+		desc:        "A contact point that sends notifications to Google Chat.",
+		fieldMapper: map[string]fieldMapper{},
 	}
 }
 
@@ -416,53 +233,21 @@ func (g googleChatNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (g googleChatNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "url")
-	}
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, g, p.UID), g.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (g googleChatNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["url"] = json["url"].(string)
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(g.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type kafkaNotifier struct{}
 
 var _ notifier = (*kafkaNotifier)(nil)
 
 func (k kafkaNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "kafka",
-		typeStr:      "kafka",
-		desc:         "A contact point that publishes notifications to Apache Kafka topics.",
-		secureFields: []string{"rest_proxy_url", "password"},
+		field:   "kafka",
+		typeStr: "kafka",
+		desc:    "A contact point that publishes notifications to Apache Kafka topics.",
+		fieldMapper: map[string]fieldMapper{
+			"rest_proxy_url": newKeyMapper("kafkaRestProxy"),
+			"topic":          newKeyMapper("kafkaTopic"),
+			"api_version":    newKeyMapper("apiVersion"),
+			"cluster_id":     newKeyMapper("kafkaClusterId"),
+		},
 	}
 }
 
@@ -515,62 +300,16 @@ func (k kafkaNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (k kafkaNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["kafkaRestProxy"]; ok && v != nil {
-		notifier["rest_proxy_url"] = v.(string)
-		delete(settings, "kafkaRestProxy")
-	}
-	if v, ok := settings["kafkaTopic"]; ok && v != nil {
-		notifier["topic"] = v.(string)
-		delete(settings, "kafkaTopic")
-	}
-	packNotifierStringField(&settings, &notifier, "description", "description")
-	packNotifierStringField(&settings, &notifier, "details", "details")
-	packNotifierStringField(&settings, &notifier, "username", "username")
-	packNotifierStringField(&settings, &notifier, "password", "password")
-	packNotifierStringField(&settings, &notifier, "apiVersion", "api_version")
-	packNotifierStringField(&settings, &notifier, "kafkaClusterId", "cluster_id")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, k, p.UID), k.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (k kafkaNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["kafkaRestProxy"] = json["rest_proxy_url"].(string)
-	settings["kafkaTopic"] = json["topic"].(string)
-	unpackNotifierStringField(&json, &settings, "description", "description")
-	unpackNotifierStringField(&json, &settings, "details", "details")
-	unpackNotifierStringField(&json, &settings, "username", "username")
-	unpackNotifierStringField(&json, &settings, "password", "password")
-	unpackNotifierStringField(&json, &settings, "api_version", "apiVersion")
-	unpackNotifierStringField(&json, &settings, "cluster_id", "kafkaClusterId")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(k.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type lineNotifier struct{}
 
 var _ notifier = (*lineNotifier)(nil)
 
 func (o lineNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "line",
-		typeStr:      "LINE",
-		desc:         "A contact point that sends notifications to LINE.me.",
-		secureFields: []string{"token"},
+		field:       "line",
+		typeStr:     "LINE",
+		desc:        "A contact point that sends notifications to LINE.me.",
+		fieldMapper: map[string]fieldMapper{},
 	}
 }
 
@@ -595,47 +334,21 @@ func (o lineNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (o lineNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "token", "token")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	packNotifierStringField(&settings, &notifier, "description", "description")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, o, p.UID), o.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (o lineNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "token", "token")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	unpackNotifierStringField(&json, &settings, "description", "description")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(o.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type oncallNotifier struct{}
 
 var _ notifier = (*oncallNotifier)(nil)
 
 func (w oncallNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "oncall",
-		typeStr:      "oncall",
-		desc:         "A contact point that sends notifications to Grafana On-Call.",
-		secureFields: []string{"basic_auth_password", "authorization_credentials"},
+		field:   "oncall",
+		typeStr: "oncall",
+		desc:    "A contact point that sends notifications to Grafana On-Call.",
+		fieldMapper: map[string]fieldMapper{
+			"http_method":         newKeyMapper("httpMethod"),
+			"basic_auth_user":     newKeyMapper("username"),
+			"basic_auth_password": newKeyMapper("password"),
+			"max_alerts":          newFieldMapper("maxAlerts", valueAsInt, valueAsInt),
+		},
 	}
 }
 
@@ -691,84 +404,22 @@ func (w oncallNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (w oncallNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "url", "url")
-	packNotifierStringField(&settings, &notifier, "httpMethod", "http_method")
-	packNotifierStringField(&settings, &notifier, "username", "basic_auth_user")
-	packNotifierStringField(&settings, &notifier, "password", "basic_auth_password")
-	packNotifierStringField(&settings, &notifier, "authorization_scheme", "authorization_scheme")
-	packNotifierStringField(&settings, &notifier, "authorization_credentials", "authorization_credentials")
-	packNotifierStringField(&settings, &notifier, "message", "message")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	if v, ok := settings["maxAlerts"]; ok && v != nil {
-		switch typ := v.(type) {
-		case int:
-			notifier["max_alerts"] = v.(int)
-		case float64:
-			notifier["max_alerts"] = int(v.(float64))
-		case string:
-			val, err := strconv.Atoi(typ)
-			if err != nil {
-				panic(fmt.Errorf("failed to parse value of 'maxAlerts' to integer: %w", err))
-			}
-			notifier["max_alerts"] = val
-		default:
-			panic(fmt.Sprintf("unexpected type %T for 'maxAlerts': %v", typ, typ))
-		}
-		delete(settings, "maxAlerts")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, w, p.UID), w.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (w oncallNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "url", "url")
-	unpackNotifierStringField(&json, &settings, "http_method", "httpMethod")
-	unpackNotifierStringField(&json, &settings, "basic_auth_user", "username")
-	unpackNotifierStringField(&json, &settings, "basic_auth_password", "password")
-	unpackNotifierStringField(&json, &settings, "authorization_scheme", "authorization_scheme")
-	unpackNotifierStringField(&json, &settings, "authorization_credentials", "authorization_credentials")
-	unpackNotifierStringField(&json, &settings, "message", "message")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	if v, ok := json["max_alerts"]; ok && v != nil {
-		switch typ := v.(type) {
-		case int:
-			settings["maxAlerts"] = v.(int)
-		case float64:
-			settings["maxAlerts"] = int(v.(float64))
-		default:
-			panic(fmt.Sprintf("unexpected type for maxAlerts: %v", typ))
-		}
-	}
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(w.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type opsGenieNotifier struct{}
 
 var _ notifier = (*opsGenieNotifier)(nil)
 
 func (o opsGenieNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "opsgenie",
-		typeStr:      "opsgenie",
-		desc:         "A contact point that sends notifications to OpsGenie.",
-		secureFields: []string{"api_key"},
+		field:   "opsgenie",
+		typeStr: "opsgenie",
+		desc:    "A contact point that sends notifications to OpsGenie.",
+		fieldMapper: map[string]fieldMapper{
+			"url":               newKeyMapper("apiUrl"),
+			"api_key":           newKeyMapper("apiKey"),
+			"auto_close":        newKeyMapper("autoClose"),
+			"override_priority": newKeyMapper("overridePriority"),
+			"send_tags_as":      newKeyMapper("sendTagsAs"),
+		},
 	}
 }
 
@@ -844,117 +495,18 @@ func (o opsGenieNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (o opsGenieNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["apiUrl"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "apiUrl")
-	}
-	if v, ok := settings["apiKey"]; ok && v != nil {
-		notifier["api_key"] = v.(string)
-		delete(settings, "apiKey")
-	}
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-	if v, ok := settings["description"]; ok && v != nil {
-		notifier["description"] = v.(string)
-		delete(settings, "description")
-	}
-	if v, ok := settings["autoClose"]; ok && v != nil {
-		notifier["auto_close"] = v.(bool)
-		delete(settings, "autoClose")
-	}
-	if v, ok := settings["overridePriority"]; ok && v != nil {
-		notifier["override_priority"] = v.(bool)
-		delete(settings, "overridePriority")
-	}
-	if v, ok := settings["sendTagsAs"]; ok && v != nil {
-		notifier["send_tags_as"] = v.(string)
-		delete(settings, "sendTagsAs")
-	}
-	if v, ok := settings["responders"]; ok && v != nil {
-		items := v.([]any)
-		responders := make([]map[string]any, 0, len(items))
-		for _, item := range items {
-			itemMap := item.(map[string]any)
-			responder := make(map[string]any, 4)
-			packNotifierStringField(&itemMap, &responder, "type", "type")
-			packNotifierStringField(&itemMap, &responder, "id", "id")
-			packNotifierStringField(&itemMap, &responder, "name", "name")
-			packNotifierStringField(&itemMap, &responder, "username", "username")
-			responders = append(responders, responder)
-		}
-		notifier["responders"] = responders
-		delete(settings, "responders")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, o, p.UID), o.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (o opsGenieNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	if v, ok := json["url"]; ok && v != nil {
-		settings["apiUrl"] = v.(string)
-	}
-	if v, ok := json["api_key"]; ok && v != nil {
-		settings["apiKey"] = v.(string)
-	}
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	if v, ok := json["description"]; ok && v != nil {
-		settings["description"] = v.(string)
-	}
-	if v, ok := json["auto_close"]; ok && v != nil {
-		settings["autoClose"] = v.(bool)
-	}
-	if v, ok := json["override_priority"]; ok && v != nil {
-		settings["overridePriority"] = v.(bool)
-	}
-	if v, ok := json["send_tags_as"]; ok && v != nil {
-		settings["sendTagsAs"] = v.(string)
-	}
-	if v, ok := json["responders"]; ok && v != nil {
-		items := v.([]any)
-		responders := make([]map[string]any, 0, len(items))
-		for _, item := range items {
-			tfResponder := item.(map[string]any)
-			responder := make(map[string]any, 4)
-			unpackNotifierStringField(&tfResponder, &responder, "type", "type")
-			unpackNotifierStringField(&tfResponder, &responder, "id", "id")
-			unpackNotifierStringField(&tfResponder, &responder, "name", "name")
-			unpackNotifierStringField(&tfResponder, &responder, "username", "username")
-			responders = append(responders, responder)
-		}
-		settings["responders"] = responders
-	}
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(o.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type pagerDutyNotifier struct{}
 
 var _ notifier = (*pagerDutyNotifier)(nil)
 
 func (n pagerDutyNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "pagerduty",
-		typeStr:      "pagerduty",
-		desc:         "A contact point that sends notifications to PagerDuty.",
-		secureFields: []string{"integration_key"},
+		field:   "pagerduty",
+		typeStr: "pagerduty",
+		desc:    "A contact point that sends notifications to PagerDuty.",
+		fieldMapper: map[string]fieldMapper{
+			"integration_key": newKeyMapper("integrationKey"),
+		},
 	}
 }
 
@@ -1023,114 +575,26 @@ func (n pagerDutyNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (n pagerDutyNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["integrationKey"]; ok && v != nil {
-		notifier["integration_key"] = v.(string)
-		delete(settings, "integrationKey")
-	}
-	if v, ok := settings["severity"]; ok && v != nil {
-		notifier["severity"] = v.(string)
-		delete(settings, "severity")
-	}
-	if v, ok := settings["class"]; ok && v != nil {
-		notifier["class"] = v.(string)
-		delete(settings, "class")
-	}
-	if v, ok := settings["component"]; ok && v != nil {
-		notifier["component"] = v.(string)
-		delete(settings, "component")
-	}
-	if v, ok := settings["group"]; ok && v != nil {
-		notifier["group"] = v.(string)
-		delete(settings, "group")
-	}
-	if v, ok := settings["summary"]; ok && v != nil {
-		notifier["summary"] = v.(string)
-		delete(settings, "summary")
-	}
-	if v, ok := settings["source"]; ok && v != nil {
-		notifier["source"] = v.(string)
-		delete(settings, "source")
-	}
-	if v, ok := settings["client"]; ok && v != nil {
-		notifier["client"] = v.(string)
-		delete(settings, "client")
-	}
-	if v, ok := settings["client_url"]; ok && v != nil {
-		notifier["client_url"] = v.(string)
-		delete(settings, "client_url")
-	}
-	if v, ok := settings["details"]; ok && v != nil {
-		notifier["details"] = unpackMap(v)
-		delete(settings, "details")
-	}
-	if v, ok := settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "url")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, n, p.UID), n.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (n pagerDutyNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["integrationKey"] = json["integration_key"].(string)
-	if v, ok := json["severity"]; ok && v != nil {
-		settings["severity"] = v.(string)
-	}
-	if v, ok := json["class"]; ok && v != nil {
-		settings["class"] = v.(string)
-	}
-	if v, ok := json["component"]; ok && v != nil {
-		settings["component"] = v.(string)
-	}
-	if v, ok := json["group"]; ok && v != nil {
-		settings["group"] = v.(string)
-	}
-	if v, ok := json["summary"]; ok && v != nil {
-		settings["summary"] = v.(string)
-	}
-	if v, ok := json["source"]; ok && v != nil {
-		settings["source"] = v.(string)
-	}
-	if v, ok := json["client"]; ok && v != nil {
-		settings["client"] = v.(string)
-	}
-	if v, ok := json["client_url"]; ok && v != nil {
-		settings["client_url"] = v.(string)
-	}
-	if v, ok := json["details"]; ok && v != nil {
-		settings["details"] = unpackMap(v)
-	}
-	if v, ok := json["url"]; ok && v != nil {
-		settings["url"] = v.(string)
-	}
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(n.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type pushoverNotifier struct{}
 
 var _ notifier = (*pushoverNotifier)(nil)
 
 func (n pushoverNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "pushover",
-		typeStr:      "pushover",
-		desc:         "A contact point that sends notifications to Pushover.",
-		secureFields: []string{"user_key", "api_token"},
+		field:   "pushover",
+		typeStr: "pushover",
+		desc:    "A contact point that sends notifications to Pushover.",
+		fieldMapper: map[string]fieldMapper{
+			"user_key":     newKeyMapper("userKey"),
+			"api_token":    newKeyMapper("apiToken"),
+			"ok_sound":     newKeyMapper("okSound"),
+			"upload_image": newKeyMapper("uploadImage"),
+			// For unclear legacy reasons, these are sent as a string to Grafana API.
+			"ok_priority": newFieldMapper("okPriority", valueAsInt, valueAsString),
+			"priority":    newFieldMapper("", valueAsInt, valueAsString),
+			"retry":       newFieldMapper("", valueAsInt, valueAsString),
+			"expire":      newFieldMapper("", valueAsInt, valueAsString),
+		},
 	}
 }
 
@@ -1201,136 +665,18 @@ func (n pushoverNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (n pushoverNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["userKey"]; ok && v != nil {
-		notifier["user_key"] = v.(string)
-		delete(settings, "userKey")
-	}
-	if v, ok := settings["apiToken"]; ok && v != nil {
-		notifier["api_token"] = v.(string)
-		delete(settings, "apiToken")
-	}
-	if v, ok := settings["priority"]; ok && v != nil {
-		priority, err := strconv.Atoi(v.(string))
-		if err != nil {
-			return nil, err
-		}
-		notifier["priority"] = priority
-		delete(settings, "priority")
-	}
-	if v, ok := settings["okPriority"]; ok && v != nil {
-		priority, err := strconv.Atoi(v.(string))
-		if err != nil {
-			return nil, err
-		}
-		notifier["ok_priority"] = priority
-		delete(settings, "okPriority")
-	}
-	if v, ok := settings["retry"]; ok && v != nil {
-		priority, err := strconv.Atoi(v.(string))
-		if err != nil {
-			return nil, err
-		}
-		notifier["retry"] = priority
-		delete(settings, "retry")
-	}
-	if v, ok := settings["expire"]; ok && v != nil {
-		priority, err := strconv.Atoi(v.(string))
-		if err != nil {
-			return nil, err
-		}
-		notifier["expire"] = priority
-		delete(settings, "expire")
-	}
-	if v, ok := settings["device"]; ok && v != nil {
-		notifier["device"] = v.(string)
-		delete(settings, "device")
-	}
-	if v, ok := settings["sound"]; ok && v != nil {
-		notifier["sound"] = v.(string)
-		delete(settings, "sound")
-	}
-	if v, ok := settings["okSound"]; ok && v != nil {
-		notifier["ok_sound"] = v.(string)
-		delete(settings, "okSound")
-	}
-	if v, ok := settings["title"]; ok && v != nil {
-		notifier["title"] = v.(string)
-		delete(settings, "title")
-	}
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-	if v, ok := settings["uploadImage"]; ok && v != nil {
-		notifier["upload_image"] = v.(bool)
-		delete(settings, "uploadImage")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, n, p.UID), n.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (n pushoverNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["userKey"] = json["user_key"].(string)
-	settings["apiToken"] = json["api_token"].(string)
-	if v, ok := json["priority"]; ok && v != nil {
-		settings["priority"] = strconv.Itoa(v.(int))
-	}
-	if v, ok := json["ok_priority"]; ok && v != nil {
-		settings["okPriority"] = strconv.Itoa(v.(int))
-	}
-	if v, ok := json["retry"]; ok && v != nil {
-		settings["retry"] = strconv.Itoa(v.(int))
-	}
-	if v, ok := json["expire"]; ok && v != nil {
-		settings["expire"] = strconv.Itoa(v.(int))
-	}
-	if v, ok := json["device"]; ok && v != nil {
-		settings["device"] = v.(string)
-	}
-	if v, ok := json["sound"]; ok && v != nil {
-		settings["sound"] = v.(string)
-	}
-	if v, ok := json["ok_sound"]; ok && v != nil {
-		settings["okSound"] = v.(string)
-	}
-	if v, ok := json["title"]; ok && v != nil {
-		settings["title"] = v.(string)
-	}
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	if v, ok := json["upload_image"]; ok && v != nil {
-		settings["uploadImage"] = v.(bool)
-	}
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(n.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type sensugoNotifier struct{}
 
 var _ notifier = (*sensugoNotifier)(nil)
 
 func (s sensugoNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "sensugo",
-		typeStr:      "sensugo",
-		desc:         "A contact point that sends notifications to SensuGo.",
-		secureFields: []string{"api_key"},
+		field:   "sensugo",
+		typeStr: "sensugo",
+		desc:    "A contact point that sends notifications to SensuGo.",
+		fieldMapper: map[string]fieldMapper{
+			"api_key": newKeyMapper("apikey"),
+		},
 	}
 }
 
@@ -1375,74 +721,6 @@ func (s sensugoNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (s sensugoNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-	if v, ok := settings["url"]; ok && v != nil {
-		notifier["url"] = v.(string)
-		delete(settings, "url")
-	}
-	if v, ok := settings["apikey"]; ok && v != nil {
-		notifier["api_key"] = v.(string)
-		delete(settings, "apikey")
-	}
-	if v, ok := settings["entity"]; ok && v != nil {
-		notifier["entity"] = v.(string)
-		delete(settings, "entity")
-	}
-	if v, ok := settings["check"]; ok && v != nil {
-		notifier["check"] = v.(string)
-		delete(settings, "check")
-	}
-	if v, ok := settings["namespace"]; ok && v != nil {
-		notifier["namespace"] = v.(string)
-		delete(settings, "namespace")
-	}
-	if v, ok := settings["handler"]; ok && v != nil {
-		notifier["handler"] = v.(string)
-		delete(settings, "handler")
-	}
-	if v, ok := settings["message"]; ok && v != nil {
-		notifier["message"] = v.(string)
-		delete(settings, "message")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, s, p.UID), s.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (s sensugoNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	settings["url"] = json["url"].(string)
-	settings["apikey"] = json["api_key"].(string)
-	if v, ok := json["entity"]; ok && v != nil {
-		settings["entity"] = v.(string)
-	}
-	if v, ok := json["check"]; ok && v != nil {
-		settings["check"] = v.(string)
-	}
-	if v, ok := json["namespace"]; ok && v != nil {
-		settings["namespace"] = v.(string)
-	}
-	if v, ok := json["handler"]; ok && v != nil {
-		settings["handler"] = v.(string)
-	}
-	if v, ok := json["message"]; ok && v != nil {
-		settings["message"] = v.(string)
-	}
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(s.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type slackNotifier struct{}
 
 var _ notifier = (*slackNotifier)(nil)
@@ -1455,10 +733,15 @@ func (s slackNotifier) HasData(data map[string]any) bool {
 
 func (s slackNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "slack",
-		typeStr:      "slack",
-		desc:         "A contact point that sends notifications to Slack.",
-		secureFields: []string{"url", "token"},
+		field:   "slack",
+		typeStr: "slack",
+		desc:    "A contact point that sends notifications to Slack.",
+		fieldMapper: map[string]fieldMapper{
+			"endpoint_url":    newKeyMapper("endpointUrl"),
+			"mention_channel": newKeyMapper("mentionChannel"),
+			"mention_users":   newKeyMapper("mentionUsers"),
+			"mention_groups":  newKeyMapper("mentionGroups"),
+		},
 	}
 }
 
@@ -1534,68 +817,23 @@ func (s slackNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (s slackNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "endpointUrl", "endpoint_url")
-	packNotifierStringField(&settings, &notifier, "url", "url")
-	packNotifierStringField(&settings, &notifier, "token", "token")
-	packNotifierStringField(&settings, &notifier, "recipient", "recipient")
-	packNotifierStringField(&settings, &notifier, "text", "text")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	packNotifierStringField(&settings, &notifier, "username", "username")
-	packNotifierStringField(&settings, &notifier, "icon_emoji", "icon_emoji")
-	packNotifierStringField(&settings, &notifier, "icon_url", "icon_url")
-	packNotifierStringField(&settings, &notifier, "mentionChannel", "mention_channel")
-	packNotifierStringField(&settings, &notifier, "mentionUsers", "mention_users")
-	packNotifierStringField(&settings, &notifier, "mentionGroups", "mention_groups")
-	packNotifierStringField(&settings, &notifier, "color", "color")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, s, p.UID), s.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-
-	return notifier, nil
-}
-
-func (s slackNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "endpoint_url", "endpointUrl")
-	unpackNotifierStringField(&json, &settings, "url", "url")
-	unpackNotifierStringField(&json, &settings, "token", "token")
-	unpackNotifierStringField(&json, &settings, "recipient", "recipient")
-	unpackNotifierStringField(&json, &settings, "text", "text")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	unpackNotifierStringField(&json, &settings, "username", "username")
-	unpackNotifierStringField(&json, &settings, "icon_emoji", "icon_emoji")
-	unpackNotifierStringField(&json, &settings, "icon_url", "icon_url")
-	unpackNotifierStringField(&json, &settings, "mention_channel", "mentionChannel")
-	unpackNotifierStringField(&json, &settings, "mention_users", "mentionUsers")
-	unpackNotifierStringField(&json, &settings, "mention_groups", "mentionGroups")
-	unpackNotifierStringField(&json, &settings, "color", "color")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(s.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type snsNotifier struct{}
 
 var _ notifier = (*snsNotifier)(nil)
 
 func (s snsNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "sns",
-		typeStr:      "sns",
-		desc:         "A contact point that sends notifications to Amazon SNS. Requires Amazon Managed Grafana.",
-		secureFields: []string{"access_key", "secret_key"},
+		field:   "sns",
+		typeStr: "sns",
+		desc:    "A contact point that sends notifications to Amazon SNS. Requires Amazon Managed Grafana.",
+		fieldMapper: map[string]fieldMapper{
+			"auth_provider":   newKeyMapper("authProvider"),
+			"access_key":      newKeyMapper("accessKey"),
+			"secret_key":      newKeyMapper("secretKey"),
+			"assume_role_arn": newKeyMapper("assumeRoleARN"),
+			"message_format":  newKeyMapper("messageFormat"),
+			"external_id":     newKeyMapper("externalId"),
+		},
 	}
 }
 
@@ -1654,60 +892,19 @@ func (s snsNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (s snsNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "topic", "topic")
-	packNotifierStringField(&settings, &notifier, "authProvider", "auth_provider")
-	packNotifierStringField(&settings, &notifier, "accessKey", "access_key")
-	packNotifierStringField(&settings, &notifier, "secretKey", "secret_key")
-	packNotifierStringField(&settings, &notifier, "assumeRoleARN", "assume_role_arn")
-	packNotifierStringField(&settings, &notifier, "messageFormat", "message_format")
-	packNotifierStringField(&settings, &notifier, "body", "body")
-	packNotifierStringField(&settings, &notifier, "subject", "subject")
-	packNotifierStringField(&settings, &notifier, "externalId", "external_id")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, s, p.UID), s.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-
-	return notifier, nil
-}
-
-func (s snsNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "topic", "topic")
-	unpackNotifierStringField(&json, &settings, "auth_provider", "authProvider")
-	unpackNotifierStringField(&json, &settings, "access_key", "accessKey")
-	unpackNotifierStringField(&json, &settings, "secret_key", "secretKey")
-	unpackNotifierStringField(&json, &settings, "assume_role_arn", "assumeRoleARN")
-	unpackNotifierStringField(&json, &settings, "message_format", "messageFormat")
-	unpackNotifierStringField(&json, &settings, "body", "body")
-	unpackNotifierStringField(&json, &settings, "subject", "subject")
-	unpackNotifierStringField(&json, &settings, "external_id", "externalId")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(s.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type teamsNotifier struct{}
 
 var _ notifier = (*teamsNotifier)(nil)
 
 func (t teamsNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "teams",
-		typeStr:      "teams",
-		desc:         "A contact point that sends notifications to Microsoft Teams.",
-		secureFields: []string{"url"},
+		field:   "teams",
+		typeStr: "teams",
+		desc:    "A contact point that sends notifications to Microsoft Teams.",
+		fieldMapper: map[string]fieldMapper{
+			"section_title": newKeyMapper("sectiontitle"),
+			"chat_id":       newKeyMapper("chatid"),
+		},
 	}
 }
 
@@ -1737,49 +934,19 @@ func (t teamsNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (t teamsNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "url", "url")
-	packNotifierStringField(&settings, &notifier, "message", "message")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	packNotifierStringField(&settings, &notifier, "sectiontitle", "section_title")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, t, p.UID), t.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (t teamsNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "url", "url")
-	unpackNotifierStringField(&json, &settings, "message", "message")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	unpackNotifierStringField(&json, &settings, "section_title", "sectiontitle")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(t.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type telegramNotifier struct{}
 
 var _ notifier = (*telegramNotifier)(nil)
 
 func (t telegramNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "telegram",
-		typeStr:      "telegram",
-		desc:         "A contact point that sends notifications to Telegram.",
-		secureFields: []string{"token"},
+		field:   "telegram",
+		typeStr: "telegram",
+		desc:    "A contact point that sends notifications to Telegram.",
+		fieldMapper: map[string]fieldMapper{
+			"token":   newKeyMapper("bottoken"),
+			"chat_id": newKeyMapper("chatid"),
+		},
 	}
 }
 
@@ -1830,74 +997,16 @@ func (t telegramNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (t telegramNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "bottoken", "token")
-	packNotifierStringField(&settings, &notifier, "chatid", "chat_id")
-	packNotifierStringField(&settings, &notifier, "message_thread_id", "message_thread_id")
-	packNotifierStringField(&settings, &notifier, "message", "message")
-	packNotifierStringField(&settings, &notifier, "parse_mode", "parse_mode")
-
-	if v, ok := settings["disable_web_page_preview"]; ok && v != nil {
-		notifier["disable_web_page_preview"] = v.(bool)
-		delete(settings, "disable_web_page_preview")
-	}
-	if v, ok := settings["protect_content"]; ok && v != nil {
-		notifier["protect_content"] = v.(bool)
-		delete(settings, "protect_content")
-	}
-	if v, ok := settings["disable_notifications"]; ok && v != nil {
-		notifier["disable_notifications"] = v.(bool)
-		delete(settings, "disable_notifications")
-	}
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, t, p.UID), t.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (t telegramNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "token", "bottoken")
-	unpackNotifierStringField(&json, &settings, "chat_id", "chatid")
-	unpackNotifierStringField(&json, &settings, "message_thread_id", "message_thread_id")
-	unpackNotifierStringField(&json, &settings, "message", "message")
-	unpackNotifierStringField(&json, &settings, "parse_mode", "parse_mode")
-
-	if v, ok := json["disable_web_page_preview"]; ok && v != nil {
-		settings["disable_web_page_preview"] = v.(bool)
-	}
-	if v, ok := json["protect_content"]; ok && v != nil {
-		settings["protect_content"] = v.(bool)
-	}
-	if v, ok := json["disable_notifications"]; ok && v != nil {
-		settings["disable_notifications"] = v.(bool)
-	}
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(t.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type threemaNotifier struct{}
 
 var _ notifier = (*threemaNotifier)(nil)
 
 func (t threemaNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "threema",
-		typeStr:      "threema",
-		desc:         "A contact point that sends notifications to Threema.",
-		secureFields: []string{"api_secret"},
+		field:       "threema",
+		typeStr:     "threema",
+		desc:        "A contact point that sends notifications to Threema.",
+		fieldMapper: map[string]fieldMapper{},
 	}
 }
 
@@ -1932,51 +1041,18 @@ func (t threemaNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (t threemaNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "gateway_id", "gateway_id")
-	packNotifierStringField(&settings, &notifier, "recipient_id", "recipient_id")
-	packNotifierStringField(&settings, &notifier, "api_secret", "api_secret")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	packNotifierStringField(&settings, &notifier, "description", "description")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, t, p.UID), t.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (t threemaNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "gateway_id", "gateway_id")
-	unpackNotifierStringField(&json, &settings, "recipient_id", "recipient_id")
-	unpackNotifierStringField(&json, &settings, "api_secret", "api_secret")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	unpackNotifierStringField(&json, &settings, "description", "description")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(t.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type victorOpsNotifier struct{}
 
 var _ notifier = (*victorOpsNotifier)(nil)
 
 func (v victorOpsNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "victorops",
-		typeStr:      "victorops",
-		desc:         "A contact point that sends notifications to VictorOps (now known as Splunk OnCall).",
-		secureFields: []string{"url"},
+		field:   "victorops",
+		typeStr: "victorops",
+		desc:    "A contact point that sends notifications to VictorOps (now known as Splunk OnCall).",
+		fieldMapper: map[string]fieldMapper{
+			"message_type": newKeyMapper("messageType"),
+		},
 	}
 }
 
@@ -2006,49 +1082,18 @@ func (v victorOpsNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (v victorOpsNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "url", "url")
-	packNotifierStringField(&settings, &notifier, "messageType", "message_type")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	packNotifierStringField(&settings, &notifier, "description", "description")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, v, p.UID), v.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (v victorOpsNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "url", "url")
-	unpackNotifierStringField(&json, &settings, "message_type", "messageType")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	unpackNotifierStringField(&json, &settings, "description", "description")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(v.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
-}
-
 type webexNotifier struct{}
 
 var _ notifier = (*webexNotifier)(nil)
 
 func (w webexNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "webex",
-		typeStr:      "webex",
-		desc:         "A contact point that sends notifications to Cisco Webex.",
-		secureFields: []string{"token"},
+		field:   "webex",
+		typeStr: "webex",
+		desc:    "A contact point that sends notifications to Cisco Webex.",
+		fieldMapper: map[string]fieldMapper{
+			"token": newKeyMapper("bot_token"),
+		},
 	}
 }
 
@@ -2076,39 +1121,6 @@ func (w webexNotifier) schema() *schema.Resource {
 		Description: "ID of the Webex Teams room where to send the messages.",
 	}
 	return r
-}
-
-func (w webexNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "bot_token", "token")
-	packNotifierStringField(&settings, &notifier, "api_url", "api_url")
-	packNotifierStringField(&settings, &notifier, "message", "message")
-	packNotifierStringField(&settings, &notifier, "room_id", "room_id")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, w, p.UID), w.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (w webexNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "token", "bot_token")
-	unpackNotifierStringField(&json, &settings, "api_url", "api_url")
-	unpackNotifierStringField(&json, &settings, "message", "message")
-	unpackNotifierStringField(&json, &settings, "room_id", "room_id")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(w.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
 }
 
 type webhookNotifier struct{}
@@ -2188,14 +1200,6 @@ func (w webhookNotifier) schema() *schema.Resource {
 	return r
 }
 
-func (w webhookNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	return packNotifier(p, data, w), nil
-}
-
-func (w webhookNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	return unpackNotifier(raw.(map[string]any), name, w)
-}
-
 type wecomNotifier struct{}
 
 var _ notifier = (*wecomNotifier)(nil)
@@ -2208,10 +1212,13 @@ func (w wecomNotifier) HasData(data map[string]any) bool {
 
 func (w wecomNotifier) meta() notifierMeta {
 	return notifierMeta{
-		field:        "wecom",
-		typeStr:      "wecom",
-		desc:         "A contact point that sends notifications to WeCom.",
-		secureFields: []string{"url", "secret"},
+		field:   "wecom",
+		typeStr: "wecom",
+		desc:    "A contact point that sends notifications to WeCom.",
+		fieldMapper: map[string]fieldMapper{
+			"msg_type": newKeyMapper("msgtype"),
+			"to_user":  newKeyMapper("touser"),
+		},
 	}
 }
 
@@ -2261,45 +1268,4 @@ func (w wecomNotifier) schema() *schema.Resource {
 		Description: "The ID of user that should receive the message. Multiple entries should be separated by '|'. Default: @all.",
 	}
 	return r
-}
-
-func (w wecomNotifier) pack(p *models.EmbeddedContactPoint, data *schema.ResourceData) (any, error) {
-	notifier := packCommonNotifierFields(p)
-	settings := p.Settings.(map[string]any)
-
-	packNotifierStringField(&settings, &notifier, "url", "url")
-	packNotifierStringField(&settings, &notifier, "message", "message")
-	packNotifierStringField(&settings, &notifier, "title", "title")
-	packNotifierStringField(&settings, &notifier, "secret", "secret")
-	packNotifierStringField(&settings, &notifier, "corp_id", "corp_id")
-	packNotifierStringField(&settings, &notifier, "agent_id", "agent_id")
-	packNotifierStringField(&settings, &notifier, "msgtype", "msg_type")
-	packNotifierStringField(&settings, &notifier, "touser", "to_user")
-
-	packSecureFields(notifier, getNotifierConfigFromStateWithUID(data, w, p.UID), w.meta().secureFields)
-
-	notifier["settings"] = packSettings(p)
-	return notifier, nil
-}
-
-func (w wecomNotifier) unpack(raw any, name string) *models.EmbeddedContactPoint {
-	json := raw.(map[string]any)
-	uid, disableResolve, settings := unpackCommonNotifierFields(json)
-
-	unpackNotifierStringField(&json, &settings, "url", "url")
-	unpackNotifierStringField(&json, &settings, "message", "message")
-	unpackNotifierStringField(&json, &settings, "title", "title")
-	unpackNotifierStringField(&json, &settings, "secret", "secret")
-	unpackNotifierStringField(&json, &settings, "corp_id", "corp_id")
-	unpackNotifierStringField(&json, &settings, "agent_id", "agent_id")
-	unpackNotifierStringField(&json, &settings, "msg_type", "msgtype")
-	unpackNotifierStringField(&json, &settings, "to_user", "touser")
-
-	return &models.EmbeddedContactPoint{
-		UID:                   uid,
-		Name:                  name,
-		Type:                  common.Ref(w.meta().typeStr),
-		DisableResolveMessage: disableResolve,
-		Settings:              settings,
-	}
 }


### PR DESCRIPTION
### Changes
- Improves test coverage for packing and unpacking of alerting contact point resources.  
- Refactors notifier-specific `pack` and `unpack` methods to use shared `packNotifier` and `unpackNotifier` functions.  
- These functions use the existing Terraform schema to automatically handle all fields, ~including nested hierarchies~ and sensitive fields, removing the need for redundant `secureFields` and manual field enumeration.  

### Why
Previously, packing and unpacking was done manually for both sensitive and non-sensitive fields. Sensitive fields had to be listed in `secureFields`, while non-sensitive fields were individually mapped in `pack` and `unpack` methods.  

This created duplication with the schema definition and made every schema change require edits in multiple places:  
1. Update the `schema` method.  
2. Update `pack` to store the field in Terraform state.  
3. Update `unpack` to send the field to the Grafana API.  
4. Update `secureFields` if the field was sensitive.  

Because of this, the code was harder to maintain and the actual logic that mattered for each notifier, such as key or value transformations, was buried in boilerplate.  

For example:  
- In the `pushover` notifier, the TF field `ok_priority` maps to `okPriority` in the Grafana API. The value is stored as an integer in Terraform but sent as a string to the API. This important detail was easy to miss among all the repetitive field mappings.  

~The old approach also did not support deeply nested fields/secrets, which we need for upcoming work (ex. `http_config`).~ **NOTE**: Extracted support for packing/unpacking nested schemas from this PR to make the noop refactor easier to review, will add it back with the PR for `http_config` and `payload` webhook fields.

The new approach:
- Uses the schema as the single source of truth for packing and unpacking.  
- Automatically handles sensitive fields without needing a separate `secureFields` list.  
- Makes notifier-specific code smaller and clearer by keeping only the field transformations that actually differ.  
- Reduces duplication and makes schema changes easier and less error-prone.
- Supports both sensitive and non-sensitive deeply nested fields.

### Reviewer notes
Tested to ensure TF state and Grafana state remains consistent before and after the refactor:  
- Existing Terraform state remains unchanged after update and destroy/apply.
- Existing Grafana state remains unchanged after update and destroy/apply.

This was done with the existing "fully defined contact points" as well as the newly added "minimal contact points" to ensure defaults/omissions were unaffected.