### PR TITLE
fix(rules): Revert to dynamic type for expressions in recording and alert rules

### DIFF
--- a/docs/resources/apps_rules_recordingrule_v0alpha1.md
+++ b/docs/resources/apps_rules_recordingrule_v0alpha1.md
@@ -31,7 +31,7 @@ resource "grafana_apps_rules_recordingrule_v0alpha1" "example" {
     }
     paused = true
     expressions = {
-      "A" = jsonencode({
+      "A" = {
         model = {
           editorMode    = "code"
           expr          = "count(up{})"
@@ -49,7 +49,7 @@ resource "grafana_apps_rules_recordingrule_v0alpha1" "example" {
         }
         query_type = ""
         source     = true
-      })
+      }
     }
     target_datasource_uid = "target_ds_uid"
     metric                = "tf-metric"
@@ -105,7 +105,7 @@ Optional:
 
 Required:
 
-- `expressions` (Map of String) A sequence of stages that describe the contents of the rule. Each value is a JSON string representing an expression object.
+- `expressions` (Dynamic) A sequence of stages that describe the contents of the rule.
 - `metric` (String) The name of the metric to write to.
 - `target_datasource_uid` (String) The UID of the datasource to write the metric to.
 - `title` (String) The title of the recording rule.

--- a/examples/resources/grafana_apps_rules_alertrule_v0alpha1/resource.tf
+++ b/examples/resources/grafana_apps_rules_alertrule_v0alpha1/resource.tf
@@ -14,7 +14,7 @@ resource "grafana_apps_rules_alertrule_v0alpha1" "example" {
     }
     paused = true
     expressions = {
-      "A" = jsonencode({
+      "A" = {
         model = {
           datasource = {
             type = "prometheus"
@@ -36,8 +36,8 @@ resource "grafana_apps_rules_alertrule_v0alpha1" "example" {
         }
         query_type = ""
         source     = true
-      })
-      "B" = jsonencode({
+      }
+      "B" = {
         model = {
           conditions = [
             {
@@ -71,7 +71,7 @@ resource "grafana_apps_rules_alertrule_v0alpha1" "example" {
         datasource_uid = "__expr__"
         query_type     = ""
         source         = false
-      })
+      }
     }
     for = "5m"
     labels = {

--- a/examples/resources/grafana_apps_rules_recordingrule_v0alpha1/resource.tf
+++ b/examples/resources/grafana_apps_rules_recordingrule_v0alpha1/resource.tf
@@ -16,7 +16,7 @@ resource "grafana_apps_rules_recordingrule_v0alpha1" "example" {
     }
     paused = true
     expressions = {
-      "A" = jsonencode({
+      "A" = {
         model = {
           editorMode    = "code"
           expr          = "count(up{})"
@@ -34,7 +34,7 @@ resource "grafana_apps_rules_recordingrule_v0alpha1" "example" {
         }
         query_type = ""
         source     = true
-      })
+      }
     }
     target_datasource_uid = "target_ds_uid"
     metric                = "tf-metric"

--- a/internal/resources/appplatform/rule_common.go
+++ b/internal/resources/appplatform/rule_common.go
@@ -208,6 +208,189 @@ func (v PrometheusDurationWithMillisValidator) ValidateString(ctx context.Contex
 	}
 }
 
+// ExpressionsDynamicValidator validates that the dynamic value is a valid expressions map
+type ExpressionsDynamicValidator struct{}
+
+func (v ExpressionsDynamicValidator) Description(_ context.Context) string {
+	return "expressions must be a map of HCL expression objects with exactly one marked as source"
+}
+
+func (v ExpressionsDynamicValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v ExpressionsDynamicValidator) ValidateDynamic(ctx context.Context, req validator.DynamicRequest, resp *validator.DynamicResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Extract the underlying value
+	underlyingValue := req.ConfigValue.UnderlyingValue()
+
+	// Handle both Map and Object types (HCL can parse as either depending on syntax)
+	var elements map[string]attr.Value
+
+	switch v := underlyingValue.(type) {
+	case types.Map:
+		elements = v.Elements()
+	case types.Object:
+		elements = v.Attributes()
+	default:
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Expressions Type",
+			"Expressions must be a map of HCL objects",
+		)
+		return
+	}
+
+	if len(elements) == 0 {
+		return
+	}
+
+	// Validate that exactly one expression is marked as source
+	sourceCount := 0
+	for key, rawVal := range elements {
+		obj, ok := rawVal.(types.Object)
+		if !ok {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtMapKey(key),
+				"Invalid Expression Type",
+				fmt.Sprintf("Expression '%s' must be an object", key),
+			)
+			continue
+		}
+
+		// Check if this expression has source = true
+		// Extract source field directly from attributes
+		attrs := obj.Attributes()
+		if sourceAttr, ok := attrs["source"]; ok && !sourceAttr.IsNull() && !sourceAttr.IsUnknown() {
+			if sourceBool, ok := sourceAttr.(types.Bool); ok && sourceBool.ValueBool() {
+				sourceCount++
+			}
+		}
+
+		// Validate that required fields are present
+		// Check if model attribute exists and is valid JSON
+		if modelAttr, ok := attrs["model"]; !ok || modelAttr.IsNull() || modelAttr.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtMapKey(key).AtName("model"),
+				"Missing Required Field",
+				fmt.Sprintf("Expression '%s' must have a 'model' field", key),
+			)
+		} else if strModel, ok := modelAttr.(types.String); ok {
+			// Validate that it's valid JSON
+			modelStr := strModel.ValueString()
+			if modelStr != "" {
+				var temp map[string]any
+				if err := json.Unmarshal([]byte(modelStr), &temp); err != nil {
+					resp.Diagnostics.AddAttributeError(
+						req.Path.AtMapKey(key).AtName("model"),
+						"Invalid Model JSON",
+						fmt.Sprintf("Expression '%s' model must be valid JSON: %v", key, err),
+					)
+				}
+			}
+		}
+	}
+
+	if sourceCount != 1 {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Expression Map",
+			fmt.Sprintf("Exactly one expression must be marked as source, found %d", sourceCount),
+		)
+	}
+}
+
+// ParseExpressionsFromDynamic extracts and validates expressions from a dynamic type value
+func ParseExpressionsFromDynamic(ctx context.Context, dynamicValue types.Dynamic) (map[string]types.Object, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if dynamicValue.IsNull() || dynamicValue.IsUnknown() {
+		return nil, diags
+	}
+
+	// Extract the underlying value
+	underlyingValue := dynamicValue.UnderlyingValue()
+
+	// Handle both Map and Object types (HCL can parse as either depending on syntax)
+	var elements map[string]attr.Value
+
+	switch v := underlyingValue.(type) {
+	case types.Map:
+		elements = v.Elements()
+	case types.Object:
+		elements = v.Attributes()
+	default:
+		diags.AddError("Invalid data", "Expressions must be a map or object of HCL objects")
+		return nil, diags
+	}
+
+	result := make(map[string]types.Object)
+	for key, rawVal := range elements {
+		obj, ok := rawVal.(types.Object)
+		if !ok {
+			diags.AddError("Invalid data", fmt.Sprintf("Expression '%s' is not an object", key))
+			continue
+		}
+
+		attrs := obj.Attributes()
+		newAttrs := make(map[string]attr.Value)
+
+		for attrName := range ruleExpressionType.AttrTypes {
+			if val, ok := attrs[attrName]; ok {
+				newAttrs[attrName] = val
+			} else {
+				switch attrName {
+				case "query_type", "datasource_uid", "model":
+					newAttrs[attrName] = types.StringNull()
+				case "source":
+					newAttrs[attrName] = types.BoolNull()
+				case "relative_time_range":
+					newAttrs[attrName] = types.ObjectNull(relativeTimeRangeType.AttrTypes)
+				default:
+					newAttrs[attrName] = types.StringNull()
+				}
+			}
+		}
+
+		if modelAttr, ok := attrs["model"]; ok && !modelAttr.IsNull() && !modelAttr.IsUnknown() {
+			var jsonStr string
+			if dynVal, ok := modelAttr.(types.Dynamic); ok {
+				jsonStr, _ = ConvertModelToJSON(ctx, dynVal)
+			} else if objVal, ok := modelAttr.(types.Object); ok {
+				tempDyn := types.DynamicValue(objVal)
+				jsonStr, _ = ConvertModelToJSON(ctx, tempDyn)
+			}
+			newAttrs["model"] = types.StringValue(jsonStr)
+		}
+
+		convertedObj, d := types.ObjectValue(ruleExpressionType.AttrTypes, newAttrs)
+		if d.HasError() {
+			diags.Append(d...)
+			continue
+		}
+		result[key] = convertedObj
+	}
+
+	return result, diags
+}
+
+// ConvertExpressionsMapToDynamic converts a map of expression objects to a dynamic value
+func ConvertExpressionsMapToDynamic(ctx context.Context, expressions map[string]attr.Value) (types.Dynamic, diag.Diagnostics) {
+	if len(expressions) == 0 {
+		return types.DynamicNull(), diag.Diagnostics{}
+	}
+
+	exprMapValue, d := types.MapValue(ruleExpressionType, expressions)
+	if d.HasError() {
+		return types.DynamicNull(), d
+	}
+
+	return types.DynamicValue(exprMapValue), diag.Diagnostics{}
+}
+
 // convertTerraformValueToGo converts a Terraform attr.Value to a Go any type for JSON marshaling
 func convertTerraformValueToGo(ctx context.Context, val attr.Value, diags *diag.Diagnostics) any {
 	if val.IsNull() || val.IsUnknown() {


### PR DESCRIPTION
Revert back to a dynamic type for expressions in the recording rule and alert rule resources. The previous usage of a map of strings which had to contain the jsonencoded objects was a workaround for an issue in the crossplane provider.

This at least gives us `apply` time validation of the expression object, however it does not give us `plan` and `validate` time validation. For that we will need to use the new terraform framework object nested types, which are currently unsupported in this provider.
