### PR TITLE
fix(oncall): enable creation of web based schedules through tf

### DIFF
--- a/examples/resources/grafana_oncall_schedule/resource.tf
+++ b/examples/resources/grafana_oncall_schedule/resource.tf
@@ -42,3 +42,19 @@ resource "grafana_oncall_schedule" "example_schedule" {
   ]
   ical_url_overrides = "https://example.com/example_overrides_ical.ics"
 }
+
+// Web based schedule
+resource "grafana_oncall_schedule" "example_schedule" {
+  name      = "Example Calendar Schadule"
+  type      = "web"
+  time_zone = "America/New_York"
+
+  // Optional: specify the team to which the schedule belongs
+  team_id = data.grafana_oncall_team.my_team.id
+
+  // Is highly recommended to set ignore changes on all properties to avoid
+  // recreating the schedule all the time due to changes on the Web UI.
+  lifecycle {
+    ignore_changes = all
+  }
+}


### PR DESCRIPTION
 ## Description

This PR fixes an issue that prevented the creation of web type schedules in Grafana OnCall using Terraform. Although the provider was intended to support all schedule types, a validation conflict caused the creation of web schedules to fail.

The provider was incorrectly returning the error `Error: time_zone can not be set with type: web`. 

<img width="2238" height="1170" alt="image" src="https://github.com/user-attachments/assets/b40b170e-d24b-40f8-8267-b652e56697de" />

This contradicted the Grafana OnCall API, which requires the time_zone field for this schedule type and would fail with the error `Error: POST <oncall_api_url>/api/v1/schedules/: 400 {time_zone: [This field is required.]}`.

<img width="2214" height="1148" alt="image" src="https://github.com/user-attachments/assets/0a51f8a2-db72-46a4-9485-0aa547b076a3" />

This fix resolves the conflicting validation logic, allowing time_zone to be correctly passed to the API for web schedules.

## Key Changes

 - `time_zone` logic: The validation for the time_zone field has been adjusted to allow its use with web type schedules, resolving the API conflict.
 - Forced recreation for `web` schedules: Implemented the CustomizeDiff function, which forces the resource to be recreated (ForceNew) whenever any of its attributes are changed and the type is web. This ensures that the Terraform state remains consistent, as changes in the Grafana UI are not reflected back into the state.
 - `web` schedule example: Added a new grafana_oncall_schedule resource example with type = "web" to demonstrate its correct usage, including the lifecycle { ignore_changes = all } block.

 ## How to Test

   1. Create a new grafana_oncall_schedule resource with type = "web".
   2. Run terraform apply and verify that the schedule was created correctly in Grafana OnCall, whereas it would have failed before.
   3. Change an attribute in the .tf file (e.g., the name).
   4. Run terraform apply again and confirm that the old schedule was destroyed and a new one was created.
   5. To test the synchronization, add the lifecycle { ignore_changes = all } block to the resource, modify the schedule in the Grafana UI, and then run terraform plan. No changes should be detected.

## Additional Details

* API request that was made to On Call to create the Web Schedule manually:
```bash
curl --location '$GRAFANA_ONCALL_URL/api/v1/schedules/' \
--header 'Content-Type: application/json' \
--header 'Authorization: $GRAFANA_ONCALL_ACCESS_TOKEN' \
--data '{
    "name": "[TEST] Example Schedule",
    "type": "web",
    "time_zone": "UTC"
}'
```
* Apply working with the modified version:
```tf
resource "grafana_oncall_schedule" "test" {
  name      = "[TEST] Example Schedule"
  type      = "web"
  time_zone = "UTC"
}
``` 
<img width="1868" height="1300" alt="image" src="https://github.com/user-attachments/assets/4c200b80-52be-40b8-ade8-823921eae934" />

* Replace working with the modified version: 
<img width="2374" height="1410" alt="image" src="https://github.com/user-attachments/assets/52b212d7-45fb-4f63-bae7-a62b18b455f7" />

* If no attributes changed, nothing happens:
<img width="2106" height="594" alt="image" src="https://github.com/user-attachments/assets/8eb5f6de-70bd-4cdf-b2d9-cad952cc89cf" />

* If ignore changes used, nothing happens:
```tf
resource "grafana_oncall_schedule" "test" {
  name      = "[TEST] Example Schedule - Changed"
  type      = "web"
  time_zone = "UTC"

  lifecycle {
    ignore_changes = all
  }
}
```

<img width="2970" height="1486" alt="image" src="https://github.com/user-attachments/assets/4bc57b95-1a40-4b38-b07a-6eb9ea8c0c38" />
<img width="2100" height="594" alt="image" src="https://github.com/user-attachments/assets/9bd94821-b4ee-4358-ac04-f6430d349617" />




