### PR TITLE
fix: extend default retry status codes with 412

### DIFF
--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -367,6 +367,28 @@ func TestAccFolder_PreventDeletionNested(t *testing.T) {
 	})
 }
 
+func TestAccFolder_RapidCreation(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	folderCount := 100
+
+	var checks []resource.TestCheckFunc
+	for i := 0; i < folderCount; i++ {
+		checks = append(checks, resource.TestCheckResourceAttr(fmt.Sprintf("grafana_folder.rapid[%d]", i), "title", fmt.Sprintf("Rapid Test Folder %s %d", name, i)))
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFolderExample_RapidCreation(name, folderCount),
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+		},
+	})
+}
+
 // This is a bug in Grafana, not the provider. It was fixed in 9.2.7+ and 9.3.0+, this test will check for regressions
 func TestAccFolder_createFromDifferentRoles(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.2.7")
@@ -474,4 +496,14 @@ func testAccFolderExample_PreventDeletion(name string, preventDeletion bool) str
 			%[2]s
 		}
 	`, name, preventDeletionStr)
+}
+
+func testAccFolderExample_RapidCreation(name string, count int) string {
+	return fmt.Sprintf(`
+        resource "grafana_folder" "rapid" {
+            count = %[2]d
+            uid   = "rapid-test-%[1]s-${count.index}"
+            title = "Rapid Test Folder %[1]s ${count.index}"
+        }
+    `, name, count)
 }

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -382,8 +382,14 @@ func TestAccFolder_RapidCreation(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFolderExample_RapidCreation(folderCount),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Config: fmt.Sprintf(`
+					resource "grafana_folder" "rapid" {
+						count = %[1]d
+						uid   = "rapid_test_${count.index}"
+						title = "Rapid Test Folder ${count.index}"
+					}
+				`, folderCount),
+				Check: resource.ComposeTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -496,14 +502,4 @@ func testAccFolderExample_PreventDeletion(name string, preventDeletion bool) str
 			%[2]s
 		}
 	`, name, preventDeletionStr)
-}
-
-func testAccFolderExample_RapidCreation(count int) string {
-	return fmt.Sprintf(`
-        resource "grafana_folder" "rapid" {
-            count = %[1]d
-            uid   = "rapid_test_${count.index}"
-            title = "Rapid Test Folder ${count.index}"
-        }
-    `, count)
 }

--- a/internal/resources/grafana/resource_folder_test.go
+++ b/internal/resources/grafana/resource_folder_test.go
@@ -370,19 +370,19 @@ func TestAccFolder_PreventDeletionNested(t *testing.T) {
 func TestAccFolder_RapidCreation(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 
-	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	folderCount := 100
 
 	var checks []resource.TestCheckFunc
-	for i := 0; i < folderCount; i++ {
-		checks = append(checks, resource.TestCheckResourceAttr(fmt.Sprintf("grafana_folder.rapid[%d]", i), "title", fmt.Sprintf("Rapid Test Folder %s %d", name, i)))
+	for i := range folderCount {
+		name := fmt.Sprintf("grafana_folder.rapid.%d", i)
+		checks = append(checks, resource.TestCheckResourceAttr(name, "title", fmt.Sprintf("Rapid Test Folder %d", i)))
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFolderExample_RapidCreation(name, folderCount),
+				Config: testAccFolderExample_RapidCreation(folderCount),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -498,12 +498,12 @@ func testAccFolderExample_PreventDeletion(name string, preventDeletion bool) str
 	`, name, preventDeletionStr)
 }
 
-func testAccFolderExample_RapidCreation(name string, count int) string {
+func testAccFolderExample_RapidCreation(count int) string {
 	return fmt.Sprintf(`
         resource "grafana_folder" "rapid" {
-            count = %[2]d
-            uid   = "rapid-test-%[1]s-${count.index}"
-            title = "Rapid Test Folder %[1]s ${count.index}"
+            count = %[1]d
+            uid   = "rapid_test_${count.index}"
+            title = "Rapid Test Folder ${count.index}"
         }
-    `, name, count)
+    `, count)
 }

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -133,6 +133,7 @@ func (c *ProviderConfig) SetDefaults() error {
 			types.StringValue("429"),
 			types.StringValue("5xx"),
 			types.StringValue("401"), // In high load scenarios, Grafana sometimes returns 401s (unable to authenticate the user?)
+			types.StringValue("412"), // Grafana sometimes returns 412s when creating folders in rapid succession
 		})
 	}
 


### PR DESCRIPTION
The issue surfaces intermittently when creating folders in rapid succession. The Grafana server returns `412` response code for some of the folders. In this PR, we extend the default retry HTTP status codes with the new status code encountered. This approach permanently alleviates the problem on the terraform provider side.

**Fixes:** https://github.com/grafana/support-escalations/issues/18187 & https://github.com/grafana/terraform-provider-grafana/issues/2176

**Note:** I haven't been able to pinpoint the issue on the grafana side. I am still looking into it. Most importantly checking where this weird race condition is being triggered.