### PR TITLE
frontend-o11y: Add ability to override the API URL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -307,6 +307,7 @@ Replace <stack-slug> and <app-id> with the appropriate values for your environme
 - `fleet_management_auth` (String, Sensitive) A Grafana Fleet Management basic auth in the `username:password` format. May alternatively be set via the `GRAFANA_FLEET_MANAGEMENT_AUTH` environment variable.
 - `fleet_management_url` (String) A Grafana Fleet Management API address. May alternatively be set via the `GRAFANA_FLEET_MANAGEMENT_URL` environment variable.
 - `frontend_o11y_api_access_token` (String, Sensitive) A Grafana Frontend Observability API access token. May alternatively be set via the `GRAFANA_FRONTEND_O11Y_API_ACCESS_TOKEN` environment variable.
+- `frontend_o11y_api_url` (String) The Grafana Frontend Observability API URL. This is optional, and should only be set to override the default API. May alternatively be set via the `GRAFANA_FRONTEND_O11Y_API_URL` environment variable.
 - `http_headers` (Map of String, Sensitive) Optional. HTTP headers mapping keys to values used for accessing the Grafana and Grafana Cloud APIs. May alternatively be set via the `GRAFANA_HTTP_HEADERS` environment variable in JSON format.
 - `insecure_skip_verify` (Boolean) Skip TLS certificate verification. May alternatively be set via the `GRAFANA_INSECURE_SKIP_VERIFY` environment variable.
 - `k6_access_token` (String, Sensitive) The k6 Cloud API token. May alternatively be set via the `GRAFANA_K6_ACCESS_TOKEN` environment variable.

--- a/internal/common/frontendo11yapi/client.go
+++ b/internal/common/frontendo11yapi/client.go
@@ -17,6 +17,7 @@ import (
 var _ json.Unmarshaler = &App{}
 
 type Client struct {
+	apiURL         string
 	authToken      string
 	client         *http.Client
 	cloudAPIHost   string
@@ -30,7 +31,7 @@ const (
 	pathPrefix     = "/api/v1"
 )
 
-func NewClient(cloudAPIHost string, authToken string, client *http.Client, userAgent string, defaultHeaders map[string]string) (*Client, error) {
+func NewClient(feo11yAPIURL, cloudAPIHost, authToken string, client *http.Client, userAgent string, defaultHeaders map[string]string) (*Client, error) {
 	if client == nil {
 		retryClient := retryablehttp.NewClient()
 		retryClient.RetryMax = defaultRetries
@@ -39,6 +40,7 @@ func NewClient(cloudAPIHost string, authToken string, client *http.Client, userA
 	}
 
 	return &Client{
+		apiURL:         feo11yAPIURL,
 		authToken:      authToken,
 		client:         client,
 		cloudAPIHost:   cloudAPIHost,
@@ -110,6 +112,11 @@ var faroEndpointURLsAfterCutoff = map[string]faroEndpointURLRegionCutoff{
 // Some regions have hardcoded exception URLs, and some regions have different URLs based on
 // when the stack was created.
 func (c *Client) FaroEndpointURL(regionSlug string, createdAt time.Time) string {
+	// The URL is manually supplied.
+	if c.apiURL != "" {
+		return c.apiURL
+	}
+
 	if cutoffInfo, ok := faroEndpointURLsAfterCutoff[regionSlug]; ok {
 		if createdAt.After(cutoffInfo.cutoffDate) {
 			return cutoffInfo.faroEndpointURL

--- a/internal/common/frontendo11yapi/client_test.go
+++ b/internal/common/frontendo11yapi/client_test.go
@@ -20,7 +20,7 @@ func Test_NewClient(t *testing.T) {
 	defaultHeaders := map[string]string{}
 
 	t.Run("successfully creates a new client", func(t *testing.T) {
-		client, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", &http.Client{}, "some-user-agent", defaultHeaders)
+		client, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", &http.Client{}, "some-user-agent", defaultHeaders)
 
 		assert.NotNil(t, client)
 		assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestClient_CreateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		acutalApp, err := c.CreateApp(context.Background(), svr.URL, 1, frontendo11yapi.App{
 			Name: "Test App",
@@ -106,7 +106,7 @@ func TestClient_CreateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.CreateApp(context.Background(), svr.URL, 1, frontendo11yapi.App{})
 		require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestClient_CreateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.CreateApp(context.Background(), svr.URL, 1, frontendo11yapi.App{Name: "test app"})
 
@@ -134,7 +134,7 @@ func TestClient_CreateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.CreateApp(context.Background(), svr.URL, 1, frontendo11yapi.App{Name: "test app"})
 
@@ -167,7 +167,7 @@ func TestClient_GetApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		acutalApp, err := c.GetApp(context.Background(), svr.URL, 1, 1)
 		assert.NoError(t, err)
@@ -195,7 +195,7 @@ func TestClient_GetApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.GetApp(context.Background(), svr.URL, 1, 1)
 		require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestClient_GetApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.GetApp(context.Background(), svr.URL, 1, 1)
 
@@ -223,7 +223,7 @@ func TestClient_GetApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.GetApp(context.Background(), svr.URL, 1, 1)
 
@@ -267,7 +267,7 @@ func TestClient_GetApps(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		acutalApps, err := c.GetApps(context.Background(), svr.URL, 1)
 		assert.NoError(t, err)
@@ -309,7 +309,7 @@ func TestClient_GetApps(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.GetApps(context.Background(), svr.URL, 1)
 		require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestClient_GetApps(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.GetApps(context.Background(), svr.URL, 1)
 
@@ -337,7 +337,7 @@ func TestClient_GetApps(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.GetApps(context.Background(), svr.URL, 1)
 
@@ -384,7 +384,7 @@ func TestClient_UpdateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		acutalApp, err := c.UpdateApp(context.Background(), svr.URL, 1, 1, frontendo11yapi.App{
 			Name: "New Name",
@@ -425,7 +425,7 @@ func TestClient_UpdateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.UpdateApp(context.Background(), svr.URL, 1, 1, frontendo11yapi.App{})
 		require.NoError(t, err)
@@ -438,7 +438,7 @@ func TestClient_UpdateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.UpdateApp(context.Background(), svr.URL, 1, 1, frontendo11yapi.App{Name: "Test App"})
 
@@ -454,7 +454,7 @@ func TestClient_UpdateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.UpdateApp(context.Background(), svr.URL, 1, 1, frontendo11yapi.App{Name: "Test App"})
 
@@ -470,7 +470,7 @@ func TestClient_UpdateApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		_, err = c.UpdateApp(context.Background(), svr.URL, 1, 1, frontendo11yapi.App{Name: "Test App"})
 
@@ -492,7 +492,7 @@ func TestClient_DeleteApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		err = c.DeleteApp(context.Background(), svr.URL, 1, 1)
 
@@ -508,7 +508,7 @@ func TestClient_DeleteApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		err = c.DeleteApp(context.Background(), svr.URL, 1, 1)
 		require.NoError(t, err)
@@ -520,7 +520,7 @@ func TestClient_DeleteApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		err = c.DeleteApp(context.Background(), svr.URL, 1, 1)
 
@@ -535,7 +535,7 @@ func TestClient_DeleteApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		err = c.DeleteApp(context.Background(), svr.URL, 1, 1)
 
@@ -551,7 +551,7 @@ func TestClient_DeleteApp(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		c, err := frontendo11yapi.NewClient("grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
 		require.NoError(t, err)
 		err = c.DeleteApp(context.Background(), svr.URL, 1, 1)
 
@@ -564,7 +564,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	defaultHeaders := map[string]string{}
 
 	t.Run("returns exception URL for 'au' region", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("au", time.Now())
@@ -572,7 +572,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns exception URL for 'eu' region", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("eu", time.Now())
@@ -580,7 +580,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns exception URL for 'us' region", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("us", time.Now())
@@ -588,7 +588,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns exception URL for 'us-azure' region", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("us-azure", time.Now())
@@ -596,7 +596,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns cutoff URL for 'prod-us-east-0' region when created after cutoff date", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		// Created after cutoff date (2024-12-18)
@@ -606,7 +606,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns default URL for 'prod-us-east-0' region when created before cutoff date", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		// Created before cutoff date (2024-12-18)
@@ -616,7 +616,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns default URL with grafana.net for non-exception regions", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("prod-some-region", time.Now())
@@ -624,7 +624,7 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns default URL with grafana-dev.net for dev stacks", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana-dev.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("prod-some-region", time.Now())
@@ -632,10 +632,28 @@ func TestClient_FaroEndpointURL(t *testing.T) {
 	})
 
 	t.Run("returns default URL with grafana-ops.net for ops stacks", func(t *testing.T) {
-		c, err := frontendo11yapi.NewClient("grafana-ops.net", "token", &http.Client{}, "ua", defaultHeaders)
+		c, err := frontendo11yapi.NewClient("", "grafana-ops.net", "token", &http.Client{}, "ua", defaultHeaders)
 		require.NoError(t, err)
 
 		url := c.FaroEndpointURL("prod-some-region", time.Now())
 		assert.Equal(t, "https://faro-api-prod-some-region.grafana-ops.net/faro", url)
+	})
+
+	t.Run("returns manually supplied URL when feo11yAPIURL is set", func(t *testing.T) {
+		customURL := "https://custom-faro-api.example.com/faro"
+		c, err := frontendo11yapi.NewClient(customURL, "grafana.net", "token", &http.Client{}, "ua", defaultHeaders)
+		require.NoError(t, err)
+
+		// Should return the custom URL regardless of region or cloudAPIHost
+		url := c.FaroEndpointURL("us", time.Now())
+		assert.Equal(t, customURL, url)
+
+		// Should also override exception regions like 'au'
+		url = c.FaroEndpointURL("au", time.Now())
+		assert.Equal(t, customURL, url)
+
+		// Should also override cutoff-based URLs
+		url = c.FaroEndpointURL("prod-us-east-0", time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.Equal(t, customURL, url)
 	})
 }

--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -347,6 +347,7 @@ func createFrontendO11yClient(client *common.Client, providerConfig ProviderConf
 	cHost := fmt.Sprintf("%s.net", cHostParts[len(cHostParts)-2])
 
 	apiClient, err := frontendo11yapi.NewClient(
+		providerConfig.FrontendO11YAPIURL.ValueString(),
 		cHost,
 		token,
 		getRetryClient(providerConfig),

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -52,8 +52,10 @@ type ProviderConfig struct {
 	ConnectionsAPIAccessToken types.String `tfsdk:"connections_api_access_token"`
 	ConnectionsAPIURL         types.String `tfsdk:"connections_api_url"`
 
-	FleetManagementAuth        types.String `tfsdk:"fleet_management_auth"`
-	FleetManagementURL         types.String `tfsdk:"fleet_management_url"`
+	FleetManagementAuth types.String `tfsdk:"fleet_management_auth"`
+	FleetManagementURL  types.String `tfsdk:"fleet_management_url"`
+
+	FrontendO11YAPIURL         types.String `tfsdk:"frontend_o11y_api_url"`
 	FrontendO11yAPIAccessToken types.String `tfsdk:"frontend_o11y_api_access_token"`
 
 	K6URL         types.String `tfsdk:"k6_url"`
@@ -83,6 +85,7 @@ func (c *ProviderConfig) SetDefaults() error {
 	c.ConnectionsAPIURL = envDefaultFuncString(c.ConnectionsAPIURL, "GRAFANA_CONNECTIONS_API_URL", "https://connections-api.grafana.net")
 	c.FleetManagementAuth = envDefaultFuncString(c.FleetManagementAuth, "GRAFANA_FLEET_MANAGEMENT_AUTH")
 	c.FleetManagementURL = envDefaultFuncString(c.FleetManagementURL, "GRAFANA_FLEET_MANAGEMENT_URL")
+	c.FrontendO11YAPIURL = envDefaultFuncString(c.FrontendO11YAPIURL, "GRAFANA_FRONTEND_O11Y_API_URL")
 	c.FrontendO11yAPIAccessToken = envDefaultFuncString(c.FrontendO11yAPIAccessToken, "GRAFANA_FRONTEND_O11Y_API_ACCESS_TOKEN")
 
 	if v, err := envDefaultFuncInt64(c.OrgID, "GRAFANA_ORG_ID", 1); err != nil {
@@ -265,6 +268,10 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			"fleet_management_url": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "A Grafana Fleet Management API address. May alternatively be set via the `GRAFANA_FLEET_MANAGEMENT_URL` environment variable.",
+			},
+			"frontend_o11y_api_url": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The Grafana Frontend Observability API URL. This is optional, and should only be set to override the default API. May alternatively be set via the `GRAFANA_FRONTEND_O11Y_API_URL` environment variable.",
 			},
 			"frontend_o11y_api_access_token": schema.StringAttribute{
 				Optional:            true,

--- a/pkg/provider/legacy_provider.go
+++ b/pkg/provider/legacy_provider.go
@@ -188,6 +188,13 @@ func Provider(version string) *schema.Provider {
 				Description:  "A Grafana Fleet Management API address. May alternatively be set via the `GRAFANA_FLEET_MANAGEMENT_URL` environment variable.",
 				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 			},
+
+			"frontend_o11y_api_url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The Grafana Frontend Observability API URL. This is optional, and should only be set to override the default API. May alternatively be set via the `GRAFANA_FRONTEND_O11Y_API_URL` environment variable.",
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+			},
 			"frontend_o11y_api_access_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -283,6 +290,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			ConnectionsAPIURL:          stringValueOrNull(d, "connections_api_url"),
 			FleetManagementAuth:        stringValueOrNull(d, "fleet_management_auth"),
 			FleetManagementURL:         stringValueOrNull(d, "fleet_management_url"),
+			FrontendO11YAPIURL:         stringValueOrNull(d, "frontend_o11y_api_url"),
 			FrontendO11yAPIAccessToken: stringValueOrNull(d, "frontend_o11y_api_access_token"),
 			K6URL:                      stringValueOrNull(d, "k6_url"),
 			K6AccessToken:              stringValueOrNull(d, "k6_access_token"),


### PR DESCRIPTION
Sometimes the API URL is different from the one we generate from API response.