### PR TITLE
fix(oncall): make integration labels idempotent

### DIFF
--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -867,7 +867,10 @@ func flattenLabels(labels []*onCallAPI.Label) []map[string]string {
 //  2. Label ordering: the API may return labels in a different order than the config, but TypeList
 //     compares positionally. We suppress the diff when the set of {key,value} pairs is identical.
 func labelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// Suppress the synthetic "id" field that was previously stored in state
+	// TODO: remove in next major version.
+	// Suppress the synthetic "id" field that was previously stored in state by
+	// the old flattenLabels. Users upgrading still have "id" in their state and
+	// would see a spurious diff showing its removal without this.
 	if strings.HasSuffix(k, ".id") {
 		return true
 	}

--- a/internal/resources/oncall/resource_integration_labels_test.go
+++ b/internal/resources/oncall/resource_integration_labels_test.go
@@ -1,0 +1,131 @@
+package oncall
+
+import (
+	"testing"
+
+	onCallAPI "github.com/grafana/amixr-api-go-client"
+)
+
+func TestFlattenLabels_NoIDField(t *testing.T) {
+	labels := []*onCallAPI.Label{
+		{Key: onCallAPI.KeyValueName{Name: "severity"}, Value: onCallAPI.KeyValueName{Name: "critical"}},
+	}
+
+	result := flattenLabels(labels)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 label, got %d", len(result))
+	}
+	if _, exists := result[0]["id"]; exists {
+		t.Error("flattenLabels should not include an 'id' field; it causes spurious diffs because the config never specifies it")
+	}
+	if result[0]["key"] != "severity" {
+		t.Errorf("expected key 'severity', got %q", result[0]["key"])
+	}
+	if result[0]["value"] != "critical" {
+		t.Errorf("expected value 'critical', got %q", result[0]["value"])
+	}
+}
+
+func TestFlattenLabels_Empty(t *testing.T) {
+	result := flattenLabels(nil)
+	if len(result) != 0 {
+		t.Fatalf("expected 0 labels, got %d", len(result))
+	}
+}
+
+func TestExpandLabels_NilElement(t *testing.T) {
+	input := []any{
+		nil,
+		map[string]any{"key": "severity", "value": "critical"},
+		nil,
+	}
+
+	result := expandLabels(input)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 label, got %d", len(result))
+	}
+	if result[0].Key.Name != "severity" {
+		t.Errorf("expected key 'severity', got %q", result[0].Key.Name)
+	}
+	if result[0].Value.Name != "critical" {
+		t.Errorf("expected value 'critical', got %q", result[0].Value.Name)
+	}
+}
+
+func TestExpandLabels_AllNil(t *testing.T) {
+	input := []any{nil, nil}
+
+	result := expandLabels(input)
+
+	if len(result) != 0 {
+		t.Fatalf("expected 0 labels, got %d", len(result))
+	}
+}
+
+func TestLabelsSetEqual_SameOrder(t *testing.T) {
+	a := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+		map[string]any{"key": "team", "value": "platform"},
+	}
+	b := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+		map[string]any{"key": "team", "value": "platform"},
+	}
+	if !labelsSetEqual(a, b) {
+		t.Error("expected labels with same content and order to be equal")
+	}
+}
+
+func TestLabelsSetEqual_DifferentOrder(t *testing.T) {
+	a := []any{
+		map[string]any{"key": "team", "value": "platform"},
+		map[string]any{"key": "severity", "value": "critical"},
+	}
+	b := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+		map[string]any{"key": "team", "value": "platform"},
+	}
+	if !labelsSetEqual(a, b) {
+		t.Error("expected labels with same content in different order to be equal")
+	}
+}
+
+func TestLabelsSetEqual_IgnoresIDField(t *testing.T) {
+	// Old state has "id" field, new config does not
+	a := []any{
+		map[string]any{"id": "severity", "key": "severity", "value": "critical"},
+	}
+	b := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+	}
+	if !labelsSetEqual(a, b) {
+		t.Error("expected labels to be equal even when old state has 'id' field")
+	}
+}
+
+func TestLabelsSetEqual_DifferentValues(t *testing.T) {
+	a := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+	}
+	b := []any{
+		map[string]any{"key": "severity", "value": "warning"},
+	}
+	if labelsSetEqual(a, b) {
+		t.Error("expected labels with different values to NOT be equal")
+	}
+}
+
+func TestLabelsSetEqual_DifferentCount(t *testing.T) {
+	a := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+	}
+	b := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+		map[string]any{"key": "team", "value": "platform"},
+	}
+	if labelsSetEqual(a, b) {
+		t.Error("expected labels with different count to NOT be equal")
+	}
+}


### PR DESCRIPTION
# Motivation

This PR fixes https://github.com/grafana/terraform-provider-grafana/issues/2169 and is not breaking as https://github.com/grafana/terraform-provider-grafana/pull/2343 is.

The `labels` and `dynamic_labels` attributes caused spurious diffs on
every plan due to two issues:

1. flattenLabels() injected a synthetic "id" field (set to the label
   key name) that is never present in user configuration.

2. TypeList compares elements positionally, but the API may return
   labels in a different order than the config, causing labels to
   appear swapped or removed.

Fix by adding a DiffSuppressFunc that:
- Suppresses the synthetic "id" and map-size diffs from old state
- Compares labels as a set of {key, value} pairs, ignoring order

Also remove the synthetic "id" from flattenLabels() so new state
no longer includes it.
