### PR TITLE
auth: Remove org preferences validation

### DIFF
--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -28,6 +28,6 @@ data "grafana_organization_preferences" "test" {}
 
 - `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `id` (String) The ID of this resource.
-- `theme` (String) The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.
-- `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.
+- `theme` (String) The Organization theme. Any string value is supported, including custom themes. Common values are `light`, `dark`, `system`, or an empty string for the default.
+- `timezone` (String) The Organization timezone. Any string value is supported, including IANA timezone names. Common values are `utc`, `browser`, or an empty string for the default.
 - `week_start` (String) The Organization week start day. Available values are `sunday`, `monday`, `saturday`, or an empty string for the default.

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -28,8 +28,8 @@ resource "grafana_organization_preferences" "test" {
 
 - `home_dashboard_uid` (String) The Organization home dashboard UID. This is only available in Grafana 9.0+.
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
-- `theme` (String) The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.
-- `timezone` (String) The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.
+- `theme` (String) The Organization theme. Any string value is supported, including custom themes. Common values are `light`, `dark`, `system`, or an empty string for the default.
+- `timezone` (String) The Organization timezone. Any string value is supported, including IANA timezone names. Common values are `utc`, `browser`, or an empty string for the default.
 - `week_start` (String) The Organization week start day. Available values are `sunday`, `monday`, `saturday`, or an empty string for the default. Defaults to ``.
 
 ### Read-Only

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -31,10 +31,9 @@ func resourceOrganizationPreferences() *common.Resource {
 		Schema: map[string]*schema.Schema{
 			"org_id": orgIDAttribute(),
 			"theme": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "The Organization theme. Available values are `light`, `dark`, `system`, or an empty string for the default.",
-				ValidateFunc: validation.StringInSlice([]string{"light", "dark", "system", ""}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Organization theme. Any string value is supported, including custom themes. Common values are `light`, `dark`, `system`, or an empty string for the default.",
 			},
 			"home_dashboard_uid": {
 				Type:        schema.TypeString,
@@ -42,10 +41,9 @@ func resourceOrganizationPreferences() *common.Resource {
 				Description: "The Organization home dashboard UID. This is only available in Grafana 9.0+.",
 			},
 			"timezone": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "The Organization timezone. Available values are `utc`, `browser`, or an empty string for the default.",
-				ValidateFunc: validation.StringInSlice([]string{"utc", "browser", ""}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Organization timezone. Any string value is supported, including IANA timezone names. Common values are `utc`, `browser`, or an empty string for the default.",
 			},
 			"week_start": {
 				Type:         schema.TypeString,

--- a/internal/resources/grafana/resource_organization_preferences_test.go
+++ b/internal/resources/grafana/resource_organization_preferences_test.go
@@ -72,6 +72,11 @@ func TestAccResourceOrganizationPreferences(t *testing.T) {
 		Timezone:  "browser",
 		WeekStart: "saturday",
 	}
+	gildedgrovePrefs := models.Preferences{
+		Theme:     "gildedgrove",
+		Timezone:  "Europe/Berlin",
+		WeekStart: "sunday",
+	}
 	emptyPrefs := models.Preferences{
 		Theme:     "",
 		Timezone:  "",
@@ -117,6 +122,19 @@ func TestAccResourceOrganizationPreferences(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", finalPrefs.Theme),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", finalPrefs.Timezone),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", finalPrefs.WeekStart),
+					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
+				),
+			},
+			// test with gildedgrove theme and Europe/Berlin timezone
+			{
+				Config: testOrganizationPreferencesConfig(testRandName, gildedgrovePrefs),
+				Check: resource.ComposeTestCheckFunc(
+					orgCheckExists.exists("grafana_organization.test", &org),
+					testAccCheckOrganizationPreferences(&org, gildedgrovePrefs),
+					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "id", common.IDRegexp),
+					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", gildedgrovePrefs.Theme),
+					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", gildedgrovePrefs.Timezone),
+					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", gildedgrovePrefs.WeekStart),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
 				),
 			},

--- a/internal/resources/grafana/resource_organization_preferences_test.go
+++ b/internal/resources/grafana/resource_organization_preferences_test.go
@@ -72,11 +72,6 @@ func TestAccResourceOrganizationPreferences(t *testing.T) {
 		Timezone:  "browser",
 		WeekStart: "saturday",
 	}
-	gildedgrovePrefs := models.Preferences{
-		Theme:     "gildedgrove",
-		Timezone:  "Europe/Berlin",
-		WeekStart: "sunday",
-	}
 	emptyPrefs := models.Preferences{
 		Theme:     "",
 		Timezone:  "",
@@ -122,19 +117,6 @@ func TestAccResourceOrganizationPreferences(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", finalPrefs.Theme),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", finalPrefs.Timezone),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", finalPrefs.WeekStart),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
-				),
-			},
-			// test with gildedgrove theme and Europe/Berlin timezone
-			{
-				Config: testOrganizationPreferencesConfig(testRandName, gildedgrovePrefs),
-				Check: resource.ComposeTestCheckFunc(
-					orgCheckExists.exists("grafana_organization.test", &org),
-					testAccCheckOrganizationPreferences(&org, gildedgrovePrefs),
-					resource.TestMatchResourceAttr("grafana_organization_preferences.test", "id", common.IDRegexp),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "theme", gildedgrovePrefs.Theme),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "timezone", gildedgrovePrefs.Timezone),
-					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "week_start", gildedgrovePrefs.WeekStart),
 					resource.TestCheckResourceAttr("grafana_organization_preferences.test", "home_dashboard_uid", testRandName),
 				),
 			},


### PR DESCRIPTION
This PR removes the validation on user preferences - previously introduced [here](https://github.com/grafana/terraform-provider-grafana/pull/1193); thus, delegating the validation to the API instead.

This validation is limited to a small subset of themes and time zone preferences that are valid and accepted by Grafana's API.

fixes: https://github.com/grafana/support-escalations/issues/19395