### PR TITLE
irm: enable grafana assistant webhook preset

### DIFF
--- a/docs/resources/oncall_outgoing_webhook.md
+++ b/docs/resources/oncall_outgoing_webhook.md
@@ -57,7 +57,7 @@ resource "grafana_oncall_outgoing_webhook" "test-acc-outgoing_webhook-incident" 
 - `integration_filter` (List of String) Restricts the outgoing webhook to only trigger if the event came from a selected integration. If no integrations are selected the outgoing webhook will trigger for any integration.
 - `is_webhook_enabled` (Boolean) Controls whether the outgoing webhook will trigger or is ignored. Defaults to `true`.
 - `password` (String, Sensitive) The auth data of the webhook. Used for Basic authentication
-- `preset` (String) The preset of the outgoing webhook. Possible values are: `simple_webhook`, `advanced_webhook`, `grafana_sift`, `incident_webhook`. If no preset is set, the default preset is `advanced_webhook`.
+- `preset` (String) The preset of the outgoing webhook. Possible values are: `simple_webhook`, `advanced_webhook`, `grafana_sift`, `grafana_assistant`, `incident_webhook`. If no preset is set, the default preset is `advanced_webhook`.
 - `team_id` (String) The ID of the OnCall team (using the `grafana_oncall_team` datasource).
 - `trigger_template` (String) A template used to dynamically determine whether the webhook should execute based on the content of the payload.
 - `trigger_type` (String) The type of event that will cause this outgoing webhook to execute. The events available will depend on the preset used. For alert group webhooks, the possible triggers are: `escalation`, `alert group created`, `status change`, `acknowledge`, `resolve`, `silence`, `unsilence`, `unresolve`, `unacknowledge`, `resolution note added`, `personal notification`; for incident webhooks: `incident declared`, `incident changed`, `incident resolved`. Defaults to `escalation`.

--- a/internal/resources/oncall/resource_outgoing_webhook.go
+++ b/internal/resources/oncall/resource_outgoing_webhook.go
@@ -15,10 +15,11 @@ import (
 // modified by users; these fields are automatically suppressed from diffs when a preset is active.
 // presetControlledFields maps preset names to lists of field names that are controlled by that preset
 var presetControlledFields = map[string][]string{
-	"advanced_webhook": {},
-	"grafana_sift":     {"authorization_header", "data", "forward_whole_payload", "headers", "http_method", "password", "url", "user"},
-	"incident_webhook": {"integration_filter"},
-	"simple_webhook":   {"authorization_header", "data", "forward_whole_payload", "headers", "http_method", "integration_filter", "password", "trigger_template", "trigger_type", "user"},
+	"advanced_webhook":  {},
+	"grafana_sift":      {"authorization_header", "data", "forward_whole_payload", "headers", "http_method", "password", "url", "user"},
+	"incident_webhook":  {"integration_filter"},
+	"grafana_assistant": {"authorization_header", "data", "forward_whole_payload", "headers", "http_method", "password", "url", "user"},
+	"simple_webhook":    {"authorization_header", "data", "forward_whole_payload", "headers", "http_method", "integration_filter", "password", "trigger_template", "trigger_type", "user"},
 }
 
 // isFieldControlledByPreset checks if a field is controlled by the current preset
@@ -67,7 +68,7 @@ func resourceOutgoingWebhook() *common.Resource {
 			"preset": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The preset of the outgoing webhook. Possible values are: `simple_webhook`, `advanced_webhook`, `grafana_sift`, `incident_webhook`. If no preset is set, the default preset is `advanced_webhook`.",
+				Description: "The preset of the outgoing webhook. Possible values are: `simple_webhook`, `advanced_webhook`, `grafana_sift`, `grafana_assistant`, `incident_webhook`. If no preset is set, the default preset is `advanced_webhook`.",
 			},
 			"team_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Allow defining webhooks using the now available `grafana_assistant` preset:
```

resource "grafana_oncall_outgoing_webhook" "Assistant" {
  provider      = grafana.oncall
  name          = "Trigger Grafana Assistant"
  preset        = "grafana_assistant"
  trigger_type  = "alert group created"
}
```