### PR TITLE
fix: introduce a mutex for folder resource crud operations

### DIFF
--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -51,12 +51,23 @@ type Client struct {
 	K6APIConfig *k6providerapi.K6APIConfig
 
 	alertingMutex sync.Mutex
+	folderMutex   sync.Mutex
 }
 
 // WithAlertingMutex is a helper function that wraps a CRUD Terraform function with a mutex.
 func WithAlertingMutex[T schema.CreateContextFunc | schema.ReadContextFunc | schema.UpdateContextFunc | schema.DeleteContextFunc](f T) T {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		lock := &meta.(*Client).alertingMutex
+		lock.Lock()
+		defer lock.Unlock()
+		return f(ctx, d, meta)
+	}
+}
+
+// WithFolderMutex is a helper function that wraps a CRUD Terraform function with a mutex.
+func WithFolderMutex[T schema.CreateContextFunc | schema.ReadContextFunc | schema.UpdateContextFunc | schema.DeleteContextFunc](f T) T {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+		lock := &meta.(*Client).folderMutex
 		lock.Lock()
 		defer lock.Unlock()
 		return f(ctx, d, meta)

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -29,10 +29,10 @@ func resourceFolder() *common.Resource {
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
 `,
 
-		CreateContext: CreateFolder,
-		DeleteContext: DeleteFolder,
+		CreateContext: common.WithFolderMutex[schema.CreateContextFunc](CreateFolder),
+		DeleteContext: common.WithFolderMutex[schema.DeleteContextFunc](DeleteFolder),
 		ReadContext:   ReadFolder,
-		UpdateContext: UpdateFolder,
+		UpdateContext: common.WithFolderMutex[schema.UpdateContextFunc](UpdateFolder),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},


### PR DESCRIPTION
We are still sporadically experiencing `412` errors when creating folders in a bulk fashion. I haven't been able to spot the race condition on the grafana side - it must be a very subtle one. Thus, introducing here a mutex for the folder resource create, update and delete operations.

**Related Tickets:** https://github.com/grafana/terraform-provider-grafana/issues/2176#issuecomment-3275307905 and https://github.com/grafana/support-escalations/issues/18187#issuecomment-3268608234