### PR TITLE
fix(provider): set User-Agent on clients that were missing it

### DIFF
--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -173,6 +173,7 @@ func createGrafanaAPIClient(client *common.Client, providerConfig ProviderConfig
 	if cfg.HTTPHeaders, err = getHTTPHeadersMap(providerConfig); err != nil {
 		return err
 	}
+	cfg.HTTPHeaders["User-Agent"] = providerConfig.UserAgent.ValueString()
 	client.GrafanaAPI = goapi.NewHTTPClientWithConfig(strfmt.Default, &cfg)
 	client.GrafanaAPIConfig = &cfg
 
@@ -269,6 +270,7 @@ func createSLOClient(client *common.Client, providerConfig ProviderConfig) error
 	sloConfig.Scheme = client.GrafanaAPIURLParsed.Scheme
 	sloConfig.DefaultHeader, err = getHTTPHeadersMap(providerConfig)
 	sloConfig.DefaultHeader["Authorization"] = "Bearer " + providerConfig.Auth.ValueString()
+	sloConfig.UserAgent = providerConfig.UserAgent.ValueString()
 	sloConfig.HTTPClient = getRetryClient(providerConfig)
 	client.SLOClient = slo.NewAPIClient(sloConfig)
 
@@ -310,6 +312,7 @@ func createCloudProviderClient(client *common.Client, providerConfig ProviderCon
 	if err != nil {
 		return fmt.Errorf("failed to get provider default HTTP headers: %w", err)
 	}
+	providerHeaders["User-Agent"] = providerConfig.UserAgent.ValueString()
 
 	apiClient, err := cloudproviderapi.NewClient(
 		providerConfig.CloudProviderAccessToken.ValueString(),

--- a/pkg/provider/legacy_provider_test.go
+++ b/pkg/provider/legacy_provider_test.go
@@ -29,8 +29,11 @@ func TestProviderConfigure(t *testing.T) {
 	// Helper for header tests
 	checkHeaders := func(t *testing.T, provider *schema.Provider) {
 		gotHeaders := provider.Meta().(*common.Client).GrafanaAPIConfig.HTTPHeaders
-		if len(gotHeaders) != 4 {
-			t.Errorf("expected 4 HTTP header, got %d", len(gotHeaders))
+		if len(gotHeaders) != 5 {
+			t.Errorf("expected 5 HTTP headers, got %d", len(gotHeaders))
+		}
+		if gotHeaders["User-Agent"] == "" {
+			t.Error("expected User-Agent HTTP header to be set")
 		}
 		if gotHeaders["Authorization"] != "Bearer test" {
 			t.Errorf("expected HTTP header Authorization to be \"Bearer test\", got %q", gotHeaders["Authorization"])


### PR DESCRIPTION
## Summary

- Set the `User-Agent` header on the Grafana OpenAPI, SLO, and CloudProvider clients
- These clients were not propagating the provider's `UserAgent` config, making API requests appear as generic Go or OpenAPI-Generator clients in server logs

## Clients not covered

The following clients need upstream library changes to support setting User-Agent:

- **ML client** (`machine-learning-go-client`): The `Config` struct has no `UserAgent` or headers field. Would need either an upstream addition or an HTTP transport wrapper.
- **SM client** (`synthetic-monitoring-api-go-client`): Only supports `X-Client-ID`/`X-Client-Version` custom headers via `SetCustomClientID`/`SetCustomClientVersion`. No `User-Agent` support. Same options: upstream change or transport wrapper.

Both could be worked around with an `http.RoundTripper` wrapper that injects the header, but the cleaner path is adding `UserAgent` support upstream in those libraries.

## Clients already covered

AppPlatform, Cloud (gcom), OnCall, Connections, FleetManagement, FrontendO11y, Asserts, and K6 clients already set `UserAgent` correctly.

## Test plan

- [ ] Verify `User-Agent` header appears in Grafana server logs for OpenAPI client requests
- [ ] Verify `User-Agent` header appears for SLO API requests
- [ ] Verify `User-Agent` header appears for CloudProvider API requests