### PR TITLE
fix: prevent nil pointer panic in AppPlatform resource Configure

### DIFF
--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -228,6 +228,15 @@ func (r *Resource[T, L]) Configure(ctx context.Context, req resource.ConfigureRe
 		return
 	}
 
+	if client.GrafanaAppPlatformAPI == nil {
+		resp.Diagnostics.AddError(
+			"Grafana App Platform API client not configured",
+			"The grafana provider must be configured with 'url' and 'auth' to use App Platform resources. "+
+				"Please check your provider configuration.",
+		)
+		return
+	}
+
 	rcli, err := client.GrafanaAppPlatformAPI.ClientFor(r.config.Kind)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/resources/appplatform/secret_keeper_activation_resource.go
+++ b/internal/resources/appplatform/secret_keeper_activation_resource.go
@@ -73,6 +73,15 @@ func (r *keeperActivationResource) Configure(ctx context.Context, req resource.C
 		return
 	}
 
+	if client.GrafanaAppPlatformAPI == nil {
+		resp.Diagnostics.AddError(
+			"Grafana App Platform API client not configured",
+			"The grafana provider must be configured with 'url' and 'auth' to use App Platform resources. "+
+				"Please check your provider configuration.",
+		)
+		return
+	}
+
 	rcli, err := client.GrafanaAppPlatformAPI.ClientFor(v1beta1.KeeperKind())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Grafana App Platform API client", err.Error())


### PR DESCRIPTION
## Summary
- Add nil guard for `GrafanaAppPlatformAPI` in `Configure` methods of `appplatform.Resource` and `keeperActivationResource`
- When the provider is configured without `url`/`auth` (e.g. cloud-only config with `cloud_access_policy_token`), `GrafanaAppPlatformAPI` stays nil, causing a panic during `ValidateResourceConfig`
- The fix turns the crash into a clear diagnostic error directing users to configure `url` and `auth`

## Context
Customer reported a provider crash (SIGSEGV) when using `grafana_apps_dashboard_dashboard_v2beta1` on Grafana 13.0.0. Stack trace pointed to `resource.go:231` where `client.GrafanaAppPlatformAPI.ClientFor()` is called on a nil receiver.

Related: https://github.com/grafana/support-escalations/issues/20971

## Test plan
- [x] `go build .` passes
- [x] `TestAccDashboardV2_basic` passes (happy path unbroken)
- [x] All unit tests pass
- [ ] Verify with cloud-only provider config (no `url`/`auth`) that the error message is shown instead of a panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)