### PR TITLE
Migrate public dashboard resource to Framework SDK

### DIFF
--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -5,7 +5,8 @@ subcategory: "Grafana OSS"
 description: |-
   Manages Grafana public dashboards.
   Note: This resource is available only with Grafana 10.2+.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
+ - Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/
+ - HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
 ---
 
 # grafana_dashboard_public (Resource)

--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -5,8 +5,7 @@ subcategory: "Grafana OSS"
 description: |-
   Manages Grafana public dashboards.
   Note: This resource is available only with Grafana 10.2+.
- - Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/
- - HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
 ---
 
 # grafana_dashboard_public (Resource)

--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -86,7 +86,7 @@ resource "grafana_dashboard_public" "my_public_dashboard2" {
 - `access_token` (String) A public unique identifier of a public dashboard. This is used to construct its URL. It's automatically generated if not provided when creating a public dashboard.
 - `annotations_enabled` (Boolean) Set to `true` to show annotations. The default value is `false`.
 - `is_enabled` (Boolean) Set to `true` to enable the public dashboard. The default value is `false`.
-- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
+- `org_id` (String) The Organization ID. If not set, the default organization is used for basic authentication, or the one that owns your service account for token authentication.
 - `share` (String) Set the share mode. The default value is `public`.
 - `time_selection_enabled` (Boolean) Set to `true` to enable the time picker in the public dashboard. The default value is `false`.
 - `uid` (String) The unique identifier of a public dashboard. It's automatically generated if not provided when creating a public dashboard.

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -4,25 +4,64 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/grafana/grafana-openapi-client-go/client/dashboard_public"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var resourcePublicDashboardID = common.NewResourceID(
-	common.OptionalIntIDField("orgID"),
-	common.StringIDField("dashboardUID"),
-	common.StringIDField("publicDashboardUID"),
+var (
+	_ resource.Resource                = &publicDashboardResource{}
+	_ resource.ResourceWithConfigure   = &publicDashboardResource{}
+	_ resource.ResourceWithImportState = &publicDashboardResource{}
+
+	resourcePublicDashboardName = "grafana_dashboard_public"
+	resourcePublicDashboardID   = common.NewResourceID(
+		common.OptionalIntIDField("orgID"),
+		common.StringIDField("dashboardUID"),
+		common.StringIDField("publicDashboardUID"),
+	)
 )
 
 func resourcePublicDashboard() *common.Resource {
-	schema := &schema.Resource{
+	return common.NewResource(
+		common.CategoryGrafanaOSS,
+		resourcePublicDashboardName,
+		resourcePublicDashboardID,
+		&publicDashboardResource{},
+	)
+}
 
-		Description: `
+type resourcePublicDashboardModel struct {
+	ID                   types.String `tfsdk:"id"`
+	OrgID                types.String `tfsdk:"org_id"`
+	UID                  types.String `tfsdk:"uid"`
+	DashboardUID         types.String `tfsdk:"dashboard_uid"`
+	AccessToken          types.String `tfsdk:"access_token"`
+	TimeSelectionEnabled types.Bool   `tfsdk:"time_selection_enabled"`
+	IsEnabled            types.Bool   `tfsdk:"is_enabled"`
+	AnnotationsEnabled   types.Bool   `tfsdk:"annotations_enabled"`
+	Share                types.String `tfsdk:"share"`
+}
+
+type publicDashboardResource struct {
+	basePluginFrameworkResource
+}
+
+func (r *publicDashboardResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = resourcePublicDashboardName
+}
+
+func (r *publicDashboardResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `
 Manages Grafana public dashboards.
 
 **Note:** This resource is available only with Grafana 10.2+.
@@ -30,140 +69,233 @@ Manages Grafana public dashboards.
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
 * [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
 `,
-
-		CreateContext: CreatePublicDashboard,
-		ReadContext:   ReadPublicDashboard,
-		UpdateContext: UpdatePublicDashboard,
-		DeleteContext: DeletePublicDashboard,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"org_id": orgIDAttribute(),
-			"uid": {
-				Type:     schema.TypeString,
-				Computed: true,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of this resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"org_id": pluginFrameworkOrgIDAttribute(),
+			"uid": schema.StringAttribute{
 				Optional: true,
+				Computed: true,
 				Description: "The unique identifier of a public dashboard. " +
 					"It's automatically generated if not provided when creating a public dashboard. ",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"dashboard_uid": {
-				Type:        schema.TypeString,
+			"dashboard_uid": schema.StringAttribute{
 				Required:    true,
 				Description: "The unique identifier of the original dashboard.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"access_token": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"access_token": schema.StringAttribute{
 				Optional: true,
+				Computed: true,
 				Description: "A public unique identifier of a public dashboard. This is used to construct its URL. " +
 					"It's automatically generated if not provided when creating a public dashboard. ",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"time_selection_enabled": {
-				Type:        schema.TypeBool,
+			"time_selection_enabled": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "Set to `true` to enable the time picker in the public dashboard. The default value is `false`.",
 			},
-			"is_enabled": {
-				Type:        schema.TypeBool,
+			"is_enabled": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "Set to `true` to enable the public dashboard. The default value is `false`.",
 			},
-			"annotations_enabled": {
-				Type:        schema.TypeBool,
+			"annotations_enabled": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "Set to `true` to show annotations. The default value is `false`.",
 			},
-			"share": {
-				Type:        schema.TypeString,
+			"share": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Set the share mode. The default value is `public`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
-
-	return common.NewLegacySDKResource(
-		common.CategoryGrafanaOSS,
-		"grafana_dashboard_public",
-		resourcePublicDashboardID,
-		schema,
-	)
 }
 
-func CreatePublicDashboard(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
-	dashboardUID := d.Get("dashboard_uid").(string)
-
-	publicDashboardPayload := makePublicDashboard(d)
-	resp, err := client.DashboardPublic.CreatePublicDashboard(dashboardUID, publicDashboardPayload)
-	if err != nil {
-		return diag.FromErr(err)
+func (r *publicDashboardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	data, diags := r.read(ctx, req.ID)
+	resp.Diagnostics = diags
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	pd := resp.Payload
-
-	d.SetId(resourcePublicDashboardID.Make(orgID, pd.DashboardUID, pd.UID))
-	return ReadPublicDashboard(ctx, d, meta)
+	if data == nil {
+		resp.Diagnostics.AddError("Resource not found", fmt.Sprintf("public dashboard %q not found", req.ID))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }
-func UpdatePublicDashboard(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, orgID, compositeID := OAPIClientFromExistingOrgResource(meta, d.Id())
-	dashboardUID, publicDashboardUID, _ := strings.Cut(compositeID, ":")
 
-	publicDashboard := makePublicDashboard(d)
+func (r *publicDashboardResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data resourcePublicDashboardModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, orgID, err := r.clientFromNewOrgResource(data.OrgID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to get client", err.Error())
+		return
+	}
+
+	payload := publicDashboardFromModel(&data)
+	createResp, err := client.DashboardPublic.CreatePublicDashboard(data.DashboardUID.ValueString(), payload)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create public dashboard", err.Error())
+		return
+	}
+	pd := createResp.Payload
+	data.ID = types.StringValue(resourcePublicDashboardID.Make(orgID, pd.DashboardUID, pd.UID))
+
+	readData, diags := r.read(ctx, data.ID.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
+
+func (r *publicDashboardResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data resourcePublicDashboardModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readData, diags := r.read(ctx, data.ID.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if readData == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
+
+func (r *publicDashboardResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data resourcePublicDashboardModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, orgID, split, err := r.clientFromExistingOrgResource(resourcePublicDashboardID, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse resource ID", err.Error())
+		return
+	}
+	dashboardUID := fmt.Sprintf("%v", split[0])
+	publicDashboardUID := fmt.Sprintf("%v", split[1])
+
 	params := dashboard_public.NewUpdatePublicDashboardParams().
 		WithDashboardUID(dashboardUID).
 		WithUID(publicDashboardUID).
-		WithBody(publicDashboard)
-	resp, err := client.DashboardPublic.UpdatePublicDashboard(params)
+		WithBody(publicDashboardFromModel(&data))
+	updateResp, err := client.DashboardPublic.UpdatePublicDashboard(params)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Failed to update public dashboard", err.Error())
+		return
 	}
-	pd := resp.Payload
+	pd := updateResp.Payload
+	data.ID = types.StringValue(fmt.Sprintf("%d:%s:%s", orgID, pd.DashboardUID, pd.UID))
 
-	d.SetId(fmt.Sprintf("%d:%s:%s", orgID, pd.DashboardUID, pd.UID))
-	return ReadPublicDashboard(ctx, d, meta)
+	readData, diags := r.read(ctx, data.ID.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
 }
 
-func DeletePublicDashboard(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, _, compositeID := OAPIClientFromExistingOrgResource(meta, d.Id())
-	dashboardUID, publicDashboardUID, _ := strings.Cut(compositeID, ":")
-	_, err := client.DashboardPublic.DeletePublicDashboard(publicDashboardUID, dashboardUID)
+func (r *publicDashboardResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data resourcePublicDashboardModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	return diag.FromErr(err)
-}
+	client, _, split, err := r.clientFromExistingOrgResource(resourcePublicDashboardID, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse resource ID", err.Error())
+		return
+	}
+	dashboardUID := fmt.Sprintf("%v", split[0])
+	publicDashboardUID := fmt.Sprintf("%v", split[1])
 
-func makePublicDashboard(d *schema.ResourceData) *models.PublicDashboardDTO {
-	return &models.PublicDashboardDTO{
-		UID:                  d.Get("uid").(string),
-		AccessToken:          d.Get("access_token").(string),
-		TimeSelectionEnabled: d.Get("time_selection_enabled").(bool),
-		IsEnabled:            d.Get("is_enabled").(bool),
-		AnnotationsEnabled:   d.Get("annotations_enabled").(bool),
-		Share:                models.ShareType(d.Get("share").(string)),
+	_, err = client.DashboardPublic.DeletePublicDashboard(publicDashboardUID, dashboardUID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to delete public dashboard", err.Error())
 	}
 }
 
-func ReadPublicDashboard(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, orgID, compositeID := OAPIClientFromExistingOrgResource(meta, d.Id())
-	dashboardUID, _, _ := strings.Cut(compositeID, ":")
+func (r *publicDashboardResource) read(_ context.Context, id string) (*resourcePublicDashboardModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	client, orgID, split, err := r.clientFromExistingOrgResource(resourcePublicDashboardID, id)
+	if err != nil {
+		diags.AddError("Failed to parse resource ID", err.Error())
+		return nil, diags
+	}
+	dashboardUID := fmt.Sprintf("%v", split[0])
 
 	resp, err := client.DashboardPublic.GetPublicDashboard(dashboardUID)
-	if err, shouldReturn := common.CheckReadError("dashboard", d, err); shouldReturn {
-		return err
+	if err != nil {
+		if common.IsNotFoundError(err) {
+			return nil, diags
+		}
+		diags.AddError("Failed to read public dashboard", err.Error())
+		return nil, diags
 	}
 	pd := resp.Payload
 
-	d.Set("org_id", strconv.FormatInt(orgID, 10))
-
-	d.Set("uid", pd.UID)
-	d.Set("dashboard_uid", pd.DashboardUID)
-	d.Set("access_token", pd.AccessToken)
-	d.Set("time_selection_enabled", pd.TimeSelectionEnabled)
-	d.Set("is_enabled", pd.IsEnabled)
-	d.Set("annotations_enabled", pd.AnnotationsEnabled)
-	d.Set("share", pd.Share)
-
-	d.SetId(fmt.Sprintf("%d:%s:%s", orgID, pd.DashboardUID, pd.UID))
-
-	return nil
+	data := &resourcePublicDashboardModel{
+		ID:                   types.StringValue(fmt.Sprintf("%d:%s:%s", orgID, pd.DashboardUID, pd.UID)),
+		OrgID:                types.StringValue(strconv.FormatInt(orgID, 10)),
+		UID:                  types.StringValue(pd.UID),
+		DashboardUID:         types.StringValue(pd.DashboardUID),
+		AccessToken:          types.StringValue(pd.AccessToken),
+		TimeSelectionEnabled: types.BoolValue(pd.TimeSelectionEnabled),
+		IsEnabled:            types.BoolValue(pd.IsEnabled),
+		AnnotationsEnabled:   types.BoolValue(pd.AnnotationsEnabled),
+		Share:                types.StringValue(string(pd.Share)),
+	}
+	return data, diags
 }
+
+func publicDashboardFromModel(data *resourcePublicDashboardModel) *models.PublicDashboardDTO {
+	return &models.PublicDashboardDTO{
+		UID:                  data.UID.ValueString(),
+		AccessToken:          data.AccessToken.ValueString(),
+		TimeSelectionEnabled: data.TimeSelectionEnabled.ValueBool(),
+		IsEnabled:            data.IsEnabled.ValueBool(),
+		AnnotationsEnabled:   data.AnnotationsEnabled.ValueBool(),
+		Share:                models.ShareType(data.Share.ValueString()),
+	}
+}
+

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -298,4 +298,3 @@ func publicDashboardFromModel(data *resourcePublicDashboardModel) *models.Public
 		Share:                models.ShareType(data.Share.ValueString()),
 	}
 }
-


### PR DESCRIPTION
### **Review Guide**

This PR migrates `grafana_dashboard_public` from SDKv2 to the Plugin Framework.

**`resource_dashboard_public.go`** — full rewrite. Notable points:
- `NewLegacySDKResource` → `common.NewResource` with `publicDashboardResource{}` embedding `basePluginFrameworkResource`
- Package-level CRUD functions (`CreatePublicDashboard`, `ReadPublicDashboard`, etc.) → methods on the struct
- `*schema.ResourceData` → typed `resourcePublicDashboardModel` with `tfsdk` tags
- `makePublicDashboard(d)` → `publicDashboardFromModel(&data)` (same mapping, different signature)
- `OAPIClientFromNewOrgResource` / `OAPIClientFromExistingOrgResource` → `r.clientFromNewOrgResource` / `r.clientFromExistingOrgResource`
- `schema.ImportStatePassthroughContext` → explicit `ImportState` method calling `r.read(req.ID)`
- `common.CheckReadError` → `common.IsNotFoundError` + `resp.State.RemoveResource(ctx)` on 404
- The three bool attributes (`time_selection_enabled`, `is_enabled`, `annotations_enabled`) are now `Optional+Computed` with `Default: booldefault.StaticBool(false)`. In SDKv2 they were `Optional` only — omitting them left the value absent from state, which could cause plan noise. The explicit default makes plans deterministic.
- `dashboard_uid` now has `RequiresReplace()` — implicit in SDKv2 (changing it would effectively create a different resource), now enforced explicitly
- `share` is now `Optional+Computed` with `UseStateForUnknown` — preserves the server-returned value across plans when the user omits it from config

**`docs/resources/dashboard_public.md`** — regenerated; only change is the `org_id` description update from `pluginFrameworkOrgIDAttribute()`.

### **Issue Ref**
https://github.com/grafana/deployment_tools/issues/499007
