### PR TITLE
Make k6 API URL configurable in the plugin installation

### DIFF
--- a/docs/resources/k6_installation.md
+++ b/docs/resources/k6_installation.md
@@ -108,6 +108,10 @@ resource "grafana_k6_project" "my_k6_project" {
 - `grafana_user` (String) The user to use for the installation.
 - `stack_id` (String) The identifier of the stack to install k6 on.
 
+### Optional
+
+- `k6_api_url` (String) The URL of the k6 API.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/k6_installation.md
+++ b/docs/resources/k6_installation.md
@@ -110,7 +110,7 @@ resource "grafana_k6_project" "my_k6_project" {
 
 ### Optional
 
-- `k6_api_url` (String) The URL of the k6 API.
+- `k6_api_url` (String) The Grafaba Cloud k6 API url.
 
 ### Read-Only
 

--- a/docs/resources/k6_installation.md
+++ b/docs/resources/k6_installation.md
@@ -110,7 +110,7 @@ resource "grafana_k6_project" "my_k6_project" {
 
 ### Optional
 
-- `k6_api_url` (String) The Grafaba Cloud k6 API url.
+- `k6_api_url` (String) The Grafana Cloud k6 API url.
 
 ### Read-Only
 

--- a/internal/resources/cloud/resource_k6_installation.go
+++ b/internal/resources/cloud/resource_k6_installation.go
@@ -72,7 +72,7 @@ Required access policy scopes:
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "The URL of the k6 API.",
+				Description: "The Grafaba Cloud k6 API url.",
 			},
 			"k6_access_token": {
 				Type:        schema.TypeString,

--- a/internal/resources/cloud/resource_k6_installation.go
+++ b/internal/resources/cloud/resource_k6_installation.go
@@ -72,7 +72,7 @@ Required access policy scopes:
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "The Grafaba Cloud k6 API url.",
+				Description: "The Grafana Cloud k6 API url.",
 			},
 			"k6_access_token": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
This PR makes the previously hardcoded k6 URL configurable in the `grafana_k6_installation` resource.

The URL is already configurable on the provider level for other k6 resources.