### PR TITLE
feat: add grafana_organization_lookup_user data source

### DIFF
--- a/examples/data-sources/grafana_organization_lookup_user/data-source.tf
+++ b/examples/data-sources/grafana_organization_lookup_user/data-source.tf
@@ -1,0 +1,10 @@
+resource "grafana_user" "test" {
+  email    = "test.datasource@example.com"
+  name     = "Testing Datasource"
+  login    = "test-datasource"
+  password = "my-password"
+}
+
+data "grafana_organization_lookup_user" "test" {
+  login = grafana_user.test.login
+}

--- a/internal/resources/grafana/data_source_organization_lookup_user.go
+++ b/internal/resources/grafana/data_source_organization_lookup_user.go
@@ -1,0 +1,66 @@
+package grafana
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-openapi-client-go/client/org"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceOrganizationLookupUser() *common.DataSource {
+	schema := &schema.Resource{
+		Description: `
+* [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-all-users-within-the-current-organization-lookup)
+`,
+		ReadContext: dataSourceOrganizationLookupUserRead,
+		Schema: map[string]*schema.Schema{
+			"org_id": orgIDAttribute(),
+			"login": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The username of the Grafana user.",
+			},
+			"user_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The numerical ID of the Grafana user.",
+			},
+		},
+	}
+	return common.NewLegacySDKDataSource(common.CategoryGrafanaOSS, "grafana_organization_lookup_user", schema)
+}
+
+func dataSourceOrganizationLookupUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client, orgID := OAPIClientFromNewOrgResource(meta, d)
+
+	var resp interface {
+		GetPayload() []*models.UserLookupDTO
+	}
+
+	login := d.Get("login").(string)
+
+	params := org.NewGetOrgUsersForCurrentOrgLookupParams().WithQuery(&login)
+	resp, err := client.Org.GetOrgUsersForCurrentOrgLookup(params)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(resp.GetPayload()) == 0 {
+		return diag.Errorf("organization user not found with query: %q", login)
+	}
+
+	for _, user := range resp.GetPayload() {
+		if user.Login == login {
+			d.Set("user_id", user.UserID)
+			d.Set("login", user.Login)
+			d.SetId(MakeOrgResourceID(orgID, user.UserID))
+			return nil
+		}
+	}
+
+	return diag.Errorf("no organization user found with login: %q (users returned: %d)", login, len(resp.GetPayload()))
+}

--- a/internal/resources/grafana/data_source_organization_lookup_user_test.go
+++ b/internal/resources/grafana/data_source_organization_lookup_user_test.go
@@ -1,0 +1,39 @@
+package grafana_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDatasourceOrganizationLookupUser_basic(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t)
+
+	var user models.UserProfileDTO
+	checks := []resource.TestCheckFunc{
+		userCheckExists.exists("grafana_user.test", &user),
+	}
+
+	checks = append(checks,
+		resource.TestMatchResourceAttr(
+			"data.grafana_organization_lookup_user.test", "user_id", common.IDRegexp,
+		),
+		resource.TestCheckResourceAttr(
+			"data.grafana_organization_lookup_user.test", "login", "test-datasource",
+		),
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             userCheckExists.destroyed(&user, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.TestAccExample(t, "data-sources/grafana_organization_lookup_user/data-source.tf"),
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+		},
+	})
+}

--- a/internal/resources/grafana/data_source_organization_user.go
+++ b/internal/resources/grafana/data_source_organization_user.go
@@ -14,7 +14,7 @@ func datasourceOrganizationUser() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-all-users-within-the-current-organization-lookup)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-all-users-within-the-current-organization)
 `,
 		ReadContext: dataSourceOrganizationUserRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/resources.go
+++ b/internal/resources/grafana/resources.go
@@ -96,6 +96,7 @@ var DataSources = addValidationToDataSources(
 	datasourceUser(),
 	datasourceUsers(),
 	datasourceOrganizationUser(),
+	datasourceOrganizationLookupUser(),
 	datasourceRole(),
 	datasourceServiceAccount(),
 	datasourceTeam(),


### PR DESCRIPTION
Add a new data source that uses the /api/org/users/lookup endpoint to retrieve user info by login. This endpoint returns less detailed information (userId, login, avatarUrl) compared to the full /api/org/users endpoint, making it suitable for use cases that only need basic user identification without elevated permissions, like setting folder permissions by user login information.

Also fix the HTTP API doc link on the existing
grafana_organization_user data source, which was incorrectly pointing to the lookup endpoint.