### PR TITLE
Don't autoadd `id` for k8s-shaped dashboards in `grafana_dashboard` resource

### DIFF
--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -203,7 +203,9 @@ func UpdateDashboard(ctx context.Context, d *schema.ResourceData, meta any) diag
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	dashboard.Dashboard.(map[string]any)["id"] = d.Get("dashboard_id").(int)
+	if dashboardJSON, ok := dashboard.Dashboard.(map[string]any); ok && !isKubernetesStyleDashboard(dashboardJSON) {
+		dashboardJSON["id"] = d.Get("dashboard_id").(int)
+	}
 	dashboard.Overwrite = true
 	resp, err := client.Dashboards.PostDashboard(&dashboard)
 	if err != nil {
@@ -236,6 +238,13 @@ func makeDashboard(d *schema.ResourceData) (models.SaveDashboardCommand, error) 
 	delete(dashboardJSON, "id")
 	dashboard.Dashboard = dashboardJSON
 	return dashboard, nil
+}
+
+func isKubernetesStyleDashboard(dashboardJSON map[string]any) bool {
+	_, hasAPIVersion := dashboardJSON["apiVersion"].(string)
+	_, hasKind := dashboardJSON["kind"].(string)
+	_, hasSpec := dashboardJSON["spec"].(map[string]any)
+	return hasAPIVersion && hasKind && hasSpec
 }
 
 // UnmarshalDashboardConfigJSON is a convenience func for unmarshalling

--- a/internal/resources/grafana/resource_dashboard_internal_test.go
+++ b/internal/resources/grafana/resource_dashboard_internal_test.go
@@ -1,0 +1,26 @@
+package grafana
+
+import "testing"
+
+func TestIsKubernetesStyleDashboard(t *testing.T) {
+	t.Run("legacy dashboard", func(t *testing.T) {
+		if isKubernetesStyleDashboard(map[string]any{"title": "legacy"}) {
+			t.Fatal("expected legacy dashboard shape to be treated as non-kubernetes")
+		}
+	})
+
+	t.Run("kubernetes style dashboard", func(t *testing.T) {
+		if !isKubernetesStyleDashboard(map[string]any{
+			"apiVersion": "dashboard.grafana.app/v2beta1",
+			"kind":       "Dashboard",
+			"metadata": map[string]any{
+				"name": "test-dashboard",
+			},
+			"spec": map[string]any{
+				"title": "test dashboard",
+			},
+		}) {
+			t.Fatal("expected kubernetes dashboard shape to be detected")
+		}
+	})
+}


### PR DESCRIPTION

in https://github.com/grafana/grafana/pull/118946 we added support for k8s dashboards in the legacy API - however, the backend code rejects k8s-shaped dashboards with top-level `id` field


https://github.com/grafana/grafana/blob/7c4efd7dad76ff569103714be03a95c7065edfa1/pkg/api/dashboard.go#L429
