### PR TITLE
Alerting: Add provenance support to alert enrichment resource

### DIFF
--- a/docs/resources/apps_dashboard_dashboard_v1beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v1beta1.md
@@ -60,6 +60,7 @@ Optional:
 
 Read-Only:
 
+- `annotations` (Map of String) Annotations of the resource.
 - `url` (String) The full URL of the resource.
 - `uuid` (String) The globally unique identifier of a resource, used by the API for tracking.
 - `version` (String) The version of the resource.

--- a/docs/resources/apps_playlist_playlist_v0alpha1.md
+++ b/docs/resources/apps_playlist_playlist_v0alpha1.md
@@ -62,6 +62,7 @@ Optional:
 
 Read-Only:
 
+- `annotations` (Map of String) Annotations of the resource.
 - `url` (String) The full URL of the resource.
 - `uuid` (String) The globally unique identifier of a resource, used by the API for tracking.
 - `version` (String) The version of the resource.

--- a/internal/resources/appplatform/alertenrichment_resource.go
+++ b/internal/resources/appplatform/alertenrichment_resource.go
@@ -1229,7 +1229,7 @@ func parseAlertEnrichmentSpec(ctx context.Context, src types.Object, dst *v1beta
 
 	meta, err := utils.MetaAccessor(dst)
 	if err == nil {
-		if !data.DisableProvenance.IsNull() && data.DisableProvenance.ValueBool() {
+		if data.DisableProvenance.ValueBool() {
 			if meta.GetAnnotations() == nil {
 				meta.SetAnnotations(map[string]string{})
 			}

--- a/internal/resources/appplatform/alertenrichment_resource.go
+++ b/internal/resources/appplatform/alertenrichment_resource.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
 	commonapi "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -35,6 +37,10 @@ const (
 	timeoutDescription       = "Maximum execution time (e.g., '30s', '1m')"
 	defaultMaxLines          = 3
 	defaultExplainAnnotation = "ai_explanation"
+
+	provenanceAnnotationKey = "grafana.com/provenance"
+	provenanceAPI           = "api"
+	provenanceNone          = ""
 )
 
 var objAsOpts = basetypes.ObjectAsOptions{
@@ -51,6 +57,7 @@ type alertEnrichmentSpecModel struct {
 	LabelMatchers      types.List   `tfsdk:"label_matchers"`
 	AnnotationMatchers types.List   `tfsdk:"annotation_matchers"`
 	Steps              types.List   `tfsdk:"step"`
+	DisableProvenance  types.Bool   `tfsdk:"disable_provenance"`
 }
 
 // matcherModel represents a label or annotation matcher
@@ -1128,6 +1135,12 @@ Manages Grafana Alert Enrichments.
 							ElementType: types.StringType,
 							Description: "Receiver names to match. If empty, applies to all receivers.",
 						},
+						"disable_provenance": schema.BoolAttribute{
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+							Description: "Allow modifying alert enrichment outside of Terraform",
+						},
 					}
 					attrs["label_matchers"] = schema.ListAttribute{
 						Optional:    true,
@@ -1214,6 +1227,20 @@ func parseAlertEnrichmentSpec(ctx context.Context, src types.Object, dst *v1beta
 		}
 	}
 
+	meta, err := utils.MetaAccessor(dst)
+	if err == nil {
+		if !data.DisableProvenance.IsNull() && data.DisableProvenance.ValueBool() {
+			if meta.GetAnnotations() == nil {
+				meta.SetAnnotations(map[string]string{})
+			}
+			annotations := meta.GetAnnotations()
+			annotations[provenanceAnnotationKey] = ""
+			meta.SetAnnotations(annotations)
+		} else {
+			meta.SetAnnotation(provenanceAnnotationKey, provenanceAPI)
+		}
+	}
+
 	return diag.Diagnostics{}
 }
 
@@ -1289,6 +1316,12 @@ func saveAlertEnrichmentSpec(ctx context.Context, src *v1beta1.AlertEnrichment, 
 	}
 	values["step"] = stepsList
 
+	if meta, err := utils.MetaAccessor(src); err == nil {
+		values["disable_provenance"] = types.BoolValue(meta.GetAnnotation(provenanceAnnotationKey) == provenanceNone)
+	} else {
+		values["disable_provenance"] = types.BoolValue(false)
+	}
+
 	spec, d := types.ObjectValue(
 		map[string]attr.Type{
 			"title":               types.StringType,
@@ -1298,6 +1331,7 @@ func saveAlertEnrichmentSpec(ctx context.Context, src *v1beta1.AlertEnrichment, 
 			"label_matchers":      types.ListType{ElemType: matcherType},
 			"annotation_matchers": types.ListType{ElemType: matcherType},
 			"step":                types.ListType{ElemType: types.ObjectType{AttrTypes: registry.BuildElementTypes()}},
+			"disable_provenance":  types.BoolType,
 		},
 		values,
 	)

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -32,11 +32,12 @@ type ResourceModel struct {
 
 // ResourceMetadataModel is a Terraform model for the metadata of a Grafana resource.
 type ResourceMetadataModel struct {
-	UUID      types.String `tfsdk:"uuid"`
-	UID       types.String `tfsdk:"uid"`
-	FolderUID types.String `tfsdk:"folder_uid"`
-	Version   types.String `tfsdk:"version"`
-	URL       types.String `tfsdk:"url"`
+	UUID        types.String `tfsdk:"uuid"`
+	UID         types.String `tfsdk:"uid"`
+	FolderUID   types.String `tfsdk:"folder_uid"`
+	Version     types.String `tfsdk:"version"`
+	URL         types.String `tfsdk:"url"`
+	Annotations types.Map    `tfsdk:"annotations"`
 }
 
 // ResourceOptionsModel is a Terraform model for the options of a Grafana resource.
@@ -131,8 +132,14 @@ func (r *Resource[T, L]) Schema(ctx context.Context, req resource.SchemaRequest,
 						Description: "The UID of the folder to save the resource in.",
 					},
 					//
-					// TODO: add labels & annotations
+					// TODO: add labels
 					//
+
+					"annotations": schema.MapAttribute{
+						Computed:    true,
+						ElementType: types.StringType,
+						Description: "Annotations of the resource.",
+					},
 
 					// Computed by API
 					"uuid": schema.StringAttribute{
@@ -508,11 +515,12 @@ func SaveResourceToModel[T sdkresource.Object](
 			ctx,
 			// TODO: re-use these from the schema.
 			map[string]attr.Type{
-				"uuid":       types.StringType,
-				"uid":        types.StringType,
-				"folder_uid": types.StringType,
-				"version":    types.StringType,
-				"url":        types.StringType,
+				"uuid":        types.StringType,
+				"uid":         types.StringType,
+				"folder_uid":  types.StringType,
+				"version":     types.StringType,
+				"url":         types.StringType,
+				"annotations": types.MapType{ElemType: types.StringType},
 			},
 			meta,
 		)
@@ -547,6 +555,12 @@ func GetModelFromMetadata(
 	dst.UID = types.StringValue(src.GetName())
 	dst.Version = types.StringValue(src.GetResourceVersion())
 	dst.URL = types.StringValue(meta.GetSelfLink())
+
+	if annotations := meta.GetAnnotations(); len(annotations) > 0 {
+		dst.Annotations, _ = types.MapValueFrom(ctx, types.StringType, annotations)
+	} else {
+		dst.Annotations = types.MapNull(types.StringType)
+	}
 
 	return diag
 }

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -6,8 +6,10 @@ import (
 
 	sdkresource "github.com/grafana/grafana-app-sdk/resource"
 	"github.com/grafana/grafana/apps/playlist/pkg/apis/playlist/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
@@ -19,32 +21,145 @@ func makeMockResource(name, uid string) sdkresource.Object {
 	return obj
 }
 
-func TestSaveResourceToModel_ID_Field(t *testing.T) {
+func TestSaveResourceToModel(t *testing.T) {
 	ctx := context.Background()
 
-	testUUID := "test-uuid-12345"
-	src := makeMockResource("test-name", testUUID)
-
-	dst := &ResourceModel{
-		Metadata: types.ObjectValueMust(
-			map[string]attr.Type{
-				"uuid":       types.StringType,
-				"uid":        types.StringType,
-				"folder_uid": types.StringType,
-				"version":    types.StringType,
-				"url":        types.StringType,
+	tests := []struct {
+		name                  string
+		annotations           map[string]string
+		expectAnnotationsNull bool
+	}{
+		{
+			name:                  "basic ID field",
+			expectAnnotationsNull: true,
+		},
+		{
+			name: "with annotations",
+			annotations: map[string]string{
+				"grafana.com/provenance": "api",
+				"team":                   "platform",
 			},
-			map[string]attr.Value{
-				"uuid":       types.StringNull(),
-				"uid":        types.StringNull(),
-				"folder_uid": types.StringNull(),
-				"version":    types.StringNull(),
-				"url":        types.StringNull(),
-			},
-		),
+			expectAnnotationsNull: false,
+		},
+		{
+			name:                  "empty annotations map",
+			annotations:           map[string]string{},
+			expectAnnotationsNull: true,
+		},
 	}
 
-	diags := SaveResourceToModel(ctx, src, dst)
-	require.False(t, diags.HasError())
-	require.Equal(t, testUUID, dst.ID.ValueString())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testUUID := "test-uuid-12345"
+			src := makeMockResource("test-name", testUUID)
+
+			if tt.annotations != nil {
+				meta, err := utils.MetaAccessor(src)
+				require.NoError(t, err)
+				meta.SetAnnotations(tt.annotations)
+			}
+
+			dst := &ResourceModel{
+				Metadata: types.ObjectValueMust(
+					map[string]attr.Type{
+						"uuid":        types.StringType,
+						"uid":         types.StringType,
+						"folder_uid":  types.StringType,
+						"version":     types.StringType,
+						"url":         types.StringType,
+						"annotations": types.MapType{ElemType: types.StringType},
+					},
+					map[string]attr.Value{
+						"uuid":        types.StringNull(),
+						"uid":         types.StringNull(),
+						"folder_uid":  types.StringNull(),
+						"version":     types.StringNull(),
+						"url":         types.StringNull(),
+						"annotations": types.MapNull(types.StringType),
+					},
+				),
+			}
+
+			diags := SaveResourceToModel(ctx, src, dst)
+			require.False(t, diags.HasError())
+			require.Equal(t, testUUID, dst.ID.ValueString())
+
+			var metadata ResourceMetadataModel
+			dst.Metadata.As(ctx, &metadata, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    true,
+				UnhandledUnknownAsEmpty: true,
+			})
+
+			if tt.expectAnnotationsNull {
+				require.True(t, metadata.Annotations.IsNull())
+			} else {
+				require.False(t, metadata.Annotations.IsNull())
+
+				annotations := make(map[string]string)
+				metadata.Annotations.ElementsAs(ctx, &annotations, false)
+
+				for key, expectedValue := range tt.annotations {
+					require.Equal(t, expectedValue, annotations[key])
+				}
+			}
+		})
+	}
+}
+
+func TestGetModelFromMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                  string
+		annotations           map[string]string
+		expectAnnotationsNull bool
+	}{
+		{
+			name: "with annotations",
+			annotations: map[string]string{
+				"grafana.com/provenance": "api",
+				"custom.annotation":      "value",
+			},
+			expectAnnotationsNull: false,
+		},
+		{
+			name:                  "nil annotations",
+			annotations:           nil,
+			expectAnnotationsNull: true,
+		},
+		{
+			name:                  "empty annotations map",
+			annotations:           map[string]string{},
+			expectAnnotationsNull: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := makeMockResource("test-name", "test-uuid")
+
+			if tt.annotations != nil {
+				meta, err := utils.MetaAccessor(src)
+				require.NoError(t, err)
+				meta.SetAnnotations(tt.annotations)
+			}
+
+			dst := &ResourceMetadataModel{}
+			diags := GetModelFromMetadata(ctx, src, dst)
+			require.False(t, diags.HasError())
+
+			if tt.expectAnnotationsNull {
+				require.True(t, dst.Annotations.IsNull())
+			} else {
+				require.False(t, dst.Annotations.IsNull())
+
+				annotations := make(map[string]string)
+				dst.Annotations.ElementsAs(ctx, &annotations, false)
+
+				for key, expectedValue := range tt.annotations {
+					require.Equal(t, expectedValue, annotations[key])
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Add the `disable_provenance` attribute to the `grafana_apps_alertenrichment_alertenrichment_v1beta1` resource, similar to the `grafana_rule_group`:
- `disable_provenance = False` (default): applies the `grafana.com/provenance` = `api` annotation to the resource, marking it as read-only in the UI.
- `disable_provenance = True`: sets an empty `grafana.com/provenance` annotation.
