### PR TITLE
fix: add mutex to dashboard crud operations until we get rid of dual writer

### DIFF
--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -30,10 +30,10 @@ Manages Grafana dashboards.
 * [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 `,
 
-		CreateContext: CreateDashboard,
+		CreateContext: common.WithDashboardMutex[schema.CreateContextFunc](CreateDashboard),
 		ReadContext:   ReadDashboard,
-		UpdateContext: UpdateDashboard,
-		DeleteContext: DeleteDashboard,
+		UpdateContext: common.WithDashboardMutex[schema.UpdateContextFunc](UpdateDashboard),
+		DeleteContext: common.WithDashboardMutex[schema.DeleteContextFunc](DeleteDashboard),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},


### PR DESCRIPTION
Introduce a mutex to crud operations until we get rid of the dual writer for dashboards. This is just a precaution step.

**Ticket:** https://github.com/grafana/search-and-storage-team/issues/552