### PR TITLE
Alerting: Suppport more enrichers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,4 @@
 /internal/resources/slo/*                           @grafana/platform-monitoring @grafana/slo-squad
 /internal/resources/syntheticmonitoring/*           @grafana/platform-monitoring @grafana/synthetic-monitoring
 /internal/resources/appplatform/*                   @grafana/platform-monitoring @grafana/grafana-app-platform-squad
+/internal/resources/appplatform/alertenrichment*    @grafana/platform-monitoring @grafana/alerting-squad

--- a/examples/resources/grafana_apps_alertenrichment_alertenrichment_v1beta1/resource.tf
+++ b/examples/resources/grafana_apps_alertenrichment_alertenrichment_v1beta1/resource.tf
@@ -1,0 +1,110 @@
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "enrichment" {
+  metadata {
+    uid = "test_enrichment"
+  }
+
+  spec {
+    title       = "Comprehensive alert enrichment"
+    description = "Demonstrates many enrichment steps and configurations"
+
+    # Target specific alert rules by UIDs
+    alert_rule_uids = ["alert-rule-1", "alert-rule-2"]
+
+    # Target specific receiver names
+    receivers = ["webhook", "slack-critical"]
+
+    # Label matchers - supports =, !=, =~, !~ operators
+    label_matchers = [
+      {
+        type  = "="
+        name  = "severity"
+        value = "critical"
+      },
+      {
+        type  = "=~"
+        name  = "team"
+        value = "alerting|alerting-team"
+      }
+    ]
+
+    # Annotation matchers
+    annotation_matchers = [
+      {
+        type  = "!="
+        name  = "runbook_url"
+        value = ""
+      }
+    ]
+
+    # Adds annotations to alerts with the assign step
+    step {
+      assign {
+        timeout = "30s"
+        annotations = {
+          "priority"    = "high"
+          "runbook_url" = "https://runbooks.grafana.com/alert-handling"
+        }
+      }
+    }
+
+    # Calls external service
+    step {
+      external {
+        url = "https://some-api.grafana.com/alert-enrichment"
+      }
+    }
+
+    # Data source step with logs query
+    step {
+      data_source {
+        timeout = "30s"
+
+        logs_query {
+          data_source_type = "loki"
+          data_source_uid  = "loki-uid-123"
+          expr             = "{job=\"my-app\"} |= \"error\""
+          max_lines        = 5
+        }
+      }
+    }
+
+    # Data source step with raw query
+    step {
+      data_source {
+        timeout = "30s"
+
+        raw_query {
+          ref_id = "A"
+          request = jsonencode({
+            datasource = {
+              type = "prometheus"
+              uid  = "prometheus-uid-456"
+            }
+            expr          = "rate(http_requests_total[5m])"
+            refId         = "A"
+            intervalMs    = 1000
+            maxDataPoints = 43200
+          })
+        }
+      }
+    }
+
+    # Triggers a new Sift investigation
+    step {
+      sift {}
+    }
+
+    # Generates AI explanation of the alert using Grafana LLM plugin
+    step {
+      explain {
+        annotation = "ai_explanation"
+      }
+    }
+
+
+    # Trigger a new Assistant Investigation
+    step {
+      assistant_investigations {}
+    }
+  }
+}

--- a/internal/resources/appplatform/alertenrichment_resource_acc_test.go
+++ b/internal/resources/appplatform/alertenrichment_resource_acc_test.go
@@ -1,14 +1,20 @@
 package appplatform_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/grafana/authlib/claims"
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	terraformresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const alertEnrichmentResourceName = "grafana_apps_alertenrichment_alertenrichment_v1beta1.test"
@@ -33,14 +39,20 @@ func importStateIDFunc(resourceName string) terraformresource.ImportStateIdFunc 
 
 // alertEnrichmentConfigBuilder helps build HCL for alert enrichments
 type alertEnrichmentConfigBuilder struct {
-	uid           string
-	title         string
-	description   string
-	alertRuleUIDs []string
-	receivers     []string
-	labelMatchers []matcherConfig
-	annotMatchers []matcherConfig
-	assignSteps   []assignStepConfig
+	uid                         string
+	title                       string
+	description                 string
+	alertRuleUIDs               []string
+	receivers                   []string
+	labelMatchers               []matcherConfig
+	annotMatchers               []matcherConfig
+	assignSteps                 []assignStepConfig
+	assistantInvestigationsStep *assistantInvestigationsStepConfig
+	externalStep                *externalStepConfig
+	assertsStep                 *assertsStepConfig
+	explainStep                 *explainStepConfig
+	siftStep                    *siftStepConfig
+	dataSourceSteps             []dataSourceStepConfig
 }
 
 type matcherConfig struct {
@@ -52,6 +64,46 @@ type matcherConfig struct {
 type assignStepConfig struct {
 	timeout     string
 	annotations map[string]string
+}
+
+type assistantInvestigationsStepConfig struct {
+	timeout string
+}
+
+type externalStepConfig struct {
+	timeout string
+	url     string
+}
+
+type assertsStepConfig struct {
+	timeout string
+}
+
+type explainStepConfig struct {
+	timeout    string
+	annotation string
+}
+
+type siftStepConfig struct {
+	timeout string
+}
+
+type dataSourceStepConfig struct {
+	timeout   string
+	logsQuery *logsQueryConfig
+	rawQuery  *rawQueryConfig
+}
+
+type logsQueryConfig struct {
+	dataSourceType string
+	dataSourceUID  string
+	expr           string
+	maxLines       int
+}
+
+type rawQueryConfig struct {
+	refID   string
+	request string
 }
 
 func newAlertEnrichmentConfig(uid, title string) *alertEnrichmentConfigBuilder {
@@ -90,6 +142,67 @@ func (b *alertEnrichmentConfigBuilder) withAssignStep(timeout string, annotation
 	b.assignSteps = append(b.assignSteps, assignStepConfig{
 		timeout:     timeout,
 		annotations: annotations,
+	})
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withAssistantInvestigationsStep(timeout string) *alertEnrichmentConfigBuilder {
+	b.assistantInvestigationsStep = &assistantInvestigationsStepConfig{
+		timeout: timeout,
+	}
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withExternalStep(timeout string, url string) *alertEnrichmentConfigBuilder {
+	b.externalStep = &externalStepConfig{
+		timeout: timeout,
+		url:     url,
+	}
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withAssertsStep(timeout string) *alertEnrichmentConfigBuilder {
+	b.assertsStep = &assertsStepConfig{
+		timeout: timeout,
+	}
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withExplainStep(timeout string, annotation string) *alertEnrichmentConfigBuilder {
+	b.explainStep = &explainStepConfig{
+		timeout:    timeout,
+		annotation: annotation,
+	}
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withSiftStep(timeout string) *alertEnrichmentConfigBuilder {
+	b.siftStep = &siftStepConfig{
+		timeout: timeout,
+	}
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withDataSourceLogsStep(timeout, dataSourceType, dataSourceUID, expr string, maxLines int) *alertEnrichmentConfigBuilder {
+	b.dataSourceSteps = append(b.dataSourceSteps, dataSourceStepConfig{
+		timeout: timeout,
+		logsQuery: &logsQueryConfig{
+			dataSourceType: dataSourceType,
+			dataSourceUID:  dataSourceUID,
+			expr:           expr,
+			maxLines:       maxLines,
+		},
+	})
+	return b
+}
+
+func (b *alertEnrichmentConfigBuilder) withDataSourceRawStep(timeout, refID, request string) *alertEnrichmentConfigBuilder {
+	b.dataSourceSteps = append(b.dataSourceSteps, dataSourceStepConfig{
+		timeout: timeout,
+		rawQuery: &rawQueryConfig{
+			refID:   refID,
+			request: request,
+		},
 	})
 	return b
 }
@@ -174,7 +287,18 @@ func (b *alertEnrichmentConfigBuilder) buildMatchers() string {
 }
 
 func (b *alertEnrichmentConfigBuilder) buildSteps() string {
-	return b.buildAssignStep()
+	var config string
+
+	// Maintain a consistent order to simplify test assertions
+	config += b.buildAssignStep()
+	config += b.buildAssistantInvestigationStep()
+	config += b.buildExternalStep()
+	config += b.buildAssertsStep()
+	config += b.buildExplainStep()
+	config += b.buildSiftStep()
+	config += b.buildDataSourceStep()
+
+	return config
 }
 
 func (b *alertEnrichmentConfigBuilder) buildAssignStep() string {
@@ -206,6 +330,149 @@ func (b *alertEnrichmentConfigBuilder) buildAssignStep() string {
 		config += `
           }
         }`
+	}
+	return config
+}
+
+func (b *alertEnrichmentConfigBuilder) buildAssistantInvestigationStep() string {
+	if b.assistantInvestigationsStep == nil {
+		return ""
+	}
+
+	timeout := b.assistantInvestigationsStep.timeout
+	if timeout == "" {
+		timeout = "30s"
+	}
+	return fmt.Sprintf(`
+        step {
+          assistant_investigations {
+            timeout = "%s"
+          }
+        }`, timeout)
+}
+
+func (b *alertEnrichmentConfigBuilder) buildExternalStep() string {
+	if b.externalStep == nil || b.externalStep.url == "" {
+		return ""
+	}
+
+	timeout := b.externalStep.timeout
+	if timeout == "" {
+		timeout = "30s"
+	}
+	return fmt.Sprintf(`
+        step {
+          external {
+            timeout = "%s"
+            url = "%s"
+          }
+        }`, timeout, b.externalStep.url)
+}
+
+func (b *alertEnrichmentConfigBuilder) buildAssertsStep() string {
+	if b.assertsStep == nil {
+		return ""
+	}
+
+	timeout := b.assertsStep.timeout
+	if timeout == "" {
+		timeout = "30s"
+	}
+	return fmt.Sprintf(`
+        step {
+          asserts {
+            timeout = "%s"
+          }
+        }`, timeout)
+}
+
+func (b *alertEnrichmentConfigBuilder) buildExplainStep() string {
+	if b.explainStep == nil {
+		return ""
+	}
+
+	timeout := b.explainStep.timeout
+	if timeout == "" {
+		timeout = "30s"
+	}
+	config := fmt.Sprintf(`
+        step {
+          explain {
+            timeout = "%s"`, timeout)
+	if b.explainStep.annotation != "" {
+		config += fmt.Sprintf(`
+            annotation = "%s"`, b.explainStep.annotation)
+	}
+	config += `
+          }
+        }`
+	return config
+}
+
+func (b *alertEnrichmentConfigBuilder) buildSiftStep() string {
+	if b.siftStep == nil {
+		return ""
+	}
+
+	timeout := b.siftStep.timeout
+	if timeout == "" {
+		timeout = "30s"
+	}
+	return fmt.Sprintf(`
+        step {
+          sift {
+            timeout = "%s"
+          }
+        }`, timeout)
+}
+
+func (b *alertEnrichmentConfigBuilder) buildDataSourceStep() string {
+	if len(b.dataSourceSteps) == 0 {
+		return ""
+	}
+	var config string
+	for _, step := range b.dataSourceSteps {
+		timeout := step.timeout
+		if timeout == "" {
+			timeout = "30s"
+		}
+		block := fmt.Sprintf(`
+        step {
+          data_source {
+            timeout = "%s"`, timeout)
+
+		if step.logsQuery != nil {
+			block += `
+            logs_query {`
+			block += fmt.Sprintf(`
+                data_source_type = "%s"
+                expr = "%s"`, step.logsQuery.dataSourceType, step.logsQuery.expr)
+			if step.logsQuery.dataSourceUID != "" {
+				block += fmt.Sprintf(`
+                data_source_uid = "%s"`, step.logsQuery.dataSourceUID)
+			}
+			if step.logsQuery.maxLines > 0 {
+				block += fmt.Sprintf(`
+                max_lines = %d`, step.logsQuery.maxLines)
+			}
+			block += `
+            }`
+		} else if step.rawQuery != nil {
+			block += `
+            raw_query {`
+			block += fmt.Sprintf(`
+                request = %s`, step.rawQuery.request)
+			if step.rawQuery.refID != "" {
+				block += fmt.Sprintf(`
+                ref_id = "%s"`, step.rawQuery.refID)
+			}
+			block += `
+            }`
+		}
+		block += `
+          }
+        }`
+		config += block
 	}
 	return config
 }
@@ -249,6 +516,13 @@ func TestAccAlertEnrichment(t *testing.T) {
 							"second_assign": "true",
 							"sequence":      "2",
 						}).
+						withAssistantInvestigationsStep("31s").
+						withExternalStep("32s", "https://example.com/enrich").
+						withAssertsStep("33s").
+						withExplainStep("34s", "explanation").
+						withSiftStep("35s").
+						withDataSourceLogsStep("36s", "loki", "test-loki-uid", `{job=\"my-app\"} | json | level=\"error\"`, 5).
+						withDataSourceRawStep("37s", "A", `"{\"datasource\":{\"type\":\"prometheus\",\"uid\":\"test-uid\"},\"expr\":\"up\",\"refId\":\"A\"}"`).
 						build(),
 					Check: terraformresource.ComposeTestCheckFunc(
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "comprehensive-alert-enrichment"),
@@ -258,7 +532,7 @@ func TestAccAlertEnrichment(t *testing.T) {
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.label_matchers.#", "2"),
 
 						// Verify steps and ordering
-						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "2"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "9"),
 						// First assign step
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.assign.annotations.%", "4"),
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.assign.timeout", "30s"),
@@ -267,6 +541,26 @@ func TestAccAlertEnrichment(t *testing.T) {
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.1.assign.timeout", "25s"),
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.1.assign.annotations.second_assign", "true"),
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.1.assign.annotations.sequence", "2"),
+
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.2.assistant_investigations.timeout", "31s"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.3.external.timeout", "32s"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.3.external.url", "https://example.com/enrich"),
+
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.4.asserts.timeout", "33s"),
+
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.5.explain.timeout", "34s"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.5.explain.annotation", "explanation"),
+
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.6.sift.timeout", "35s"),
+
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.7.data_source.logs_query.data_source_type", "loki"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.7.data_source.logs_query.data_source_uid", "test-loki-uid"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.7.data_source.logs_query.expr", `{job="my-app"} | json | level="error"`),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.7.data_source.logs_query.max_lines", "5"),
+
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.8.data_source.raw_query.ref_id", "A"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.8.data_source.raw_query.request", `{"datasource":{"type":"prometheus","uid":"test-uid"},"expr":"up","refId":"A"}`),
+
 						terraformresource.TestCheckResourceAttrSet(alertEnrichmentResourceName, "id"),
 					),
 				},
@@ -345,21 +639,17 @@ func TestAccAlertEnrichment(t *testing.T) {
 						terraformresource.TestCheckResourceAttrSet(alertEnrichmentResourceName, "id"),
 					),
 				},
-				// Remove some fields
+				// Remove all fields to minimal configuration (just title, no steps)
 				{
-					Config: newAlertEnrichmentConfig(uid, "minimal-alert-enrichment").
-						withDescription("").withAssignStep("5s", map[string]string{
-						"minimal": "true",
-					}).
-						build(),
+					Config: testAccAlertEnrichmentMinimal(uid),
 					Check: terraformresource.ComposeTestCheckFunc(
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "minimal-alert-enrichment"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", ""),
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.alert_rule_uids.#", "0"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.receivers.#", "0"),
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.label_matchers.#", "0"),
 						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.annotation_matchers.#", "0"),
-						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
-						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.assign.annotations.%", "1"),
-						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.assign.timeout", "5s"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "0"),
 						terraformresource.TestCheckResourceAttrSet(alertEnrichmentResourceName, "id"),
 					),
 				},
@@ -367,7 +657,98 @@ func TestAccAlertEnrichment(t *testing.T) {
 					ResourceName:      alertEnrichmentResourceName,
 					ImportState:       true,
 					ImportStateVerify: true,
+					ImportStateVerifyIgnore: []string{
+						"options.%",
+						"options.overwrite",
+					},
 					ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+				},
+			},
+		})
+	})
+
+	t.Run("invalid_assign_empty_annotations", func(t *testing.T) {
+		randSuffix := acctest.RandString(6)
+
+		terraformresource.ParallelTest(t, terraformresource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []terraformresource.TestStep{
+				{
+					Config:      testAccAlertEnrichmentAssignEmptyAnnotations(fmt.Sprintf("invalid-assign-%s", randSuffix)),
+					ExpectError: regexp.MustCompile("Missing Required Attribute"),
+				},
+			},
+		})
+	})
+
+	t.Run("invalid_data_source_both_queries", func(t *testing.T) {
+		randSuffix := acctest.RandString(6)
+
+		terraformresource.ParallelTest(t, terraformresource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []terraformresource.TestStep{
+				{
+					Config:      testAccAlertEnrichmentDataSourceBothQueries(fmt.Sprintf("invalid-ds-both-%s", randSuffix)),
+					ExpectError: regexp.MustCompile("Invalid number of attributes"),
+				},
+			},
+		})
+	})
+
+	t.Run("invalid_data_source_no_queries", func(t *testing.T) {
+		randSuffix := acctest.RandString(6)
+
+		terraformresource.ParallelTest(t, terraformresource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []terraformresource.TestStep{
+				{
+					Config:      testAccAlertEnrichmentDataSourceNoQueries(fmt.Sprintf("invalid-ds-none-%s", randSuffix)),
+					ExpectError: regexp.MustCompile("Invalid number of attributes"),
+				},
+			},
+		})
+	})
+
+	t.Run("invalid_timeout_format", func(t *testing.T) {
+		randSuffix := acctest.RandString(6)
+
+		terraformresource.ParallelTest(t, terraformresource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []terraformresource.TestStep{
+				{
+					Config:      testAccAlertEnrichmentInvalidTimeout(fmt.Sprintf("invalid-timeout-%s", randSuffix)),
+					ExpectError: regexp.MustCompile("invalid timeout"),
+				},
+			},
+		})
+	})
+
+	t.Run("data_source_query_type_switch", func(t *testing.T) {
+		randSuffix := acctest.RandString(6)
+		uid := fmt.Sprintf("switch-test-%s", randSuffix)
+
+		terraformresource.ParallelTest(t, terraformresource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []terraformresource.TestStep{
+				// Start with logs query
+				{
+					Config: newAlertEnrichmentConfig(uid, "Query Type Switch Test").
+						withDataSourceLogsStep("30s", "loki", "test-uid", `{job=\"test\"}`, 3).
+						build(),
+					Check: terraformresource.ComposeTestCheckFunc(
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.logs_query.data_source_type", "loki"),
+					),
+				},
+				// Switch to raw query
+				{
+					Config: newAlertEnrichmentConfig(uid, "Query Type Switch Test").
+						withDataSourceRawStep("30s", "B", `"{\"datasource\":{\"type\":\"prometheus\",\"uid\":\"prom-uid\"},\"expr\":\"up\"}"`).
+						build(),
+					Check: terraformresource.ComposeTestCheckFunc(
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+						terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.raw_query.ref_id", "B"),
+					),
 				},
 			},
 		})
@@ -553,4 +934,454 @@ func TestAccAlertEnrichment_invalidMatchers(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAccAlertEnrichment_assistantInvestigationsStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("assistant-investigation-%s", randSuffix),
+					"Assistant Investigation Test",
+				).withDescription("Tests assistant investigation").
+					withAssistantInvestigationsStep("50s").
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Assistant Investigation Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests assistant investigation"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.assistant_investigations.timeout", "50s"),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func TestAccAlertEnrichment_externalStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("external-enricher-%s", randSuffix),
+					"External Enricher Test",
+				).withDescription("Tests external HTTP enricher").
+					withExternalStep("45s", "https://grafana.com/enrich-alert").
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "External Enricher Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests external HTTP enricher"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.external.timeout", "45s"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.external.url", "https://grafana.com/enrich-alert"),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func TestAccAlertEnrichment_assertsStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("asserts-enricher-%s", randSuffix),
+					"Asserts Enricher Test",
+				).withDescription("Tests Asserts service integration").
+					withAssertsStep("50s").
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Asserts Enricher Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests Asserts service integration"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.asserts.timeout", "50s"),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func TestAccAlertEnrichment_explainStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			// Test with default annotation
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("explain-%s", randSuffix),
+					"Explain Enricher Test",
+				).withDescription("Tests AI explain enricher with default annotation").
+					withExplainStep("55s", "").
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Explain Enricher Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests AI explain enricher with default annotation"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.explain.timeout", "55s"),
+				),
+			},
+			// Update to custom annotation
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("explain-%s", randSuffix),
+					"Explain Enricher Custom Test",
+				).withDescription("Tests AI explain enricher with custom annotation").
+					withExplainStep("45s", "custom_explanation_field").
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Explain Enricher Custom Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests AI explain enricher with custom annotation"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.explain.timeout", "45s"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.explain.annotation", "custom_explanation_field"),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func TestAccAlertEnrichment_siftStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("sift-enricher-%s", randSuffix),
+					"Sift Enricher Test",
+				).withDescription("Tests Sift service integration").
+					withSiftStep("40s").
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Sift Enricher Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests Sift service integration"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.sift.timeout", "40s"),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func TestAccAlertEnrichment_dataSourceLogsStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("datasource-logs-%s", randSuffix),
+					"Data Source Logs Query Test",
+				).withDescription("Tests data source logs query enricher").
+					withDataSourceLogsStep("35s", "loki", "test-loki-uid", `{job=\"my-app\"} | json | severity=\"error\"`, 5).
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Data Source Logs Query Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests data source logs query enricher"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.timeout", "35s"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.logs_query.data_source_type", "loki"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.logs_query.data_source_uid", "test-loki-uid"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.logs_query.expr", `{job="my-app"} | json | severity="error"`),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.logs_query.max_lines", "5"),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func TestAccAlertEnrichment_dataSourceRawStep(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	randSuffix := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAlertEnrichmentResourceDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("datasource-raw-%s", randSuffix),
+					"Data Source Raw Query Test",
+				).withDescription("Tests data source raw query enricher").
+					withDataSourceRawStep("25s", "A", `"{\"datasource\":{\"type\":\"prometheus\",\"uid\":\"test-uid\"},\"expr\":\"up\",\"refId\":\"A\"}"`).
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Data Source Raw Query Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests data source raw query enricher"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.timeout", "25s"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.raw_query.ref_id", "A"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.raw_query.request", `{"datasource":{"type":"prometheus","uid":"test-uid"},"expr":"up","refId":"A"}`),
+				),
+			},
+			// Test without refId
+			{
+				Config: newAlertEnrichmentConfig(
+					fmt.Sprintf("datasource-raw-%s", randSuffix),
+					"Data Source Raw Query No RefId Test",
+				).withDescription("Tests raw query without refId").
+					withDataSourceRawStep("15s", "", `"{\"datasource\":{\"type\":\"loki\",\"uid\":\"loki-uid\"},\"expr\":\"{job=\\\"test\\\"}\"}" `).
+					build(),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.title", "Data Source Raw Query No RefId Test"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.description", "Tests raw query without refId"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.#", "1"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.timeout", "15s"),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.raw_query.request", `{"datasource":{"type":"loki","uid":"loki-uid"},"expr":"{job=\"test\"}"}`),
+					terraformresource.TestCheckResourceAttr(alertEnrichmentResourceName, "spec.step.0.data_source.raw_query.ref_id", ""),
+				),
+			},
+			{
+				ResourceName:      alertEnrichmentResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"options.%",
+					"options.overwrite",
+				},
+				ImportStateIdFunc: importStateIDFunc(alertEnrichmentResourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckAlertEnrichmentResourceDestroy(s *terraform.State) error {
+	client := testutils.Provider.Meta().(*common.Client)
+
+	for _, r := range s.RootModule().Resources {
+		if r.Type != alertEnrichmentResourceName {
+			continue
+		}
+
+		rcli, err := client.GrafanaAppPlatformAPI.ClientFor(v1beta1.AlertEnrichmentKind())
+		if err != nil {
+			return fmt.Errorf("failed to create app platform client: %w", err)
+		}
+
+		ns := claims.OrgNamespaceFormatter(client.GrafanaOrgID)
+		namespacedClient := resource.NewNamespaced(
+			resource.NewTypedClient[*v1beta1.AlertEnrichment, *v1beta1.AlertEnrichmentList](rcli, v1beta1.AlertEnrichmentKind()),
+			ns,
+		)
+
+		if _, err := namespacedClient.Get(context.Background(), r.Primary.ID); err == nil {
+			return fmt.Errorf("AlertEnrichment %s still exists", r.Primary.ID)
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error checking if AlertEnrichment %s exists: %w", r.Primary.ID, err)
+		}
+	}
+	return nil
+}
+
+func TestAccAlertEnrichment_emptySteps(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=12.2.0")
+
+	uid := acctest.RandString(10)
+
+	terraformresource.ParallelTest(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []terraformresource.TestStep{
+			{
+				Config:      testAccAlertEnrichmentEmptySteps(uid),
+				ExpectError: regexp.MustCompile("Invalid step configuration"),
+			},
+		},
+	})
+}
+
+func testAccAlertEnrichmentMinimal(uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "test" {
+  metadata {
+    uid = "%s"
+  }
+
+  spec {
+    title = "minimal-alert-enrichment"
+  }
+}
+`, uid)
+}
+
+func testAccAlertEnrichmentEmptySteps(uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "test" {
+  metadata {
+    uid = "%s"
+  }
+
+  spec {
+    title = "Empty Steps Enrichment"
+    description = "This should fail validation"
+
+    # Empty steps block - this should cause validation error
+    step {
+    }
+  }
+}
+`, uid)
+}
+
+func testAccAlertEnrichmentAssignEmptyAnnotations(uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "test" {
+  metadata {
+    uid = "%s"
+  }
+
+  spec {
+    title = "Invalid Assign Step"
+    description = "This should fail validation"
+
+    step {
+      assign {
+        timeout = "30s"
+        # Missing annotations - should fail requireAttrsWhenPresent validation
+      }
+    }
+  }
+}
+`, uid)
+}
+
+func testAccAlertEnrichmentDataSourceBothQueries(uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "test" {
+  metadata {
+    uid = "%s"
+  }
+
+  spec {
+    title = "Invalid Data Source Step"
+    description = "This should fail validation"
+
+    step {
+      data_source {
+        timeout = "30s"
+        # Both queries configured - should fail attributeCountExactly(1) validation
+        logs_query {
+          data_source_type = "loki"
+          expr = "{job=\"test\"}"
+        }
+        raw_query {
+          request = "{\"expr\":\"up\"}"
+        }
+      }
+    }
+  }
+}
+`, uid)
+}
+
+func testAccAlertEnrichmentDataSourceNoQueries(uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "test" {
+  metadata {
+    uid = "%s"
+  }
+
+  spec {
+    title = "Invalid Data Source Step"
+    description = "This should fail validation"
+
+    step {
+      data_source {
+        timeout = "30s"
+        # Neither query configured - should fail attributeCountExactly(1) validation
+      }
+    }
+  }
+}
+`, uid)
+}
+
+func testAccAlertEnrichmentInvalidTimeout(uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_apps_alertenrichment_alertenrichment_v1beta1" "test" {
+  metadata {
+    uid = "%s"
+  }
+
+  spec {
+    title = "Invalid Timeout Step"
+    description = "This should fail validation"
+
+    step {
+      assign {
+        timeout = "invalid-timeout-format"
+        annotations = {
+          test = "value"
+        }
+      }
+    }
+  }
+}
+`, uid)
 }


### PR DESCRIPTION
Continuation of https://github.com/grafana/terraform-provider-grafana/pull/2332.

Adds support for more enrichment types:
- external
- sift
- assistant
- data source query
- explain

Part of github.com/grafana/alerting-enricher/issues/73