### PR TITLE
fix: allowing for type "web" for grafana_oncall_schedule update

### DIFF
--- a/internal/resources/oncall/resource_schedule.go
+++ b/internal/resources/oncall/resource_schedule.go
@@ -227,7 +227,7 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, client 
 
 	timeZoneData, timeZoneOk := d.GetOk("time_zone")
 	if timeZoneOk {
-		if isScheduleTypeCalendar(typeData) {
+		if isScheduleTypeCalendar(typeData) || isScheduleTypeWeb(typeData) {
 			updateOptions.TimeZone = timeZoneData.(string)
 		} else {
 			return diag.Errorf("time_zone can not be set with type: %s", typeData)


### PR DESCRIPTION
Recently, there was a change to update the grafana_oncall_schedule resource to update timezones, which required for the create to allow type "web". We need to apply that for the updating of the resource as well