### PR TITLE
delete pdc fields from json_data when generating updated state

### DIFF
--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -19,7 +19,13 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 )
 
+const (
+	pdcEnableSecureSocksProxy   = "enableSecureSocksProxy"
+	pdcSecureSocksProxyUsername = "secureSocksProxyUsername"
+)
+
 func resourceDataSource() *common.Resource {
+
 	schema := &schema.Resource{
 
 		Description: `
@@ -167,6 +173,17 @@ func datasourceJSONDataAttribute() *schema.Schema {
 					errors.New("teamHttpHeaders is a reserved key and cannot be used in JSON data. Use the data_source_config_lbac_rules resource instead"),
 				}
 			}
+
+			if strings.Contains(i.(string), pdcEnableSecureSocksProxy) {
+				return nil, []error{
+					errors.New(pdcEnableSecureSocksProxy + " is a reserved key and cannot be used in JSON data."),
+				}
+			}
+			if strings.Contains(i.(string), pdcSecureSocksProxyUsername) {
+				return nil, []error{
+					errors.New(pdcSecureSocksProxyUsername + " is a reserved key and cannot be used in JSON data."),
+				}
+			}
 			return validation.StringIsJSON(i, s)
 		},
 		StateFunc: func(v any) string {
@@ -182,8 +199,8 @@ func datasourceJSONDataAttribute() *schema.Schema {
 			json.Unmarshal([]byte(newValue), &newValueUnmarshalled)
 			pdcNetworkID := d.Get("private_data_source_connect_network_id")
 			if pdcNetworkID != "" {
-				newValueUnmarshalled["enableSecureSocksProxy"] = true
-				newValueUnmarshalled["secureSocksProxyUsername"] = pdcNetworkID
+				newValueUnmarshalled[pdcEnableSecureSocksProxy] = true
+				newValueUnmarshalled[pdcSecureSocksProxyUsername] = pdcNetworkID
 			}
 			newValue, _ = structure.FlattenJsonToString(newValueUnmarshalled)
 
@@ -338,8 +355,8 @@ func datasourceConfigToState(d *schema.ResourceData, dataSource *models.DataSour
 	// the state so that the state matches the user config. The consequence of
 	// having a diff here is suppressed in the DiffSuppressFunc, but there is
 	// a risk that the encoding of the map provides an inconsistent result.
-	delete(gottenJSONData, "enableSecureSocksProxy")
-	delete(gottenJSONData, "secureSocksProxyUsername")
+	delete(gottenJSONData, pdcEnableSecureSocksProxy)
+	delete(gottenJSONData, pdcSecureSocksProxyUsername)
 
 	encodedJSONData, err := json.Marshal(gottenJSONData)
 	if err != nil {
@@ -398,8 +415,8 @@ func stateToDatasourceConfig(d *schema.ResourceData) (map[string]any, map[string
 	pdcNetworkID := d.Get("private_data_source_connect_network_id")
 	if pdcNetworkID != nil {
 		if id := pdcNetworkID.(string); id != "" {
-			jd["enableSecureSocksProxy"] = true
-			jd["secureSocksProxyUsername"] = pdcNetworkID
+			jd[pdcEnableSecureSocksProxy] = true
+			jd[pdcSecureSocksProxyUsername] = pdcNetworkID
 		}
 	}
 

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -25,7 +25,6 @@ const (
 )
 
 func resourceDataSource() *common.Resource {
-
 	schema := &schema.Resource{
 
 		Description: `

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -176,12 +176,12 @@ func datasourceJSONDataAttribute() *schema.Schema {
 
 			if strings.Contains(i.(string), pdcEnableSecureSocksProxy) {
 				return nil, []error{
-					errors.New(pdcEnableSecureSocksProxy + " is a reserved key and cannot be used in JSON data."),
+					errors.New(pdcEnableSecureSocksProxy + " is a reserved key and cannot be used in JSON data"),
 				}
 			}
 			if strings.Contains(i.(string), pdcSecureSocksProxyUsername) {
 				return nil, []error{
-					errors.New(pdcSecureSocksProxyUsername + " is a reserved key and cannot be used in JSON data."),
+					errors.New(pdcSecureSocksProxyUsername + " is a reserved key and cannot be used in JSON data"),
 				}
 			}
 			return validation.StringIsJSON(i, s)

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -333,6 +333,14 @@ func datasourceToState(d *schema.ResourceData, dataSource *models.DataSource) di
 
 func datasourceConfigToState(d *schema.ResourceData, dataSource *models.DataSource) diag.Diagnostics {
 	gottenJSONData, gottenHeaders := removeHeadersFromJSONData(dataSource.JSONData.(map[string]any))
+
+	// These PDC fields are added by the provider, so we should remove them from
+	// the state so that the state matches the user config. The consequence of
+	// having a diff here is suppressed in the DiffSuppressFunc, but there is
+	// a risk that the encoding of the map provides an inconsistent result.
+	delete(gottenJSONData, "enableSecureSocksProxy")
+	delete(gottenJSONData, "secureSocksProxyUsername")
+
 	encodedJSONData, err := json.Marshal(gottenJSONData)
 	if err != nil {
 		return diag.Errorf("Failed to marshal JSON data: %s", err)

--- a/internal/resources/grafana/resource_data_source_test.go
+++ b/internal/resources/grafana/resource_data_source_test.go
@@ -341,6 +341,50 @@ func TestAccDataSource_ValidateHttpHeaders(t *testing.T) {
 	})
 }
 
+func TestAccDataSource_PDCReservedProperties(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	t.Run("enableSecureSocksProxy", func(t *testing.T) {
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: `
+					resource "grafana_data_source" "influx" {
+						type         = "influxdb"
+						name         = "anything"
+						url          = "http://acc-test.invalid/"
+						json_data_encoded = jsonencode({
+							enableSecureSocksProxy = true
+						})
+					}`,
+					ExpectError: regexp.MustCompile(`enableSecureSocksProxy is a reserved key and cannot be used in JSON data.`),
+				},
+			},
+		})
+	})
+
+	t.Run("secureSocksProxyUsername", func(t *testing.T) {
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: `
+					resource "grafana_data_source" "influx" {
+						type         = "influxdb"
+						name         = "anything"
+						url          = "http://acc-test.invalid/"
+						json_data_encoded = jsonencode({
+							secureSocksProxyUsername = "pdc-network-id"
+						})
+					}`,
+					ExpectError: regexp.MustCompile(`secureSocksProxyUsername is a reserved key and cannot be used in JSON data.`),
+				},
+			},
+		})
+	})
+}
+
 func TestAccDatasource_PDCPropertiesRemovedFromState(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t)
 

--- a/internal/resources/grafana/resource_data_source_test.go
+++ b/internal/resources/grafana/resource_data_source_test.go
@@ -358,7 +358,7 @@ func TestAccDataSource_PDCReservedProperties(t *testing.T) {
 							enableSecureSocksProxy = true
 						})
 					}`,
-					ExpectError: regexp.MustCompile(`enableSecureSocksProxy is a reserved key and cannot be used in JSON data.`),
+					ExpectError: regexp.MustCompile(`enableSecureSocksProxy is a reserved key and cannot be used in JSON data`),
 				},
 			},
 		})
@@ -378,7 +378,7 @@ func TestAccDataSource_PDCReservedProperties(t *testing.T) {
 							secureSocksProxyUsername = "pdc-network-id"
 						})
 					}`,
-					ExpectError: regexp.MustCompile(`secureSocksProxyUsername is a reserved key and cannot be used in JSON data.`),
+					ExpectError: regexp.MustCompile(`secureSocksProxyUsername is a reserved key and cannot be used in JSON data`),
 				},
 			},
 		})


### PR DESCRIPTION
Unit test run with `make testacc-oss-docker TESTARGS="-run ^TestAccDatasource_PDCPropertiesRemovedFromState$"`


Related to https://github.com/grafana/support-escalations/issues/18903

Prior to this change, when applying a `grafana_data_source` resource that has a `private_data_source_connect_network_id` property, the `json_data_encoded` field for this data source in the returned state would contain a `enableSecureSocksProxy` and a `enableSecureSocksProxy` key. 

This diff between the config and the state is suppressed by the  `DiffSuppressFunc` for data source json, but there may be times when the marshalling of this map would produce different results, since go maps have no ordering guarantees. 

I have not been able to reproduce the issue seen in https://github.com/grafana/support-escalations/issues/18903, but it seems like a good idea to remove this diff between state and config anyway.