### PR TITLE
applatform: remove dynamic types from alertrule resource using map

### DIFF
--- a/docs/resources/apps_rules_alertrule_v0alpha1.md
+++ b/docs/resources/apps_rules_alertrule_v0alpha1.md
@@ -103,7 +103,7 @@ resource "grafana_apps_rules_alertrule_v0alpha1" "example" {
     }
     panel_ref = {
       dashboard_uid = "dashboard123"
-      panel_id      = 5
+      panel_id      = "5"
     }
   }
 }
@@ -167,7 +167,7 @@ Optional:
 - `labels` (Map of String) Key-value pairs to attach to the alert rule that can be used in matching, grouping, and routing.
 - `missing_series_evals_to_resolve` (Number) The number of missing series evaluations that must occur before the rule is considered to be resolved.
 - `notification_settings` (Block, Optional) Notification settings for the rule. If specified, it overrides the notification policies. (see [below for nested schema](#nestedblock--spec--notification_settings))
-- `panel_ref` (Object) Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields. (see [below for nested schema](#nestedatt--spec--panel_ref))
+- `panel_ref` (Map of String) Reference to a panel that this alert rule is associated with. Should be an object with 'dashboard_uid' (string) and 'panel_id' (number) fields.
 - `paused` (Boolean) Sets whether the rule should be paused or not.
 - `trigger` (Block, Optional) The trigger configuration for the alert rule. (see [below for nested schema](#nestedblock--spec--trigger))
 
@@ -186,15 +186,6 @@ Optional:
 - `group_wait` (String) Time to wait to buffer alerts of the same group before sending a notification.
 - `mute_timings` (List of String) A list of mute timing names to apply to alerts that match this policy.
 - `repeat_interval` (String) Minimum time interval for re-sending a notification if an alert is still firing.
-
-
-<a id="nestedatt--spec--panel_ref"></a>
-### Nested Schema for `spec.panel_ref`
-
-Optional:
-
-- `dashboard_uid` (String)
-- `panel_id` (Number)
 
 
 <a id="nestedblock--spec--trigger"></a>

--- a/examples/resources/grafana_apps_rules_alertrule_v0alpha1/resource.tf
+++ b/examples/resources/grafana_apps_rules_alertrule_v0alpha1/resource.tf
@@ -88,7 +88,7 @@ resource "grafana_apps_rules_alertrule_v0alpha1" "example" {
     }
     panel_ref = {
       dashboard_uid = "dashboard123"
-      panel_id      = 5
+      panel_id      = "5"
     }
   }
 }


### PR DESCRIPTION
This dynamic type was preventing generation of crossplane provider tooling as dynamic types are not supported. Follow up to #2426

Object type is also not supported unfortunately. Follow up to #2463

Co-authored-by: William Wernert <william.wernert@grafana.com>
