### PR TITLE
fix(release): add disk cleanup to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   #  uses: ./.github/workflows/cloud-acc-tests.yml
   goreleaser:
     runs-on: ubuntu-latest
-    #needs: 
+    #needs:
     #  - run-cloud-tests
     steps:
     - name: Checkout
@@ -36,11 +36,21 @@ jobs:
         persist-credentials: false
     - name: Unshallow
       run: git fetch --prune --unshallow
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
     - name: Set up Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version-file: go.mod
-        cache: false
+        cache: true
     - name: Get secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@c8ac4a279df46ebd1f85064119a0835098b88092
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version-file: go.mod
-        cache: true
+        cache: false
     - name: Get secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@c8ac4a279df46ebd1f85064119a0835098b88092
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Unshallow
       run: git fetch --prune --unshallow
     - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@54081f138730dfc15788a16ea1f97d8457feca80 # v1.3.1
       with:
         tool-cache: false
         android: true


### PR DESCRIPTION
Release builds are failing with `no space left on device` errors during GoReleaser compilation (see example [here](https://github.com/grafana/terraform-provider-grafana/actions/runs/19373609244/job/55439750835)).

This PR adds `jlumbroso/free-disk-space` action to free several GB before GoReleaser builds. 