### PR TITLE
Add a ListCollectors cache the collectorResource

### DIFF
--- a/internal/resources/fleetmanagement/resource_collector.go
+++ b/internal/resources/fleetmanagement/resource_collector.go
@@ -117,6 +117,9 @@ func (r *collectorResource) ImportState(ctx context.Context, req resource.Import
 		return
 	}
 
+	// Invalidate cache after import to ensure subsequent reads get fresh data
+	r.resetCache()
+
 	state, diags := collectorMessageToResourceModel(ctx, getResp.Msg)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/resources/fleetmanagement/resource_collector.go
+++ b/internal/resources/fleetmanagement/resource_collector.go
@@ -153,6 +153,9 @@ func (r *collectorResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// Invalidate cache after mutation
+	r.resetCache()
+
 	getReq := &collectorv1.GetCollectorRequest{
 		Id: collector.Id,
 	}
@@ -247,6 +250,9 @@ func (r *collectorResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	// Invalidate cache after mutation
+	r.resetCache()
+
 	getReq := &collectorv1.GetCollectorRequest{
 		Id: collector.Id,
 	}
@@ -285,4 +291,14 @@ func (r *collectorResource) Delete(ctx context.Context, req resource.DeleteReque
 		resp.Diagnostics.AddError("Failed to delete collector", err.Error())
 		return
 	}
+
+	// Invalidate cache after mutation
+	r.resetCache()
+}
+
+// resetCache invalidates the ListCollectors cache so the next Read will fetch fresh data
+func (r *collectorResource) resetCache() {
+	r.listOnce = sync.Once{}
+	r.collectorCache = nil
+	r.listErr = nil
 }


### PR DESCRIPTION
Uses a cached `ListCollectors` response in the `collectorResource`'s `Read()` function to reduce the number of calls while performing `terraform plan`. 

Note that `terraform apply` will still make N `Create`/`Update`/`DeleteCollector` requests + N `GetCollector` requests. This was left as-is for now as updates aren't done in bulk and caching a `ListCollectors` request would have stale collectors for all but the first call to `Update()`.