### PR TITLE
fix(oncall): sort labels to prevent perpetual drift

### DIFF
--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -852,19 +852,17 @@ func flattenLabels(labels []*onCallAPI.Label) []map[string]string {
 		})
 	}
 
-	// Sort labels by key (then value, then id) to produce a deterministic
-	// order, preventing perpetual drift when the API returns labels in a
-	// different order. Label keys are not guaranteed to be unique (the UI
-	// enforces uniqueness but the provider schema and API client do not),
-	// so we add value and id as tie-breakers to ensure a total ordering.
+	// Sort labels by key, then value, to produce a deterministic order,
+	// preventing perpetual drift when the API returns labels in a different
+	// order. Label keys are not guaranteed to be unique (the UI enforces
+	// uniqueness but the provider schema and API client do not), so we use
+	// value as a tie-breaker. Note: "id" is currently set to l.Key.Name
+	// (same as "key"), so it is not useful as a tie-breaker.
 	sort.SliceStable(flattenedLabels, func(i, j int) bool {
 		if flattenedLabels[i]["key"] != flattenedLabels[j]["key"] {
 			return flattenedLabels[i]["key"] < flattenedLabels[j]["key"]
 		}
-		if flattenedLabels[i]["value"] != flattenedLabels[j]["value"] {
-			return flattenedLabels[i]["value"] < flattenedLabels[j]["value"]
-		}
-		return flattenedLabels[i]["id"] < flattenedLabels[j]["id"]
+		return flattenedLabels[i]["value"] < flattenedLabels[j]["value"]
 	})
 
 	return flattenedLabels

--- a/internal/resources/oncall/resource_integration_labels_test.go
+++ b/internal/resources/oncall/resource_integration_labels_test.go
@@ -1,0 +1,79 @@
+package oncall
+
+import (
+	"testing"
+
+	onCallAPI "github.com/grafana/amixr-api-go-client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenLabels_SortedByKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []*onCallAPI.Label
+		expected []map[string]string
+	}{
+		{
+			name:     "empty labels",
+			input:    []*onCallAPI.Label{},
+			expected: []map[string]string{},
+		},
+		{
+			name: "single label",
+			input: []*onCallAPI.Label{
+				{Key: onCallAPI.KeyValueName{Name: "service"}, Value: onCallAPI.KeyValueName{Name: "web"}},
+			},
+			expected: []map[string]string{
+				{"id": "service", "key": "service", "value": "web"},
+			},
+		},
+		{
+			name: "already sorted labels",
+			input: []*onCallAPI.Label{
+				{Key: onCallAPI.KeyValueName{Name: "alpha"}, Value: onCallAPI.KeyValueName{Name: "val1"}},
+				{Key: onCallAPI.KeyValueName{Name: "beta"}, Value: onCallAPI.KeyValueName{Name: "val2"}},
+				{Key: onCallAPI.KeyValueName{Name: "gamma"}, Value: onCallAPI.KeyValueName{Name: "val3"}},
+			},
+			expected: []map[string]string{
+				{"id": "alpha", "key": "alpha", "value": "val1"},
+				{"id": "beta", "key": "beta", "value": "val2"},
+				{"id": "gamma", "key": "gamma", "value": "val3"},
+			},
+		},
+		{
+			name: "unsorted labels are returned sorted by key",
+			input: []*onCallAPI.Label{
+				{Key: onCallAPI.KeyValueName{Name: "service_name"}, Value: onCallAPI.KeyValueName{Name: "{{ payload.commonLabels.service_name }}"}},
+				{Key: onCallAPI.KeyValueName{Name: "namespace"}, Value: onCallAPI.KeyValueName{Name: "{{ payload.commonLabels.namespace }}"}},
+				{Key: onCallAPI.KeyValueName{Name: "severity"}, Value: onCallAPI.KeyValueName{Name: "{{ payload.commonLabels.severity }}"}},
+				{Key: onCallAPI.KeyValueName{Name: "project"}, Value: onCallAPI.KeyValueName{Name: "{{ payload.commonLabels.project }}"}},
+			},
+			expected: []map[string]string{
+				{"id": "namespace", "key": "namespace", "value": "{{ payload.commonLabels.namespace }}"},
+				{"id": "project", "key": "project", "value": "{{ payload.commonLabels.project }}"},
+				{"id": "service_name", "key": "service_name", "value": "{{ payload.commonLabels.service_name }}"},
+				{"id": "severity", "key": "severity", "value": "{{ payload.commonLabels.severity }}"},
+			},
+		},
+		{
+			name: "reverse sorted labels are returned sorted by key",
+			input: []*onCallAPI.Label{
+				{Key: onCallAPI.KeyValueName{Name: "z_label"}, Value: onCallAPI.KeyValueName{Name: "last"}},
+				{Key: onCallAPI.KeyValueName{Name: "m_label"}, Value: onCallAPI.KeyValueName{Name: "middle"}},
+				{Key: onCallAPI.KeyValueName{Name: "a_label"}, Value: onCallAPI.KeyValueName{Name: "first"}},
+			},
+			expected: []map[string]string{
+				{"id": "a_label", "key": "a_label", "value": "first"},
+				{"id": "m_label", "key": "m_label", "value": "middle"},
+				{"id": "z_label", "key": "z_label", "value": "last"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := flattenLabels(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/resources/oncall/resource_integration_labels_test.go
+++ b/internal/resources/oncall/resource_integration_labels_test.go
@@ -68,6 +68,19 @@ func TestFlattenLabels_SortedByKey(t *testing.T) {
 				{"id": "z_label", "key": "z_label", "value": "last"},
 			},
 		},
+		{
+			name: "duplicate keys are sorted by value as tie-breaker",
+			input: []*onCallAPI.Label{
+				{Key: onCallAPI.KeyValueName{Name: "dup_key"}, Value: onCallAPI.KeyValueName{Name: "second_value"}},
+				{Key: onCallAPI.KeyValueName{Name: "other_key"}, Value: onCallAPI.KeyValueName{Name: "other_value"}},
+				{Key: onCallAPI.KeyValueName{Name: "dup_key"}, Value: onCallAPI.KeyValueName{Name: "first_value"}},
+			},
+			expected: []map[string]string{
+				{"id": "dup_key", "key": "dup_key", "value": "first_value"},
+				{"id": "dup_key", "key": "dup_key", "value": "second_value"},
+				{"id": "other_key", "key": "other_key", "value": "other_value"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fix perpetual drift on `grafana_oncall_integration` `labels` and `dynamic_labels` caused by the OnCall API returning labels in non-deterministic order
- Sort labels by key in `flattenLabels` using `sort.SliceStable` to produce a deterministic order regardless of API response ordering
- Add unit tests covering empty, single, sorted, unsorted, and reverse-sorted label inputs

Closes #2559

## Test plan

- [x] Unit tests pass (`go test ./internal/resources/oncall/ -run TestFlattenLabels -v`)
- [x] Acceptance tests with 2+ labels show no drift after apply