### PR TITLE
CI: Ignore problematic link when doing doc check

### DIFF
--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,8 +1,3 @@
-[checking]
-# Throttle requests per host to avoid GitHub (and other) rate limits (429)
-# default is 10
-maxrequestspersecond=1
-
 [filtering]
 checkextern=1
 ignore=

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -9,6 +9,9 @@ ignore=
   # https://regex101.com/r/Pl0jCn/1
   \/\*\!sc\*\/
 ignorewarnings=http-redirected
+# Ignore rate limiting (429) only for this GitHub URL; other URLs still fail on 429
+ignorewarningsforurls=
+  ^https://github\.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API\.md#apiv1registerinstall$ ^http-rate-limited
 
 [MarkdownCheck]
 filename_re=.*\.md


### PR DESCRIPTION
Throttling requests didn't help fix the flaky `unit tests / doc`: https://github.com/grafana/terraform-provider-grafana/pull/2574, https://github.com/grafana/terraform-provider-grafana/pull/2596.

[Logs](https://github.com/grafana/terraform-provider-grafana/actions/runs/23005195447/job/66803426313?pr=2577) always show https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md#apiv1registerinstall as being the one to fail the job. I checked that it's not a broken link so let's try ignoring it and seeing if it makes the link check more reliable.