### PR TITLE
Update k6 test schedules to support cron expressions

### DIFF
--- a/docs/data-sources/k6_schedule.md
+++ b/docs/data-sources/k6_schedule.md
@@ -63,6 +63,7 @@ output "complete_schedule_info" {
     next_run        = data.grafana_k6_schedule.from_load_test.next_run
     created_by      = data.grafana_k6_schedule.from_load_test.created_by
     recurrence_rule = data.grafana_k6_schedule.from_load_test.recurrence_rule
+    cron            = data.grafana_k6_schedule.from_load_test.cron
   }
 }
 ```
@@ -77,11 +78,21 @@ output "complete_schedule_info" {
 ### Read-Only
 
 - `created_by` (String) The email of the user who created the schedule.
+- `cron` (Block, Read-only) The cron schedule to trigger the test periodically. If null, the test will run only once on the 'starts' date. (see [below for nested schema](#nestedblock--cron))
 - `deactivated` (Boolean) Whether the schedule is deactivated.
 - `id` (String) Numeric identifier of the schedule.
 - `next_run` (String) The next scheduled execution time.
 - `recurrence_rule` (Block, Read-only) The schedule recurrence settings. If null, the test will run only once on the starts date. (see [below for nested schema](#nestedblock--recurrence_rule))
 - `starts` (String) The start time for the schedule (RFC3339 format).
+
+<a id="nestedblock--cron"></a>
+### Nested Schema for `cron`
+
+Read-Only:
+
+- `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+- `timezone` (String) The timezone of the cron expression.
+
 
 <a id="nestedblock--recurrence_rule"></a>
 ### Nested Schema for `recurrence_rule`

--- a/docs/data-sources/k6_schedule.md
+++ b/docs/data-sources/k6_schedule.md
@@ -91,7 +91,7 @@ output "complete_schedule_info" {
 Read-Only:
 
 - `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-- `timezone` (String) The timezone of the cron expression.
+- `timezone` (String) The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.
 
 
 <a id="nestedblock--recurrence_rule"></a>

--- a/docs/data-sources/k6_schedules.md
+++ b/docs/data-sources/k6_schedules.md
@@ -45,6 +45,21 @@ resource "grafana_k6_load_test" "schedules_load_test_2" {
   ]
 }
 
+resource "grafana_k6_load_test" "schedules_load_test_3" {
+  project_id = grafana_k6_project.schedules_project.id
+  name       = "Terraform Test Load Test for Schedules (3)"
+  script     = <<-EOT
+    export default function() {
+      console.log('Hello from k6 schedules test!');
+    }
+  EOT
+
+  depends_on = [
+    grafana_k6_project.schedules_project,
+  ]
+}
+
+
 
 resource "grafana_k6_schedule" "test_schedule_1" {
   load_test_id = grafana_k6_load_test.schedules_load_test.id
@@ -63,13 +78,27 @@ resource "grafana_k6_schedule" "test_schedule_1" {
 resource "grafana_k6_schedule" "test_schedule_2" {
   load_test_id = grafana_k6_load_test.schedules_load_test_2.id
   starts       = "2023-12-26T14:00:00Z"
+  recurrence_rule {
+    frequency = "WEEKLY"
+    interval  = 2
+    until     = "2047-01-31T23:59:59Z"
+  }
+
+  depends_on = [
+    grafana_k6_load_test.schedules_load_test_2,
+  ]
+}
+
+resource "grafana_k6_schedule" "test_schedule_3" {
+  load_test_id = grafana_k6_load_test.schedules_load_test_3.id
+  starts       = "2023-12-26T14:00:00Z"
   cron {
     schedule = "0 10 1 12 6"
     timezone = "UTC"
   }
 
   depends_on = [
-    grafana_k6_load_test.schedules_load_test_2,
+    grafana_k6_load_test.schedules_load_test_3,
   ]
 }
 
@@ -78,6 +107,7 @@ data "grafana_k6_schedules" "from_load_test_id" {
   depends_on = [
     grafana_k6_schedule.test_schedule_1,
     grafana_k6_schedule.test_schedule_2,
+    grafana_k6_schedule.test_schedule_3,
   ]
 }
 ```

--- a/docs/data-sources/k6_schedules.md
+++ b/docs/data-sources/k6_schedules.md
@@ -63,10 +63,9 @@ resource "grafana_k6_schedule" "test_schedule_1" {
 resource "grafana_k6_schedule" "test_schedule_2" {
   load_test_id = grafana_k6_load_test.schedules_load_test_2.id
   starts       = "2023-12-26T14:00:00Z"
-  recurrence_rule {
-    frequency = "WEEKLY"
-    interval  = 2
-    until     = "2047-01-31T23:59:59Z"
+  cron {
+    schedule = "0 10 1 12 6"
+    timezone = "UTC"
   }
 
   depends_on = [
@@ -97,12 +96,22 @@ data "grafana_k6_schedules" "from_load_test_id" {
 Read-Only:
 
 - `created_by` (String)
+- `cron` (Object) (see [below for nested schema](#nestedobjatt--schedules--cron))
 - `deactivated` (Boolean)
 - `id` (String)
 - `load_test_id` (String)
 - `next_run` (String)
 - `recurrence_rule` (Object) (see [below for nested schema](#nestedobjatt--schedules--recurrence_rule))
 - `starts` (String)
+
+<a id="nestedobjatt--schedules--cron"></a>
+### Nested Schema for `schedules.cron`
+
+Read-Only:
+
+- `schedule` (String)
+- `timezone` (String)
+
 
 <a id="nestedobjatt--schedules--recurrence_rule"></a>
 ### Nested Schema for `schedules.recurrence_rule`

--- a/docs/resources/k6_schedule.md
+++ b/docs/resources/k6_schedule.md
@@ -105,7 +105,7 @@ resource "grafana_k6_schedule" "one_time" {
 Optional:
 
 - `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-- `timezone` (String) The timezone of the cron expression.
+- `timezone` (String) The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.
 
 
 <a id="nestedblock--recurrence_rule"></a>

--- a/docs/resources/k6_schedule.md
+++ b/docs/resources/k6_schedule.md
@@ -31,6 +31,16 @@ resource "grafana_k6_load_test" "scheduled_test" {
   ]
 }
 
+resource "grafana_k6_schedule" "cron_monthly" {
+  load_test_id = grafana_k6_load_test.scheduled_test.id
+  starts       = "2024-12-25T10:00:00Z"
+  cron {
+    schedule = "0 10 1 * *"
+    timezone = "UTC"
+  }
+}
+
+
 resource "grafana_k6_schedule" "daily" {
   load_test_id = grafana_k6_load_test.scheduled_test.id
   starts       = "2024-12-25T10:00:00Z"
@@ -79,7 +89,8 @@ resource "grafana_k6_schedule" "one_time" {
 
 ### Optional
 
-- `recurrence_rule` (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. (see [below for nested schema](#nestedblock--recurrence_rule))
+- `cron` (Block, Optional) The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set. (see [below for nested schema](#nestedblock--cron))
+- `recurrence_rule` (Block, Optional) The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set. (see [below for nested schema](#nestedblock--recurrence_rule))
 
 ### Read-Only
 
@@ -87,6 +98,15 @@ resource "grafana_k6_schedule" "one_time" {
 - `deactivated` (Boolean) Whether the schedule is deactivated.
 - `id` (String) Numeric identifier of the schedule.
 - `next_run` (String) The next scheduled execution time.
+
+<a id="nestedblock--cron"></a>
+### Nested Schema for `cron`
+
+Optional:
+
+- `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
+- `timezone` (String) The timezone of the cron expression.
+
 
 <a id="nestedblock--recurrence_rule"></a>
 ### Nested Schema for `recurrence_rule`

--- a/examples/data-sources/grafana_k6_schedule/data-source.tf
+++ b/examples/data-sources/grafana_k6_schedule/data-source.tf
@@ -48,5 +48,6 @@ output "complete_schedule_info" {
     next_run        = data.grafana_k6_schedule.from_load_test.next_run
     created_by      = data.grafana_k6_schedule.from_load_test.created_by
     recurrence_rule = data.grafana_k6_schedule.from_load_test.recurrence_rule
+    cron            = data.grafana_k6_schedule.from_load_test.cron
   }
 }

--- a/examples/data-sources/grafana_k6_schedules/data-source.tf
+++ b/examples/data-sources/grafana_k6_schedules/data-source.tf
@@ -48,10 +48,9 @@ resource "grafana_k6_schedule" "test_schedule_1" {
 resource "grafana_k6_schedule" "test_schedule_2" {
   load_test_id = grafana_k6_load_test.schedules_load_test_2.id
   starts       = "2023-12-26T14:00:00Z"
-  recurrence_rule {
-    frequency = "WEEKLY"
-    interval  = 2
-    until     = "2047-01-31T23:59:59Z"
+  cron {
+    schedule = "0 10 1 12 6"
+    timezone = "UTC"
   }
 
   depends_on = [

--- a/examples/data-sources/grafana_k6_schedules/data-source.tf
+++ b/examples/data-sources/grafana_k6_schedules/data-source.tf
@@ -30,6 +30,21 @@ resource "grafana_k6_load_test" "schedules_load_test_2" {
   ]
 }
 
+resource "grafana_k6_load_test" "schedules_load_test_3" {
+  project_id = grafana_k6_project.schedules_project.id
+  name       = "Terraform Test Load Test for Schedules (3)"
+  script     = <<-EOT
+    export default function() {
+      console.log('Hello from k6 schedules test!');
+    }
+  EOT
+
+  depends_on = [
+    grafana_k6_project.schedules_project,
+  ]
+}
+
+
 
 resource "grafana_k6_schedule" "test_schedule_1" {
   load_test_id = grafana_k6_load_test.schedules_load_test.id
@@ -48,13 +63,27 @@ resource "grafana_k6_schedule" "test_schedule_1" {
 resource "grafana_k6_schedule" "test_schedule_2" {
   load_test_id = grafana_k6_load_test.schedules_load_test_2.id
   starts       = "2023-12-26T14:00:00Z"
+  recurrence_rule {
+    frequency = "WEEKLY"
+    interval  = 2
+    until     = "2047-01-31T23:59:59Z"
+  }
+
+  depends_on = [
+    grafana_k6_load_test.schedules_load_test_2,
+  ]
+}
+
+resource "grafana_k6_schedule" "test_schedule_3" {
+  load_test_id = grafana_k6_load_test.schedules_load_test_3.id
+  starts       = "2023-12-26T14:00:00Z"
   cron {
     schedule = "0 10 1 12 6"
     timezone = "UTC"
   }
 
   depends_on = [
-    grafana_k6_load_test.schedules_load_test_2,
+    grafana_k6_load_test.schedules_load_test_3,
   ]
 }
 
@@ -63,5 +92,6 @@ data "grafana_k6_schedules" "from_load_test_id" {
   depends_on = [
     grafana_k6_schedule.test_schedule_1,
     grafana_k6_schedule.test_schedule_2,
+    grafana_k6_schedule.test_schedule_3,
   ]
 }

--- a/examples/resources/grafana_k6_schedule/resource.tf
+++ b/examples/resources/grafana_k6_schedule/resource.tf
@@ -16,6 +16,16 @@ resource "grafana_k6_load_test" "scheduled_test" {
   ]
 }
 
+resource "grafana_k6_schedule" "cron_monthly" {
+  load_test_id = grafana_k6_load_test.scheduled_test.id
+  starts       = "2024-12-25T10:00:00Z"
+  cron {
+    schedule = "0 10 1 * *"
+    timezone = "UTC"
+  }
+}
+
+
 resource "grafana_k6_schedule" "daily" {
   load_test_id = grafana_k6_load_test.scheduled_test.id
   starts       = "2024-12-25T10:00:00Z"

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/grafana/grafana/apps/dashboard v0.0.0-20250424064802-2fbb2d6f5d27
 	github.com/grafana/grafana/apps/playlist v0.0.0-20250424064802-2fbb2d6f5d27
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250901080157-a0280d701b28
-	github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20250715154343-32edc34ec1db
+	github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20251022100644-dd6cfbb68f85
 	github.com/grafana/machine-learning-go-client v0.8.2
 	github.com/grafana/river v0.3.0
 	github.com/grafana/slo-openapi-client/go/slo v0.0.0-20250218172929-ab9cae090da6

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/grafana/grafana/apps/playlist v0.0.0-20250424064802-2fbb2d6f5d27 h1:a
 github.com/grafana/grafana/apps/playlist v0.0.0-20250424064802-2fbb2d6f5d27/go.mod h1:9U44mptAJW8bkvgPgCxsnki58/nz3wKPgDayeyeFWJs=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250901080157-a0280d701b28 h1:PgMfX4OPENz/iXmtDDIW9+poZY4UD0hhmXm7flVclDo=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250901080157-a0280d701b28/go.mod h1:av5N0Naq+8VV9MLF7zAkihy/mVq5UbS2EvRSJukDHlY=
-github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20250715154343-32edc34ec1db h1:GZGkcFrQF09j8rZfxcIRql7liBf1U7pdmqSAseGintg=
-github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20250715154343-32edc34ec1db/go.mod h1:RBPBP7qIR/K6qzQEQYESVhp/XJspiBTOyBEBCbPXrvI=
+github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20251022100644-dd6cfbb68f85 h1:GmbPOHOiw/oa3sfGpKSsf6p5R1Ko/c6aYrZvTRfMbUY=
+github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20251022100644-dd6cfbb68f85/go.mod h1:RBPBP7qIR/K6qzQEQYESVhp/XJspiBTOyBEBCbPXrvI=
 github.com/grafana/machine-learning-go-client v0.8.2 h1:TvU4e+Kgg4GhwBNYTMjBUNq4tbhcxe0L8w1eo/UfV2M=
 github.com/grafana/machine-learning-go-client v0.8.2/go.mod h1:GQKDn10CZqG11l1Qtc6BZ5V6e54fSv5Vi8wskWn3BWs=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/internal/resources/k6/data_source_k6_schedule.go
+++ b/internal/resources/k6/data_source_k6_schedule.go
@@ -117,7 +117,7 @@ func (d *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 						Computed:    true,
 					},
 					"timezone": schema.StringAttribute{
-						Description: "The timezone of the cron expression.",
+						Description: "The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.",
 						Computed:    true,
 					},
 				},

--- a/internal/resources/k6/data_source_k6_schedule.go
+++ b/internal/resources/k6/data_source_k6_schedule.go
@@ -36,6 +36,7 @@ type scheduleDataSourceModel struct {
 	LoadTestID     types.String         `tfsdk:"load_test_id"`
 	Starts         types.String         `tfsdk:"starts"`
 	RecurrenceRule *recurrenceRuleModel `tfsdk:"recurrence_rule"`
+	Cron           *cronScheduleModel   `tfsdk:"cron"`
 	Deactivated    types.Bool           `tfsdk:"deactivated"`
 	NextRun        types.String         `tfsdk:"next_run"`
 	CreatedBy      types.String         `tfsdk:"created_by"`
@@ -108,6 +109,19 @@ func (d *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 					},
 				},
 			},
+			"cron": schema.SingleNestedBlock{
+				Description: "The cron schedule to trigger the test periodically. If null, the test will run only once on the 'starts' date.",
+				Attributes: map[string]schema.Attribute{
+					"schedule": schema.StringAttribute{
+						Description: "A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.",
+						Computed:    true,
+					},
+					"timezone": schema.StringAttribute{
+						Description: "The timezone of the cron expression.",
+						Computed:    true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -172,7 +186,7 @@ func populateScheduleDataSourceModel(schedule *k6.ScheduleApiModel, model *sched
 	}
 
 	// Extract recurrence rule details
-	if recurrenceRule, ok := schedule.GetRecurrenceRuleOk(); ok {
+	if recurrenceRule, ok := schedule.GetRecurrenceRuleOk(); ok && recurrenceRule != nil {
 		model.RecurrenceRule = &recurrenceRuleModel{
 			Frequency: types.StringValue(string(recurrenceRule.GetFrequency())),
 		}
@@ -205,5 +219,14 @@ func populateScheduleDataSourceModel(schedule *k6.ScheduleApiModel, model *sched
 		}
 	} else {
 		model.RecurrenceRule = nil
+	}
+
+	if cronSchedule, ok := schedule.GetCronOk(); ok && cronSchedule != nil {
+		model.Cron = &cronScheduleModel{
+			Schedule: types.StringValue(cronSchedule.GetSchedule()),
+			Timezone: types.StringValue(cronSchedule.GetTimeZone()),
+		}
+	} else {
+		model.Cron = nil
 	}
 }

--- a/internal/resources/k6/data_source_k6_schedules.go
+++ b/internal/resources/k6/data_source_k6_schedules.go
@@ -71,6 +71,12 @@ func (d *schedulesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 								"byday":     types.ListType{ElemType: types.StringType},
 							},
 						},
+						"cron": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"schedule": types.StringType,
+								"timezone": types.StringType,
+							},
+						},
 						"deactivated": types.BoolType,
 						"next_run":    types.StringType,
 						"created_by":  types.StringType,
@@ -152,6 +158,26 @@ func (d *schedulesDataSource) Read(ctx context.Context, req datasource.ReadReque
 			})
 		}
 
+		// Create cron object
+		var cronObj attr.Value
+		if scheduleModel.Cron != nil {
+			cronObj, _ = types.ObjectValue(
+				map[string]attr.Type{
+					"schedule": types.StringType,
+					"timezone": types.StringType,
+				},
+				map[string]attr.Value{
+					"schedule": scheduleModel.Cron.Schedule,
+					"timezone": scheduleModel.Cron.Timezone,
+				},
+			)
+		} else {
+			cronObj = types.ObjectNull(map[string]attr.Type{
+				"schedule": types.StringType,
+				"timezone": types.StringType,
+			})
+		}
+
 		// Create schedule object
 		scheduleObj, _ := types.ObjectValue(
 			map[string]attr.Type{
@@ -167,6 +193,12 @@ func (d *schedulesDataSource) Read(ctx context.Context, req datasource.ReadReque
 						"byday":     types.ListType{ElemType: types.StringType},
 					},
 				},
+				"cron": types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"schedule": types.StringType,
+						"timezone": types.StringType,
+					},
+				},
 				"deactivated": types.BoolType,
 				"next_run":    types.StringType,
 				"created_by":  types.StringType,
@@ -176,6 +208,7 @@ func (d *schedulesDataSource) Read(ctx context.Context, req datasource.ReadReque
 				"load_test_id":    scheduleModel.LoadTestID,
 				"starts":          scheduleModel.Starts,
 				"recurrence_rule": recurrenceRuleObj,
+				"cron":            cronObj,
 				"deactivated":     scheduleModel.Deactivated,
 				"next_run":        scheduleModel.NextRun,
 				"created_by":      scheduleModel.CreatedBy,
@@ -199,6 +232,12 @@ func (d *schedulesDataSource) Read(ctx context.Context, req datasource.ReadReque
 						"count":     types.Int32Type,
 						"until":     types.StringType,
 						"byday":     types.ListType{ElemType: types.StringType},
+					},
+				},
+				"cron": types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"schedule": types.StringType,
+						"timezone": types.StringType,
 					},
 				},
 				"deactivated": types.BoolType,

--- a/internal/resources/k6/data_source_k6_schedules_test.go
+++ b/internal/resources/k6/data_source_k6_schedules_test.go
@@ -60,7 +60,8 @@ func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 
 						for i := range count {
 							scheduleLoadTestID := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.load_test_id", i)]
-							if scheduleLoadTestID == loadTest1ID {
+							switch scheduleLoadTestID {
+							case loadTest1ID:
 								foundLoadTest1Schedule = true
 								// Validate specific attributes for load test 1 schedule
 								starts := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.starts", i)]
@@ -71,16 +72,20 @@ func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 								if frequency != "MONTHLY" {
 									return fmt.Errorf("expected frequency to be MONTHLY, got %s", frequency)
 								}
-							} else if scheduleLoadTestID == loadTest2ID {
+							case loadTest2ID:
 								foundLoadTest2Schedule = true
 								// Validate specific attributes for load test 2 schedule
 								starts := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.starts", i)]
 								if starts != "2023-12-26T14:00:00Z" {
 									return fmt.Errorf("expected starts to be 2023-12-26T14:00:00Z, got %s", starts)
 								}
-								frequency := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.recurrence_rule.frequency", i)]
-								if frequency != "WEEKLY" {
-									return fmt.Errorf("expected frequency to be WEEKLY, got %s", frequency)
+								cronSchedule := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.cron.schedule", i)]
+								if cronSchedule != "0 10 1 12 6" {
+									return fmt.Errorf("expected cron to be 0 10 1 12 6, got %s", cronSchedule)
+								}
+								timezone := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.cron.timezone", i)]
+								if timezone != "UTC" {
+									return fmt.Errorf("expected timezone to be UTC, got %s", timezone)
 								}
 							}
 						}

--- a/internal/resources/k6/data_source_k6_schedules_test.go
+++ b/internal/resources/k6/data_source_k6_schedules_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
-	var loadTest1, loadTest2 k6.LoadTestApiModel
+	var loadTest1, loadTest2, loadTest3 k6.LoadTestApiModel
 
 	projectName := "Terraform Schedules Test Project " + acctest.RandString(8)
 	loadTestName := "Terraform Test Load Test for Schedules " + acctest.RandString(8)
@@ -32,6 +32,7 @@ func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					loadTestCheckExists.exists("grafana_k6_load_test.schedules_load_test", &loadTest1),
 					loadTestCheckExists.exists("grafana_k6_load_test.schedules_load_test_2", &loadTest2),
+					loadTestCheckExists.exists("grafana_k6_load_test.schedules_load_test_3", &loadTest3),
 					// Data source attributes
 					resource.TestCheckResourceAttrSet("data.grafana_k6_schedules.from_load_test_id", "id"),
 					// Should have at least 2 schedules (the ones we created)
@@ -54,9 +55,11 @@ func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 						// Check that our created schedules are in the list
 						loadTest1ID := strconv.Itoa(int(loadTest1.GetId()))
 						loadTest2ID := strconv.Itoa(int(loadTest2.GetId()))
+						loadTest3ID := strconv.Itoa(int(loadTest3.GetId()))
 
 						foundLoadTest1Schedule := false
 						foundLoadTest2Schedule := false
+						foundLoadTest3Schedule := false
 
 						for i := range count {
 							scheduleLoadTestID := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.load_test_id", i)]
@@ -79,6 +82,17 @@ func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 								if starts != "2023-12-26T14:00:00Z" {
 									return fmt.Errorf("expected starts to be 2023-12-26T14:00:00Z, got %s", starts)
 								}
+								frequency := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.recurrence_rule.frequency", i)]
+								if frequency != "WEEKLY" {
+									return fmt.Errorf("expected frequency to be WEEKLY, got %s", frequency)
+								}
+							case loadTest3ID:
+								foundLoadTest3Schedule = true
+								// Validate specific attributes for load test 3 schedule
+								starts := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.starts", i)]
+								if starts != "2023-12-26T14:00:00Z" {
+									return fmt.Errorf("expected starts to be 2023-12-26T14:00:00Z, got %s", starts)
+								}
 								cronSchedule := rs.Primary.Attributes[fmt.Sprintf("schedules.%d.cron.schedule", i)]
 								if cronSchedule != "0 10 1 12 6" {
 									return fmt.Errorf("expected cron to be 0 10 1 12 6, got %s", cronSchedule)
@@ -96,7 +110,9 @@ func TestAccDataSourceK6Schedules_basic(t *testing.T) {
 						if !foundLoadTest2Schedule {
 							return fmt.Errorf("schedule for load test 2 (%s) not found", loadTest2ID)
 						}
-
+						if !foundLoadTest3Schedule {
+							return fmt.Errorf("schedule for load test 3 (%s) not found", loadTest3ID)
+						}
 						return nil
 					},
 				),

--- a/internal/resources/k6/resource_schedule.go
+++ b/internal/resources/k6/resource_schedule.go
@@ -165,7 +165,7 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						Optional:    true,
 					},
 					"timezone": schema.StringAttribute{
-						Description: "The timezone of the cron expression.",
+						Description: "The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.",
 						Optional:    true,
 					},
 				},

--- a/internal/resources/k6/resource_schedule.go
+++ b/internal/resources/k6/resource_schedule.go
@@ -55,12 +55,19 @@ type recurrenceRuleModel struct {
 	Byday     []types.String `tfsdk:"byday"`
 }
 
+// cronScheduleModel maps the cron schedule schema data.
+type cronScheduleModel struct {
+	Schedule types.String `tfsdk:"schedule"`
+	Timezone types.String `tfsdk:"timezone"`
+}
+
 // scheduleResourceModel maps the resource schema data.
 type scheduleResourceModel struct {
 	ID             types.String         `tfsdk:"id"`
 	LoadTestID     types.String         `tfsdk:"load_test_id"`
 	Starts         types.String         `tfsdk:"starts"`
 	RecurrenceRule *recurrenceRuleModel `tfsdk:"recurrence_rule"`
+	Cron           *cronScheduleModel   `tfsdk:"cron"`
 	Deactivated    types.Bool           `tfsdk:"deactivated"`
 	NextRun        types.String         `tfsdk:"next_run"`
 	CreatedBy      types.String         `tfsdk:"created_by"`
@@ -115,7 +122,7 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 		},
 		Blocks: map[string]schema.Block{
 			"recurrence_rule": schema.SingleNestedBlock{
-				Description: "The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date.",
+				Description: "The schedule recurrence settings. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.",
 				Attributes: map[string]schema.Attribute{
 					"frequency": schema.StringAttribute{
 						Description: "The frequency of the schedule (HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY).",
@@ -147,6 +154,28 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Validators: []validator.Object{
 					objectvalidator.AlsoRequires(
 						path.MatchRelative().AtName("frequency"),
+					),
+				},
+			},
+			"cron": schema.SingleNestedBlock{
+				Description: "The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.",
+				Attributes: map[string]schema.Attribute{
+					"schedule": schema.StringAttribute{
+						Description: "A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.",
+						Optional:    true,
+					},
+					"timezone": schema.StringAttribute{
+						Description: "The timezone of the cron expression.",
+						Optional:    true,
+					},
+				},
+				Validators: []validator.Object{
+					objectvalidator.AlsoRequires(
+						path.MatchRelative().AtName("schedule"),
+						path.MatchRelative().AtName("timezone"),
+					),
+					objectvalidator.ConflictsWith(
+						path.MatchRoot("recurrence_rule"),
 					),
 				},
 			},
@@ -184,8 +213,9 @@ func (r *scheduleResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	scheduleRequest := k6.NewCreateScheduleRequest(startsTime)
+
 	// Parse recurrence rule
-	var recurrenceRule *k6.ScheduleRecurrenceRule
 	if plan.RecurrenceRule != nil {
 		// Parse frequency
 		frequency, err := k6.NewFrequencyFromValue(plan.RecurrenceRule.Frequency.ValueString())
@@ -197,7 +227,7 @@ func (r *scheduleResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 
-		recurrenceRule = k6.NewScheduleRecurrenceRule(*frequency)
+		recurrenceRule := k6.NewScheduleRecurrenceRule(*frequency)
 		if !plan.RecurrenceRule.Interval.IsNull() {
 			recurrenceRule.SetInterval(plan.RecurrenceRule.Interval.ValueInt32())
 		}
@@ -222,6 +252,13 @@ func (r *scheduleResource) Create(ctx context.Context, req resource.CreateReques
 			}
 			recurrenceRule.SetByday(byday)
 		}
+
+		scheduleRequest.SetRecurrenceRule(*recurrenceRule)
+	}
+
+	if plan.Cron != nil {
+		cronSchedule := k6.NewScheduleCron(plan.Cron.Schedule.ValueString(), plan.Cron.Timezone.ValueString())
+		scheduleRequest.SetCron(*cronSchedule)
 	}
 
 	// Check if a schedule already exists for this load test
@@ -238,9 +275,6 @@ func (r *scheduleResource) Create(ctx context.Context, req resource.CreateReques
 		)
 		return
 	}
-
-	// Generate API request body from plan
-	scheduleRequest := k6.NewCreateScheduleRequest(startsTime, *k6.NewNullableScheduleRecurrenceRule(recurrenceRule))
 
 	// Create new schedule
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
@@ -366,8 +400,9 @@ func (r *scheduleResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	scheduleRequest := k6.NewCreateScheduleRequest(startsTime)
+
 	// Parse recurrence rule
-	var recurrenceRule *k6.ScheduleRecurrenceRule
 	if plan.RecurrenceRule != nil {
 		// Parse frequency
 		frequency, err := k6.NewFrequencyFromValue(plan.RecurrenceRule.Frequency.ValueString())
@@ -379,7 +414,7 @@ func (r *scheduleResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 
-		recurrenceRule = k6.NewScheduleRecurrenceRule(*frequency)
+		recurrenceRule := k6.NewScheduleRecurrenceRule(*frequency)
 		if !plan.RecurrenceRule.Interval.IsNull() {
 			recurrenceRule.SetInterval(plan.RecurrenceRule.Interval.ValueInt32())
 		}
@@ -404,10 +439,14 @@ func (r *scheduleResource) Update(ctx context.Context, req resource.UpdateReques
 			}
 			recurrenceRule.SetByday(byday)
 		}
+
+		scheduleRequest.SetRecurrenceRule(*recurrenceRule)
 	}
 
-	// Generate API request body from plan
-	scheduleRequest := k6.NewCreateScheduleRequest(startsTime, *k6.NewNullableScheduleRecurrenceRule(recurrenceRule))
+	if plan.Cron != nil {
+		cronSchedule := k6.NewScheduleCron(plan.Cron.Schedule.ValueString(), plan.Cron.Timezone.ValueString())
+		scheduleRequest.SetCron(*cronSchedule)
+	}
 
 	// Update schedule (replaces existing schedule for the load test)
 	ctx = context.WithValue(ctx, k6.ContextAccessToken, r.config.Token)
@@ -509,7 +548,7 @@ func (r *scheduleResource) populateModelFromAPI(schedule *k6.ScheduleApiModel, m
 	}
 
 	// Extract recurrence rule details
-	if recurrenceRule, ok := schedule.GetRecurrenceRuleOk(); ok {
+	if recurrenceRule, ok := schedule.GetRecurrenceRuleOk(); ok && recurrenceRule != nil {
 		model.RecurrenceRule = &recurrenceRuleModel{
 			Frequency: types.StringValue(string(recurrenceRule.GetFrequency())),
 		}
@@ -542,6 +581,15 @@ func (r *scheduleResource) populateModelFromAPI(schedule *k6.ScheduleApiModel, m
 		}
 	} else {
 		model.RecurrenceRule = nil
+	}
+
+	if cronSchedule, ok := schedule.GetCronOk(); ok && cronSchedule != nil {
+		model.Cron = &cronScheduleModel{
+			Schedule: types.StringValue(cronSchedule.GetSchedule()),
+			Timezone: types.StringValue(cronSchedule.GetTimeZone()),
+		}
+	} else {
+		model.Cron = nil
 	}
 }
 


### PR DESCRIPTION
https://github.com/grafana/k6-cloud/issues/3652

Update k6 test schedule resource and data sources to support cron expressions.