### PR TITLE
chore: update test matrix to Grafana 11.6.8 and 12.3.0

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - run: make integration-test
 
   cloudinstance:
-    concurrency: 
+    concurrency:
       group: cloud-instance
       cancel-in-progress: false
     runs-on: ubuntu-latest
@@ -70,45 +70,42 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3 # Try 3 times to make sure we don't report failures on flaky tests
           command: make testacc-cloud-instance
-  
+
   local:
     strategy:
       fail-fast: false # Let all versions run, even if one fails
       matrix:
         # OSS tests, run on all versions
-        version: ['11.0.0', '10.4.3', '9.5.18']
+        version: ['12.3.0', '11.6.8']
         type: ['oss']
         subset: ['basic', 'other', 'long']
         include:
-          - version: '11.0.0'
+          - version: '12.3.0'
             type: 'oss'
             subset: examples
           # TLS proxy tests, run only on latest version
-          - version: '11.0.0'
+          - version: '12.3.0'
             type: 'tls'
             subset: 'basic'
           # Sub-path tests. Runs tests on localhost:3000/grafana/
-          - version: '11.0.0'
+          - version: '12.3.0'
             type: 'subpath'
             subset: 'basic'
-          - version: '11.0.0'
+          - version: '12.3.0'
             type: 'subpath'
             subset: 'other'
           # Enterprise tests
-          - version: '11.0.0'
+          - version: '12.3.0'
             type: 'enterprise'
             subset: 'enterprise'
-          - version: '10.4.3'
-            type: 'enterprise'
-            subset: 'enterprise'
-          - version: '9.5.18'
+          - version: '11.6.8'
             type: 'enterprise'
             subset: 'enterprise'
           # Generate tests
-          - version: '11.0.0'
+          - version: '12.3.0'
             type: 'enterprise'
             subset: 'generate'
-          - version: '10.4.3'
+          - version: '11.6.8'
             type: 'enterprise'
             subset: 'generate'
     name: ${{ matrix.version }} - ${{ matrix.type }} - ${{ matrix.subset }}
@@ -158,7 +155,7 @@ jobs:
           command: make testacc-${{ matrix.type }}-docker
         env:
           GRAFANA_VERSION: ${{ matrix.version }}
-          TESTARGS: >- 
+          TESTARGS: >-
             ${{ matrix.subset == 'enterprise' && '-skip="TestAccGenerate" -parallel 2' || '' }}
             ${{ matrix.subset == 'basic' && '-run=".*_basic" -short -parallel 2' || '' }}
             ${{ matrix.subset == 'other' && '-skip=".*_basic" -short -parallel 2' || '' }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-GRAFANA_VERSION ?= 11.0.0
+GRAFANA_VERSION ?= 12.3.0
 DOCKER_COMPOSE_ARGS ?= --force-recreate --detach --remove-orphans --wait --renew-anon-volumes
 
 testacc:


### PR DESCRIPTION
Updates the CI test matrix to support Grafana 12.3.0 (latest stable) and 11.6.8 (latest 11.x), removing outdated versions 9.5.18, 10.4.3, and 11.0.0.

## Changes

### Test Matrix (`.github/workflows/acc-tests.yml`)
- **Before:** `['11.0.0', '10.4.3', '9.5.18']`
- **After:** `['12.3.0', '11.6.8']`

### Default Version (`GNUmakefile`)
- Updates `GRAFANA_VERSION` default from `11.0.0` → `12.3.0`

### Test Cleanup (`resource_alerting_notification_policy_test.go`)
- Removed test case limited to `>=9.1.0,<=11.1.0`
- Simplified error message test (removed version-specific test cases for unsupported versions)
