### PR TITLE
Add ID field to app platform resources

### DIFF
--- a/docs/resources/apps_dashboard_dashboard_v1beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v1beta1.md
@@ -25,6 +25,10 @@ Manages Grafana dashboards using the new Grafana APIs.
 - `options` (Block, Optional) Options for applying the resource. (see [below for nested schema](#nestedblock--options))
 - `spec` (Block, Optional) The spec of the resource. (see [below for nested schema](#nestedblock--spec))
 
+### Read-Only
+
+- `id` (String) The ID of the resource derived from UID.
+
 <a id="nestedblock--metadata"></a>
 ### Nested Schema for `metadata`
 

--- a/docs/resources/apps_dashboard_dashboard_v1beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v1beta1.md
@@ -27,7 +27,7 @@ Manages Grafana dashboards using the new Grafana APIs.
 
 ### Read-Only
 
-- `id` (String) The ID of the resource derived from UID.
+- `id` (String) The ID of the resource derived from UUID.
 
 <a id="nestedblock--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/resources/apps_playlist_playlist_v0alpha1.md
+++ b/docs/resources/apps_playlist_playlist_v0alpha1.md
@@ -25,6 +25,10 @@ Manages Grafana playlists using the new Grafana APIs.
 - `options` (Block, Optional) Options for applying the resource. (see [below for nested schema](#nestedblock--options))
 - `spec` (Block, Optional) The spec of the resource. (see [below for nested schema](#nestedblock--spec))
 
+### Read-Only
+
+- `id` (String) The ID of the resource derived from UID.
+
 <a id="nestedblock--metadata"></a>
 ### Nested Schema for `metadata`
 

--- a/docs/resources/apps_playlist_playlist_v0alpha1.md
+++ b/docs/resources/apps_playlist_playlist_v0alpha1.md
@@ -27,7 +27,7 @@ Manages Grafana playlists using the new Grafana APIs.
 
 ### Read-Only
 
-- `id` (String) The ID of the resource derived from UID.
+- `id` (String) The ID of the resource derived from UUID.
 
 <a id="nestedblock--metadata"></a>
 ### Nested Schema for `metadata`

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -24,6 +24,7 @@ import (
 
 // ResourceModel is a Terraform model for a Grafana resource.
 type ResourceModel struct {
+	ID       types.String `tfsdk:"id"`
 	Metadata types.Object `tfsdk:"metadata"`
 	Spec     types.Object `tfsdk:"spec"`
 	Options  types.Object `tfsdk:"options"`
@@ -106,6 +107,15 @@ func (r *Resource[T, L]) Schema(ctx context.Context, req resource.SchemaRequest,
 		Description:         sch.Description,
 		MarkdownDescription: sch.MarkdownDescription,
 		DeprecationMessage:  sch.DeprecationMessage,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the resource derived from UID.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
 		Blocks: map[string]schema.Block{
 			"metadata": schema.SingleNestedBlock{
 				Description: "The metadata of the resource.",
@@ -509,6 +519,8 @@ func SaveResourceToModel[T sdkresource.Object](
 			return diag
 		}
 	}
+
+	dst.ID = meta.UID
 
 	return diag
 }

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -110,7 +110,7 @@ func (r *Resource[T, L]) Schema(ctx context.Context, req resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
-				Description: "The ID of the resource derived from UID.",
+				Description: "The ID of the resource derived from UUID.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -520,7 +520,7 @@ func SaveResourceToModel[T sdkresource.Object](
 		}
 	}
 
-	dst.ID = meta.UID
+	dst.ID = meta.UUID
 
 	return diag
 }

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -9,18 +9,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
-func makeMockResource(name string) sdkresource.Object {
+func makeMockResource(name, uid string) sdkresource.Object {
 	obj := v0alpha1.PlaylistKind().Schema.ZeroValue()
 	obj.SetName(name)
+	obj.SetUID(k8stypes.UID(uid))
 	return obj
 }
 
 func TestSaveResourceToModel_ID_Field(t *testing.T) {
 	ctx := context.Background()
 
-	src := makeMockResource("test-uid")
+	testUUID := "test-uuid-12345"
+	src := makeMockResource("test-name", testUUID)
 
 	dst := &ResourceModel{
 		Metadata: types.ObjectValueMust(
@@ -43,5 +46,5 @@ func TestSaveResourceToModel_ID_Field(t *testing.T) {
 
 	diags := SaveResourceToModel(ctx, src, dst)
 	require.False(t, diags.HasError())
-	require.Equal(t, "test-uid", dst.ID.ValueString())
+	require.Equal(t, testUUID, dst.ID.ValueString())
 }

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -1,0 +1,47 @@
+package appplatform
+
+import (
+	"context"
+	"testing"
+
+	sdkresource "github.com/grafana/grafana-app-sdk/resource"
+	"github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMockResource(name string) sdkresource.Object {
+	obj := v0alpha1.PlaylistKind().Schema.ZeroValue()
+	obj.SetName(name)
+	return obj
+}
+
+func TestSaveResourceToModel_ID_Field(t *testing.T) {
+	ctx := context.Background()
+
+	src := makeMockResource("test-uid")
+
+	dst := &ResourceModel{
+		Metadata: types.ObjectValueMust(
+			map[string]attr.Type{
+				"uuid":       types.StringType,
+				"uid":        types.StringType,
+				"folder_uid": types.StringType,
+				"version":    types.StringType,
+				"url":        types.StringType,
+			},
+			map[string]attr.Value{
+				"uuid":       types.StringNull(),
+				"uid":        types.StringNull(),
+				"folder_uid": types.StringNull(),
+				"version":    types.StringNull(),
+				"url":        types.StringNull(),
+			},
+		),
+	}
+
+	diags := SaveResourceToModel(ctx, src, dst)
+	require.False(t, diags.HasError())
+	require.Equal(t, "test-uid", dst.ID.ValueString())
+}


### PR DESCRIPTION
Adding a computed ID field to the app platform base Resource model. This field is [required](https://developer.hashicorp.com/terraform/plugin/framework/acctests#no-id-found-in-attributes) with by the current testing framework version for acceptance tests.

The field is computed and should not result in a plan change. Tested locally:

1. Created a new `grafana_apps_playlist_playlist_v0alpha1` resource
2. Applied it with the old provider version and checked the state: no id field

```
terraform state show 'grafana_apps_playlist_playlist_v0alpha1.test_playlist'

# grafana_apps_playlist_playlist_v0alpha1.test_playlist:
resource "grafana_apps_playlist_playlist_v0alpha1" "test_playlist" {
    metadata {
        uid     = "tf_test_playlist"
        uuid    = "D2tQoZxmFNLHZ55sHDzaooxGV97VxtexXNl9nDE2E8sX"
        version = "1757057965719"
    }
    options {
        overwrite = true
    }
    spec {
        interval = "1h"
        items    = [
            {
                type  = "dashboard_by_uid"
                value = "ed155665"
            },
        ]
        title    = "[tf] Test Playlist"
    }
}
```

3. Updated the provider version and ran the plan again:

```
terraform plan

...
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```