### PR TITLE
feat: add alertmanager_uid support for contact points and notification policies

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -43,6 +43,7 @@ resource "grafana_contact_point" "my_contact_point" {
 ### Optional
 
 - `alertmanager` (Block Set) A contact point that sends notifications to other Alertmanager instances. (see [below for nested schema](#nestedblock--alertmanager))
+- `alertmanager_uid` (String) The UID of the Alertmanager to manage contact points for. When set, uses the Alertmanager Config API instead of the provisioning API. This allows managing contact points on external alertmanagers (e.g., `grafanacloud-ngalertmanager`).
 - `dingding` (Block Set) A contact point that sends notifications to DingDing. (see [below for nested schema](#nestedblock--dingding))
 - `disable_provenance` (Boolean) Allow modifying the contact point from other sources than Terraform or the Grafana API. Defaults to `false`.
 - `discord` (Block Set) A contact point that sends notifications as Discord messages (see [below for nested schema](#nestedblock--discord))

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -117,6 +117,7 @@ resource "grafana_notification_policy" "my_notification_policy" {
 
 ### Optional
 
+- `alertmanager_uid` (String) The UID of the Alertmanager to manage notification policies for. When set, uses the Alertmanager Config API instead of the provisioning API. This allows managing notification policies on external alertmanagers (e.g., `grafanacloud-ngalertmanager`).
 - `disable_provenance` (Boolean) Allow modifying the notification policy from other sources than Terraform or the Grafana API. Defaults to `false`.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
 - `group_wait` (String) Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.

--- a/examples/resources/grafana_contact_point/_acc_external_alertmanager.tf
+++ b/examples/resources/grafana_contact_point/_acc_external_alertmanager.tf
@@ -1,0 +1,30 @@
+# This example shows how to manage contact points on an external alertmanager
+# (e.g., grafanacloud-ngalertmanager) using the alertmanager_uid attribute.
+#
+# When using alertmanager_uid with a native (non-Grafana-managed) alertmanager,
+# the provider automatically converts notifier fields to native Alertmanager format.
+
+resource "grafana_contact_point" "external_am_opsgenie" {
+  alertmanager_uid = "grafanacloud-ngalertmanager"
+  name             = "opsgenie"
+
+  opsgenie {
+    api_key = "your-api-key"
+    url     = "https://api.eu.opsgenie.com/"
+    message = "{{ .CommonAnnotations.summary }}"
+    settings = {
+      # For native alertmanager, og_priority is automatically mapped to "priority"
+      og_priority = "P3"
+      tags        = "env={{ .CommonLabels.env }}"
+    }
+  }
+}
+
+resource "grafana_contact_point" "external_am_webhook" {
+  alertmanager_uid = "grafanacloud-ngalertmanager"
+  name             = "webhook"
+
+  webhook {
+    url = "https://example.com/webhook"
+  }
+}

--- a/examples/resources/grafana_notification_policy/_acc_external_alertmanager.tf
+++ b/examples/resources/grafana_notification_policy/_acc_external_alertmanager.tf
@@ -1,0 +1,42 @@
+# This example shows how to manage notification policies on an external alertmanager
+# (e.g., grafanacloud-ngalertmanager) using the alertmanager_uid attribute.
+
+resource "grafana_contact_point" "external_am_opsgenie" {
+  alertmanager_uid = "grafanacloud-ngalertmanager"
+  name             = "opsgenie"
+
+  opsgenie {
+    api_key = "your-api-key"
+    url     = "https://api.eu.opsgenie.com/"
+    message = "{{ .CommonAnnotations.summary }}"
+  }
+}
+
+resource "grafana_contact_point" "external_am_oncall" {
+  alertmanager_uid = "grafanacloud-ngalertmanager"
+  name             = "grafana-oncall"
+
+  webhook {
+    url = "https://oncall.example.com/webhook"
+  }
+}
+
+resource "grafana_notification_policy" "external_am" {
+  alertmanager_uid = "grafanacloud-ngalertmanager"
+  contact_point    = grafana_contact_point.external_am_opsgenie.name
+  group_by         = ["cluster", "region", "alertname"]
+
+  group_wait      = "10s"
+  group_interval  = "1m"
+  repeat_interval = "5m"
+
+  # Send to Grafana OnCall first, then continue to default (OpsGenie)
+  policy {
+    contact_point = grafana_contact_point.external_am_oncall.name
+    continue      = true
+  }
+
+  policy {
+    contact_point = grafana_contact_point.external_am_opsgenie.name
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 require (
 	github.com/evanw/esbuild v0.25.10
 	github.com/google/uuid v1.6.0
+	github.com/iancoleman/strcase v0.3.0
 	github.com/knadh/koanf/v2 v2.3.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/hrmsk66/terraform-exec v0.21.0 h1:k/hnRAZULf6rkzJW7v2fRKAA1wAshyiUv1c
 github.com/hrmsk66/terraform-exec v0.21.0/go.mod h1:rHqaL9Y7oPlRDZffl2xr/UkSrIhKL2l9G5P81Sza7Ts=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/internal/resources/grafana/alerting_amconfig_api.go
+++ b/internal/resources/grafana/alerting_amconfig_api.go
@@ -1,0 +1,138 @@
+package grafana
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+)
+
+const orgIDHeader = "X-Grafana-Org-Id"
+
+// AMConfigClient is an HTTP client for the Alertmanager Config API.
+type AMConfigClient struct {
+	client   *http.Client
+	baseURL  url.URL
+	apiKey   string
+	username string
+	password string
+}
+
+// NewAMConfigClient creates a new AMConfigClient from the provider meta.
+func NewAMConfigClient(meta any, httpClient *http.Client) (*AMConfigClient, error) {
+	metaClient := meta.(*common.Client)
+	transportConfig := metaClient.GrafanaAPIConfig
+	if transportConfig == nil {
+		return nil, fmt.Errorf("transport configuration not available")
+	}
+
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+
+	baseURL := url.URL{
+		Scheme: transportConfig.Schemes[0],
+		Host:   transportConfig.Host,
+	}
+
+	c := &AMConfigClient{
+		client:  httpClient,
+		baseURL: baseURL,
+		apiKey:  transportConfig.APIKey,
+	}
+
+	if transportConfig.BasicAuth != nil {
+		c.username = transportConfig.BasicAuth.Username()
+		c.password, _ = transportConfig.BasicAuth.Password()
+	}
+
+	return c, nil
+}
+
+// Get fetches the Alertmanager configuration for the given alertmanager UID.
+// It returns the full config as a generic map to preserve all unknown fields through round-trip.
+func (c *AMConfigClient) Get(ctx context.Context, orgID int64, amUID string) (map[string]any, error) {
+	req, err := c.newRequest(ctx, orgID, amUID, http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alertmanager config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("alertmanager %q not found", amUID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to get alertmanager config, status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var config map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode alertmanager config: %w", err)
+	}
+	return config, nil
+}
+
+// Post writes the Alertmanager configuration for the given alertmanager UID.
+func (c *AMConfigClient) Post(ctx context.Context, orgID int64, amUID string, config map[string]any) error {
+	jsonData, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alertmanager config: %w", err)
+	}
+
+	req, err := c.newRequest(ctx, orgID, amUID, http.MethodPost, jsonData)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to post alertmanager config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to post alertmanager config, status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// newRequest creates an HTTP request for the AM Config API endpoint.
+func (c *AMConfigClient) newRequest(ctx context.Context, orgID int64, amUID string, method string, body []byte) (*http.Request, error) {
+	reqURL := c.baseURL
+	reqURL.Path = fmt.Sprintf("/api/alertmanager/%s/config/api/v1/alerts", amUID)
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL.String(), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if orgID > 0 {
+		req.Header.Set(orgIDHeader, fmt.Sprintf("%d", orgID))
+	}
+
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	} else if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	return req, nil
+}

--- a/internal/resources/grafana/alerting_amconfig_api_test.go
+++ b/internal/resources/grafana/alerting_amconfig_api_test.go
@@ -1,0 +1,258 @@
+package grafana
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestAMConfigClient_Get(t *testing.T) {
+	t.Run("successfully fetches config", func(t *testing.T) {
+		expectedConfig := map[string]any{
+			"route": map[string]any{
+				"receiver": "default",
+			},
+			"receivers": []any{
+				map[string]any{"name": "default"},
+			},
+		}
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			if r.URL.Path != "/api/alertmanager/grafana/config/api/v1/alerts" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			if r.Header.Get("Authorization") != "Bearer test-api-key" {
+				t.Errorf("unexpected Authorization header: %s", r.Header.Get("Authorization"))
+			}
+			if r.Header.Get(orgIDHeader) != "1" {
+				t.Errorf("unexpected org ID header: %s", r.Header.Get(orgIDHeader))
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(expectedConfig)
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:  svr.Client(),
+			baseURL: *svrURL,
+			apiKey:  "test-api-key",
+		}
+
+		config, err := client.Get(context.Background(), 1, "grafana")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		route, ok := config["route"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected route in config, got %v", config)
+		}
+		if route["receiver"] != "default" {
+			t.Errorf("expected receiver 'default', got %v", route["receiver"])
+		}
+	})
+
+	t.Run("returns error on 404", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:  svr.Client(),
+			baseURL: *svrURL,
+			apiKey:  "test-api-key",
+		}
+
+		_, err := client.Get(context.Background(), 1, "unknown-am")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != `alertmanager "unknown-am" not found` {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("returns error on server error", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("internal error"))
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:  svr.Client(),
+			baseURL: *svrURL,
+			apiKey:  "test-api-key",
+		}
+
+		_, err := client.Get(context.Background(), 1, "grafana")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "failed to get alertmanager config, status 500: internal error" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("uses basic auth when no API key", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, pass, ok := r.BasicAuth()
+			if !ok {
+				t.Error("expected basic auth")
+			}
+			if user != "admin" || pass != "password" {
+				t.Errorf("unexpected credentials: %s:%s", user, pass)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:   svr.Client(),
+			baseURL:  *svrURL,
+			username: "admin",
+			password: "password",
+		}
+
+		_, err := client.Get(context.Background(), 1, "grafana")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("omits org header when orgID is 0", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get(orgIDHeader) != "" {
+				t.Error("expected no org ID header when orgID is 0")
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:  svr.Client(),
+			baseURL: *svrURL,
+			apiKey:  "test-api-key",
+		}
+
+		_, err := client.Get(context.Background(), 0, "grafana")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestAMConfigClient_Post(t *testing.T) {
+	t.Run("successfully posts config", func(t *testing.T) {
+		configToPost := map[string]any{
+			"route": map[string]any{
+				"receiver": "updated",
+			},
+		}
+
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if r.URL.Path != "/api/alertmanager/grafana/config/api/v1/alerts" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("unexpected Content-Type: %s", r.Header.Get("Content-Type"))
+			}
+			if r.Header.Get("Authorization") != "Bearer test-api-key" {
+				t.Errorf("unexpected Authorization header: %s", r.Header.Get("Authorization"))
+			}
+
+			body, _ := io.ReadAll(r.Body)
+			var received map[string]any
+			json.Unmarshal(body, &received)
+
+			route, ok := received["route"].(map[string]any)
+			if !ok || route["receiver"] != "updated" {
+				t.Errorf("unexpected request body: %s", string(body))
+			}
+
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:  svr.Client(),
+			baseURL: *svrURL,
+			apiKey:  "test-api-key",
+		}
+
+		err := client.Post(context.Background(), 1, "grafana", configToPost)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("returns error on server error", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("invalid config"))
+		}))
+		defer svr.Close()
+
+		svrURL, _ := url.Parse(svr.URL)
+		client := &AMConfigClient{
+			client:  svr.Client(),
+			baseURL: *svrURL,
+			apiKey:  "test-api-key",
+		}
+
+		err := client.Post(context.Background(), 1, "grafana", map[string]any{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "failed to post alertmanager config, status 400: invalid config" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("accepts 200, 201, and 202 status codes", func(t *testing.T) {
+		statusCodes := []int{http.StatusOK, http.StatusCreated, http.StatusAccepted}
+
+		for _, statusCode := range statusCodes {
+			t.Run(http.StatusText(statusCode), func(t *testing.T) {
+				svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(statusCode)
+				}))
+				defer svr.Close()
+
+				svrURL, _ := url.Parse(svr.URL)
+				client := &AMConfigClient{
+					client:  svr.Client(),
+					baseURL: *svrURL,
+					apiKey:  "test-api-key",
+				}
+
+				err := client.Post(context.Background(), 1, "grafana", map[string]any{})
+				if err != nil {
+					t.Errorf("unexpected error for status %d: %v", statusCode, err)
+				}
+			})
+		}
+	})
+}

--- a/internal/resources/grafana/alerting_amconfig_helpers.go
+++ b/internal/resources/grafana/alerting_amconfig_helpers.go
@@ -1,0 +1,330 @@
+package grafana
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/iancoleman/strcase"
+)
+
+const (
+	// grafanaAlertmanagerUID is the UID of the built-in Grafana Alertmanager.
+	grafanaAlertmanagerUID = "grafana"
+
+	// Native Alertmanager supported contact point types.
+	notifierTypeEmail     = "email"
+	notifierTypePagerduty = "pagerduty"
+	notifierTypePushover  = "pushover"
+	notifierTypeSlack     = "slack"
+	notifierTypeOpsgenie  = "opsgenie"
+	notifierTypeVictorops = "victorops"
+	notifierTypeWebhook   = "webhook"
+	notifierTypeWecom     = "wecom"
+	notifierTypeTelegram  = "telegram"
+	notifierTypeSns       = "sns"
+	notifierTypeTeams     = "teams"
+	notifierTypeWebex     = "webex"
+	notifierTypeDiscord   = "discord"
+)
+
+// parseNotificationPolicyAMConfigID parses a resource ID of format {orgID}:{amUID}/policy.
+func parseNotificationPolicyAMConfigID(id string) (int64, string) {
+	orgID, rest := SplitOrgResourceID(id)
+	amUID, _, _ := strings.Cut(rest, "/")
+	return orgID, amUID
+}
+
+// parseContactPointAMConfigID parses a resource ID of format {orgID}:{amUID}/{name}.
+func parseContactPointAMConfigID(id string) (int64, string, string) {
+	orgID, rest := SplitOrgResourceID(id)
+	amUID, name, _ := strings.Cut(rest, "/")
+	return orgID, amUID, name
+}
+
+// routeModelToAMConfig converts a models.Route to the AM Config API format (map[string]any).
+// Since models.Route JSON tags already match the AM Config field names, we use JSON marshaling
+// and only need to handle object_matchers → matchers conversion (structured → string format).
+func routeModelToAMConfig(r *models.Route) (map[string]any, error) {
+	// Convert ObjectMatchers to string-format matchers for the AM Config API
+	var matchers []string
+	for _, m := range r.ObjectMatchers {
+		matchers = append(matchers, fmt.Sprintf("%s%s%s", m[0], m[1], m[2]))
+	}
+
+	// Marshal the route to JSON, then unmarshal to map to get all fields
+	data, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal route: %w", err)
+	}
+	var route map[string]any
+	if err := json.Unmarshal(data, &route); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal route: %w", err)
+	}
+
+	// Remove fields not used in AM Config API
+	delete(route, "object_matchers")
+	delete(route, "provenance")
+
+	// Add string-format matchers if present
+	if len(matchers) > 0 {
+		route["matchers"] = matchers
+	}
+
+	// Recursively convert child routes
+	if r.Routes != nil {
+		routes := make([]any, 0, len(r.Routes))
+		for _, child := range r.Routes {
+			childMap, err := routeModelToAMConfig(child)
+			if err != nil {
+				return nil, err
+			}
+			routes = append(routes, childMap)
+		}
+		route["routes"] = routes
+	}
+
+	return route, nil
+}
+
+// amConfigToRouteModel converts an AM Config API route (map[string]any) to a models.Route.
+// Since models.Route JSON tags match the AM Config field names, we use JSON marshaling
+// and only need to handle matchers → object_matchers conversion (string → structured format).
+func amConfigToRouteModel(m map[string]any) (*models.Route, error) {
+	// Extract and convert string-format matchers before JSON unmarshaling.
+	// Handle both []any (from JSON decoding) and []string (from direct Go code).
+	var objectMatchers models.ObjectMatchers
+	if matchersRaw, ok := m["matchers"]; ok {
+		switch v := matchersRaw.(type) {
+		case []any:
+			for _, raw := range v {
+				if s, ok := raw.(string); ok {
+					objectMatchers = append(objectMatchers, parseMatcherString(s))
+				}
+			}
+		case []string:
+			for _, s := range v {
+				objectMatchers = append(objectMatchers, parseMatcherString(s))
+			}
+		}
+	}
+
+	// Remove fields that don't map cleanly to models.Route before marshaling.
+	// "matchers" uses a different format (string vs structured) and "routes"
+	// are handled recursively below to process matchers in child routes.
+	cleaned := make(map[string]any, len(m))
+	for k, v := range m {
+		cleaned[k] = v
+	}
+	delete(cleaned, "matchers")
+	delete(cleaned, "routes")
+
+	data, err := json.Marshal(cleaned)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal route map: %w", err)
+	}
+	var route models.Route
+	if err := json.Unmarshal(data, &route); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal route: %w", err)
+	}
+
+	route.ObjectMatchers = objectMatchers
+
+	// Recursively convert child routes (JSON unmarshal already handles this,
+	// but we need to process matchers in children too)
+	if routesRaw, ok := m["routes"]; ok {
+		if routesList, ok := routesRaw.([]any); ok {
+			routes := make([]*models.Route, 0, len(routesList))
+			for _, child := range routesList {
+				if childMap, ok := child.(map[string]any); ok {
+					childRoute, err := amConfigToRouteModel(childMap)
+					if err != nil {
+						return nil, err
+					}
+					routes = append(routes, childRoute)
+				}
+			}
+			route.Routes = routes
+		}
+	}
+
+	return &route, nil
+}
+
+// parseMatcherString parses a matcher string like "label=value" or "label=~value" into an ObjectMatcher.
+func parseMatcherString(s string) models.ObjectMatcher {
+	for _, op := range []string{"=~", "!~", "!=", "="} {
+		idx := strings.Index(s, op)
+		if idx >= 0 {
+			return models.ObjectMatcher{
+				s[:idx],
+				op,
+				s[idx+len(op):],
+			}
+		}
+	}
+	return models.ObjectMatcher{s, "=", ""}
+}
+
+// isGrafanaManagedAM detects whether the alertmanager is Grafana-managed (uses grafana_managed_receiver_configs)
+// or native (uses standard Alertmanager receiver configs like opsgenie_configs, webhook_configs, etc.).
+func isGrafanaManagedAM(amUID string, amConfig map[string]any) bool {
+	// The built-in "grafana" alertmanager is always Grafana-managed.
+	// Note: grafanacloud-ngalertmanager is a native Alertmanager, not Grafana-managed.
+	if amUID == grafanaAlertmanagerUID {
+		return true
+	}
+
+	// Check existing receivers for grafana_managed_receiver_configs
+	receivers, _ := amConfig["receivers"].([]any)
+	for _, r := range receivers {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := rm["grafana_managed_receiver_configs"]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isNativeAMSupportedType returns true if the Grafana contact point type has a native Alertmanager equivalent.
+// Types like oncall, googlechat, kafka, line, sensu, threema are Grafana-only.
+func isNativeAMSupportedType(grafanaType string) bool {
+	switch grafanaType {
+	case notifierTypeEmail, notifierTypePagerduty, notifierTypePushover, notifierTypeSlack,
+		notifierTypeOpsgenie, notifierTypeVictorops, notifierTypeWebhook, notifierTypeWecom,
+		notifierTypeTelegram, notifierTypeSns, notifierTypeTeams, notifierTypeWebex, notifierTypeDiscord:
+		return true
+	default:
+		return false
+	}
+}
+
+// grafanaTypeToNativeConfigKey converts a Grafana notifier type to the native Alertmanager config key.
+// e.g. "opsgenie" → "opsgenie_configs", "teams" → "msteams_configs"
+func grafanaTypeToNativeConfigKey(grafanaType string) string {
+	switch grafanaType {
+	case notifierTypeTeams:
+		return "msteams_configs"
+	case notifierTypeWecom:
+		return "wechat_configs"
+	default:
+		return grafanaType + "_configs"
+	}
+}
+
+// nativeConfigKeyToGrafanaType converts a native Alertmanager config key to the Grafana notifier type.
+// e.g. "opsgenie_configs" → "opsgenie", "msteams_configs" → "teams"
+func nativeConfigKeyToGrafanaType(configKey string) string {
+	switch configKey {
+	case "msteams_configs":
+		return notifierTypeTeams
+	case "wechat_configs":
+		return notifierTypeWecom
+	default:
+		return strings.TrimSuffix(configKey, "_configs")
+	}
+}
+
+// isGrafanaOnlySetting returns true if the setting is Grafana-specific and doesn't exist in native Alertmanager.
+func isGrafanaOnlySetting(key string) bool {
+	switch key {
+	case "overridePriority", "override_priority", "sendTagsAs", "send_tags_as":
+		return true
+	default:
+		return false
+	}
+}
+
+// grafanaToNativeFieldName maps a Grafana-specific field name to its native Alertmanager equivalent.
+// Returns the original key if no mapping exists.
+func grafanaToNativeFieldName(key string) string {
+	if key == "og_priority" {
+		return "priority"
+	}
+	return key
+}
+
+// nativeToGrafanaFieldName maps a native Alertmanager field name to its Grafana equivalent.
+// Returns the original key if no mapping exists.
+func nativeToGrafanaFieldName(key string) string {
+	if key == "priority" {
+		return "og_priority"
+	}
+	return key
+}
+
+// embeddedContactPointToNativeConfig converts a Grafana EmbeddedContactPoint to a native Alertmanager
+// receiver config entry. It returns the config key (e.g. "opsgenie_configs") and the config map.
+// Returns an error for Grafana-only types that don't exist in native Alertmanager.
+func embeddedContactPointToNativeConfig(p *models.EmbeddedContactPoint) (string, map[string]any, error) {
+	if !isNativeAMSupportedType(*p.Type) {
+		return "", nil, fmt.Errorf("contact point type %q is not supported by native Alertmanager", *p.Type)
+	}
+
+	configKey := grafanaTypeToNativeConfigKey(*p.Type)
+
+	settings, ok := p.Settings.(map[string]any)
+	if !ok {
+		return "", nil, fmt.Errorf("unexpected settings type %T", p.Settings)
+	}
+
+	native := make(map[string]any, len(settings)+1)
+	for k, v := range settings {
+		// Skip Grafana-only settings that don't exist in native Alertmanager
+		if isGrafanaOnlySetting(k) {
+			continue
+		}
+		snakeKey := strcase.ToSnake(k)
+		// Also check the snake_case version
+		if isGrafanaOnlySetting(snakeKey) {
+			continue
+		}
+		// Skip false booleans — these are likely unset Grafana-specific defaults
+		// that would be rejected by native alertmanagers as unknown fields.
+		if b, ok := v.(bool); ok && !b {
+			continue
+		}
+		// Apply field mappings for Grafana fields that have native equivalents
+		snakeKey = grafanaToNativeFieldName(snakeKey)
+		native[snakeKey] = v
+	}
+
+	native["send_resolved"] = !p.DisableResolveMessage
+
+	return configKey, native, nil
+}
+
+// nativeConfigToEmbeddedContactPoint converts a native Alertmanager config entry to a Grafana EmbeddedContactPoint.
+func nativeConfigToEmbeddedContactPoint(grafanaType string, name string, config map[string]any) *models.EmbeddedContactPoint {
+	// Extract send_resolved before converting keys
+	sendResolved := true
+	if sr, ok := config["send_resolved"].(bool); ok {
+		sendResolved = sr
+	}
+
+	settings := make(map[string]any, len(config))
+	for k, v := range config {
+		if k == "send_resolved" {
+			continue
+		}
+		// Apply reverse field mappings for native fields that have Grafana equivalents
+		key := nativeToGrafanaFieldName(k)
+		if key == k {
+			// No mapping found, convert to camelCase
+			key = strcase.ToLowerCamel(k)
+		}
+		settings[key] = v
+	}
+
+	return &models.EmbeddedContactPoint{
+		Name:                  name,
+		Type:                  &grafanaType,
+		DisableResolveMessage: !sendResolved,
+		Settings:              settings,
+	}
+}

--- a/internal/resources/grafana/alerting_amconfig_helpers_test.go
+++ b/internal/resources/grafana/alerting_amconfig_helpers_test.go
@@ -1,0 +1,510 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+)
+
+const testReceiverOpsgenie = "opsgenie"
+
+func TestParseMatcherString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected models.ObjectMatcher
+	}{
+		{
+			input:    "alertname=~.+",
+			expected: models.ObjectMatcher{"alertname", "=~", ".+"},
+		},
+		{
+			input:    "severity!=critical",
+			expected: models.ObjectMatcher{"severity", "!=", "critical"},
+		},
+		{
+			input:    "env=production",
+			expected: models.ObjectMatcher{"env", "=", "production"},
+		},
+		{
+			input:    "name!~test.*",
+			expected: models.ObjectMatcher{"name", "!~", "test.*"},
+		},
+		{
+			input:    "label=value=with=equals",
+			expected: models.ObjectMatcher{"label", "=", "value=with=equals"},
+		},
+		{
+			input:    "label=",
+			expected: models.ObjectMatcher{"label", "=", ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := parseMatcherString(tc.input)
+			if result[0] != tc.expected[0] || result[1] != tc.expected[1] || result[2] != tc.expected[2] {
+				t.Errorf("parseMatcherString(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func newTestRoute() *models.Route {
+	return &models.Route{
+		Receiver:       testReceiverOpsgenie,
+		GroupBy:        []string{"cluster", "region", "alertname"},
+		GroupWait:      "10s",
+		GroupInterval:  "1m",
+		RepeatInterval: "5m",
+		Routes: []*models.Route{
+			{
+				Receiver: "grafana-oncall",
+				Continue: true,
+				ObjectMatchers: models.ObjectMatchers{
+					{"alertname", "=~", ".+"},
+				},
+				MuteTimeIntervals:   []string{"weekends"},
+				ActiveTimeIntervals: []string{"business-hours"},
+			},
+		},
+	}
+}
+
+func TestRouteModelToAMConfig(t *testing.T) {
+	original := newTestRoute()
+	amConfig, err := routeModelToAMConfig(original)
+	if err != nil {
+		t.Fatalf("routeModelToAMConfig failed: %v", err)
+	}
+
+	if amConfig["receiver"] != testReceiverOpsgenie {
+		t.Errorf("expected receiver %q, got %v", testReceiverOpsgenie, amConfig["receiver"])
+	}
+	groupBy, ok := amConfig["group_by"].([]any)
+	if !ok || len(groupBy) != 3 {
+		t.Errorf("expected group_by with 3 items, got %v (type %T)", amConfig["group_by"], amConfig["group_by"])
+	}
+	routes, ok := amConfig["routes"].([]any)
+	if !ok || len(routes) != 1 {
+		t.Fatalf("expected 1 child route, got %v", amConfig["routes"])
+	}
+	childRoute := routes[0].(map[string]any)
+	if childRoute["receiver"] != "grafana-oncall" {
+		t.Errorf("expected child receiver 'grafana-oncall', got %v", childRoute["receiver"])
+	}
+	if childRoute["continue"] != true {
+		t.Errorf("expected continue=true, got %v", childRoute["continue"])
+	}
+	matchers, ok := childRoute["matchers"].([]string)
+	if !ok || len(matchers) != 1 || matchers[0] != "alertname=~.+" {
+		t.Errorf("expected matchers ['alertname=~.+'], got %v", childRoute["matchers"])
+	}
+}
+
+func TestRouteModelToAMConfigRoundTrip(t *testing.T) {
+	original := newTestRoute()
+	amConfig, err := routeModelToAMConfig(original)
+	if err != nil {
+		t.Fatalf("routeModelToAMConfig failed: %v", err)
+	}
+
+	roundTripped, err := amConfigToRouteModel(amConfig)
+	if err != nil {
+		t.Fatalf("amConfigToRouteModel failed: %v", err)
+	}
+
+	if roundTripped.Receiver != original.Receiver {
+		t.Errorf("receiver: got %q, want %q", roundTripped.Receiver, original.Receiver)
+	}
+	if len(roundTripped.GroupBy) != len(original.GroupBy) {
+		t.Errorf("group_by length: got %d, want %d", len(roundTripped.GroupBy), len(original.GroupBy))
+	}
+	if roundTripped.GroupWait != original.GroupWait {
+		t.Errorf("group_wait: got %q, want %q", roundTripped.GroupWait, original.GroupWait)
+	}
+	if len(roundTripped.Routes) != 1 {
+		t.Fatalf("routes length: got %d, want 1", len(roundTripped.Routes))
+	}
+
+	child := roundTripped.Routes[0]
+	if child.Receiver != "grafana-oncall" {
+		t.Errorf("child receiver: got %q, want %q", child.Receiver, "grafana-oncall")
+	}
+	if !child.Continue {
+		t.Error("child continue: got false, want true")
+	}
+	if len(child.ObjectMatchers) != 1 {
+		t.Fatalf("child matchers length: got %d, want 1", len(child.ObjectMatchers))
+	}
+}
+
+func TestParseContactPointAMConfigID(t *testing.T) {
+	tests := []struct {
+		id          string
+		expectOrgID int64
+		expectAMUID string
+		expectName  string
+	}{
+		{
+			id:          "1:grafana/my-receiver",
+			expectOrgID: 1,
+			expectAMUID: "grafana",
+			expectName:  "my-receiver",
+		},
+		{
+			id:          "42:grafanacloud-ngalertmanager/opsgenie",
+			expectOrgID: 42,
+			expectAMUID: "grafanacloud-ngalertmanager",
+			expectName:  "opsgenie",
+		},
+		{
+			id:          "0:grafana/test",
+			expectOrgID: 0,
+			expectAMUID: "grafana",
+			expectName:  "test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			orgID, amUID, name := parseContactPointAMConfigID(tc.id)
+			if orgID != tc.expectOrgID {
+				t.Errorf("orgID: got %d, want %d", orgID, tc.expectOrgID)
+			}
+			if amUID != tc.expectAMUID {
+				t.Errorf("amUID: got %q, want %q", amUID, tc.expectAMUID)
+			}
+			if name != tc.expectName {
+				t.Errorf("name: got %q, want %q", name, tc.expectName)
+			}
+		})
+	}
+}
+
+func TestIsGrafanaManagedAM(t *testing.T) {
+	tests := []struct {
+		name     string
+		amUID    string
+		amConfig map[string]any
+		expected bool
+	}{
+		{
+			name:     "built-in grafana AM is always managed",
+			amUID:    "grafana",
+			amConfig: map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "grafanacloud-ngalertmanager without grafana_managed_receiver_configs is not managed",
+			amUID:    "grafanacloud-ngalertmanager",
+			amConfig: map[string]any{},
+			expected: false,
+		},
+		{
+			name:  "AM with grafana_managed_receiver_configs is managed",
+			amUID: "custom-grafana-am",
+			amConfig: map[string]any{
+				"receivers": []any{
+					map[string]any{
+						"name":                             "default",
+						"grafana_managed_receiver_configs": []any{},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "AM with native configs is not managed",
+			amUID: "my-external-am",
+			amConfig: map[string]any{
+				"receivers": []any{
+					map[string]any{
+						"name": "default",
+						"opsgenie_configs": []any{
+							map[string]any{"api_key": "xxx"},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "AM with no receivers and unknown UID is not managed",
+			amUID:    "some-external-am",
+			amConfig: map[string]any{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isGrafanaManagedAM(tc.amUID, tc.amConfig)
+			if result != tc.expected {
+				t.Errorf("isGrafanaManagedAM(%q, ...) = %v, want %v", tc.amUID, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestEmbeddedContactPointToNativeConfig(t *testing.T) {
+	t.Run(testReceiverOpsgenie, func(t *testing.T) {
+		typ := testReceiverOpsgenie
+		p := &models.EmbeddedContactPoint{
+			UID:                   "uid1",
+			Name:                  "test",
+			Type:                  &typ,
+			DisableResolveMessage: false,
+			Settings: map[string]any{
+				"apiKey":  "secret",
+				"apiUrl":  "https://api.eu.opsgenie.com/",
+				"message": "{{ .CommonAnnotations.summary }}",
+			},
+		}
+
+		configKey, native, err := embeddedContactPointToNativeConfig(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if configKey != "opsgenie_configs" {
+			t.Errorf("configKey: got %q, want %q", configKey, "opsgenie_configs")
+		}
+		if native["api_key"] != "secret" {
+			t.Errorf("api_key: got %v, want %q", native["api_key"], "secret")
+		}
+		if native["api_url"] != "https://api.eu.opsgenie.com/" {
+			t.Errorf("api_url: got %v, want %q", native["api_url"], "https://api.eu.opsgenie.com/")
+		}
+		if native["message"] != "{{ .CommonAnnotations.summary }}" {
+			t.Errorf("message: got %v", native["message"])
+		}
+		if native["send_resolved"] != true {
+			t.Errorf("send_resolved: got %v, want true", native["send_resolved"])
+		}
+	})
+
+	t.Run("skips false booleans", func(t *testing.T) {
+		typ := testReceiverOpsgenie
+		p := &models.EmbeddedContactPoint{
+			Type: &typ,
+			Settings: map[string]any{
+				"apiKey":    "secret",
+				"autoClose": false,
+			},
+		}
+
+		_, native, err := embeddedContactPointToNativeConfig(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := native["auto_close"]; ok {
+			t.Error("auto_close should be omitted when false")
+		}
+	})
+
+	t.Run("unsupported type", func(t *testing.T) {
+		typ := "oncall"
+		p := &models.EmbeddedContactPoint{
+			Type:     &typ,
+			Settings: map[string]any{},
+		}
+
+		_, _, err := embeddedContactPointToNativeConfig(p)
+		if err == nil {
+			t.Error("expected error for unsupported type")
+		}
+	})
+
+	t.Run("filters grafana-only settings", func(t *testing.T) {
+		typ := testReceiverOpsgenie
+		p := &models.EmbeddedContactPoint{
+			Type: &typ,
+			Settings: map[string]any{
+				"apiKey":           "secret",
+				"message":          "test",
+				"overridePriority": true,
+				"sendTagsAs":       "tags",
+			},
+		}
+
+		_, native, err := embeddedContactPointToNativeConfig(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Valid native fields should be present
+		if native["api_key"] != "secret" {
+			t.Errorf("api_key: got %v, want %q", native["api_key"], "secret")
+		}
+		if native["message"] != "test" {
+			t.Errorf("message: got %v, want %q", native["message"], "test")
+		}
+		// Grafana-only fields should be filtered out
+		if _, ok := native["override_priority"]; ok {
+			t.Error("override_priority should be filtered out")
+		}
+		if _, ok := native["send_tags_as"]; ok {
+			t.Error("send_tags_as should be filtered out")
+		}
+	})
+
+	t.Run("maps og_priority to priority for native AM", func(t *testing.T) {
+		typ := testReceiverOpsgenie
+		p := &models.EmbeddedContactPoint{
+			Type: &typ,
+			Settings: map[string]any{
+				"apiKey":      "secret",
+				"og_priority": "{{ .CommonAnnotations.priority }}",
+			},
+		}
+
+		_, native, err := embeddedContactPointToNativeConfig(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// og_priority should be mapped to priority
+		if native["priority"] != "{{ .CommonAnnotations.priority }}" {
+			t.Errorf("priority: got %v, want %q", native["priority"], "{{ .CommonAnnotations.priority }}")
+		}
+		// og_priority should not exist
+		if _, ok := native["og_priority"]; ok {
+			t.Error("og_priority should be mapped to priority, not kept")
+		}
+	})
+}
+
+func TestNativeConfigToEmbeddedContactPoint(t *testing.T) {
+	t.Run("basic conversion", func(t *testing.T) {
+		config := map[string]any{
+			"api_key":       "secret",
+			"api_url":       "https://api.eu.opsgenie.com/",
+			"message":       "test message",
+			"send_resolved": false,
+		}
+
+		p := nativeConfigToEmbeddedContactPoint(testReceiverOpsgenie, "test-receiver", config)
+
+		if *p.Type != testReceiverOpsgenie {
+			t.Errorf("Type: got %q, want %q", *p.Type, testReceiverOpsgenie)
+		}
+		if p.Name != "test-receiver" {
+			t.Errorf("Name: got %q, want %q", p.Name, "test-receiver")
+		}
+		if !p.DisableResolveMessage {
+			t.Error("DisableResolveMessage: got false, want true (send_resolved was false)")
+		}
+
+		settings := p.Settings.(map[string]any)
+		if settings["apiKey"] != "secret" {
+			t.Errorf("apiKey: got %v, want %q", settings["apiKey"], "secret")
+		}
+		if settings["apiUrl"] != "https://api.eu.opsgenie.com/" {
+			t.Errorf("apiUrl: got %v, want %q", settings["apiUrl"], "https://api.eu.opsgenie.com/")
+		}
+		if settings["message"] != "test message" {
+			t.Errorf("message: got %v, want %q", settings["message"], "test message")
+		}
+		if _, ok := settings["sendResolved"]; ok {
+			t.Error("sendResolved should not be in settings (extracted to DisableResolveMessage)")
+		}
+	})
+
+	t.Run("maps priority to og_priority for Grafana", func(t *testing.T) {
+		config := map[string]any{
+			"api_key":  "secret",
+			"priority": "{{ .CommonAnnotations.priority }}",
+		}
+
+		p := nativeConfigToEmbeddedContactPoint(testReceiverOpsgenie, "test-receiver", config)
+
+		settings := p.Settings.(map[string]any)
+		// priority should be mapped to og_priority
+		if settings["og_priority"] != "{{ .CommonAnnotations.priority }}" {
+			t.Errorf("og_priority: got %v, want %q", settings["og_priority"], "{{ .CommonAnnotations.priority }}")
+		}
+		// priority should not exist (mapped to og_priority)
+		if _, ok := settings["priority"]; ok {
+			t.Error("priority should be mapped to og_priority, not kept")
+		}
+	})
+}
+
+func TestParseNotificationPolicyAMConfigID(t *testing.T) {
+	tests := []struct {
+		id          string
+		expectOrgID int64
+		expectAMUID string
+	}{
+		{
+			id:          "1:grafana/policy",
+			expectOrgID: 1,
+			expectAMUID: "grafana",
+		},
+		{
+			id:          "42:grafanacloud-ngalertmanager/policy",
+			expectOrgID: 42,
+			expectAMUID: "grafanacloud-ngalertmanager",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			orgID, amUID := parseNotificationPolicyAMConfigID(tc.id)
+			if orgID != tc.expectOrgID {
+				t.Errorf("orgID: got %d, want %d", orgID, tc.expectOrgID)
+			}
+			if amUID != tc.expectAMUID {
+				t.Errorf("amUID: got %q, want %q", amUID, tc.expectAMUID)
+			}
+		})
+	}
+}
+
+// TestNonEmptyNotifier verifies that the nonEmptyNotifier function correctly
+// identifies empty vs non-empty notifier data. This is critical for the AM Config
+// path where empty notifier entries without UIDs should be skipped.
+func TestNonEmptyNotifier(t *testing.T) {
+	notifier := opsGenieNotifier{}
+
+	tests := []struct {
+		name     string
+		data     map[string]any
+		expected bool
+	}{
+		{
+			name:     "empty data is not non-empty",
+			data:     map[string]any{},
+			expected: false,
+		},
+		{
+			name: "data with only optional fields is not non-empty",
+			data: map[string]any{
+				"auto_close":        false,
+				"override_priority": false,
+				"responders":        []any{},
+			},
+			expected: false,
+		},
+		{
+			name: "data with required field (api_key) is non-empty",
+			data: map[string]any{
+				"api_key": "secret-key",
+			},
+			expected: true,
+		},
+		{
+			name: "data with empty string for required field is not non-empty",
+			data: map[string]any{
+				"api_key": "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := nonEmptyNotifier(notifier, tc.data)
+			if result != tc.expected {
+				t.Errorf("nonEmptyNotifier(...) = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `alertmanager_uid` attribute to `grafana_contact_point` and `grafana_notification_policy` resources
- Enables managing alerting resources on external alertmanagers (e.g., `grafanacloud-ngalertmanager`) via the AM Config API
- Automatically detects Grafana-managed vs native alertmanager format and converts contact point settings accordingly

Closes #799

## Changes

- **New AM Config API client** (`alerting_amconfig_api.go`): Testable HTTP client for the `/api/alertmanager/{recipient}/config/api/v1/alerts` endpoint
- **Conversion helpers** (`alerting_amconfig_helpers.go`): Functions to convert between Grafana and native Alertmanager formats (routes, receivers, matchers)
- **Contact point support**: CRUD operations via AM Config API when `alertmanager_uid` is set
- **Notification policy support**: CRUD operations via AM Config API when `alertmanager_uid` is set
- **Field mapping**: Handles differences between Grafana and native AM (e.g., `og_priority` ↔ `priority`, `teams` ↔ `msteams_configs`)
- **Grafana-only settings filtered**: Settings like `overridePriority`, `sendTagsAs` are excluded for native AMs