### PR TITLE
Alerting: Enrichment is in public preview

### DIFF
--- a/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
+++ b/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
@@ -4,14 +4,14 @@ page_title: "grafana_apps_alertenrichment_alertenrichment_v1beta1 Resource - ter
 subcategory: "Alerting"
 description: |-
   Manages Grafana Cloud Alert Enrichment https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/.
-  Alert enrichment is currently in private preview. Grafana Labs offers support on a best-effort basis, and breaking changes might occur prior to the feature being made generally available
+  Alert enrichment is currently in public preview. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 ---
 
 # grafana_apps_alertenrichment_alertenrichment_v1beta1 (Resource)
 
 Manages [Grafana Cloud Alert Enrichment](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/).
 
-Alert enrichment is currently in private preview. Grafana Labs offers support on a best-effort basis, and breaking changes might occur prior to the feature being made generally available
+Alert enrichment is currently in public preview. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
 ## Example Usage
 

--- a/internal/resources/appplatform/alertenrichment_resource.go
+++ b/internal/resources/appplatform/alertenrichment_resource.go
@@ -1113,7 +1113,7 @@ func AlertEnrichment() NamedResource {
 				MarkdownDescription: `
 Manages [Grafana Cloud Alert Enrichment](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/).
 
-Alert enrichment is currently in private preview. Grafana Labs offers support on a best-effort basis, and breaking changes might occur prior to the feature being made generally available
+Alert enrichment is currently in public preview. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 `,
 				SpecAttributes: func() map[string]schema.Attribute {
 					attrs := map[string]schema.Attribute{


### PR DESCRIPTION
Updated the wording [here](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/apps_alertenrichment_alertenrichment_v1beta1) to match the [official documentation](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/)