### PR TITLE
perf: Improve access policies data source performance

### DIFF
--- a/docs/data-sources/cloud_access_policies.md
+++ b/docs/data-sources/cloud_access_policies.md
@@ -28,7 +28,7 @@ Required access policy scopes:
 ### Optional
 
 - `name_filter` (String) If set, only access policies with the specified name will be returned. This is faster than filtering in Terraform.
-- `region_filter` (String) If set, only access policies in the specified region will be returned. This is faster than filtering in Terraform.
+- `region_filter` (String) If set, only access policies in the specified region will be returned. Otherwise, fetches from all available regions (more resource intensive).
 
 ### Read-Only
 


### PR DESCRIPTION
This PR improves the performance of the `grafana_cloud_access_policies` data source by:

- Parallelizing multi-region API calls (10 concurrent requests)
- Leverage server-side name filtering to reduce network traffic
- Updating documentation to clarify performance implications of the `region_filter`