### PR TITLE
refactor(cloud): migrate cloud_stack resource and data source from sdkv2 to framework

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -30,8 +30,7 @@ data "grafana_cloud_stack" "test" {
 
 ### Required
 
-- `slug` (String) Subdomain that the Grafana instance will be available at (i.e. setting slug to “<stack_slug>” will make the instance
-available at “https://<stack_slug>.grafana.net".
+- `slug` (String) Subdomain that the Grafana instance will be available at (i.e. setting slug to "<stack_slug>" will make the instance available at "https://<stack_slug>.grafana.net".
 
 ### Read-Only
 
@@ -42,7 +41,7 @@ available at “https://<stack_slug>.grafana.net".
 - `alertmanager_user_id` (Number) User ID of the Alertmanager instance configured for this stack.
 - `cluster_name` (String) Name of the cluster where this stack resides.
 - `cluster_slug` (String) Slug of the cluster where this stack resides.
-- `delete_protection` (Boolean) Whether to enable delete protection for the stack, preventing accidental deletion.
+- `delete_protection` (Boolean) Whether delete protection is enabled for the stack.
 - `description` (String) Description of stack.
 - `fleet_management_name` (String) Name of the Fleet Management instance configured for this stack.
 - `fleet_management_private_connectivity_info_private_dns` (String) Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)
@@ -60,7 +59,7 @@ available at “https://<stack_slug>.grafana.net".
 - `graphite_user_id` (Number)
 - `id` (String) The stack id assigned to this stack by Grafana.
 - `influx_url` (String) Base URL of the InfluxDB instance configured for this stack. The username is the same as the metrics' (`prometheus_user_id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/push-from-telegraf/ for docs on how to use this.
-- `labels` (Map of String) A map of labels to assign to the stack. Label keys and values must match the following regexp: "^[a-zA-Z0-9/\\-._]+$" and stacks cannot have more than 10 labels.
+- `labels` (Map of String) A map of labels assigned to the stack.
 - `logs_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Logs instance (Optional)
 - `logs_name` (String)
 - `logs_private_connectivity_info_private_dns` (String) Private DNS for Logs when using AWS PrivateLink (only for AWS stacks)
@@ -105,4 +104,4 @@ available at “https://<stack_slug>.grafana.net".
 - `traces_status` (String)
 - `traces_url` (String) Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL.
 - `traces_user_id` (Number)
-- `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
+- `url` (String) Custom URL for the Grafana instance.

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -45,7 +45,7 @@ resource "grafana_cloud_stack" "test" {
 - `region_slug` (String) Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.
 - `url` (String) Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack
 - `wait_for_readiness` (Boolean) Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.
-- `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s`.
+- `wait_for_readiness_timeout` (String) How long to wait for readiness (if enabled). Defaults to `5m0s` (5 minutes).
 
 ### Read-Only
 

--- a/internal/resources/cloud/data_source_cloud_stack.go
+++ b/internal/resources/cloud/data_source_cloud_stack.go
@@ -3,37 +3,356 @@ package cloud
 import (
 	"context"
 
-	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+var _ datasource.DataSource = &CloudStackDataSource{}
+var _ datasource.DataSourceWithConfigure = &CloudStackDataSource{}
+
+var dataSourceCloudStackName = "grafana_cloud_stack"
+
 func datasourceStack() *common.DataSource {
-	schema := &schema.Resource{
+	return common.NewDataSource(
+		common.CategoryCloud,
+		dataSourceCloudStackName,
+		&CloudStackDataSource{},
+	)
+}
+
+type CloudStackDataSource struct {
+	basePluginFrameworkDataSource
+}
+
+func (r *CloudStackDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = dataSourceCloudStackName
+}
+
+func (r *CloudStackDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
 		Description: "Data source for Grafana Stack",
-		ReadContext: withClient[schema.ReadContextFunc](datasourceStackRead),
-		Schema: common.CloneResourceSchemaForDatasource(resourceStack().Schema, map[string]*schema.Schema{
-			"slug": {
-				Type:     schema.TypeString,
-				Required: true,
-				Description: `
-Subdomain that the Grafana instance will be available at (i.e. setting slug to “<stack_slug>” will make the instance
-available at “https://<stack_slug>.grafana.net".`,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The stack id assigned to this stack by Grafana.",
 			},
-			"region_slug": {
-				Type:        schema.TypeString,
+			"slug": schema.StringAttribute{
+				Required:    true,
+				Description: `Subdomain that the Grafana instance will be available at (i.e. setting slug to "<stack_slug>" will make the instance available at "https://<stack_slug>.grafana.net".`,
+			},
+			"name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of stack. Conventionally matches the url of the instance (e.g. `<stack_slug>.grafana.net`).",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Description of stack.",
+			},
+			"url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Custom URL for the Grafana instance.",
+			},
+			"region_slug": schema.StringAttribute{
 				Computed:    true,
 				Description: "The region this stack is deployed to.",
 			},
-			"wait_for_readiness":         nil,
-			"wait_for_readiness_timeout": nil,
-		}),
+			"cluster_slug": schema.StringAttribute{
+				Computed:    true,
+				Description: "Slug of the cluster where this stack resides.",
+			},
+			"cluster_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the cluster where this stack resides.",
+			},
+			"org_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Organization id to assign to this stack.",
+			},
+			"org_slug": schema.StringAttribute{
+				Computed:    true,
+				Description: "Organization slug to assign to this stack.",
+			},
+			"org_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Organization name to assign to this stack.",
+			},
+			"status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Status of the stack.",
+			},
+			"labels": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "A map of labels assigned to the stack.",
+			},
+			"delete_protection": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether delete protection is enabled for the stack.",
+			},
+
+			// IP Allow List CNAMEs
+			"grafanas_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the grafana instance (Optional)",
+			},
+
+			// Prometheus (Metrics/Mimir)
+			"prometheus_user_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Prometheus user ID. Used for e.g. remote_write.",
+			},
+			"prometheus_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Prometheus url for this instance.",
+			},
+			"prometheus_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Prometheus name for this instance.",
+			},
+			"prometheus_remote_endpoint": schema.StringAttribute{
+				Computed:    true,
+				Description: "Use this URL to query hosted metrics data e.g. Prometheus data source in Grafana",
+			},
+			"prometheus_remote_write_endpoint": schema.StringAttribute{
+				Computed:    true,
+				Description: "Use this URL to send prometheus metrics to Grafana cloud",
+			},
+			"prometheus_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Prometheus status for this instance.",
+			},
+			"prometheus_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Prometheus when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"prometheus_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Prometheus when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"prometheus_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Prometheus instance (Optional)",
+			},
+
+			// Alertmanager
+			"alertmanager_user_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "User ID of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Status of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Alertmanager instances (Optional)",
+			},
+
+			// OnCall
+			"oncall_api_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the OnCall API instance configured for this stack.",
+			},
+
+			// Logs (Loki)
+			"logs_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"logs_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"logs_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"logs_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"logs_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Logs when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"logs_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Logs when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"logs_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Logs instance (Optional)",
+			},
+
+			// Traces (Tempo)
+			"traces_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"traces_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"traces_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL.",
+			},
+			"traces_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"traces_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Traces when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"traces_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Traces when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"traces_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Traces instance (Optional)",
+			},
+
+			// Profiles (Pyroscope)
+			"profiles_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"profiles_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"profiles_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"profiles_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"profiles_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Profiles when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"profiles_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Profiles when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"profiles_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Profiles instance (Optional)",
+			},
+
+			// Graphite
+			"graphite_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"graphite_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"graphite_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"graphite_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"graphite_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Graphite when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"graphite_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Graphite when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"graphite_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Graphite instance (Optional)",
+			},
+
+			// Fleet Management
+			"fleet_management_user_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "User ID of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Status of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"fleet_management_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)",
+			},
+
+			// Connections
+			"influx_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the InfluxDB instance configured for this stack. The username is the same as the metrics' (`prometheus_user_id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/push-from-telegraf/ for docs on how to use this.",
+			},
+			"otlp_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the OTLP instance configured for this stack. The username is the stack's ID (`id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/ for docs on how to use this.",
+			},
+			"otlp_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for OTLP when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"otlp_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for OTLP when using AWS PrivateLink (only for AWS stacks)",
+			},
+
+			// PDC
+			"pdc_api_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for PDC's API when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"pdc_api_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for PDC's API when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"pdc_gateway_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"pdc_gateway_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)",
+			},
+
+			// Note: wait_for_readiness and wait_for_readiness_timeout are not included as they are resource-only attributes
+		},
 	}
-	return common.NewLegacySDKDataSource(common.CategoryCloud, "grafana_cloud_stack", schema)
 }
 
-func datasourceStackRead(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	d.SetId(d.Get("slug").(string))
-	return readStack(ctx, d, client)
+func (r *CloudStackDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Read Terraform state data into a temporary struct with just the slug
+	var data struct {
+		Slug types.String `tfsdk:"slug"`
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Use the shared read function
+	model, diags := ReadStackData(ctx, r.client, data.Slug.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }

--- a/internal/resources/cloud/data_source_cloud_stack_test.go
+++ b/internal/resources/cloud/data_source_cloud_stack_test.go
@@ -52,6 +52,7 @@ resource "grafana_cloud_stack" "test" {
   name = "%s"
   slug = "%s"
   region_slug = "eu"
+  delete_protection = false
 }
 data "grafana_cloud_stack" "test" {
   slug = grafana_cloud_stack.test.slug

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -13,11 +14,21 @@ import (
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkdiag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const defaultReadinessTimeout = time.Minute * 5
@@ -25,248 +36,24 @@ const defaultReadinessTimeout = time.Minute * 5
 var (
 	stackLabelRegex = regexp.MustCompile(`^[a-zA-Z0-9/\-._]+$`)
 	stackSlugRegex  = regexp.MustCompile(`^[a-z][a-z0-9]+$`)
-	resourceStackID = common.NewResourceID(common.StringIDField("stackSlugOrID"))
 )
 
-func privateConnectivityDescription(prefix, service string) *schema.Schema {
-	return common.ComputedStringWithDescription(
-		fmt.Sprintf(
-			"%s for %s when using AWS PrivateLink (only for AWS stacks)",
-			prefix,
-			service,
-		))
-}
+var _ resource.Resource = &CloudStackResource{}
+var _ resource.ResourceWithConfigure = &CloudStackResource{}
+var _ resource.ResourceWithImportState = &CloudStackResource{}
 
-func ipAllowListCNAMEDescription(service string) *schema.Schema {
-	return common.ComputedStringWithDescription(
-		fmt.Sprintf(
-			"Comma-separated list of CNAMEs that can be whitelisted to access %s (Optional)", service,
-		),
-	)
+var resourceCloudStackName = "grafana_cloud_stack"
+
+type CloudStackResource struct {
+	basePluginFrameworkResource
 }
 
 func resourceStack() *common.Resource {
-	schema := &schema.Resource{
-		Description: `
-* [Official documentation](https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#stacks/)
-
-Required access policy scopes:
-
-* stacks:read
-* stacks:write
-* stacks:delete
-`,
-
-		CreateContext: withClient[schema.CreateContextFunc](createStack),
-		UpdateContext: withClient[schema.UpdateContextFunc](updateStack),
-		DeleteContext: withClient[schema.DeleteContextFunc](deleteStack),
-		ReadContext:   withClient[schema.ReadContextFunc](readStack),
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The stack id assigned to this stack by Grafana.",
-			},
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Name of stack. Conventionally matches the url of the instance (e.g. `<stack_slug>.grafana.net`).",
-			},
-			"description": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Description of stack.",
-			},
-			"slug": {
-				Type:     schema.TypeString,
-				Required: true,
-				Description: "Subdomain that the Grafana instance will be available at. " +
-					"Setting slug to `<stack_slug>` will make the instance available at `https://<stack_slug>.grafana.net`.",
-				ValidateFunc: validation.All(
-					validation.StringMatch(stackSlugRegex, "must be a lowercase alphanumeric string and must start with a letter."),
-					validation.StringLenBetween(1, 29),
-				),
-			},
-			"region_slug": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.`,
-				DiffSuppressFunc: func(_, oldValue, newValue string, _ *schema.ResourceData) bool {
-					return oldValue == newValue || newValue == "" // Ignore default region
-				},
-			},
-			"cluster_slug": common.ComputedStringWithDescription("Slug of the cluster where this stack resides."),
-			"cluster_name": common.ComputedStringWithDescription("Name of the cluster where this stack resides."),
-			"url": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack",
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-					return oldValue == newValue ||
-						// No diff if we're using the default URL
-						(oldValue == defaultStackURL(d.Get("slug").(string)) && newValue == "")
-				},
-			},
-			"wait_for_readiness": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
-				// Suppress the diff if the stack is already created
-				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool { return !d.IsNewResource() },
-			},
-			"wait_for_readiness_timeout": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          defaultReadinessTimeout.String(),
-				ValidateDiagFunc: common.ValidateDuration,
-				// Only used when wait_for_readiness is true
-				DiffSuppressFunc: func(_, _, newValue string, d *schema.ResourceData) bool {
-					return newValue == defaultReadinessTimeout.String()
-				},
-				Description: "How long to wait for readiness (if enabled).",
-			},
-			"org_id":   common.ComputedIntWithDescription("Organization id to assign to this stack."),
-			"org_slug": common.ComputedStringWithDescription("Organization slug to assign to this stack."),
-			"org_name": common.ComputedStringWithDescription("Organization name to assign to this stack."),
-			"status":   common.ComputedStringWithDescription("Status of the stack."),
-			"labels": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Description: fmt.Sprintf("A map of labels to assign to the stack. Label keys and values must match the following regexp: %q and stacks cannot have more than 10 labels.", stackLabelRegex.String()),
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				ValidateFunc: func(i any, s string) ([]string, []error) {
-					labels := i.(map[string]any)
-					if len(labels) > 10 {
-						return nil, []error{fmt.Errorf("stacks cannot have more than 10 labels")}
-					}
-					for k, v := range labels {
-						if !stackLabelRegex.MatchString(k) {
-							return nil, []error{fmt.Errorf("label key %q does not match %q", k, stackLabelRegex.String())}
-						}
-						if !stackLabelRegex.MatchString(v.(string)) {
-							return nil, []error{fmt.Errorf("label value %q does not match %q", v, stackLabelRegex.String())}
-						}
-					}
-					return nil, nil
-				},
-			},
-			"delete_protection": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether to enable delete protection for the stack, preventing accidental deletion.",
-			},
-
-			"grafanas_ip_allow_list_cname": ipAllowListCNAMEDescription("the grafana instance"),
-
-			// Metrics (Mimir/Prometheus)
-			"prometheus_user_id":                                common.ComputedIntWithDescription("Prometheus user ID. Used for e.g. remote_write."),
-			"prometheus_url":                                    common.ComputedStringWithDescription("Prometheus url for this instance."),
-			"prometheus_name":                                   common.ComputedStringWithDescription("Prometheus name for this instance."),
-			"prometheus_remote_endpoint":                        common.ComputedStringWithDescription("Use this URL to query hosted metrics data e.g. Prometheus data source in Grafana"),
-			"prometheus_remote_write_endpoint":                  common.ComputedStringWithDescription("Use this URL to send prometheus metrics to Grafana cloud"),
-			"prometheus_status":                                 common.ComputedStringWithDescription("Prometheus status for this instance."),
-			"prometheus_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "Prometheus"),
-			"prometheus_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "Prometheus"),
-			"prometheus_ip_allow_list_cname":                    ipAllowListCNAMEDescription("the Prometheus instance"),
-
-			// Alertmanager
-			"alertmanager_user_id":             common.ComputedIntWithDescription("User ID of the Alertmanager instance configured for this stack."),
-			"alertmanager_name":                common.ComputedStringWithDescription("Name of the Alertmanager instance configured for this stack."),
-			"alertmanager_url":                 common.ComputedStringWithDescription("Base URL of the Alertmanager instance configured for this stack."),
-			"alertmanager_status":              common.ComputedStringWithDescription("Status of the Alertmanager instance configured for this stack."),
-			"alertmanager_ip_allow_list_cname": ipAllowListCNAMEDescription("the Alertmanager instances"),
-
-			// OnCall
-			"oncall_api_url": common.ComputedStringWithDescription("Base URL of the OnCall API instance configured for this stack."),
-
-			// Logs (Loki)
-			"logs_user_id": common.ComputedInt(),
-			"logs_name":    common.ComputedString(),
-			"logs_url":     common.ComputedString(),
-			"logs_status":  common.ComputedString(),
-			"logs_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "Logs"),
-			"logs_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "Logs"),
-			"logs_ip_allow_list_cname":                    ipAllowListCNAMEDescription("the Logs instance"),
-
-			// Traces (Tempo)
-			"traces_user_id": common.ComputedInt(),
-			"traces_name":    common.ComputedString(),
-			"traces_url":     common.ComputedStringWithDescription("Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL."),
-			"traces_status":  common.ComputedString(),
-			"traces_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "Traces"),
-			"traces_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "Traces"),
-			"traces_ip_allow_list_cname":                    ipAllowListCNAMEDescription("the Traces instance"),
-
-			// Profiles (Pyroscope)
-			"profiles_user_id": common.ComputedInt(),
-			"profiles_name":    common.ComputedString(),
-			"profiles_url":     common.ComputedString(),
-			"profiles_status":  common.ComputedString(),
-			"profiles_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "Profiles"),
-			"profiles_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "Profiles"),
-			"profiles_ip_allow_list_cname":                    ipAllowListCNAMEDescription("the Profiles instance"),
-
-			// Graphite
-			"graphite_user_id": common.ComputedInt(),
-			"graphite_name":    common.ComputedString(),
-			"graphite_url":     common.ComputedString(),
-			"graphite_status":  common.ComputedString(),
-			"graphite_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "Graphite"),
-			"graphite_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "Graphite"),
-			"graphite_ip_allow_list_cname":                    ipAllowListCNAMEDescription("the Graphite instance"),
-
-			// Fleet Management
-			"fleet_management_user_id":                                common.ComputedIntWithDescription("User ID of the Fleet Management instance configured for this stack."),
-			"fleet_management_name":                                   common.ComputedStringWithDescription("Name of the Fleet Management instance configured for this stack."),
-			"fleet_management_url":                                    common.ComputedStringWithDescription("Base URL of the Fleet Management instance configured for this stack."),
-			"fleet_management_status":                                 common.ComputedStringWithDescription("Status of the Fleet Management instance configured for this stack."),
-			"fleet_management_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "Fleet Management"),
-			"fleet_management_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "Fleet Management"),
-
-			// Connections
-			"influx_url": common.ComputedStringWithDescription("Base URL of the InfluxDB instance configured for this stack. The username is the same as the metrics' (`prometheus_user_id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/push-from-telegraf/ for docs on how to use this."),
-			"otlp_url":   common.ComputedStringWithDescription("Base URL of the OTLP instance configured for this stack. The username is the stack's ID (`id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/ for docs on how to use this."),
-			"otlp_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "OTLP"),
-			"otlp_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "OTLP"),
-
-			// pdc
-			"pdc_api_private_connectivity_info_private_dns":      privateConnectivityDescription("Private DNS", "PDC's API"),
-			"pdc_api_private_connectivity_info_service_name":     privateConnectivityDescription("Service Name", "PDC's API"),
-			"pdc_gateway_private_connectivity_info_private_dns":  privateConnectivityDescription("Private DNS", "PDC's Gateway"),
-			"pdc_gateway_private_connectivity_info_service_name": privateConnectivityDescription("Service Name", "PDC's Gateway"),
-		},
-		CustomizeDiff: customdiff.All(
-			customdiff.ComputedIf("url", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
-				return diff.HasChange("slug")
-			}),
-			customdiff.ComputedIf("alertmanager_name", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
-				return diff.HasChange("slug")
-			}),
-			customdiff.ComputedIf("logs_name", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
-				return diff.HasChange("slug")
-			}),
-			customdiff.ComputedIf("traces_name", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
-				return diff.HasChange("slug")
-			}),
-			customdiff.ComputedIf("prometheus_name", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
-				return diff.HasChange("slug")
-			}),
-		),
-	}
-
-	return common.NewLegacySDKResource(
+	return common.NewResource(
 		common.CategoryCloud,
-		"grafana_cloud_stack",
-		resourceStackID,
-		schema,
+		resourceCloudStackName,
+		common.NewResourceID(common.StringIDField("stackSlugOrID")),
+		&CloudStackResource{},
 	).
 		WithLister(cloudListerFunction(listStacks)).
 		WithPreferredResourceNameField("name")
@@ -285,332 +72,681 @@ func listStacks(ctx context.Context, client *gcom.APIClient, data *ListerData) (
 	return stackSlugs, nil
 }
 
-func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	stack := gcom.PostInstancesRequest{
-		Name:             d.Get("name").(string),
-		Slug:             common.Ref(d.Get("slug").(string)),
-		Url:              common.Ref(d.Get("url").(string)),
-		Region:           common.Ref(d.Get("region_slug").(string)),
-		Description:      common.Ref(d.Get("description").(string)),
-		Labels:           common.Ref(common.UnpackMap[string](d.Get("labels"))),
-		DeleteProtection: common.Ref(d.Get("delete_protection").(bool)),
+func (r *CloudStackResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = resourceCloudStackName
+}
+
+func (r *CloudStackResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `
+* [Official documentation](https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#stacks/)
+
+Required access policy scopes:
+
+* stacks:read
+* stacks:write
+* stacks:delete
+`,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The stack id assigned to this stack by Grafana.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of stack. Conventionally matches the url of the instance (e.g. `<stack_slug>.grafana.net`).",
+			},
+			"description": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Description of stack.",
+			},
+			"slug": schema.StringAttribute{
+				Required:    true,
+				Description: "Subdomain that the Grafana instance will be available at. Setting slug to `<stack_slug>` will make the instance available at `https://<stack_slug>.grafana.net`.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(stackSlugRegex, "must be a lowercase alphanumeric string and must start with a letter."),
+					stringvalidator.LengthBetween(1, 29),
+				},
+			},
+			"region_slug": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"cluster_slug": schema.StringAttribute{
+				Computed:    true,
+				Description: "Slug of the cluster where this stack resides.",
+			},
+			"cluster_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the cluster where this stack resides.",
+			},
+			"url": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Custom URL for the Grafana instance. Must have a CNAME setup to point to `.grafana.net` before creating the stack",
+			},
+			"wait_for_readiness": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"wait_for_readiness_timeout": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(defaultReadinessTimeout.String()),
+				Description: "How long to wait for readiness (if enabled).",
+			},
+			"org_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Organization id to assign to this stack.",
+			},
+			"org_slug": schema.StringAttribute{
+				Computed:    true,
+				Description: "Organization slug to assign to this stack.",
+			},
+			"org_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Organization name to assign to this stack.",
+			},
+			"status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Status of the stack.",
+			},
+			"labels": schema.MapAttribute{
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: fmt.Sprintf("A map of labels to assign to the stack. Label keys and values must match the following regexp: %q and stacks cannot have more than 10 labels.", stackLabelRegex.String()),
+				Validators: []validator.Map{
+					mapvalidator.SizeAtMost(10),
+					mapvalidator.KeysAre(stringvalidator.RegexMatches(stackLabelRegex, "label key must match "+stackLabelRegex.String())),
+					mapvalidator.ValueStringsAre(stringvalidator.RegexMatches(stackLabelRegex, "label value must match "+stackLabelRegex.String())),
+				},
+			},
+			"delete_protection": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether to enable delete protection for the stack, preventing accidental deletion.",
+			},
+
+			// IP Allow List CNAMEs
+			"grafanas_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the grafana instance (Optional)",
+			},
+
+			// Prometheus (Metrics/Mimir) - all computed
+			"prometheus_user_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "Prometheus user ID. Used for e.g. remote_write.",
+			},
+			"prometheus_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Prometheus url for this instance.",
+			},
+			"prometheus_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Prometheus name for this instance.",
+			},
+			"prometheus_remote_endpoint": schema.StringAttribute{
+				Computed:    true,
+				Description: "Use this URL to query hosted metrics data e.g. Prometheus data source in Grafana",
+			},
+			"prometheus_remote_write_endpoint": schema.StringAttribute{
+				Computed:    true,
+				Description: "Use this URL to send prometheus metrics to Grafana cloud",
+			},
+			"prometheus_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Prometheus status for this instance.",
+			},
+			"prometheus_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Prometheus when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"prometheus_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Prometheus when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"prometheus_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Prometheus instance (Optional)",
+			},
+
+			// Alertmanager - all computed
+			"alertmanager_user_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "User ID of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Status of the Alertmanager instance configured for this stack.",
+			},
+			"alertmanager_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Alertmanager instances (Optional)",
+			},
+
+			// OnCall
+			"oncall_api_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the OnCall API instance configured for this stack.",
+			},
+
+			// Logs (Loki) - all computed
+			"logs_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"logs_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"logs_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"logs_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"logs_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Logs when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"logs_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Logs when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"logs_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Logs instance (Optional)",
+			},
+
+			// Traces (Tempo) - all computed
+			"traces_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"traces_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"traces_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the Traces instance configured for this stack. To use this in the Tempo data source in Grafana, append `/tempo` to the URL.",
+			},
+			"traces_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"traces_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Traces when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"traces_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Traces when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"traces_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Traces instance (Optional)",
+			},
+
+			// Profiles (Pyroscope) - all computed
+			"profiles_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"profiles_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"profiles_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"profiles_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"profiles_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Profiles when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"profiles_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Profiles when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"profiles_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Profiles instance (Optional)",
+			},
+
+			// Graphite - all computed
+			"graphite_user_id": schema.Int64Attribute{
+				Computed: true,
+			},
+			"graphite_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"graphite_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"graphite_status": schema.StringAttribute{
+				Computed: true,
+			},
+			"graphite_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Graphite when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"graphite_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Graphite when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"graphite_ip_allow_list_cname": schema.StringAttribute{
+				Computed:    true,
+				Description: "Comma-separated list of CNAMEs that can be whitelisted to access the Graphite instance (Optional)",
+			},
+
+			// Fleet Management - all computed
+			"fleet_management_user_id": schema.Int64Attribute{
+				Computed:    true,
+				Description: "User ID of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_status": schema.StringAttribute{
+				Computed:    true,
+				Description: "Status of the Fleet Management instance configured for this stack.",
+			},
+			"fleet_management_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for Fleet Management when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"fleet_management_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for Fleet Management when using AWS PrivateLink (only for AWS stacks)",
+			},
+
+			// Connections
+			"influx_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the InfluxDB instance configured for this stack. The username is the same as the metrics' (`prometheus_user_id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/push-from-telegraf/ for docs on how to use this.",
+			},
+			"otlp_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Base URL of the OTLP instance configured for this stack. The username is the stack's ID (`id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/ for docs on how to use this.",
+			},
+			"otlp_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for OTLP when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"otlp_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for OTLP when using AWS PrivateLink (only for AWS stacks)",
+			},
+
+			// PDC
+			"pdc_api_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for PDC's API when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"pdc_api_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for PDC's API when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"pdc_gateway_private_connectivity_info_private_dns": schema.StringAttribute{
+				Computed:    true,
+				Description: "Private DNS for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)",
+			},
+			"pdc_gateway_private_connectivity_info_service_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service Name for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)",
+			},
+		},
+	}
+}
+
+func (r *CloudStackResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data StackModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
+	// Convert labels if present
+	var labels map[string]string
+	if !data.Labels.IsNull() && !data.Labels.IsUnknown() {
+		resp.Diagnostics.Append(data.Labels.ElementsAs(ctx, &labels, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	stack := gcom.PostInstancesRequest{
+		Name:             data.Name.ValueString(),
+		Slug:             common.Ref(data.Slug.ValueString()),
+		Url:              common.Ref(data.URL.ValueString()),
+		Region:           common.Ref(data.RegionSlug.ValueString()),
+		Description:      common.Ref(data.Description.ValueString()),
+		Labels:           common.Ref(labels),
+		DeleteProtection: common.Ref(data.DeleteProtection.ValueBool()),
+	}
+
+	fmt.Printf("Starting to create: %+v\n", stack)
+
 	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		req := client.InstancesAPI.PostInstances(ctx).PostInstancesRequest(stack).XRequestId(ClientRequestID())
-		createdStack, _, err := req.Execute()
+		createReq := r.client.InstancesAPI.PostInstances(ctx).PostInstancesRequest(stack).XRequestId(ClientRequestID())
+		createdStack, httpResp, err := createReq.Execute()
+
+		// Helper function to get response body
+		getResponseBody := func(resp *http.Response) string {
+			if resp == nil || resp.Body == nil {
+				return ""
+			}
+			body, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				return fmt.Sprintf("(error reading body: %v)", readErr)
+			}
+			return string(body)
+		}
+
+		if httpResp != nil {
+			fmt.Printf("Response Status: %+v\n", httpResp)
+		}
+
 		switch {
 		case err != nil && strings.Contains(strings.ToLower(err.Error()), "conflict"):
-			// If the API returns a conflict error, it means that the stack already exists
-			// It may also mean that the stack was recently deleted and is still in the process of being deleted
-			// In that case, we want to retry
-			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
-			return retry.RetryableError(err)
+			time.Sleep(10 * time.Second)
+			errMsg := fmt.Sprintf("conflict error: %v", err)
+			if httpResp != nil {
+				bodyMsg := getResponseBody(httpResp)
+				errMsg = fmt.Sprintf("conflict error (status %d): %v - response: %s", httpResp.StatusCode, err, bodyMsg)
+			}
+			return retry.RetryableError(fmt.Errorf("%s", errMsg))
 		case err != nil:
-			// If we had an error that isn't a a conflict error (already exists), try to read the stack
-			// Sometimes, the stack is created but the API returns an error (e.g. 504)
-			readReq := client.InstancesAPI.GetInstance(ctx, *stack.Slug)
+			// If we had an error that isn't a conflict, try to read the stack
+			readReq := r.client.InstancesAPI.GetInstance(ctx, *stack.Slug)
 			readStack, _, readErr := readReq.Execute()
 			if readErr == nil {
-				d.SetId(strconv.FormatInt(int64(readStack.Id), 10))
+				data.ID = types.StringValue(strconv.FormatInt(int64(readStack.Id), 10))
 				return nil
 			}
-			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
-			return retry.RetryableError(fmt.Errorf("failed to create stack: %w", err))
+			time.Sleep(10 * time.Second)
+			errMsg := fmt.Sprintf("failed to create stack: %v", err)
+			if httpResp != nil {
+				bodyMsg := getResponseBody(httpResp)
+				errMsg = fmt.Sprintf("failed to create stack (status %d): %v - response: %s", httpResp.StatusCode, err, bodyMsg)
+			}
+			return retry.RetryableError(fmt.Errorf("%s", errMsg))
 		default:
-			d.SetId(strconv.FormatInt(int64(createdStack.Id), 10))
+			data.ID = types.StringValue(strconv.FormatInt(int64(createdStack.Id), 10))
 		}
 		return nil
 	})
 	if err != nil {
-		return apiError(err)
+		resp.Diagnostics.AddError("Failed to create stack", err.Error())
+		return
 	}
 
-	if diag := readStack(ctx, d, client); diag != nil {
-		return diag
+	// Read back the full stack data
+	model, diags := ReadStackData(ctx, r.client, data.ID.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if d.Get("wait_for_readiness").(bool) {
+	// Preserve the wait_for_readiness settings from the plan
+	model.WaitForReadiness = data.WaitForReadiness
+	model.WaitForReadinessTimeout = data.WaitForReadinessTimeout
+
+	// Wait for readiness if requested
+	if model.WaitForReadiness.ValueBool() {
 		timeout := defaultReadinessTimeout
-		if timeoutVal := d.Get("wait_for_readiness_timeout").(string); timeoutVal != "" {
-			timeout, _ = time.ParseDuration(timeoutVal)
+		if !model.WaitForReadinessTimeout.IsNull() && model.WaitForReadinessTimeout.ValueString() != "" {
+			timeout, _ = time.ParseDuration(model.WaitForReadinessTimeout.ValueString())
 		}
-		return waitForStackReadiness(ctx, timeout, d.Get("url").(string))
+		diags = waitForStackReadinessFramework(ctx, timeout, model.URL.ValueString())
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
-	return nil
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
-func updateStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	id, err := resourceStackID.Single(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
+func (r *CloudStackResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data StackModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Use the shared read function
+	model, diags := ReadStackData(ctx, r.client, data.ID.ValueString())
+	if diags.HasError() {
+		// Check if it's a not found error
+		for _, d := range diags.Errors() {
+			if strings.Contains(d.Summary(), "not found") || strings.Contains(d.Summary(), "deleted") {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+		}
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Preserve wait_for_readiness settings from state
+	model.WaitForReadiness = data.WaitForReadiness
+	model.WaitForReadinessTimeout = data.WaitForReadinessTimeout
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func (r *CloudStackResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data StackModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert labels if present
+	var labels map[string]string
+	if !data.Labels.IsNull() && !data.Labels.IsUnknown() {
+		resp.Diagnostics.Append(data.Labels.ElementsAs(ctx, &labels, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Default to the slug if the URL is not set
-	url := d.Get("url").(string)
+	url := data.URL.ValueString()
 	if url == "" {
-		url = defaultStackURL(d.Get("slug").(string))
+		url = defaultStackURL(data.Slug.ValueString())
 	}
 
 	stack := gcom.PostInstanceRequest{
-		Name:             common.Ref(d.Get("name").(string)),
-		Slug:             common.Ref(d.Get("slug").(string)),
-		Description:      common.Ref(d.Get("description").(string)),
+		Name:             common.Ref(data.Name.ValueString()),
+		Slug:             common.Ref(data.Slug.ValueString()),
+		Description:      common.Ref(data.Description.ValueString()),
 		Url:              &url,
-		Labels:           common.Ref(common.UnpackMap[string](d.Get("labels"))),
-		DeleteProtection: common.Ref(d.Get("delete_protection").(bool)),
+		Labels:           common.Ref(labels),
+		DeleteProtection: common.Ref(data.DeleteProtection.ValueBool()),
 	}
-	req := client.InstancesAPI.PostInstance(ctx, id.(string)).PostInstanceRequest(stack).XRequestId(ClientRequestID())
-	_, _, err = req.Execute()
+
+	updateReq := r.client.InstancesAPI.PostInstance(ctx, data.ID.ValueString()).PostInstanceRequest(stack).XRequestId(ClientRequestID())
+	_, httpResp, err := updateReq.Execute()
 	if err != nil {
-		return apiError(err)
+		errMsg := fmt.Sprintf("error: %v", err)
+		if httpResp != nil && httpResp.Body != nil {
+			body, _ := io.ReadAll(httpResp.Body)
+			httpResp.Body.Close()
+			errMsg = fmt.Sprintf("error (status %d): %v - response: %s", httpResp.StatusCode, err, string(body))
+		} else if httpResp != nil {
+			errMsg = fmt.Sprintf("error (status %d): %v", httpResp.StatusCode, err)
+		}
+		resp.Diagnostics.AddError("Failed to update stack", errMsg)
+		return
 	}
 
-	if diag := readStack(ctx, d, client); diag != nil {
-		return diag
+	// Read back the full stack data
+	model, diags := ReadStackData(ctx, r.client, data.ID.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if d.Get("wait_for_readiness").(bool) {
+	// Preserve wait_for_readiness settings from plan
+	model.WaitForReadiness = data.WaitForReadiness
+	model.WaitForReadinessTimeout = data.WaitForReadinessTimeout
+
+	// Wait for readiness if requested
+	if model.WaitForReadiness.ValueBool() {
 		timeout := defaultReadinessTimeout
-		if timeoutVal := d.Get("wait_for_readiness_timeout").(string); timeoutVal != "" {
-			timeout, _ = time.ParseDuration(timeoutVal)
+		if !model.WaitForReadinessTimeout.IsNull() && model.WaitForReadinessTimeout.ValueString() != "" {
+			timeout, _ = time.ParseDuration(model.WaitForReadinessTimeout.ValueString())
 		}
-		return waitForStackReadiness(ctx, timeout, d.Get("url").(string))
-	}
-	return nil
-}
-
-func deleteStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	id, err := resourceStackID.Single(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	req := client.InstancesAPI.DeleteInstance(ctx, id.(string)).XRequestId(ClientRequestID())
-	_, _, err = req.Execute()
-	return apiError(err)
-}
-
-func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	id, err := resourceStackID.Single(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	req := client.InstancesAPI.GetInstance(ctx, id.(string))
-	stack, _, err := req.Execute()
-	if err, shouldReturn := common.CheckReadError("stack", d, err); shouldReturn {
-		return err
-	}
-
-	if stack.Status == "deleted" {
-		return common.WarnMissing("stack", d)
-	}
-
-	var connections *gcom.FormattedApiInstanceConnections
-	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		resp, httpResp, err := client.InstancesAPI.GetConnections(ctx, id.(string)).Execute()
-		if err != nil {
-			if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
-		}
-		connections = resp
-		return nil
-	})
-	if err != nil {
-		return apiError(err)
-	}
-
-	if err := flattenStack(d, stack, connections); err != nil {
-		return diag.FromErr(err)
-	}
-	// Always set the wait attribute to true after creation
-	// It no longer matters and this will prevent drift if the stack was imported
-	// The "if" condition is here to allow using the same Read function for the data source
-	if v, ok := d.GetOk("wait_for_readiness"); ok && !v.(bool) {
-		d.Set("wait_for_readiness", true)
-	}
-
-	return nil
-}
-
-func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, connections *gcom.FormattedApiInstanceConnections) error {
-	id := strconv.FormatInt(int64(stack.Id), 10)
-
-	// getting tenants information for later use
-	privateConnectivityInfo := connections.PrivateConnectivityInfo
-	tenants := privateConnectivityInfo.GetTenants()
-
-	d.SetId(id)
-	d.Set("name", stack.Name)
-	d.Set("slug", stack.Slug)
-	d.Set("url", stack.Url)
-	runIfTenantFound(tenants, "grafana", func(tenant gcom.TenantsInner) {
-		addIPAllowListIfPresent(d, "grafana", tenant)
-	})
-
-	d.Set("status", stack.Status)
-	d.Set("region_slug", stack.RegionSlug)
-	d.Set("cluster_slug", stack.ClusterSlug)
-	d.Set("cluster_name", stack.ClusterName)
-	d.Set("description", stack.Description)
-	d.Set("labels", stack.Labels)
-	d.Set("delete_protection", stack.DeleteProtection)
-
-	d.Set("org_id", stack.OrgId)
-	d.Set("org_slug", stack.OrgSlug)
-	d.Set("org_name", stack.OrgName)
-
-	d.Set("prometheus_user_id", stack.HmInstancePromId)
-	d.Set("prometheus_url", stack.HmInstancePromUrl)
-	d.Set("prometheus_name", stack.HmInstancePromName)
-	reURL, err := appendPath(stack.HmInstancePromUrl, "/api/prom")
-	if err != nil {
-		return err
-	}
-	d.Set("prometheus_remote_endpoint", reURL)
-	rweURL, err := appendPath(stack.HmInstancePromUrl, "/api/prom/push")
-	if err != nil {
-		return err
-	}
-	d.Set("prometheus_remote_write_endpoint", rweURL)
-	d.Set("prometheus_status", stack.HmInstancePromStatus)
-	runIfTenantFound(tenants, "prometheus", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "prometheus", tenant)
-		addIPAllowListIfPresent(d, "prometheus", tenant)
-	})
-
-	d.Set("logs_user_id", stack.HlInstanceId)
-	d.Set("logs_url", stack.HlInstanceUrl)
-	d.Set("logs_name", stack.HlInstanceName)
-	d.Set("logs_status", stack.HlInstanceStatus)
-	runIfTenantFound(tenants, "logs", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "logs", tenant)
-		addIPAllowListIfPresent(d, "logs", tenant)
-	})
-
-	d.Set("alertmanager_user_id", stack.AmInstanceId)
-	d.Set("alertmanager_name", stack.AmInstanceName)
-	d.Set("alertmanager_url", stack.AmInstanceUrl)
-	d.Set("alertmanager_status", stack.AmInstanceStatus)
-	runIfTenantFound(tenants, "alerts", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "alertmanager", tenant)
-		addIPAllowListIfPresent(d, "alertmanager", tenant)
-	})
-
-	if oncallURL := connections.OncallApiUrl; oncallURL.IsSet() {
-		d.Set("oncall_api_url", oncallURL.Get())
-	}
-
-	d.Set("traces_user_id", stack.HtInstanceId)
-	d.Set("traces_name", stack.HtInstanceName)
-	d.Set("traces_url", stack.HtInstanceUrl)
-	d.Set("traces_status", stack.HtInstanceStatus)
-	runIfTenantFound(tenants, "traces", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "traces", tenant)
-		addIPAllowListIfPresent(d, "traces", tenant)
-	})
-
-	d.Set("profiles_user_id", stack.HpInstanceId)
-	d.Set("profiles_name", stack.HpInstanceName)
-	d.Set("profiles_url", stack.HpInstanceUrl)
-	d.Set("profiles_status", stack.HpInstanceStatus)
-	runIfTenantFound(tenants, "profiles", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "profiles", tenant)
-		addIPAllowListIfPresent(d, "profiles", tenant)
-	})
-
-	d.Set("graphite_user_id", stack.HmInstanceGraphiteId)
-	d.Set("graphite_name", stack.HmInstanceGraphiteName)
-	d.Set("graphite_url", stack.HmInstanceGraphiteUrl)
-	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
-	runIfTenantFound(tenants, "graphite", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "graphite", tenant)
-		addIPAllowListIfPresent(d, "graphite", tenant)
-	})
-
-	d.Set("fleet_management_user_id", stack.AgentManagementInstanceId)
-	d.Set("fleet_management_name", stack.AgentManagementInstanceName)
-	d.Set("fleet_management_url", stack.AgentManagementInstanceUrl)
-	d.Set("fleet_management_status", stack.AgentManagementInstanceStatus)
-	runIfTenantFound(tenants, "agent-management", func(tenant gcom.TenantsInner) {
-		addPrivateConnectivityInfoIfPresent(d, "fleet_management", tenant)
-	})
-
-	if otlpURL := connections.OtlpHttpUrl; otlpURL.IsSet() {
-		d.Set("otlp_url", otlpURL.Get())
-		if privateConnectivityInfo.Otlp != nil && privateConnectivityInfo.Otlp.InfoAnyOf != nil {
-			otlp := privateConnectivityInfo.Otlp
-			addPrivateConnectivityInfo(d, "otlp", otlp.InfoAnyOf.PrivateDNS, otlp.InfoAnyOf.ServiceName)
+		diags = waitForStackReadinessFramework(ctx, timeout, model.URL.ValueString())
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 	}
-	if privateConnectivityInfo.Pdc != nil {
-		pdc := privateConnectivityInfo.Pdc
-		addPrivateConnectivityInfo(d, "pdc_api", pdc.Api.InfoAnyOf.PrivateDNS, pdc.Api.InfoAnyOf.ServiceName)
-		addPrivateConnectivityInfo(d, "pdc_gateway", pdc.Gateway.InfoAnyOf.PrivateDNS, pdc.Gateway.InfoAnyOf.ServiceName)
-	}
 
-	if influxURL := connections.InfluxUrl; influxURL.IsSet() {
-		d.Set("influx_url", influxURL.Get())
-	}
-
-	return nil
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
-func runIfTenantFound(
-	tenants []gcom.TenantsInner,
-	tenantType string,
-	action func(gcom.TenantsInner),
-) {
-	for _, tenant := range tenants {
-		if tenant.Type == tenantType {
-			action(tenant)
-			break
+func (r *CloudStackResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data StackModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteReq := r.client.InstancesAPI.DeleteInstance(ctx, data.ID.ValueString()).XRequestId(ClientRequestID())
+	_, httpResp, err := deleteReq.Execute()
+	if err != nil {
+		errMsg := fmt.Sprintf("error: %v", err)
+		if httpResp != nil && httpResp.Body != nil {
+			body, _ := io.ReadAll(httpResp.Body)
+			httpResp.Body.Close()
+			errMsg = fmt.Sprintf("error (status %d): %v - response: %s", httpResp.StatusCode, err, string(body))
+		} else if httpResp != nil {
+			errMsg = fmt.Sprintf("error (status %d): %v", httpResp.StatusCode, err)
 		}
+		resp.Diagnostics.AddError("Failed to delete stack", errMsg)
+		return
 	}
 }
 
-func addPrivateConnectivityInfoIfPresent(d *schema.ResourceData, preffix string, tenant gcom.TenantsInner) {
-	if tenant.Info != nil {
-		addPrivateConnectivityInfo(d, preffix, tenant.Info.InfoAnyOf.PrivateDNS, tenant.Info.InfoAnyOf.ServiceName)
-	}
+func (r *CloudStackResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Set the ID from the import identifier
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }
 
-func addIPAllowListIfPresent(d *schema.ResourceData, preffix string, tenant gcom.TenantsInner) {
-	if tenant.IpAllowListCNAME != nil {
-		d.Set(fmt.Sprintf("%s_ip_allow_list_cname", preffix), *tenant.IpAllowListCNAME)
-	}
-}
+// waitForStackReadinessFramework is the Framework SDK version of waitForStackReadiness
+func waitForStackReadinessFramework(ctx context.Context, timeout time.Duration, stackURL string) diag.Diagnostics {
+	var diags diag.Diagnostics
 
-func addPrivateConnectivityInfo(d *schema.ResourceData, preffix string, privateDNS, serviceName string) {
-	d.Set(fmt.Sprintf("%s_private_connectivity_info_private_dns", preffix), privateDNS)
-	d.Set(fmt.Sprintf("%s_private_connectivity_info_service_name", preffix), serviceName)
-}
-
-// Append path to baseurl
-func appendPath(baseURL, path string) (string, error) {
-	bu, err := url.Parse(baseURL)
-	if err != nil {
-		return "", err
-	}
-	u, err := bu.Parse(path)
-	if err != nil {
-		return "", err
-	}
-	return u.String(), nil
-}
-
-// waitForStackReadiness retries until the stack is ready, verified by querying the Grafana URL
-func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL string) diag.Diagnostics {
 	healthURL, joinErr := url.JoinPath(stackURL, "api", "health")
 	if joinErr != nil {
-		return diag.FromErr(joinErr)
+		diags.AddError("Failed to construct health URL", joinErr.Error())
+		return diags
 	}
 	wakePath, joinErr := url.JoinPath(stackURL, "login")
 	if joinErr != nil {
-		return diag.FromErr(joinErr)
+		diags.AddError("Failed to construct wake URL", joinErr.Error())
+		return diags
+	}
+	wakeURL := wakePath + "?disableAutoLogin=true"
+
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		// Query the instance login page directly. This makes the stack wake-up if it has been paused.
+		stackReq, err := http.NewRequestWithContext(ctx, http.MethodGet, wakeURL, nil)
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+		stackResp, err := http.DefaultClient.Do(stackReq)
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+		defer stackResp.Body.Close()
+
+		healthReq, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+		healthResp, err := http.DefaultClient.Do(healthReq)
+		if err != nil {
+			return retry.RetryableError(err)
+		}
+		defer healthResp.Body.Close()
+		if healthResp.StatusCode != 200 {
+			buf := new(bytes.Buffer)
+			body := ""
+			_, err = buf.ReadFrom(healthResp.Body)
+			if err != nil {
+				body = "unable to read response body, error: " + err.Error()
+			} else {
+				body = buf.String()
+			}
+			return retry.RetryableError(fmt.Errorf("stack was not ready in %s. Status code: %d, Body: %s", timeout, healthResp.StatusCode, body))
+		}
+
+		return nil
+	})
+	if err != nil {
+		diags.AddError("Stack readiness timeout", fmt.Sprintf("Error waiting for stack (URL: %s) to be ready: %v", healthURL, err))
+	}
+
+	return diags
+}
+
+func defaultStackURL(slug string) string {
+	return fmt.Sprintf("https://%s.grafana.net", slug)
+}
+
+// waitForStackReadinessFromSlug is a helper for SDK v2 code that needs stack readiness checking
+// This returns SDK v2 diagnostics for compatibility with existing SDK v2 resources
+func waitForStackReadinessFromSlug(ctx context.Context, timeout time.Duration, slug string, client *gcom.APIClient) sdkdiag.Diagnostics {
+	stack, _, err := client.InstancesAPI.GetInstance(ctx, slug).Execute()
+	if err != nil {
+		return sdkdiag.FromErr(err)
+	}
+
+	// Call the legacy waitForStackReadiness function
+	return waitForStackReadiness(ctx, timeout, stack.Url)
+}
+
+// waitForStackReadiness returns SDK v2 diagnostics for compatibility with SDK v2 resources
+func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL string) sdkdiag.Diagnostics {
+	healthURL, joinErr := url.JoinPath(stackURL, "api", "health")
+	if joinErr != nil {
+		return sdkdiag.FromErr(joinErr)
+	}
+	wakePath, joinErr := url.JoinPath(stackURL, "login")
+	if joinErr != nil {
+		return sdkdiag.FromErr(joinErr)
 	}
 	wakeURL := wakePath + "?disableAutoLogin=true"
 
@@ -651,21 +787,8 @@ func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL 
 		return nil
 	})
 	if err != nil {
-		return diag.Errorf("error waiting for stack (URL: %s) to be ready: %v", healthURL, err)
+		return sdkdiag.Errorf("error waiting for stack (URL: %s) to be ready: %v", healthURL, err)
 	}
 
 	return nil
-}
-
-func waitForStackReadinessFromSlug(ctx context.Context, timeout time.Duration, slug string, client *gcom.APIClient) diag.Diagnostics {
-	stack, _, err := client.InstancesAPI.GetInstance(ctx, slug).Execute()
-	if err != nil {
-		return apiError(err)
-	}
-
-	return waitForStackReadiness(ctx, timeout, stack.Url)
-}
-
-func defaultStackURL(slug string) string {
-	return fmt.Sprintf("https://%s.grafana.net", slug)
 }

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -218,7 +218,7 @@ Required access policy scopes:
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
-				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance).",
+				Description: "Whether to wait for readiness of the stack after creating it. The check is a HEAD request to the stack URL (Grafana instance). Defaults to `true`.",
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 					suppressAfterCreationBoolModifier{},
@@ -228,7 +228,7 @@ Required access policy scopes:
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString(defaultReadinessTimeout.String()),
-				Description: "How long to wait for readiness (if enabled).",
+				Description: "How long to wait for readiness (if enabled). Defaults to `5m0s` (5 minutes).",
 			},
 			"org_id": schema.Int64Attribute{
 				Computed:    true,
@@ -261,7 +261,7 @@ Required access policy scopes:
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
-				Description: "Whether to enable delete protection for the stack, preventing accidental deletion.",
+				Description: "Whether to enable delete protection for the stack, preventing accidental deletion. Defaults to `true`.",
 			},
 
 			// IP Allow List CNAMEs

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -162,6 +162,8 @@ func TestResourceStack_Basic(t *testing.T) {
 }
 
 func TestResourceStack_Invalid(t *testing.T) {
+	testutils.CheckCloudAPITestsEnabled(t)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/resources/cloud/stack_common.go
+++ b/internal/resources/cloud/stack_common.go
@@ -1,0 +1,514 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+// StackModel represents the common model for both resource and data source
+type StackModel struct {
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Slug        types.String `tfsdk:"slug"`
+	Description types.String `tfsdk:"description"`
+	URL         types.String `tfsdk:"url"`
+	RegionSlug  types.String `tfsdk:"region_slug"`
+	ClusterSlug types.String `tfsdk:"cluster_slug"`
+	ClusterName types.String `tfsdk:"cluster_name"`
+	OrgID       types.Int64  `tfsdk:"org_id"`
+	OrgSlug     types.String `tfsdk:"org_slug"`
+	OrgName     types.String `tfsdk:"org_name"`
+	Status      types.String `tfsdk:"status"`
+	Labels      types.Map    `tfsdk:"labels"`
+
+	// Delete protection (resource only, will be null for data source)
+	DeleteProtection types.Bool `tfsdk:"delete_protection"`
+
+	// Wait for readiness (resource only, will be null for data source)
+	WaitForReadiness        types.Bool   `tfsdk:"wait_for_readiness"`
+	WaitForReadinessTimeout types.String `tfsdk:"wait_for_readiness_timeout"`
+
+	// IP Allow List CNAMEs
+	GrafanaIPAllowListCNAME types.String `tfsdk:"grafanas_ip_allow_list_cname"`
+
+	// Prometheus (Metrics/Mimir)
+	PrometheusUserID                             types.Int64  `tfsdk:"prometheus_user_id"`
+	PrometheusURL                                types.String `tfsdk:"prometheus_url"`
+	PrometheusName                               types.String `tfsdk:"prometheus_name"`
+	PrometheusRemoteEndpoint                     types.String `tfsdk:"prometheus_remote_endpoint"`
+	PrometheusRemoteWriteEndpoint                types.String `tfsdk:"prometheus_remote_write_endpoint"`
+	PrometheusStatus                             types.String `tfsdk:"prometheus_status"`
+	PrometheusPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"prometheus_private_connectivity_info_private_dns"`
+	PrometheusPrivateConnectivityInfoServiceName types.String `tfsdk:"prometheus_private_connectivity_info_service_name"`
+	PrometheusIPAllowListCNAME                   types.String `tfsdk:"prometheus_ip_allow_list_cname"`
+
+	// Alertmanager
+	AlertmanagerUserID           types.Int64  `tfsdk:"alertmanager_user_id"`
+	AlertmanagerName             types.String `tfsdk:"alertmanager_name"`
+	AlertmanagerURL              types.String `tfsdk:"alertmanager_url"`
+	AlertmanagerStatus           types.String `tfsdk:"alertmanager_status"`
+	AlertmanagerIPAllowListCNAME types.String `tfsdk:"alertmanager_ip_allow_list_cname"`
+
+	// OnCall
+	OnCallAPIURL types.String `tfsdk:"oncall_api_url"`
+
+	// Logs (Loki)
+	LogsUserID                             types.Int64  `tfsdk:"logs_user_id"`
+	LogsName                               types.String `tfsdk:"logs_name"`
+	LogsURL                                types.String `tfsdk:"logs_url"`
+	LogsStatus                             types.String `tfsdk:"logs_status"`
+	LogsPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"logs_private_connectivity_info_private_dns"`
+	LogsPrivateConnectivityInfoServiceName types.String `tfsdk:"logs_private_connectivity_info_service_name"`
+	LogsIPAllowListCNAME                   types.String `tfsdk:"logs_ip_allow_list_cname"`
+
+	// Traces (Tempo)
+	TracesUserID                             types.Int64  `tfsdk:"traces_user_id"`
+	TracesName                               types.String `tfsdk:"traces_name"`
+	TracesURL                                types.String `tfsdk:"traces_url"`
+	TracesStatus                             types.String `tfsdk:"traces_status"`
+	TracesPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"traces_private_connectivity_info_private_dns"`
+	TracesPrivateConnectivityInfoServiceName types.String `tfsdk:"traces_private_connectivity_info_service_name"`
+	TracesIPAllowListCNAME                   types.String `tfsdk:"traces_ip_allow_list_cname"`
+
+	// Profiles (Pyroscope)
+	ProfilesUserID                             types.Int64  `tfsdk:"profiles_user_id"`
+	ProfilesName                               types.String `tfsdk:"profiles_name"`
+	ProfilesURL                                types.String `tfsdk:"profiles_url"`
+	ProfilesStatus                             types.String `tfsdk:"profiles_status"`
+	ProfilesPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"profiles_private_connectivity_info_private_dns"`
+	ProfilesPrivateConnectivityInfoServiceName types.String `tfsdk:"profiles_private_connectivity_info_service_name"`
+	ProfilesIPAllowListCNAME                   types.String `tfsdk:"profiles_ip_allow_list_cname"`
+
+	// Graphite
+	GraphiteUserID                             types.Int64  `tfsdk:"graphite_user_id"`
+	GraphiteName                               types.String `tfsdk:"graphite_name"`
+	GraphiteURL                                types.String `tfsdk:"graphite_url"`
+	GraphiteStatus                             types.String `tfsdk:"graphite_status"`
+	GraphitePrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"graphite_private_connectivity_info_private_dns"`
+	GraphitePrivateConnectivityInfoServiceName types.String `tfsdk:"graphite_private_connectivity_info_service_name"`
+	GraphiteIPAllowListCNAME                   types.String `tfsdk:"graphite_ip_allow_list_cname"`
+
+	// Fleet Management
+	FleetManagementUserID                             types.Int64  `tfsdk:"fleet_management_user_id"`
+	FleetManagementName                               types.String `tfsdk:"fleet_management_name"`
+	FleetManagementURL                                types.String `tfsdk:"fleet_management_url"`
+	FleetManagementStatus                             types.String `tfsdk:"fleet_management_status"`
+	FleetManagementPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"fleet_management_private_connectivity_info_private_dns"`
+	FleetManagementPrivateConnectivityInfoServiceName types.String `tfsdk:"fleet_management_private_connectivity_info_service_name"`
+
+	// Connections
+	InfluxURL                              types.String `tfsdk:"influx_url"`
+	OtlpURL                                types.String `tfsdk:"otlp_url"`
+	OtlpPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"otlp_private_connectivity_info_private_dns"`
+	OtlpPrivateConnectivityInfoServiceName types.String `tfsdk:"otlp_private_connectivity_info_service_name"`
+
+	// PDC
+	PdcAPIPrivateConnectivityInfoPrivateDNS      types.String `tfsdk:"pdc_api_private_connectivity_info_private_dns"`
+	PdcAPIPrivateConnectivityInfoServiceName     types.String `tfsdk:"pdc_api_private_connectivity_info_service_name"`
+	PdcGatewayPrivateConnectivityInfoPrivateDNS  types.String `tfsdk:"pdc_gateway_private_connectivity_info_private_dns"`
+	PdcGatewayPrivateConnectivityInfoServiceName types.String `tfsdk:"pdc_gateway_private_connectivity_info_service_name"`
+}
+
+// setBasicFields sets the basic fields on the model from the stack
+func setBasicFields(model *StackModel, stack *gcom.FormattedApiInstance) {
+	id := strconv.FormatInt(int64(stack.Id), 10)
+	model.ID = types.StringValue(id)
+	model.Name = types.StringValue(stack.Name)
+	model.Slug = types.StringValue(stack.Slug)
+	model.URL = types.StringValue(stack.Url)
+	model.Status = types.StringValue(stack.Status)
+	model.RegionSlug = types.StringValue(stack.RegionSlug)
+	model.ClusterSlug = types.StringValue(stack.ClusterSlug)
+	model.ClusterName = types.StringValue(stack.ClusterName)
+
+	if stack.Description != "" {
+		model.Description = types.StringValue(stack.Description)
+	} else {
+		model.Description = types.StringNull()
+	}
+
+	// Labels
+	if len(stack.Labels) > 0 {
+		labelsMap := make(map[string]string)
+		for k, v := range stack.Labels {
+			if strVal, ok := v.(string); ok {
+				labelsMap[k] = strVal
+			}
+		}
+		labels, _ := types.MapValueFrom(context.Background(), types.StringType, labelsMap)
+		model.Labels = labels
+	} else {
+		model.Labels = types.MapNull(types.StringType)
+	}
+
+	model.DeleteProtection = types.BoolValue(stack.DeleteProtection)
+}
+
+// setPrometheusFields sets Prometheus-related fields on the model
+func setPrometheusFields(model *StackModel, stack *gcom.FormattedApiInstance) error {
+	if stack.HmInstancePromId > 0 {
+		model.PrometheusUserID = types.Int64Value(int64(stack.HmInstancePromId))
+	} else {
+		model.PrometheusUserID = types.Int64Null()
+	}
+	model.PrometheusURL = stringValueOrNull(stack.HmInstancePromUrl)
+	model.PrometheusName = stringValueOrNull(stack.HmInstancePromName)
+
+	if stack.HmInstancePromUrl != "" {
+		reURL, err := appendPath(stack.HmInstancePromUrl, "/api/prom")
+		if err != nil {
+			return err
+		}
+		model.PrometheusRemoteEndpoint = types.StringValue(reURL)
+
+		rweURL, err := appendPath(stack.HmInstancePromUrl, "/api/prom/push")
+		if err != nil {
+			return err
+		}
+		model.PrometheusRemoteWriteEndpoint = types.StringValue(rweURL)
+	} else {
+		model.PrometheusRemoteEndpoint = types.StringNull()
+		model.PrometheusRemoteWriteEndpoint = types.StringNull()
+	}
+
+	model.PrometheusStatus = stringValueOrNull(stack.HmInstancePromStatus)
+	return nil
+}
+
+// setServiceFields sets fields for various services (Logs, Traces, Profiles, Graphite, Fleet Management)
+func setServiceFields(model *StackModel, stack *gcom.FormattedApiInstance) {
+	// Alertmanager
+	if stack.AmInstanceId > 0 {
+		model.AlertmanagerUserID = types.Int64Value(int64(stack.AmInstanceId))
+	} else {
+		model.AlertmanagerUserID = types.Int64Null()
+	}
+	model.AlertmanagerName = stringValueOrNull(stack.AmInstanceName)
+	model.AlertmanagerURL = stringValueOrNull(stack.AmInstanceUrl)
+	model.AlertmanagerStatus = stringValueOrNull(stack.AmInstanceStatus)
+
+	// Logs
+	if stack.HlInstanceId > 0 {
+		model.LogsUserID = types.Int64Value(int64(stack.HlInstanceId))
+	} else {
+		model.LogsUserID = types.Int64Null()
+	}
+	model.LogsURL = stringValueOrNull(stack.HlInstanceUrl)
+	model.LogsName = stringValueOrNull(stack.HlInstanceName)
+	model.LogsStatus = stringValueOrNull(stack.HlInstanceStatus)
+
+	// Traces
+	if stack.HtInstanceId > 0 {
+		model.TracesUserID = types.Int64Value(int64(stack.HtInstanceId))
+	} else {
+		model.TracesUserID = types.Int64Null()
+	}
+	model.TracesName = stringValueOrNull(stack.HtInstanceName)
+	model.TracesURL = stringValueOrNull(stack.HtInstanceUrl)
+	model.TracesStatus = stringValueOrNull(stack.HtInstanceStatus)
+
+	// Profiles
+	if stack.HpInstanceId > 0 {
+		model.ProfilesUserID = types.Int64Value(int64(stack.HpInstanceId))
+	} else {
+		model.ProfilesUserID = types.Int64Null()
+	}
+	model.ProfilesName = stringValueOrNull(stack.HpInstanceName)
+	model.ProfilesURL = stringValueOrNull(stack.HpInstanceUrl)
+	model.ProfilesStatus = stringValueOrNull(stack.HpInstanceStatus)
+
+	// Graphite
+	if stack.HmInstanceGraphiteId > 0 {
+		model.GraphiteUserID = types.Int64Value(int64(stack.HmInstanceGraphiteId))
+	} else {
+		model.GraphiteUserID = types.Int64Null()
+	}
+	model.GraphiteName = stringValueOrNull(stack.HmInstanceGraphiteName)
+	model.GraphiteURL = stringValueOrNull(stack.HmInstanceGraphiteUrl)
+	model.GraphiteStatus = stringValueOrNull(stack.HmInstanceGraphiteStatus)
+
+	// Fleet Management
+	if stack.AgentManagementInstanceId > 0 {
+		model.FleetManagementUserID = types.Int64Value(int64(stack.AgentManagementInstanceId))
+	} else {
+		model.FleetManagementUserID = types.Int64Null()
+	}
+	model.FleetManagementName = stringValueOrNull(stack.AgentManagementInstanceName)
+	model.FleetManagementURL = stringValueOrNull(stack.AgentManagementInstanceUrl)
+	model.FleetManagementStatus = stringValueOrNull(stack.AgentManagementInstanceStatus)
+}
+
+// setConnectionFields sets connection-related fields (OnCall, OTLP, Influx)
+func setConnectionFields(model *StackModel, connections *gcom.FormattedApiInstanceConnections) {
+	// OnCall
+	if oncallURL := connections.OncallApiUrl; oncallURL.IsSet() {
+		model.OnCallAPIURL = types.StringValue(*oncallURL.Get())
+	} else {
+		model.OnCallAPIURL = types.StringNull()
+	}
+
+	// OTLP
+	if otlpURL := connections.OtlpHttpUrl; otlpURL.IsSet() {
+		model.OtlpURL = types.StringValue(*otlpURL.Get())
+	} else {
+		model.OtlpURL = types.StringNull()
+	}
+
+	// Influx
+	if influxURL := connections.InfluxUrl; influxURL.IsSet() {
+		model.InfluxURL = types.StringValue(*influxURL.Get())
+	} else {
+		model.InfluxURL = types.StringNull()
+	}
+}
+
+// setPrivateConnectivityFields sets private connectivity and IP allow list fields from tenants
+func setPrivateConnectivityFields(model *StackModel, connections *gcom.FormattedApiInstanceConnections) {
+	privateConnectivityInfo := connections.PrivateConnectivityInfo
+	tenants := privateConnectivityInfo.GetTenants()
+
+	// Process tenants for private connectivity and IP allow lists
+	setTenantInfo := func(tenantType string, setPrivate, setIPAllow func(string, string)) {
+		for _, tenant := range tenants {
+			if tenant.Type == tenantType {
+				if tenant.Info != nil && setPrivate != nil {
+					setPrivate(tenant.Info.InfoAnyOf.PrivateDNS, tenant.Info.InfoAnyOf.ServiceName)
+				}
+				if tenant.IpAllowListCNAME != nil && setIPAllow != nil {
+					setIPAllow(*tenant.IpAllowListCNAME, "")
+				}
+				break
+			}
+		}
+	}
+
+	// Grafana
+	setTenantInfo("grafana", nil, func(cname, _ string) {
+		model.GrafanaIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Prometheus
+	setTenantInfo("prometheus", func(privateDNS, serviceName string) {
+		model.PrometheusPrivateConnectivityInfoPrivateDNS = types.StringValue(privateDNS)
+		model.PrometheusPrivateConnectivityInfoServiceName = types.StringValue(serviceName)
+	}, func(cname, _ string) {
+		model.PrometheusIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Logs
+	setTenantInfo("logs", func(privateDNS, serviceName string) {
+		model.LogsPrivateConnectivityInfoPrivateDNS = types.StringValue(privateDNS)
+		model.LogsPrivateConnectivityInfoServiceName = types.StringValue(serviceName)
+	}, func(cname, _ string) {
+		model.LogsIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Alertmanager (tenant type is "alerts")
+	setTenantInfo("alerts", nil, func(cname, _ string) {
+		model.AlertmanagerIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Traces
+	setTenantInfo("traces", func(privateDNS, serviceName string) {
+		model.TracesPrivateConnectivityInfoPrivateDNS = types.StringValue(privateDNS)
+		model.TracesPrivateConnectivityInfoServiceName = types.StringValue(serviceName)
+	}, func(cname, _ string) {
+		model.TracesIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Profiles
+	setTenantInfo("profiles", func(privateDNS, serviceName string) {
+		model.ProfilesPrivateConnectivityInfoPrivateDNS = types.StringValue(privateDNS)
+		model.ProfilesPrivateConnectivityInfoServiceName = types.StringValue(serviceName)
+	}, func(cname, _ string) {
+		model.ProfilesIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Graphite
+	setTenantInfo("graphite", func(privateDNS, serviceName string) {
+		model.GraphitePrivateConnectivityInfoPrivateDNS = types.StringValue(privateDNS)
+		model.GraphitePrivateConnectivityInfoServiceName = types.StringValue(serviceName)
+	}, func(cname, _ string) {
+		model.GraphiteIPAllowListCNAME = types.StringValue(cname)
+	})
+
+	// Fleet Management (tenant type is "agent-management")
+	setTenantInfo("agent-management", func(privateDNS, serviceName string) {
+		model.FleetManagementPrivateConnectivityInfoPrivateDNS = types.StringValue(privateDNS)
+		model.FleetManagementPrivateConnectivityInfoServiceName = types.StringValue(serviceName)
+	}, nil)
+
+	// OTLP private connectivity
+	if privateConnectivityInfo.Otlp != nil && privateConnectivityInfo.Otlp.InfoAnyOf != nil {
+		otlp := privateConnectivityInfo.Otlp
+		model.OtlpPrivateConnectivityInfoPrivateDNS = types.StringValue(otlp.InfoAnyOf.PrivateDNS)
+		model.OtlpPrivateConnectivityInfoServiceName = types.StringValue(otlp.InfoAnyOf.ServiceName)
+	} else {
+		model.OtlpPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.OtlpPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+
+	// PDC
+	if privateConnectivityInfo.Pdc != nil {
+		pdc := privateConnectivityInfo.Pdc
+		model.PdcAPIPrivateConnectivityInfoPrivateDNS = types.StringValue(pdc.Api.InfoAnyOf.PrivateDNS)
+		model.PdcAPIPrivateConnectivityInfoServiceName = types.StringValue(pdc.Api.InfoAnyOf.ServiceName)
+		model.PdcGatewayPrivateConnectivityInfoPrivateDNS = types.StringValue(pdc.Gateway.InfoAnyOf.PrivateDNS)
+		model.PdcGatewayPrivateConnectivityInfoServiceName = types.StringValue(pdc.Gateway.InfoAnyOf.ServiceName)
+	} else {
+		model.PdcAPIPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.PdcAPIPrivateConnectivityInfoServiceName = types.StringNull()
+		model.PdcGatewayPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.PdcGatewayPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+
+	// Set null values for IP allow lists that weren't found
+	setNullIfUnset := func(field types.String) types.String {
+		if field.IsNull() {
+			return types.StringNull()
+		}
+		return field
+	}
+
+	model.GrafanaIPAllowListCNAME = setNullIfUnset(model.GrafanaIPAllowListCNAME)
+	model.PrometheusIPAllowListCNAME = setNullIfUnset(model.PrometheusIPAllowListCNAME)
+	model.LogsIPAllowListCNAME = setNullIfUnset(model.LogsIPAllowListCNAME)
+	model.AlertmanagerIPAllowListCNAME = setNullIfUnset(model.AlertmanagerIPAllowListCNAME)
+	model.TracesIPAllowListCNAME = setNullIfUnset(model.TracesIPAllowListCNAME)
+	model.ProfilesIPAllowListCNAME = setNullIfUnset(model.ProfilesIPAllowListCNAME)
+	model.GraphiteIPAllowListCNAME = setNullIfUnset(model.GraphiteIPAllowListCNAME)
+
+	// Set null values for private connectivity that weren't found
+	if model.PrometheusPrivateConnectivityInfoPrivateDNS.IsNull() {
+		model.PrometheusPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.PrometheusPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+	if model.LogsPrivateConnectivityInfoPrivateDNS.IsNull() {
+		model.LogsPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.LogsPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+	if model.TracesPrivateConnectivityInfoPrivateDNS.IsNull() {
+		model.TracesPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.TracesPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+	if model.ProfilesPrivateConnectivityInfoPrivateDNS.IsNull() {
+		model.ProfilesPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.ProfilesPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+	if model.GraphitePrivateConnectivityInfoPrivateDNS.IsNull() {
+		model.GraphitePrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.GraphitePrivateConnectivityInfoServiceName = types.StringNull()
+	}
+	if model.FleetManagementPrivateConnectivityInfoPrivateDNS.IsNull() {
+		model.FleetManagementPrivateConnectivityInfoPrivateDNS = types.StringNull()
+		model.FleetManagementPrivateConnectivityInfoServiceName = types.StringNull()
+	}
+}
+
+// ReadStackData reads stack data from the API and populates the model
+func ReadStackData(ctx context.Context, client *gcom.APIClient, stackSlugOrID string) (*StackModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Get stack instance
+	req := client.InstancesAPI.GetInstance(ctx, stackSlugOrID)
+	stack, httpResp, err := req.Execute()
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			diags.AddError("Stack not found", fmt.Sprintf("Stack %s not found", stackSlugOrID))
+			return nil, diags
+		}
+		diags.AddError("Failed to read stack", err.Error())
+		return nil, diags
+	}
+
+	if stack.Status == "deleted" {
+		diags.AddError("Stack deleted", fmt.Sprintf("Stack %s is deleted", stackSlugOrID))
+		return nil, diags
+	}
+
+	// Get connections with retry
+	var connections *gcom.FormattedApiInstanceConnections
+	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		resp, httpResp, err := client.InstancesAPI.GetConnections(ctx, stackSlugOrID).Execute()
+		if err != nil {
+			if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		connections = resp
+		return nil
+	})
+	if err != nil {
+		diags.AddError("Failed to get connections", err.Error())
+		return nil, diags
+	}
+
+	// Flatten to model
+	model, err := flattenStackToModel(stack, connections)
+	if err != nil {
+		diags.AddError("Failed to flatten stack data", err.Error())
+		return nil, diags
+	}
+
+	return model, diags
+}
+
+// flattenStackToModel converts API response to StackModel
+func flattenStackToModel(stack *gcom.FormattedApiInstance, connections *gcom.FormattedApiInstanceConnections) (*StackModel, error) {
+	model := &StackModel{}
+
+	// Set basic fields
+	setBasicFields(model, stack)
+
+	// Set organization fields
+	model.OrgID = types.Int64Value(int64(stack.OrgId))
+	model.OrgSlug = types.StringValue(stack.OrgSlug)
+	model.OrgName = types.StringValue(stack.OrgName)
+
+	// Set Prometheus fields
+	if err := setPrometheusFields(model, stack); err != nil {
+		return nil, err
+	}
+
+	// Set other service fields
+	setServiceFields(model, stack)
+
+	// Set connection fields
+	setConnectionFields(model, connections)
+
+	// Set private connectivity and IP allow list fields
+	setPrivateConnectivityFields(model, connections)
+
+	return model, nil
+}
+
+// stringValueOrNull converts a string to types.String, returning null if empty
+func stringValueOrNull(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+// appendPath is kept from the original file for URL path operations
+func appendPath(baseURL, path string) (string, error) {
+	bu, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	u, err := bu.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}


### PR DESCRIPTION
This PR updates the cloud_stack resource and data source to use the Framework SDK. The refactor was assisted by Claude code.

Fixes https://github.com/grafana/deployment_tools/issues/514058
