### PR TITLE
fix(syntheticmonitoring): add mutex to prevent concurrent API request issues

### DIFF
--- a/internal/resources/syntheticmonitoring/resources.go
+++ b/internal/resources/syntheticmonitoring/resources.go
@@ -12,13 +12,13 @@ import (
 type crudWithClientFunc func(ctx context.Context, d *schema.ResourceData, client *smapi.Client) diag.Diagnostics
 
 func withClient[T schema.CreateContextFunc | schema.UpdateContextFunc | schema.ReadContextFunc | schema.DeleteContextFunc](f crudWithClientFunc) T {
-	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	return common.WithSMAPIMutex[T](func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		client := meta.(*common.Client).SMAPI
 		if client == nil {
 			return diag.Errorf("the SM client is required for this resource. Set the sm_access_token provider attribute")
 		}
 		return f(ctx, d, client)
-	}
+	})
 }
 
 var DataSources = []*common.DataSource{


### PR DESCRIPTION
## Summary
- Add mutex to serialize Synthetic Monitoring API operations
- Fixes silent failures when deleting multiple `grafana_synthetic_monitoring_check_alerts` resources concurrently

## Problem
The Synthetic Monitoring API doesn't handle concurrent requests well. When multiple resources are deleted simultaneously (e.g., during `terraform destroy`), Terraform reports success for all deletions, but only some actually succeed. The remaining resources are silently left as orphans in the API.

## Root Cause
When Terraform tries to delete multiple `grafana_synthetic_monitoring_check_alerts` resources in parallel, the concurrent `PUT /check/{id}/alerts` requests to the SM API interfere with each other. The API returns success (200 OK) for all requests, but only processes some of them.

## Solution
Add a mutex to serialize all SM API operations, similar to the existing mutexes for alerting (`alertingMutex`), folder (`folderMutex`), and dashboard (`dashboardMutex`) resources.

## Testing
Tested with 11 concurrent deletions:
- **Without fix**: 6 of 11 deletions silently failed (alerts remained in API despite Terraform reporting "destroyed")
- **With fix**: All 11 deletions succeeded correctly

## Test plan
- [x] Build passes
- [x] Manual testing with multiple concurrent create/delete operations
- [x] Verified fix resolves the issue
- [x] Verified issue exists without the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)