### PR TITLE
CI: Update Grafana versions

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false # Let all versions run, even if one fails
       matrix:
         # OSS tests, run on all supported versions (see https://endoflife.date/grafana)
-        version: ['12.3.4', '12.2.6', '12.1.8', '11.6.12']
+        version: ['12.4.1', '12.3.5', '12.2.7', '12.1.9', '11.6.13']
         type: ['oss']
         subset: ['basic', 'other', 'long']
         include:
@@ -87,35 +87,35 @@ jobs:
           - version: 'main'
             type: 'oss'
             subset: 'provisioning'
-          - version: '12.3.4'
+          - version: '12.4.1'
             type: 'oss'
             subset: examples
-          - version: '11.6.12'
+          - version: '11.6.13'
             type: 'oss'
             subset: examples
           # TLS proxy tests, run only on latest version
-          - version: '12.3.4'
+          - version: '12.4.1'
             type: 'tls'
             subset: 'basic'
           # Sub-path tests. Runs tests on localhost:3000/grafana/
-          - version: '12.3.4'
+          - version: '12.4.1'
             type: 'subpath'
             subset: 'basic'
-          - version: '12.3.4'
+          - version: '12.4.1'
             type: 'subpath'
             subset: 'other'
           # Enterprise tests
-          - version: '12.3.4'
+          - version: '12.4.1'
             type: 'enterprise'
             subset: 'enterprise'
-          - version: '11.6.12'
+          - version: '11.6.13'
             type: 'enterprise'
             subset: 'enterprise'
           # Generate tests
-          - version: '12.3.4'
+          - version: '12.4.1'
             type: 'enterprise'
             subset: 'generate'
-          - version: '11.6.12'
+          - version: '11.6.13'
             type: 'enterprise'
             subset: 'generate'
     name: ${{ matrix.version }} - ${{ matrix.type }} - ${{ matrix.subset }}

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -91,7 +91,7 @@ func (tc *generateTestCase) Run(t *testing.T) {
 }
 
 func TestAccGenerate(t *testing.T) {
-	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0", "<=12.3.5")
+	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0", "<12.3.5")
 
 	// Install Terraform to a temporary directory to avoid reinstalling it for each test case.
 	installDir := t.TempDir()

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -91,7 +91,7 @@ func (tc *generateTestCase) Run(t *testing.T) {
 }
 
 func TestAccGenerate(t *testing.T) {
-	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0")
+	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0", "<=12.3.5")
 
 	// Install Terraform to a temporary directory to avoid reinstalling it for each test case.
 	installDir := t.TempDir()

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -91,7 +91,7 @@ func (tc *generateTestCase) Run(t *testing.T) {
 }
 
 func TestAccGenerate(t *testing.T) {
-	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0", "<12.3.5")
+	testutils.CheckEnterpriseTestsEnabled(t, ">=10.0.0, <12.3.5")
 
 	// Install Terraform to a temporary directory to avoid reinstalling it for each test case.
 	installDir := t.TempDir()


### PR DESCRIPTION
Update CI versions to latest ones: https://endoflife.date/grafana