### PR TITLE
Escape k6 schedule values in docs

### DIFF
--- a/docs/data-sources/k6_schedule.md
+++ b/docs/data-sources/k6_schedule.md
@@ -90,8 +90,8 @@ output "complete_schedule_info" {
 
 Read-Only:
 
-- `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-- `timezone` (String) The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.
+- `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+- `timezone` (String) The timezone of the cron expression. For example, `UTC` or `Europe/London`.
 
 
 <a id="nestedblock--recurrence_rule"></a>

--- a/docs/resources/k6_schedule.md
+++ b/docs/resources/k6_schedule.md
@@ -104,8 +104,8 @@ resource "grafana_k6_schedule" "one_time" {
 
 Optional:
 
-- `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.
-- `timezone` (String) The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.
+- `schedule` (String) A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.
+- `timezone` (String) The timezone of the cron expression. For example, `UTC` or `Europe/London`.
 
 
 <a id="nestedblock--recurrence_rule"></a>

--- a/internal/resources/k6/data_source_k6_schedule.go
+++ b/internal/resources/k6/data_source_k6_schedule.go
@@ -113,11 +113,11 @@ func (d *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Description: "The cron schedule to trigger the test periodically. If null, the test will run only once on the 'starts' date.",
 				Attributes: map[string]schema.Attribute{
 					"schedule": schema.StringAttribute{
-						Description: "A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.",
+						Description: "A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.",
 						Computed:    true,
 					},
 					"timezone": schema.StringAttribute{
-						Description: "The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.",
+						Description: "The timezone of the cron expression. For example, `UTC` or `Europe/London`.",
 						Computed:    true,
 					},
 				},

--- a/internal/resources/k6/resource_schedule.go
+++ b/internal/resources/k6/resource_schedule.go
@@ -161,11 +161,11 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "The cron schedule to trigger the test periodically. If not specified, the test will run only once on the 'starts' date. Only one of `recurrence_rule` and `cron` can be set.",
 				Attributes: map[string]schema.Attribute{
 					"schedule": schema.StringAttribute{
-						Description: "A cron expression with exactly 5 entries, or an alias. The allowed aliases are: @yearly, @annually, @monthly, @weekly, @daily, @hourly.",
+						Description: "A cron expression with exactly 5 entries, or an alias. The allowed aliases are: `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@hourly`.",
 						Optional:    true,
 					},
 					"timezone": schema.StringAttribute{
-						Description: "The timezone of the cron expression. For example, 'UTC' or 'Europe/London'.",
+						Description: "The timezone of the cron expression. For example, `UTC` or `Europe/London`.",
 						Optional:    true,
 					},
 				},


### PR DESCRIPTION
Escape example values in k6 schedule docs. 

By default, GitHub formats unescaped words that start with `@` as a links to GitHub users.