### PR TITLE
Change Cloud Access Policy token rotation implementation

### DIFF
--- a/examples/resources/grafana_cloud_access_policy_rotating_token/resource.tf
+++ b/examples/resources/grafana_cloud_access_policy_rotating_token/resource.tf
@@ -19,15 +19,11 @@ resource "grafana_cloud_access_policy" "test" {
   }
 }
 
-resource "time_rotating" "token_rotation" {
-  rotation_days = 30
-}
-
 resource "grafana_cloud_access_policy_rotating_token" "test" {
-  region                 = "prod-us-east-0"
-  access_policy_id       = grafana_cloud_access_policy.test.policy_id
-  name_prefix            = "my-policy-rotating-token"
-  display_name           = "My Policy Rotating Token"
-  rotate_after           = time_rotating.token_rotation.unix
-  post_rotation_lifetime = "24h"
+  region                = "prod-us-east-0"
+  access_policy_id      = grafana_cloud_access_policy.test.policy_id
+  name_prefix           = "my-policy-rotating-token"
+  display_name          = "My Policy Rotating Token"
+  expire_after          = "30d"
+  early_rotation_window = "24h"
 }

--- a/internal/resources/cloud/common.go
+++ b/internal/resources/cloud/common.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/hashicorp/go-uuid"
@@ -117,6 +118,10 @@ func (r *basePluginFrameworkResource) Configure(ctx context.Context, req resourc
 	r.client = client.GrafanaCloudAPI
 }
 
+// Now returns the current time.
+// It can be overridden in tests to provide a different time.
+var Now = time.Now
+
 type getter interface {
-	Get(key string) interface{}
+	GetOk(key string) (interface{}, bool)
 }

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -108,6 +108,12 @@ func updateCloudAccessPolicyToken(ctx context.Context, d *schema.ResourceData, c
 
 // updateTokenHelper is a helper function meant to update token-related resources, like tokens or token rotations
 func updateTokenHelper(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient, tokenResourceID *common.ResourceID) diag.Diagnostics {
+	// Avoid sending update requests to the API if the fields that are being updated do not need to be updated in
+	// Grafana Cloud, only in the Terraform state.
+	if !d.HasChanges("display_name") {
+		return nil
+	}
+
 	split, err := tokenResourceID.Split(d.Id())
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Related to https://github.com/grafana/terraform-provider-grafana/issues/1705

This is an alternative approach that does not rely on the `time_rotating` resource to trigger changes on certain fields to rotate a token, as opposed to https://github.com/grafana/terraform-provider-grafana/pull/2390. Instead, it adds the `rotate_after` and `early_rotation_window` fields to handle rotations. It's a modification of what was talked in https://github.com/grafana/terraform-provider-grafana/pull/2390#issuecomment-3444216825.

It additionally adds a field to allow deleting rotated tokens instead of leaving them to expire.