### PR TITLE
Fixed the generator resource names to be HCL compliant

### DIFF
--- a/pkg/generate/postprocessing/preferred_resource_name.go
+++ b/pkg/generate/postprocessing/preferred_resource_name.go
@@ -68,5 +68,8 @@ func CleanResourceName(name string) string {
 	if cleaned[0] >= '0' && cleaned[0] <= '9' {
 		cleaned = "_" + cleaned
 	}
+	if cleaned[0] == '-' {
+		cleaned = "_" + cleaned
+	}
 	return cleaned
 }


### PR DESCRIPTION
This fixes an issue in the generator that's maybe not common but is technically problematic, at least in my use case, where some resource names end being generated with a "-" as first character, which is not HCL compliant.