### PR TITLE
fix(frontendo11y): prod-us-east-0 has a valid response

### DIFF
--- a/internal/resources/frontendo11y/common.go
+++ b/internal/resources/frontendo11y/common.go
@@ -4,11 +4,10 @@ import "fmt"
 
 // TODO: make faroEndpointUrl visible in gcom response
 var faroEndpointUrlsRegionExceptions = map[string]string{
-	"au":             "https://faro-api-prod-au-southeast-0.grafana.net/faro",
-	"eu":             "https://faro-api-prod-eu-west-0.grafana.net/faro",
-	"prod-us-east-0": "https://faro-api-prod-us-east-2.grafana.net/faro",
-	"us-azure":       "https://faro-api-prod-us-central-7.grafana.net/faro",
-	"us":             "https://faro-api-prod-us-central-0.grafana.net/faro",
+	"au":       "https://faro-api-prod-au-southeast-0.grafana.net/faro",
+	"eu":       "https://faro-api-prod-eu-west-0.grafana.net/faro",
+	"us-azure": "https://faro-api-prod-us-central-7.grafana.net/faro",
+	"us":       "https://faro-api-prod-us-central-0.grafana.net/faro",
 }
 
 // getFrontendO11yAPIURLForRegion gets the frontend o11y API URL given a region slug


### PR DESCRIPTION
There's no need for prod-us-east-0 to return https://faro-api-prod-us-east-2.grafana.net/faro because https://faro-api-prod-us-east-0.grafana.net/faro is valid