### PR TITLE
Update Fleet Management collector model to support OTel collectors

### DIFF
--- a/docs/data-sources/fleet_management_collector.md
+++ b/docs/data-sources/fleet_management_collector.md
@@ -38,6 +38,7 @@ data "grafana_fleet_management_collector" "test" {
 
 ### Read-Only
 
+- `collector_type` (String) Type of the collector (ALLOY or OTEL)
 - `enabled` (Boolean) Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 - `local_attributes` (Map of String) Local attributes for the collector
 - `remote_attributes` (Map of String) Remote attributes for the collector

--- a/docs/data-sources/fleet_management_collectors.md
+++ b/docs/data-sources/fleet_management_collectors.md
@@ -39,6 +39,7 @@ data "grafana_fleet_management_collectors" "test" {}
 
 Read-Only:
 
+- `collector_type` (String)
 - `enabled` (Boolean)
 - `id` (String)
 - `local_attributes` (Map of String)

--- a/docs/resources/fleet_management_collector.md
+++ b/docs/resources/fleet_management_collector.md
@@ -44,6 +44,7 @@ resource "grafana_fleet_management_collector" "test" {
 
 ### Optional
 
+- `collector_type` (String) Type of the collector. Must be one of: ALLOY, OTEL. Defaults to ALLOY if not specified.
 - `enabled` (Boolean) Whether remote configuration for the collector is enabled or not. If the collector is disabled, it will receive empty configurations from the Fleet Management service
 - `remote_attributes` (Map of String) Remote attributes for the collector
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/grafana/amixr-api-go-client v0.0.27
 	github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437
-	github.com/grafana/fleet-management-api v1.0.0
+	github.com/grafana/fleet-management-api v1.2.0
 	github.com/grafana/grafana-app-sdk v0.48.1
 	github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20251113191110-a4819b8e1224
 	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20251216082918-50bdab3538ca

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/grafana/amixr-api-go-client v0.0.27 h1:tmw7JcbX3D0N52mK60kYvAdRNFKH0a
 github.com/grafana/amixr-api-go-client v0.0.27/go.mod h1:ihgLhTVimmjASuZ06y/mQxPcYH3toAIuUVGK6flHsMU=
 github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437 h1:OlwbIVFcYgMjnQhpbZwRPVNrvZKTodvPMqwb8yEqVW0=
 github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437/go.mod h1:r+F8H6awwjNQt/KPZ2GNwjk8TvsJ7/gxzkXN26GlL/A=
-github.com/grafana/fleet-management-api v1.0.0 h1:twb0kBgeNRcvQi7iDXq7AFhlM2mWcN76kTXleJuPA38=
-github.com/grafana/fleet-management-api v1.0.0/go.mod h1:6iJjhjWhHZ8iwkyuDXFVTuay57JILnE3kaOPk8Nzorw=
+github.com/grafana/fleet-management-api v1.2.0 h1:nVTXK+3iwTL0aPSNlYiVagzumJ+E8DyhlZvqhpgs9Gg=
+github.com/grafana/fleet-management-api v1.2.0/go.mod h1:6iJjhjWhHZ8iwkyuDXFVTuay57JILnE3kaOPk8Nzorw=
 github.com/grafana/grafana-app-sdk v0.48.1 h1:bKJadWH18WCpJ+Zk8AezRFXCcZgGredRv+fRS+8zkek=
 github.com/grafana/grafana-app-sdk v0.48.1/go.mod h1:5LljCz+wvmGfkQ8ZKTOfserhtXNEF0cSFthoWShvN6c=
 github.com/grafana/grafana-app-sdk/logging v0.48.1 h1:veM0X5LAPyN3KsDLglWjIofndbGuf7MqnrDuDN+F/Ng=

--- a/internal/resources/fleetmanagement/data_source_collector.go
+++ b/internal/resources/fleetmanagement/data_source_collector.go
@@ -79,6 +79,10 @@ Required access policy scopes:
 					"it will receive empty configurations from the Fleet Management service",
 				Computed: true,
 			},
+			"collector_type": schema.StringAttribute{
+				Description: "Type of the collector (ALLOY or OTEL)",
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/internal/resources/fleetmanagement/data_source_collectors.go
+++ b/internal/resources/fleetmanagement/data_source_collectors.go
@@ -75,6 +75,7 @@ Required access policy scopes:
 						"remote_attributes": types.MapType{ElemType: types.StringType},
 						"local_attributes":  types.MapType{ElemType: types.StringType},
 						"enabled":           types.BoolType,
+						"collector_type":    types.StringType,
 					},
 				},
 			},

--- a/internal/resources/fleetmanagement/model_collector_test.go
+++ b/internal/resources/fleetmanagement/model_collector_test.go
@@ -25,7 +25,8 @@ func TestCollectorMessageToDataSourceModel(t *testing.T) {
 			"key3": "value3",
 			"key4": "value4",
 		},
-		Enabled: &enabled,
+		Enabled:       &enabled,
+		CollectorType: collectorv1.CollectorType_COLLECTOR_TYPE_ALLOY,
 	}
 
 	expectedModel := &collectorDataSourceModel{
@@ -44,7 +45,8 @@ func TestCollectorMessageToDataSourceModel(t *testing.T) {
 				"key4": types.StringValue("value4"),
 			},
 		),
-		Enabled: types.BoolPointerValue(&enabled),
+		Enabled:       types.BoolPointerValue(&enabled),
+		CollectorType: types.StringValue("ALLOY"),
 	}
 
 	ctx := context.Background()
@@ -63,7 +65,8 @@ func TestCollectorMessageToResourceModel(t *testing.T) {
 			"key1": "value1",
 			"key2": "value2",
 		},
-		Enabled: &enabled,
+		Enabled:       &enabled,
+		CollectorType: collectorv1.CollectorType_COLLECTOR_TYPE_ALLOY,
 	}
 
 	expectedModel := &collectorResourceModel{
@@ -75,7 +78,8 @@ func TestCollectorMessageToResourceModel(t *testing.T) {
 				"key2": types.StringValue("value2"),
 			},
 		),
-		Enabled: types.BoolPointerValue(&enabled),
+		Enabled:       types.BoolPointerValue(&enabled),
+		CollectorType: types.StringValue("ALLOY"),
 	}
 
 	ctx := context.Background()
@@ -97,7 +101,8 @@ func TestCollectorResourceModelToMessage(t *testing.T) {
 				"key2": types.StringValue("value2"),
 			},
 		),
-		Enabled: types.BoolPointerValue(&enabled),
+		Enabled:       types.BoolPointerValue(&enabled),
+		CollectorType: types.StringValue("ALLOY"),
 	}
 
 	expectedMsg := &collectorv1.Collector{
@@ -106,7 +111,8 @@ func TestCollectorResourceModelToMessage(t *testing.T) {
 			"key1": "value1",
 			"key2": "value2",
 		},
-		Enabled: &enabled,
+		Enabled:       &enabled,
+		CollectorType: collectorv1.CollectorType_COLLECTOR_TYPE_ALLOY,
 	}
 
 	ctx := context.Background()

--- a/internal/resources/fleetmanagement/resource_collector.go
+++ b/internal/resources/fleetmanagement/resource_collector.go
@@ -8,6 +8,7 @@ import (
 	collectorv1 "github.com/grafana/fleet-management-api/api/gen/proto/go/collector/v1"
 	"github.com/grafana/fleet-management-api/api/gen/proto/go/collector/v1/collectorv1connect"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -103,6 +105,14 @@ Required access policy scopes:
 				Optional: true,
 				Computed: true,
 				Default:  booldefault.StaticBool(true),
+			},
+			"collector_type": schema.StringAttribute{
+				Description: "Type of the collector. Must be one of: ALLOY, OTEL",
+				Required:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("ALLOY", "OTEL"),
+				},
 			},
 		},
 	}

--- a/internal/resources/fleetmanagement/resource_collector.go
+++ b/internal/resources/fleetmanagement/resource_collector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -107,9 +108,10 @@ Required access policy scopes:
 				Default:  booldefault.StaticBool(true),
 			},
 			"collector_type": schema.StringAttribute{
-				Description: "Type of the collector. Must be one of: ALLOY, OTEL",
-				Required:    true,
+				Description: "Type of the collector. Must be one of: ALLOY, OTEL. Defaults to ALLOY if not specified.",
+				Optional:    true,
 				Computed:    true,
+				Default:     stringdefault.StaticString("ALLOY"),
 				Validators: []validator.String{
 					stringvalidator.OneOf("ALLOY", "OTEL"),
 				},


### PR DESCRIPTION
This PR adds collector typing to Terraform, so now users can choose to specify whether they want to create alloy or otel collectors