### PR TITLE
CI: Fix action to add PR comment for SDKv2 usage

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -18,3 +18,4 @@ jobs:
           message: |
             In order to lower resource usage and have a faster runtime, PRs will not run Cloud tests automatically.
             To do so, a Grafana Labs employee must trigger the `cloud acceptance tests` workflow manually.
+          message-id: pr-cloud-tests-info

--- a/.github/workflows/sdkv2-migration-check.yml
+++ b/.github/workflows/sdkv2-migration-check.yml
@@ -71,3 +71,4 @@ jobs:
         if: github.event_name == 'pull_request' && steps.check.outputs.sdkv2_detected == 'true'
         with:
           message: ${{ steps.comment-body.outputs.body }}
+          message-id: sdkv2-migration-check


### PR DESCRIPTION
Follow up on https://github.com/grafana/terraform-provider-grafana/pull/2577

- Give the SDKv2 workflow a unique message-id: sdkv2-migration-check so its PR comment is not overwritten by the generic PR comment workflow.
- Give the generic PR comment workflow message-id: pr-cloud-tests-info so the two comments stay separate.

For https://github.com/grafana/deployment_tools/issues/511486