### PR TITLE
feat: Add grafana_rule resource for JSON-based alert management

### DIFF
--- a/internal/resources/grafana/common_check_exists_test.go
+++ b/internal/resources/grafana/common_check_exists_test.go
@@ -75,6 +75,13 @@ var (
 			return payloadOrError(resp, err)
 		},
 	)
+	ruleCheckExists = newCheckExistsHelper(
+		func(r *models.ProvisionedAlertRule) string { return r.UID },
+		func(client *goapi.GrafanaHTTPAPI, id string) (*models.ProvisionedAlertRule, error) {
+			resp, err := client.Provisioning.GetAlertRule(id)
+			return payloadOrError(resp, err)
+		},
+	)
 	annotationsCheckExists = newCheckExistsHelper(
 		func(a *models.Annotation) string { return strconv.FormatInt(a.ID, 10) },
 		func(client *goapi.GrafanaHTTPAPI, id string) (*models.Annotation, error) {

--- a/internal/resources/grafana/resource_rule.go
+++ b/internal/resources/grafana/resource_rule.go
@@ -1,0 +1,327 @@
+package grafana
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+)
+
+func resourceRule() *common.Resource {
+	schema := &schema.Resource{
+
+		Description: `
+Manages Grafana Alerting rules.
+
+* [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
+`,
+
+		CreateContext: CreateRule,
+		ReadContext:   ReadRule,
+		UpdateContext: UpdateRule,
+		DeleteContext: DeleteRule,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			oldVal, newVal := d.GetChange("config_json")
+			oldUID := extractRuleUID(oldVal.(string))
+			newUID := extractRuleUID(newVal.(string))
+			if oldUID != newUID && oldUID != "" {
+				d.ForceNew("config_json")
+			}
+			return nil
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org_id": orgIDAttribute(),
+			"uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: "The unique identifier of the alert rule. This is automatically generated if not provided when creating a rule. " +
+					"The uid allows having consistent URLs for accessing rules and when syncing rules between multiple Grafana installs.",
+			},
+			"config_json": {
+				Type:         schema.TypeString,
+				Required:     true,
+				StateFunc:    NormalizeConfigJSON,
+				ValidateFunc: validateConfigJSON,
+				Description:  "The complete alert rule model JSON.",
+			},
+			"disable_provenance": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Allow modifying the rule from other sources than Terraform or the Grafana API.",
+			},
+		},
+		SchemaVersion: 0,
+	}
+
+	return common.NewLegacySDKResource(
+		common.CategoryAlerting,
+		"grafana_rule",
+		orgResourceIDString("uid"),
+		schema,
+	).WithLister(listerFunctionOrgResource(listRules))
+}
+
+func listRules(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
+	resp, err := client.Provisioning.GetAlertRules()
+	if err != nil {
+		return nil, err
+	}
+
+	uids := []string{}
+	for _, rule := range resp.Payload {
+		uids = append(uids, MakeOrgResourceID(orgID, rule.UID))
+	}
+
+	return uids, nil
+}
+
+func CreateRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, orgID := OAPIClientFromNewOrgResource(meta, d)
+
+	rule, err := makeRule(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	params := provisioning.NewPostAlertRuleParams().WithBody(&rule)
+	if d.Get("disable_provenance").(bool) {
+		params.SetXDisableProvenance(&provenanceDisabled)
+	}
+
+	resp, err := client.Provisioning.PostAlertRule(params)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(MakeOrgResourceID(orgID, resp.Payload.UID))
+	return ReadRule(ctx, d, meta)
+}
+
+func ReadRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, orgID, uid := OAPIClientFromExistingOrgResource(meta, d.Id())
+
+	resp, err := client.Provisioning.GetAlertRule(uid)
+	if err, shouldReturn := common.CheckReadError("alert rule", d, err); shouldReturn {
+		return err
+	}
+	rule := resp.Payload
+
+	d.SetId(MakeOrgResourceID(orgID, uid))
+	d.Set("org_id", strconv.FormatInt(orgID, 10))
+	d.Set("uid", rule.UID)
+
+	disableProvenance := rule.Provenance == ""
+	d.Set("disable_provenance", disableProvenance)
+
+	configJSONBytes, err := json.Marshal(rule)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	remoteConfigJSON, err := UnmarshalConfigJSON(string(configJSONBytes))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configJSON := d.Get("config_json").(string)
+
+	// If certain fields are not set in configuration, we need to delete them from the
+	// rule JSON we just read from the Grafana API. This is so it does not
+	// create a diff.
+	if configJSON != "" {
+		configuredConfigJSON, err := UnmarshalConfigJSON(configJSON)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// Remove uid if not in config
+		if _, ok := configuredConfigJSON["uid"].(string); !ok {
+			delete(remoteConfigJSON, "uid")
+		}
+
+		// Note: We intentionally do NOT remove relativeTimeRange from remote if not in config.
+		// If someone added it via Grafana UI, that should show as drift so Terraform can revert it.
+		// We only normalize away known Grafana defaults in NormalizeConfigJSON (empty objects, to:0)
+	}
+	configJSON = NormalizeConfigJSON(remoteConfigJSON)
+	d.Set("config_json", configJSON)
+
+	return nil
+}
+
+func UpdateRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, orgID, uid := OAPIClientFromExistingOrgResource(meta, d.Id())
+
+	rule, err := makeRule(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	params := provisioning.NewPutAlertRuleParams().WithUID(uid).WithBody(&rule)
+	if d.Get("disable_provenance").(bool) {
+		params.SetXDisableProvenance(&provenanceDisabled)
+	}
+
+	resp, err := client.Provisioning.PutAlertRule(params)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(MakeOrgResourceID(orgID, resp.Payload.UID))
+	return ReadRule(ctx, d, meta)
+}
+
+func DeleteRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, _, uid := OAPIClientFromExistingOrgResource(meta, d.Id())
+	_, deleteErr := client.Provisioning.DeleteAlertRule(provisioning.NewDeleteAlertRuleParams().WithUID(uid))
+	err, _ := common.CheckReadError("alert rule", d, deleteErr)
+	return err
+}
+
+func makeRule(d *schema.ResourceData) (models.ProvisionedAlertRule, error) {
+	rule := models.ProvisionedAlertRule{}
+
+	configJSON := d.Get("config_json").(string)
+	ruleMap, err := UnmarshalConfigJSON(configJSON)
+	if err != nil {
+		return rule, err
+	}
+
+	delete(ruleMap, "id")
+	delete(ruleMap, "orgID")
+
+	// Marshal back to JSON and unmarshal into the model
+	// This is a simple way to convert map to struct
+	ruleBytes, err := json.Marshal(ruleMap)
+	if err != nil {
+		return rule, err
+	}
+
+	err = json.Unmarshal(ruleBytes, &rule)
+	if err != nil {
+		return rule, err
+	}
+
+	return rule, nil
+}
+
+// UnmarshalConfigJSON is a convenience func for unmarshalling
+// `config_json` field.
+func UnmarshalConfigJSON(configJSON string) (map[string]interface{}, error) {
+	ruleMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &ruleMap)
+	if err != nil {
+		return nil, err
+	}
+	return ruleMap, nil
+}
+
+// validateConfigJSON is the ValidateFunc for `config_json`. It
+// ensures its value is valid JSON.
+func validateConfigJSON(config interface{}, k string) ([]string, []error) {
+	configJSON := config.(string)
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
+}
+
+// NormalizeConfigJSON is the StateFunc for the `config_json` field.
+//
+// It removes fields that are managed by Grafana and should not be in the configuration.
+func NormalizeConfigJSON(config interface{}) string {
+	var ruleMap map[string]interface{}
+	switch c := config.(type) {
+	case map[string]interface{}:
+		ruleMap = c
+	case string:
+		var err error
+		ruleMap, err = UnmarshalConfigJSON(c)
+		if err != nil {
+			return c
+		}
+	}
+
+	// Remove fields that are managed by Grafana
+	delete(ruleMap, "id")
+	delete(ruleMap, "orgID")
+	delete(ruleMap, "updated")
+	delete(ruleMap, "provenance")
+
+	// Normalize the "data" field - remove default values that Grafana adds
+	if data, ok := ruleMap["data"].([]interface{}); ok {
+		for _, item := range data {
+			if dataItem, ok := item.(map[string]interface{}); ok {
+				// Remove default values that Grafana adds automatically
+				if model, ok := dataItem["model"].(map[string]interface{}); ok {
+					// Remove default maxDataPoints (43200) if present
+					if mdp, ok := model["maxDataPoints"].(float64); ok && mdp == 43200 {
+						delete(model, "maxDataPoints")
+					}
+					// Remove default intervalMs (1000) if present
+					if im, ok := model["intervalMs"].(float64); ok && im == 1000 {
+						delete(model, "intervalMs")
+					}
+				}
+
+				// Normalize relativeTimeRange - remove empty objects and default "to" value
+				if rtr, ok := dataItem["relativeTimeRange"].(map[string]interface{}); ok {
+					// Remove "to" field if it's 0 (the default value that Grafana omits)
+					if toVal, ok := rtr["to"]; ok {
+						if toFloat, ok := toVal.(float64); ok && toFloat == 0 {
+							delete(rtr, "to")
+						}
+					}
+					// Remove empty relativeTimeRange objects after cleanup
+					if len(rtr) == 0 {
+						delete(dataItem, "relativeTimeRange")
+					}
+				}
+			}
+		}
+	}
+
+	// Normalize duration fields to minute format (e.g., "5m" not "5m0s")
+	if forValue, ok := ruleMap["for"]; ok {
+		forStr, isString := forValue.(string)
+		if !isString || forStr == "" {
+			forStr = "0"
+		}
+		forDuration, err := strfmt.ParseDuration(forStr)
+		if err == nil {
+			// Convert to minutes format for consistency
+			ruleMap["for"] = fmt.Sprintf("%dm", int(forDuration.Minutes()))
+		}
+	}
+
+	j, _ := json.Marshal(ruleMap)
+
+	return string(j)
+}
+
+func extractRuleUID(jsonStr string) string {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		return ""
+	}
+	if uid, ok := parsed["uid"].(string); ok {
+		return uid
+	}
+	return ""
+}

--- a/internal/resources/grafana/resource_rule_test.go
+++ b/internal/resources/grafana/resource_rule_test.go
@@ -1,0 +1,401 @@
+package grafana_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/resources/grafana"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccRule_basic(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	var rule models.ProvisionedAlertRule
+
+	expectedInitialConfig := `{"condition":"B","data":[{"datasourceUid":"__expr__","model":{"conditions":[{"evaluator":{"params":[0],"type":"gt"},"operator":{"type":"and"},"query":{"params":["A"]},"type":"query"}],"datasource":{"type":"__expr__","uid":"__expr__"},"expression":"A","reducer":"last","refId":"B","type":"classic_conditions"},"refId":"B","relativeTimeRange":{"from":600,"to":0}}],"execErrState":"Error","folderUID":"test-folder","for":"0m","noDataState":"NoData","ruleGroup":"Test Group","title":"Test Rule","uid":"test-rule"}`
+	expectedUpdatedTitleConfig := `{"condition":"B","data":[{"datasourceUid":"__expr__","model":{"conditions":[{"evaluator":{"params":[0],"type":"gt"},"operator":{"type":"and"},"query":{"params":["A"]},"type":"query"}],"datasource":{"type":"__expr__","uid":"__expr__"},"expression":"A","reducer":"last","refId":"B","type":"classic_conditions"},"refId":"B","relativeTimeRange":{"from":600,"to":0}}],"execErrState":"Error","folderUID":"test-folder","for":"0m","noDataState":"NoData","ruleGroup":"Test Group","title":"Updated Rule Title","uid":"test-rule"}`
+	expectedUpdatedUIDConfig := `{"condition":"B","data":[{"datasourceUid":"__expr__","model":{"conditions":[{"evaluator":{"params":[0],"type":"gt"},"operator":{"type":"and"},"query":{"params":["A"]},"type":"query"}],"datasource":{"type":"__expr__","uid":"__expr__"},"expression":"A","reducer":"last","refId":"B","type":"classic_conditions"},"refId":"B","relativeTimeRange":{"from":600,"to":0}}],"execErrState":"Error","folderUID":"test-folder","for":"0m","noDataState":"NoData","ruleGroup":"Test Group","title":"Updated Rule Title","uid":"test-rule-updated"}`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             ruleCheckExists.destroyed(&rule, nil),
+		Steps: []resource.TestStep{
+			{
+				// Test resource creation.
+				Config: testutils.TestAccExample(t, "resources/grafana_rule/_acc_basic.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestCheckResourceAttr("grafana_rule.test", "id", "1:test-rule"), // <org id>:<uid>
+					resource.TestCheckResourceAttr("grafana_rule.test", "org_id", "1"),
+					resource.TestCheckResourceAttr("grafana_rule.test", "uid", "test-rule"),
+					resource.TestCheckResourceAttr(
+						"grafana_rule.test", "config_json", expectedInitialConfig,
+					),
+					testutils.CheckLister("grafana_rule.test"),
+				),
+			},
+			{
+				// Updates title.
+				Config: testutils.TestAccExample(t, "resources/grafana_rule/_acc_basic_update.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestCheckResourceAttr("grafana_rule.test", "id", "1:test-rule"), // <org id>:<uid>
+					resource.TestCheckResourceAttr("grafana_rule.test", "uid", "test-rule"),
+					resource.TestCheckResourceAttr(
+						"grafana_rule.test", "config_json", expectedUpdatedTitleConfig,
+					),
+				),
+			},
+			{
+				// Updates uid.
+				Config: testutils.TestAccExample(t, "resources/grafana_rule/_acc_basic_update_uid.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestCheckResourceAttr("grafana_rule.test", "id", "1:test-rule-updated"), // <org id>:<uid>
+					resource.TestCheckResourceAttr("grafana_rule.test", "uid", "test-rule-updated"),
+					resource.TestCheckResourceAttr(
+						"grafana_rule.test", "config_json", expectedUpdatedUIDConfig,
+					),
+				),
+			},
+			{
+				// Importing matches the state of the previous step.
+				ResourceName:            "grafana_rule.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccRule_uid_unset(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	var rule models.ProvisionedAlertRule
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             ruleCheckExists.destroyed(&rule, nil),
+		Steps: []resource.TestStep{
+			{
+				// Create rule with no uid set.
+				Config: testutils.TestAccExample(t, "resources/grafana_rule/_acc_uid_unset.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestMatchResourceAttr("grafana_rule.test", "uid", common.UIDRegexp),
+					// Config JSON should not contain uid
+					resource.TestCheckResourceAttrWith("grafana_rule.test", "config_json", func(value string) error {
+						ruleMap, err := grafana.UnmarshalConfigJSON(value)
+						if err != nil {
+							return err
+						}
+						if _, ok := ruleMap["uid"]; ok {
+							return fmt.Errorf("uid should not be in config_json when not set")
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				// Update it to add a uid. We want to ensure that this causes a diff
+				// and subsequent update.
+				Config: testutils.TestAccExample(t, "resources/grafana_rule/_acc_uid_unset_set.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestCheckResourceAttr("grafana_rule.test", "uid", "uid-previously-unset"),
+					resource.TestCheckResourceAttrWith("grafana_rule.test", "config_json", func(value string) error {
+						ruleMap, err := grafana.UnmarshalConfigJSON(value)
+						if err != nil {
+							return err
+						}
+						if uid, ok := ruleMap["uid"].(string); !ok || uid != "uid-previously-unset" {
+							return fmt.Errorf("uid should be 'uid-previously-unset' in config_json, got: %v", ruleMap["uid"])
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				// Remove the uid once again to ensure this is also supported.
+				Config: testutils.TestAccExample(t, "resources/grafana_rule/_acc_uid_unset.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestCheckResourceAttrWith("grafana_rule.test", "config_json", func(value string) error {
+						ruleMap, err := grafana.UnmarshalConfigJSON(value)
+						if err != nil {
+							return err
+						}
+						if _, ok := ruleMap["uid"]; ok {
+							return fmt.Errorf("uid should not be in config_json when not set")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRule_inOrg(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	var rule models.ProvisionedAlertRule
+	var folder models.Folder
+	var org models.OrgDetailsDTO
+
+	orgName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			ruleCheckExists.destroyed(&rule, &org),
+			folderCheckExists.destroyed(&folder, &org),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleInOrganization(orgName),
+				Check: resource.ComposeTestCheckFunc(
+					orgCheckExists.exists("grafana_organization.test", &org),
+					// Check that the folder is in the correct organization
+					folderCheckExists.exists("grafana_folder.test", &folder),
+					resource.TestCheckResourceAttr("grafana_folder.test", "uid", "folder-"+orgName),
+					resource.TestMatchResourceAttr("grafana_folder.test", "id", nonDefaultOrgIDRegexp),
+					checkResourceIsInOrg("grafana_folder.test", "grafana_organization.test"),
+
+					// Check that the rule is in the correct organization
+					ruleCheckExists.exists("grafana_rule.test", &rule),
+					resource.TestCheckResourceAttr("grafana_rule.test", "uid", "rule-"+orgName),
+					resource.TestMatchResourceAttr("grafana_rule.test", "id", nonDefaultOrgIDRegexp),
+					checkResourceIsInOrg("grafana_rule.test", "grafana_organization.test"),
+
+					testAccRuleCheckExistsInFolder(&rule, &folder),
+					testutils.CheckLister("grafana_rule.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRuleCheckExistsInFolder(rule *models.ProvisionedAlertRule, folder *models.Folder) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *rule.FolderUID != folder.UID && folder.UID != "" {
+			return fmt.Errorf("rule.FolderUID(%s) does not match folder.UID(%s)", *rule.FolderUID, folder.UID)
+		}
+		return nil
+	}
+}
+
+func Test_NormalizeConfigJSON(t *testing.T) {
+	testutils.IsUnitTest(t)
+
+	type args struct {
+		config interface{}
+	}
+
+	title := "Test Rule"
+	expected := fmt.Sprintf("{\"condition\":\"B\",\"data\":[{\"datasourceUid\":\"__expr__\",\"model\":{\"refId\":\"B\"},\"refId\":\"B\",\"relativeTimeRange\":{\"from\":600}}],\"execErrState\":\"Error\",\"folderUID\":\"test\",\"for\":\"0m\",\"noDataState\":\"NoData\",\"ruleGroup\":\"Test\",\"title\":\"%s\"}", title)
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "String rule is valid",
+			args: args{config: fmt.Sprintf("{\"title\":\"%s\",\"condition\":\"B\",\"data\":[{\"refId\":\"B\",\"datasourceUid\":\"__expr__\",\"model\":{\"refId\":\"B\"},\"relativeTimeRange\":{\"from\":600,\"to\":0}}],\"execErrState\":\"Error\",\"noDataState\":\"NoData\",\"folderUID\":\"test\",\"ruleGroup\":\"Test\",\"for\":\"0s\"}", title)},
+			want: expected,
+		},
+		{
+			name: "Map rule is valid",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B"}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0s",
+			}},
+			want: expected,
+		},
+		{
+			name: "OrgID is removed",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B"}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0s",
+				"orgID":        float64(1),
+			}},
+			want: expected,
+		},
+		{
+			name: "Provenance is removed",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B"}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0s",
+				"provenance":   "api",
+			}},
+			want: expected,
+		},
+		{
+			name: "Default maxDataPoints is removed",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B", "maxDataPoints": float64(43200)}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0s",
+			}},
+			want: expected,
+		},
+		{
+			name: "Default intervalMs is removed",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B", "intervalMs": float64(1000)}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0s",
+			}},
+			want: expected,
+		},
+		{
+			name: "Duration 0s is normalized to 0m",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B"}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0s",
+			}},
+			want: expected,
+		},
+		{
+			name: "Duration 5m0s is normalized to 5m",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B"}, "relativeTimeRange": map[string]interface{}{"from": float64(600), "to": float64(0)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "5m0s",
+			}},
+			want: fmt.Sprintf("{\"condition\":\"B\",\"data\":[{\"datasourceUid\":\"__expr__\",\"model\":{\"refId\":\"B\"},\"refId\":\"B\",\"relativeTimeRange\":{\"from\":600}}],\"execErrState\":\"Error\",\"folderUID\":\"test\",\"for\":\"5m\",\"noDataState\":\"NoData\",\"ruleGroup\":\"Test\",\"title\":\"%s\"}", title),
+		},
+		{
+			name: "RelativeTimeRange without 'to' field is preserved",
+			args: args{config: map[string]interface{}{
+				"title":        title,
+				"condition":    "B",
+				"data":         []interface{}{map[string]interface{}{"refId": "B", "datasourceUid": "__expr__", "model": map[string]interface{}{"refId": "B"}, "relativeTimeRange": map[string]interface{}{"from": float64(600)}}},
+				"execErrState": "Error",
+				"noDataState":  "NoData",
+				"folderUID":    "test",
+				"ruleGroup":    "Test",
+				"for":          "0m",
+			}},
+			want: fmt.Sprintf("{\"condition\":\"B\",\"data\":[{\"datasourceUid\":\"__expr__\",\"model\":{\"refId\":\"B\"},\"refId\":\"B\",\"relativeTimeRange\":{\"from\":600}}],\"execErrState\":\"Error\",\"folderUID\":\"test\",\"for\":\"0m\",\"noDataState\":\"NoData\",\"ruleGroup\":\"Test\",\"title\":\"%s\"}", title),
+		},
+		{
+			name: "Bad json is ignored",
+			args: args{config: "74D93920-ED26–11E3-AC10–0800200C9A66"},
+			want: "74D93920-ED26–11E3-AC10–0800200C9A66",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := grafana.NormalizeConfigJSON(tt.args.config); got != tt.want {
+				t.Errorf("NormalizeConfigJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func testAccRuleInOrganization(orgName string) string {
+	return fmt.Sprintf(`
+resource "grafana_organization" "test" {
+	name = "%[1]s"
+}
+
+resource "grafana_folder" "test" {
+	org_id  = grafana_organization.test.id
+	title   = "folder-%[1]s"
+	uid     = "folder-%[1]s"
+}
+
+resource "grafana_rule" "test" {
+	org_id      = grafana_organization.test.id
+	config_json = jsonencode({
+		title        = "rule-%[1]s"
+		uid          = "rule-%[1]s"
+		condition    = "B"
+		folderUID    = grafana_folder.test.uid
+		ruleGroup    = "Test Group"
+		noDataState  = "NoData"
+		execErrState = "Error"
+		for          = "0m"
+		data = [
+			{
+				refId         = "B"
+				datasourceUid = "__expr__"
+				model = {
+					refId = "B"
+					type  = "classic_conditions"
+					conditions = [
+						{
+							type     = "query"
+							operator = { type = "and" }
+							query    = { params = ["A"] }
+							evaluator = {
+								type   = "gt"
+								params = [0]
+							}
+						}
+					]
+					datasource = {
+						type = "__expr__"
+						uid  = "__expr__"
+					}
+					expression = "A"
+					reducer    = "last"
+				}
+				relativeTimeRange = {
+					from = 600
+					to   = 0
+				}
+			}
+		]
+	})
+}`, orgName)
+}

--- a/internal/resources/grafana/resources.go
+++ b/internal/resources/grafana/resources.go
@@ -129,6 +129,7 @@ var Resources = addValidationToResources(
 	resourceReport(),
 	resourceRole(),
 	resourceRoleAssignment(),
+	resourceRule(),
 	resourceRuleGroup(),
 	resourceTeam(),
 	resourceTeamExternalGroup(),


### PR DESCRIPTION
Introduces a new grafana_rule resource that allows managing Grafana alerting rules using raw JSON configuration. This provides an alternative to the existing grafana_rule_group resource with more flexible control over individual alert rules.

Key features:
- Manage individual alert rules via JSON configuration (config_json)
- Support for disable_provenance flag to allow external modifications
- Full CRUD operations (Create, Read, Update, Delete)
- Import support for existing rules
- Automatic normalization of Grafana-managed fields

Implementation details:
- NormalizeConfigJSON removes server-managed fields (id, orgID, updated, provenance)
- Normalizes relativeTimeRange.to when set to 0 (Grafana default)
- Removes empty relativeTimeRange objects automatically added by Grafana
- Normalizes duration fields to minute format (e.g., "5m" not "5m0s")
- CustomizeDiff forces new resource when rule UID changes

The resource ensures stable terraform plans by normalizing default values while preserving drift detection for intentional changes made outside of Terraform.