### PR TITLE
Dashboard: Allow to use v2beta1 dashboard using legacy api

### DIFF
--- a/examples/resources/grafana_dashboard/_acc_v2beta1.tf
+++ b/examples/resources/grafana_dashboard/_acc_v2beta1.tf
@@ -1,0 +1,36 @@
+resource "grafana_dashboard" "v2beta1" {
+  config_json = <<EOD
+{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "metadata": {
+    "name": "abc123"
+  },
+  "kind": "Dashboard",
+  "spec": {
+    "title": "DashboardV2beta1",
+    "elements": {},
+    "annotations": null,
+    "cursorSync": "",
+    "links": null,
+    "preload": false,
+    "tags": null,
+    "variables": null,
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": null
+      }
+    },
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": null,
+      "fiscalYearStartMonth": 0,
+      "from": "",
+      "hideTimepicker": false,
+      "to": ""
+    }
+  }
+}
+EOD
+  message     = "dashboard v2beta1"
+}

--- a/examples/resources/grafana_dashboard/_acc_v2beta1_update.tf
+++ b/examples/resources/grafana_dashboard/_acc_v2beta1_update.tf
@@ -1,0 +1,36 @@
+resource "grafana_dashboard" "v2beta1" {
+  config_json = <<EOD
+{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "metadata": {
+    "name": "abc123"
+  },
+  "kind": "Dashboard",
+  "spec": {
+    "title": "DashboardV2beta1 Updated",
+    "elements": {},
+    "annotations": null,
+    "cursorSync": "",
+    "links": null,
+    "preload": false,
+    "tags": null,
+    "variables": null,
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": null
+      }
+    },
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": null,
+      "fiscalYearStartMonth": 0,
+      "from": "",
+      "hideTimepicker": false,
+      "to": ""
+    }
+  }
+}
+EOD
+  message     = "dashboard v2beta1 updated"
+}

--- a/go.mod
+++ b/go.mod
@@ -62,8 +62,8 @@ require (
 	github.com/grafana/grafana/apps/provisioning v0.0.0-20260218091122-4fe7fb5b985e
 	github.com/grafana/grafana/apps/secret v0.0.0-20260224124528-75b1e0cf0f79
 	github.com/knadh/koanf/v2 v2.3.0
-	github.com/rogpeppe/go-internal v1.14.1
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/mod v0.33.0
 	golang.org/x/sync v0.20.0
 )
 
@@ -218,7 +218,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/grafana/grafana/apps/provisioning v0.0.0-20260218091122-4fe7fb5b985e
 	github.com/grafana/grafana/apps/secret v0.0.0-20260224124528-75b1e0cf0f79
 	github.com/knadh/koanf/v2 v2.3.0
+	github.com/rogpeppe/go-internal v1.14.1
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 )

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rogpeppe/go-internal/semver"
 
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
@@ -142,6 +143,24 @@ func CreateDashboard(ctx context.Context, d *schema.ResourceData, meta any) diag
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	if dashboardJSON, ok := dashboard.Dashboard.(map[string]any); ok && isKubernetesStyleDashboard(dashboardJSON) {
+		health, err := client.Health.GetHealth(nil)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		v := health.Payload.Version
+		if !strings.HasPrefix(v, "v") {
+			v = "v" + v
+		}
+
+		// For versions v12.x.x, we only support the spec to avoid to receive "empty title error"
+		if semver.Major(v) == "v12" {
+			return diag.Errorf("Grafana version 12 doesn't accept k8s-style json. You have to send only the spec")
+		}
+	}
+
 	resp, err := client.Dashboards.PostDashboard(&dashboard)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/rogpeppe/go-internal/semver"
+	"golang.org/x/mod/semver"
 
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -1,6 +1,7 @@
 package grafana_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -356,4 +357,52 @@ resource "grafana_dashboard" "test" {
 	  uid   = "dashboard-%[1]s"
 	})
 }`, orgName)
+}
+
+func TestAccDashboardV2Beta1(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=12.2.0")
+
+	var dashboard models.DashboardFullWithMeta
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             dashboardCheckExists.destroyed(&dashboard, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_v2beta1.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					dashboardCheckExists.exists("grafana_dashboard.v2beta1", &dashboard),
+					checkV2beta1DashboardTitle("grafana_dashboard.v2beta1", "DashboardV2beta1"),
+				),
+			},
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_v2beta1_update.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					dashboardCheckExists.exists("grafana_dashboard.v2beta1", &dashboard),
+					checkV2beta1DashboardTitle("grafana_dashboard.v2beta1", "DashboardV2beta1 Updated"),
+				),
+			},
+		},
+	})
+}
+
+func checkV2beta1DashboardTitle(resourceName, expectedTitle string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(resourceName, "config_json", func(value string) error {
+		var configJSON map[string]any
+		if err := json.Unmarshal([]byte(value), &configJSON); err != nil {
+			return fmt.Errorf("config_json is not valid JSON: %w", err)
+		}
+		spec, ok := configJSON["spec"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("config_json missing 'spec' object, got: %s", value)
+		}
+		title, ok := spec["title"].(string)
+		if !ok {
+			return fmt.Errorf("spec.title is not a string in config_json: %s", value)
+		}
+		if title != expectedTitle {
+			return fmt.Errorf("expected spec.title to be %q, got %q", expectedTitle, title)
+		}
+		return nil
+	})
 }

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -361,7 +361,7 @@ resource "grafana_dashboard" "test" {
 }
 
 func TestAccDashboardV2Beta1(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, "main")
+	testutils.CheckOSSTestsEnabled(t, ">=13.0.0")
 
 	var dashboard models.DashboardFullWithMeta
 

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -400,7 +400,7 @@ func TestAccDashboardV2beta2_new_k8_Grafana_v12_spec_only(t *testing.T) {
 				Config: k8sStyleSpecOnly(),
 				Check: resource.ComposeTestCheckFunc(
 					dashboardCheckExists.exists("grafana_dashboard.spec", &dashboard),
-					resource.TestCheckResourceAttr("grafana_dashboard.spec", "title", "DashboardV2beta1Spec"),
+					resource.TestCheckResourceAttr("grafana_dashboard.spec", "config_json", `{"elements":"{}","title":"DashboardV2beta1Spec"}`),
 				),
 			},
 		},

--- a/internal/resources/grafana/resource_dashboard_test.go
+++ b/internal/resources/grafana/resource_dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -360,7 +361,7 @@ resource "grafana_dashboard" "test" {
 }
 
 func TestAccDashboardV2Beta1(t *testing.T) {
-	testutils.CheckOSSTestsEnabled(t, ">=12.2.0")
+	testutils.CheckOSSTestsEnabled(t, "main")
 
 	var dashboard models.DashboardFullWithMeta
 
@@ -386,6 +387,40 @@ func TestAccDashboardV2Beta1(t *testing.T) {
 	})
 }
 
+func TestAccDashboardV2beta2_new_k8_Grafana_v12_spec_only(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=12.0.0")
+
+	var dashboard models.DashboardFullWithMeta
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             dashboardCheckExists.destroyed(&dashboard, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: k8sStyleSpecOnly(),
+				Check: resource.ComposeTestCheckFunc(
+					dashboardCheckExists.exists("grafana_dashboard.spec", &dashboard),
+					resource.TestCheckResourceAttr("grafana_dashboard.spec", "title", "DashboardV2beta1Spec"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDashboardV2beta2_k8_style_Grafana_v12_not_allowed(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=12.0.0")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testutils.TestAccExample(t, "resources/grafana_dashboard/_acc_v2beta1.tf"),
+				ExpectError: regexp.MustCompile(`Grafana version 12 doesn't accept k8s-style json\. You have to send only the spec`),
+			},
+		},
+	})
+}
+
 func checkV2beta1DashboardTitle(resourceName, expectedTitle string) resource.TestCheckFunc {
 	return resource.TestCheckResourceAttrWith(resourceName, "config_json", func(value string) error {
 		var configJSON map[string]any
@@ -405,4 +440,13 @@ func checkV2beta1DashboardTitle(resourceName, expectedTitle string) resource.Tes
 		}
 		return nil
 	})
+}
+
+func k8sStyleSpecOnly() string {
+	return `resource "grafana_dashboard" "spec" {
+	config_json = jsonencode({
+		"title" : "DashboardV2beta1Spec",
+		"elements" : "{}"
+	})
+}`
 }


### PR DESCRIPTION
We want to allow to use new dashboard schema using legacy API.

Since Grafana v12 and next v13 backend works different, we added some checks in Terraform to make it possible:

* Grafana v12 accepts only the k8s spec. If we pass the whole k8s-style json we had an `empty title error`, but we added a check to fail-fast if we detect it to show a proper error. Its mainly because Grafana v12 doesn't have any k8s-style check.
* Next Grafana v13 accepts [only k8s-style schema](https://github.com/grafana/grafana/blob/main/pkg/api/dashboard.go#L428) and fails if we [send only the spec](https://github.com/grafana/grafana/blob/main/pkg/api/dashboard.go#L422C5-L422C37).
* We added tests to verify these use cases and make it works for both Grafana versions.