### PR TITLE
 docs: add descriptions with links to cloud provider resources

### DIFF
--- a/docs/data-sources/cloud_provider_aws_account.md
+++ b/docs/data-sources/cloud_provider_aws_account.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_aws_account Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This datasource allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_account (Data Source)
 
+This datasource allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_aws_account.md
+++ b/docs/data-sources/cloud_provider_aws_account.md
@@ -3,20 +3,20 @@
 page_title: "grafana_cloud_provider_aws_account Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  This datasource allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  This data source allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_account (Data Source)
 
-This datasource allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
+This data source allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_aws_cloudwatch_scrape_job Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This datasource allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_cloudwatch_scrape_job (Data Source)
 
+This datasource allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -3,20 +3,20 @@
 page_title: "grafana_cloud_provider_aws_cloudwatch_scrape_job Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  This datasource allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  This data source allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_cloudwatch_scrape_job (Data Source)
 
-This datasource allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
+This data source allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_aws_cloudwatch_scrape_jobs Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This datasource allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_cloudwatch_scrape_jobs (Data Source)
 
+This datasource allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
+++ b/docs/data-sources/cloud_provider_aws_cloudwatch_scrape_jobs.md
@@ -3,20 +3,20 @@
 page_title: "grafana_cloud_provider_aws_cloudwatch_scrape_jobs Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  This datasource allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  This data source allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_cloudwatch_scrape_jobs (Data Source)
 
-This datasource allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
+This data source allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_azure_credential.md
+++ b/docs/data-sources/cloud_provider_azure_credential.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_azure_credential Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This datasource allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/
 ---
 
 # grafana_cloud_provider_azure_credential (Data Source)
 
+This datasource allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
 
 ## Example Usage
 

--- a/docs/data-sources/cloud_provider_azure_credential.md
+++ b/docs/data-sources/cloud_provider_azure_credential.md
@@ -3,20 +3,20 @@
 page_title: "grafana_cloud_provider_azure_credential Data Source - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  This datasource allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  This data source allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/
 ---
 
 # grafana_cloud_provider_azure_credential (Data Source)
 
-This datasource allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
+This data source allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_aws_account.md
+++ b/docs/resources/cloud_provider_aws_account.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_aws_account Resource - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This resource allows you to link your AWS Account to Grafana Cloud for use in creating Cloud Provider resources.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_account (Resource)
 
+This resource allows you to link your AWS Account to Grafana Cloud for use in creating Cloud Provider resources.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_aws_account.md
+++ b/docs/resources/cloud_provider_aws_account.md
@@ -4,19 +4,19 @@ page_title: "grafana_cloud_provider_aws_account Resource - terraform-provider-gr
 subcategory: "Cloud Provider"
 description: |-
   This resource allows you to link your AWS Account to Grafana Cloud for use in creating Cloud Provider resources.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_account (Resource)
 
 This resource allows you to link your AWS Account to Grafana Cloud for use in creating Cloud Provider resources.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_aws_cloudwatch_scrape_job Resource - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This resource allows you to scrape AWS CloudWatch metrics in Grafana Cloud without needing to run your own infrastructure.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_cloudwatch_scrape_job (Resource)
 
+This resource allows you to scrape AWS CloudWatch metrics in Grafana Cloud without needing to run your own infrastructure.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_cloudwatch_scrape_job.md
@@ -4,19 +4,19 @@ page_title: "grafana_cloud_provider_aws_cloudwatch_scrape_job Resource - terrafo
 subcategory: "Cloud Provider"
 description: |-
   This resource allows you to scrape AWS CloudWatch metrics in Grafana Cloud without needing to run your own infrastructure.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_cloudwatch_scrape_job (Resource)
 
 This resource allows you to scrape AWS CloudWatch metrics in Grafana Cloud without needing to run your own infrastructure.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_aws_resource_metadata_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_resource_metadata_scrape_job.md
@@ -3,12 +3,24 @@
 page_title: "grafana_cloud_provider_aws_resource_metadata_scrape_job Resource - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This resource allows you to scrape AWS resource metadata such as ARN and tags as info metrics in Grafana Cloud without needing to run your own infrastructure.
+  Use this resource if you aren't using grafana_cloud_provider_aws_cloudwatch_scrape_job, but still want to have AWS resource metadata available
+  in Grafana Cloud, for example for use with our AWS Metrics Streaming integration and/or Knowledge Graph features.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_resource_metadata_scrape_job (Resource)
 
+This resource allows you to scrape AWS resource metadata such as ARN and tags as info metrics in Grafana Cloud without needing to run your own infrastructure.
+Use this resource if you aren't using `grafana_cloud_provider_aws_cloudwatch_scrape_job`, but still want to have AWS resource metadata available 
+in Grafana Cloud, for example for use with our AWS Metrics Streaming integration and/or Knowledge Graph features.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_aws_resource_metadata_scrape_job.md
+++ b/docs/resources/cloud_provider_aws_resource_metadata_scrape_job.md
@@ -5,22 +5,22 @@ subcategory: "Cloud Provider"
 description: |-
   This resource allows you to scrape AWS resource metadata such as ARN and tags as info metrics in Grafana Cloud without needing to run your own infrastructure.
   Use this resource if you aren't using grafana_cloud_provider_aws_cloudwatch_scrape_job, but still want to have AWS resource metadata available
-  in Grafana Cloud, for example for use with our AWS Metrics Streaming integration and/or Knowledge Graph features.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  in Grafana Cloud, for example for use with our AWS Metrics Streams integration and/or Knowledge Graph features.
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/
 ---
 
 # grafana_cloud_provider_aws_resource_metadata_scrape_job (Resource)
 
 This resource allows you to scrape AWS resource metadata such as ARN and tags as info metrics in Grafana Cloud without needing to run your own infrastructure.
 Use this resource if you aren't using `grafana_cloud_provider_aws_cloudwatch_scrape_job`, but still want to have AWS resource metadata available 
-in Grafana Cloud, for example for use with our AWS Metrics Streaming integration and/or Knowledge Graph features.
+in Grafana Cloud, for example for use with our AWS Metrics Streams integration and/or Knowledge Graph features.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_azure_credential.md
+++ b/docs/resources/cloud_provider_azure_credential.md
@@ -3,12 +3,20 @@
 page_title: "grafana_cloud_provider_azure_credential Resource - terraform-provider-grafana"
 subcategory: "Cloud Provider"
 description: |-
-  
+  This resource allows you to autodiscover resources in your Azure tenant and scrape Azure Monitor metrics for those resources in Grafana Cloud without needing to run your own infrastructure.
+  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  for information on authentication and required access policy scopes.
+  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/
 ---
 
 # grafana_cloud_provider_azure_credential (Resource)
 
+This resource allows you to autodiscover resources in your Azure tenant and scrape Azure Monitor metrics for those resources in Grafana Cloud without needing to run your own infrastructure.
 
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_provider_azure_credential.md
+++ b/docs/resources/cloud_provider_azure_credential.md
@@ -4,19 +4,19 @@ page_title: "grafana_cloud_provider_azure_credential Resource - terraform-provid
 subcategory: "Cloud Provider"
 description: |-
   This resource allows you to autodiscover resources in your Azure tenant and scrape Azure Monitor metrics for those resources in Grafana Cloud without needing to run your own infrastructure.
-  See the Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
+  See the Grafana Provider configuration docs https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider
   for information on authentication and required access policy scopes.
-  Official documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/
+  Official Grafana Cloud documentation https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/
 ---
 
 # grafana_cloud_provider_azure_credential (Resource)
 
 This resource allows you to autodiscover resources in your Azure tenant and scrape Azure Monitor metrics for those resources in Grafana Cloud without needing to run your own infrastructure.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
 
 ## Example Usage
 

--- a/internal/resources/cloudprovider/data_source_aws_account.go
+++ b/internal/resources/cloudprovider/data_source_aws_account.go
@@ -43,6 +43,14 @@ func (r datasourceAWSAccount) Metadata(ctx context.Context, req datasource.Metad
 
 func (r datasourceAWSAccount) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This datasource allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ resource_id }}\".",

--- a/internal/resources/cloudprovider/data_source_aws_account.go
+++ b/internal/resources/cloudprovider/data_source_aws_account.go
@@ -44,12 +44,12 @@ func (r datasourceAWSAccount) Metadata(ctx context.Context, req datasource.Metad
 func (r datasourceAWSAccount) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: `
-This datasource allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
+This data source allows you to look up an existing Grafana Cloud AWS Account resource in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
@@ -186,6 +186,14 @@ func (r *datasourceAWSCloudWatchScrapeJob) Metadata(ctx context.Context, req dat
 
 func (r *datasourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = datasourceAWSCloudWatchScrapeJobTerraformSchema
+	resp.Schema.Description = `
+This datasource allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+`
 }
 
 func (r *datasourceAWSCloudWatchScrapeJob) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_job.go
@@ -187,12 +187,12 @@ func (r *datasourceAWSCloudWatchScrapeJob) Metadata(ctx context.Context, req dat
 func (r *datasourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = datasourceAWSCloudWatchScrapeJobTerraformSchema
 	resp.Schema.Description = `
-This datasource allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
+This data source allows you to look up an existing Grafana Cloud AWS CloudWatch Scrape Job resource in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 `
 }
 

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs.go
@@ -55,12 +55,12 @@ func (r datasourceAWSCloudWatchScrapeJobs) Metadata(ctx context.Context, req dat
 func (r datasourceAWSCloudWatchScrapeJobs) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: `
-This datasource allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
+This data source allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs.go
+++ b/internal/resources/cloudprovider/data_source_aws_cloudwatch_scrape_jobs.go
@@ -54,6 +54,14 @@ func (r datasourceAWSCloudWatchScrapeJobs) Metadata(ctx context.Context, req dat
 
 func (r datasourceAWSCloudWatchScrapeJobs) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This datasource allows you to look up all existing Grafana Cloud AWS CloudWatch Scrape Job resources in your stack.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}\".",

--- a/internal/resources/cloudprovider/data_source_azure_credential.go
+++ b/internal/resources/cloudprovider/data_source_azure_credential.go
@@ -45,6 +45,14 @@ func (r *datasourceAzureCredential) Metadata(ctx context.Context, req datasource
 
 func (r *datasourceAzureCredential) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This datasource allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ resource_id }}\".",

--- a/internal/resources/cloudprovider/data_source_azure_credential.go
+++ b/internal/resources/cloudprovider/data_source_azure_credential.go
@@ -46,12 +46,12 @@ func (r *datasourceAzureCredential) Metadata(ctx context.Context, req datasource
 func (r *datasourceAzureCredential) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: `
-This datasource allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
+This data source allows you to look up an existing Grafana Cloud Azure Credential resource in your stack.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/resource_aws_account.go
+++ b/internal/resources/cloudprovider/resource_aws_account.go
@@ -69,10 +69,10 @@ func (r resourceAWSAccount) Schema(ctx context.Context, req resource.SchemaReque
 		Description: `
 This resource allows you to link your AWS Account to Grafana Cloud for use in creating Cloud Provider resources.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/resource_aws_account.go
+++ b/internal/resources/cloudprovider/resource_aws_account.go
@@ -66,6 +66,14 @@ func (r resourceAWSAccount) Metadata(ctx context.Context, req resource.MetadataR
 
 func (r resourceAWSAccount) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This resource allows you to link your AWS Account to Grafana Cloud for use in creating Cloud Provider resources.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ resource_id }}\".",

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
@@ -65,10 +65,10 @@ func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource
 		Description: `
 This resource allows you to scrape AWS CloudWatch metrics in Grafana Cloud without needing to run your own infrastructure.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_cloudwatch_scrape_job.go
@@ -62,6 +62,14 @@ func (r resourceAWSCloudWatchScrapeJob) Metadata(ctx context.Context, req resour
 
 func (r resourceAWSCloudWatchScrapeJob) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This resource allows you to scrape AWS CloudWatch metrics in Grafana Cloud without needing to run your own infrastructure.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ name }}\".",

--- a/internal/resources/cloudprovider/resource_aws_resource_metadata_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_resource_metadata_scrape_job.go
@@ -61,6 +61,16 @@ func (r resourceAWSResourceMetadataScrapeJob) Metadata(ctx context.Context, req 
 
 func (r resourceAWSResourceMetadataScrapeJob) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This resource allows you to scrape AWS resource metadata such as ARN and tags as info metrics in Grafana Cloud without needing to run your own infrastructure.
+Use this resource if you aren't using ` + "`grafana_cloud_provider_aws_cloudwatch_scrape_job`" + `, but still want to have AWS resource metadata available 
+in Grafana Cloud, for example for use with our AWS Metrics Streaming integration and/or Knowledge Graph features.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ name }}\".",

--- a/internal/resources/cloudprovider/resource_aws_resource_metadata_scrape_job.go
+++ b/internal/resources/cloudprovider/resource_aws_resource_metadata_scrape_job.go
@@ -64,12 +64,12 @@ func (r resourceAWSResourceMetadataScrapeJob) Schema(ctx context.Context, req re
 		Description: `
 This resource allows you to scrape AWS resource metadata such as ARN and tags as info metrics in Grafana Cloud without needing to run your own infrastructure.
 Use this resource if you aren't using ` + "`grafana_cloud_provider_aws_cloudwatch_scrape_job`" + `, but still want to have AWS resource metadata available 
-in Grafana Cloud, for example for use with our AWS Metrics Streaming integration and/or Knowledge Graph features.
+in Grafana Cloud, for example for use with our AWS Metrics Streams integration and/or Knowledge Graph features.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/aws/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -132,10 +132,10 @@ func (r *resourceAzureCredential) Schema(ctx context.Context, req resource.Schem
 		Description: `
 This resource allows you to autodiscover resources in your Azure tenant and scrape Azure Monitor metrics for those resources in Grafana Cloud without needing to run your own infrastructure.
 
-See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+See the [Grafana Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
 for information on authentication and required access policy scopes.
 
-* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
+* [Official Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -129,6 +129,14 @@ func (r *resourceAzureCredential) Metadata(ctx context.Context, req resource.Met
 
 func (r *resourceAzureCredential) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: `
+This resource allows you to autodiscover resources in your Azure tenant and scrape Azure Monitor metrics for those resources in Grafana Cloud without needing to run your own infrastructure.
+
+See the [Provider configuration docs](https://registry.terraform.io/providers/grafana/grafana/latest/docs#managing-cloud-provider)
+for information on authentication and required access policy scopes.
+
+* [Official documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/monitor-cloud-provider/azure/)
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The Terraform Resource ID. This has the format \"{{ stack_id }}:{{ resource_id }}\".",


### PR DESCRIPTION
Adds schema Description fields with links to official documentation for all Grafana Cloud Provider resources and data sources. This improves the experience in the Terraform Registry by surfacing relevant documentation links directly on each resource/data source page.

Each description includes:
  - A brief summary of what the resource does
  - A link to Provider configuration docs for authentication and access policy scopes
  - A link to the relevant Official Grafana documentation
