### PR TITLE
CI: Further throttle requests per host to prevent flaky link check

### DIFF
--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,7 +1,7 @@
 [checking]
 # Throttle requests per host to avoid GitHub (and other) rate limits (429)
 # default is 10
-maxrequestspersecond=5
+maxrequestspersecond=1
 
 [filtering]
 checkextern=1


### PR DESCRIPTION
Further throttle requests per second per host since 5 req/s didn't seem to be sufficiently low:  https://github.com/grafana/terraform-provider-grafana/pull/2574 