### PR TITLE
chore: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,35 +1,36 @@
 # Populated from catalog-info.yaml and catalog-resource/catalog-data-source YAMLs in internal/resources.
+# Lines commented with "unknown team handle" have an unclear or missing GitHub team; uncomment when the correct team exists and has write access.
 
 * @grafana/platform-monitoring
 
 # internal/resources/grafana
 /internal/resources/grafana/*_alerting_*                       @grafana/alerting-squad
 /internal/resources/grafana/*_organization_user*               @grafana/identity-squad
-/internal/resources/grafana/resource_dashboard_public*         @grafana/sharing-squad
+# /internal/resources/grafana/resource_dashboard_public*         @grafana/sharing-squad  # unknown team handle
 /internal/resources/grafana/resource_dashboard_permission*     @grafana/access-squad
-/internal/resources/grafana/resource_dashboard.go              @grafana/dashboards-squad
-/internal/resources/grafana/*data_source_cache*                @grafana/grafana-operator-experience-squad
+# /internal/resources/grafana/resource_dashboard.go              @grafana/dashboards-squad  # unknown team handle
+# /internal/resources/grafana/*data_source_cache*                @grafana/grafana-operator-experience-squad  # unknown team handle
 /internal/resources/grafana/*data_source_permission*           @grafana/access-squad
 /internal/resources/grafana/*data_source_config_lbac*          @grafana/access-squad
-/internal/resources/grafana/resource_data_source.go            @grafana/data-sources
-/internal/resources/grafana/resource_data_source_config.go     @grafana/data-sources
+# /internal/resources/grafana/resource_data_source.go            @grafana/data-sources  # unknown team handle
+# /internal/resources/grafana/resource_data_source_config.go     @grafana/data-sources  # unknown team handle
 /internal/resources/grafana/*folder_permission*                @grafana/access-squad
-/internal/resources/grafana/resource_folder*                   @grafana/grafana-search-and-storage
-/internal/resources/grafana/resource_annotation*               @grafana/grafana-search-and-storage
-/internal/resources/grafana/*library_panel*                    @grafana/dataviz-squad
+# /internal/resources/grafana/resource_folder*                   @grafana/grafana-search-and-storage  # unknown team handle
+# /internal/resources/grafana/resource_annotation*               @grafana/grafana-search-and-storage  # unknown team handle
+# /internal/resources/grafana/*library_panel*                    @grafana/dataviz-squad  # unknown team handle
 /internal/resources/grafana/*organization*                     @grafana/access-squad
-/internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad
-/internal/resources/grafana/resource_report*                   @grafana/sharing-squad
+# /internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad  # unknown team handle
+# /internal/resources/grafana/resource_report*                   @grafana/sharing-squad  # unknown team handle
 /internal/resources/grafana/*role*                             @grafana/access-squad
 /internal/resources/grafana/resource_team*                     @grafana/access-squad
 /internal/resources/grafana/*service_account*                  @grafana/identity-squad
 /internal/resources/grafana/*sso*                              @grafana/identity-squad
 /internal/resources/grafana/*scim*                             @grafana/identity-squad
 /internal/resources/grafana/resource_user*                     @grafana/identity-squad
-/internal/resources/grafana/data_source_dashboard*             @grafana/dashboards-squad
-/internal/resources/grafana/data_source_data_source*           @grafana/data-sources
-/internal/resources/grafana/data_source_folder*                @grafana/grafana-search-and-storage
-/internal/resources/grafana/data_source_library_panel*         @grafana/dataviz-squad
+# /internal/resources/grafana/data_source_dashboard*             @grafana/dashboards-squad  # unknown team handle
+# /internal/resources/grafana/data_source_data_source*           @grafana/data-sources  # unknown team handle
+# /internal/resources/grafana/data_source_folder*                @grafana/grafana-search-and-storage  # unknown team handle
+# /internal/resources/grafana/data_source_library_panel*         @grafana/dataviz-squad  # unknown team handle
 /internal/resources/grafana/data_source_organization*          @grafana/access-squad
 /internal/resources/grafana/data_source_role*                  @grafana/access-squad
 /internal/resources/grafana/data_source_service_account*       @grafana/identity-squad
@@ -39,8 +40,8 @@
 # internal/resources/cloud
 /internal/resources/cloud/*_access_policy_*                    @grafana/identity-squad
 /internal/resources/cloud/*org_member*                         @grafana/identity-squad
-/internal/resources/cloud/*plugin_installation*                @grafana/plugins-platform-backend
-/internal/resources/cloud/*private_data_source_connect*        @grafana/grafana-datasources-core-services
+# /internal/resources/cloud/*plugin_installation*                @grafana/plugins-platform-backend  # unknown team handle
+# /internal/resources/cloud/*private_data_source_connect*        @grafana/grafana-datasources-core-services  # unknown team handle
 /internal/resources/cloud/*k6_installation*                    @grafana/k6-cloud-provisioning
 /internal/resources/cloud/*synthetic_monitoring_installation*  @grafana/synthetic-monitoring
 /internal/resources/cloud/*stack_service_account*              @grafana/identity-squad
@@ -52,15 +53,15 @@
 /internal/resources/appplatform/*inhibitionrule*               @grafana/alerting-squad
 /internal/resources/appplatform/*alertrule*                    @grafana/alerting-squad
 /internal/resources/appplatform/*recordingrule*                @grafana/alerting-squad
-/internal/resources/appplatform/*appo11yconfig*                @grafana/app-o11y
-/internal/resources/appplatform/*k8so11yconfig*                @grafana/app-o11y
-/internal/resources/appplatform/*secret*                       @grafana/grafana-operator-experience-squad
+# /internal/resources/appplatform/*appo11yconfig*                @grafana/app-o11y  # unknown team handle
+# /internal/resources/appplatform/*k8so11yconfig*                @grafana/app-o11y  # unknown team handle
+# /internal/resources/appplatform/*secret*                       @grafana/grafana-operator-experience-squad  # unknown team handle
 /internal/resources/appplatform/*                              @grafana/grafana-app-platform-squad
 
 # Other packages
-/internal/resources/asserts/*                                  @grafana/asserts
-/internal/resources/cloudprovider/*                            @grafana/middleware-apps
-/internal/resources/connections/*                              @grafana/middleware-apps
+# /internal/resources/asserts/*                                  @grafana/asserts  # unknown team handle
+# /internal/resources/cloudprovider/*                            @grafana/middleware-apps  # unknown team handle
+# /internal/resources/connections/*                              @grafana/middleware-apps  # unknown team handle
 /internal/resources/fleetmanagement/*                          @grafana/fleet-management-backend
 /internal/resources/frontendo11y/*                             @grafana/frontend-o11y
 /internal/resources/k6/*                                       @grafana/k6-cloud-provisioning

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,70 @@
+# Populated from catalog-info.yaml and catalog-resource/catalog-data-source YAMLs in internal/resources.
+
 * @grafana/platform-monitoring
 
-/internal/resources/grafana/*_alerting_*            @grafana/alerting-squad
-/internal/resources/cloud/*                         @grafana/grafana-com-maintainers
-/internal/resources/cloud/*_access_policy_*         @grafana/identity-squad
-/internal/resources/grafana/*_organization_user*    @grafana/identity-squad
-/internal/resources/asserts/*                       @grafana/asserts
-/internal/resources/cloudprovider/*                 @grafana/middleware-apps
-/internal/resources/connections/*                   @grafana/middleware-apps
-/internal/resources/fleetmanagement/*               @grafana/fleet-management-backend
-/internal/resources/frontendo11y/*                  @grafana/frontend-o11y
-/internal/resources/k6/*                            @grafana/k6-cloud-provisioning
-/internal/resources/machinelearning/*               @grafana/machine-learning
-/internal/resources/oncall/*                        @grafana/grafana-irm-backend
-/internal/resources/slo/*                           @grafana/slo-squad
-/internal/resources/syntheticmonitoring/*           @grafana/synthetic-monitoring
-/internal/resources/appplatform/*                   @grafana/grafana-app-platform-squad
-/internal/resources/appplatform/alertenrichment*    @grafana/alerting-squad
+# internal/resources/grafana
+/internal/resources/grafana/*_alerting_*                       @grafana/alerting-squad
+/internal/resources/grafana/*_organization_user*               @grafana/identity-squad
+/internal/resources/grafana/resource_dashboard_public*         @grafana/sharing-squad
+/internal/resources/grafana/resource_dashboard_permission*     @grafana/access-squad
+/internal/resources/grafana/resource_dashboard.go              @grafana/dashboards-squad
+/internal/resources/grafana/*data_source_cache*                @grafana/grafana-operator-experience-squad
+/internal/resources/grafana/*data_source_permission*           @grafana/access-squad
+/internal/resources/grafana/*data_source_config_lbac*          @grafana/access-squad
+/internal/resources/grafana/resource_data_source.go            @grafana/data-sources
+/internal/resources/grafana/resource_data_source_config.go     @grafana/data-sources
+/internal/resources/grafana/*folder_permission*                @grafana/access-squad
+/internal/resources/grafana/resource_folder*                   @grafana/grafana-search-and-storage
+/internal/resources/grafana/resource_annotation*               @grafana/grafana-search-and-storage
+/internal/resources/grafana/*library_panel*                    @grafana/dataviz-squad
+/internal/resources/grafana/*organization*                     @grafana/access-squad
+/internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad
+/internal/resources/grafana/resource_report*                   @grafana/sharing-squad
+/internal/resources/grafana/*role*                             @grafana/access-squad
+/internal/resources/grafana/resource_team*                     @grafana/access-squad
+/internal/resources/grafana/*service_account*                  @grafana/identity-squad
+/internal/resources/grafana/*sso*                              @grafana/identity-squad
+/internal/resources/grafana/*scim*                             @grafana/identity-squad
+/internal/resources/grafana/resource_user*                     @grafana/identity-squad
+/internal/resources/grafana/data_source_dashboard*             @grafana/dashboards-squad
+/internal/resources/grafana/data_source_data_source*           @grafana/data-sources
+/internal/resources/grafana/data_source_folder*                @grafana/grafana-search-and-storage
+/internal/resources/grafana/data_source_library_panel*         @grafana/dataviz-squad
+/internal/resources/grafana/data_source_organization*          @grafana/access-squad
+/internal/resources/grafana/data_source_role*                  @grafana/access-squad
+/internal/resources/grafana/data_source_service_account*       @grafana/identity-squad
+/internal/resources/grafana/data_source_team*                  @grafana/access-squad
+/internal/resources/grafana/data_source_user*                  @grafana/identity-squad
+
+# internal/resources/cloud
+/internal/resources/cloud/*_access_policy_*                    @grafana/identity-squad
+/internal/resources/cloud/*org_member*                         @grafana/identity-squad
+/internal/resources/cloud/*plugin_installation*                @grafana/plugins-platform-backend
+/internal/resources/cloud/*private_data_source_connect*        @grafana/grafana-datasources-core-services
+/internal/resources/cloud/*k6_installation*                    @grafana/k6-cloud-provisioning
+/internal/resources/cloud/*synthetic_monitoring_installation*  @grafana/synthetic-monitoring
+/internal/resources/cloud/*stack_service_account*              @grafana/identity-squad
+/internal/resources/cloud/resource_cloud_stack*                @grafana/grafana-com-maintainers
+/internal/resources/cloud/*                                    @grafana/grafana-com-maintainers
+
+# internal/resources/appplatform
+/internal/resources/appplatform/alertenrichment*               @grafana/alerting-squad
+/internal/resources/appplatform/*inhibitionrule*               @grafana/alerting-squad
+/internal/resources/appplatform/*alertrule*                    @grafana/alerting-squad
+/internal/resources/appplatform/*recordingrule*                @grafana/alerting-squad
+/internal/resources/appplatform/*appo11yconfig*                @grafana/app-o11y
+/internal/resources/appplatform/*k8so11yconfig*                @grafana/app-o11y
+/internal/resources/appplatform/*secret*                       @grafana/grafana-operator-experience-squad
+/internal/resources/appplatform/*                              @grafana/grafana-app-platform-squad
+
+# Other packages
+/internal/resources/asserts/*                                  @grafana/asserts
+/internal/resources/cloudprovider/*                            @grafana/middleware-apps
+/internal/resources/connections/*                              @grafana/middleware-apps
+/internal/resources/fleetmanagement/*                          @grafana/fleet-management-backend
+/internal/resources/frontendo11y/*                             @grafana/frontend-o11y
+/internal/resources/k6/*                                       @grafana/k6-cloud-provisioning
+/internal/resources/machinelearning/*                          @grafana/machine-learning
+/internal/resources/oncall/*                                   @grafana/grafana-irm-backend
+/internal/resources/slo/*                                      @grafana/slo-squad
+/internal/resources/syntheticmonitoring/*                      @grafana/synthetic-monitoring


### PR DESCRIPTION
Having a more comprehensive codeowners file could help prevent external contributions from slipping through the cracks. Relates to this [feedback](https://github.com/grafana/terraform-provider-grafana/pull/2503#issuecomment-4055181276).

This was generated based on [catalog-info.yaml](https://github.com/grafana/terraform-provider-grafana/blob/main/catalog-info.yaml) but not all team handles resolved properly. Those that didn't have been commented out and need to be addressed as a follow up.