### PR TITLE
fix(grafana): increment page when looking for service account

### DIFF
--- a/internal/resources/grafana/data_source_service_account.go
+++ b/internal/resources/grafana/data_source_service_account.go
@@ -59,6 +59,7 @@ func findServiceAccountByName(client *client.GrafanaHTTPAPI, name string) (*mode
 				return sa, nil
 			}
 		}
+		page++
 	}
 	return nil, fmt.Errorf("service account %q not found", name)
 }


### PR DESCRIPTION
The for loop walking over the pages didn't increment the page number, querying the first page forever.
