### PR TITLE
Alerting: Add provenance annotation to alert rules and recording rules

### DIFF
--- a/docs/resources/apps_rules_alertrule_v0alpha1.md
+++ b/docs/resources/apps_rules_alertrule_v0alpha1.md
@@ -5,6 +5,7 @@ subcategory: "Alerting"
 description: |-
   Manages Grafana Alert Rules.
   This resource is currently in alpha and is subject to change. Grafana 12.4+ users must enable the kubernetesAlertingRules feature toggle https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/.
+  Note: Disabling provenance for this resource is not currently supported. Using this resource WILL set the provenance and prevent editing in the UI.
 ---
 
 # grafana_apps_rules_alertrule_v0alpha1 (Resource)
@@ -12,6 +13,8 @@ description: |-
 Manages Grafana Alert Rules.
 
 This resource is currently in alpha and is subject to change. Grafana 12.4+ users must enable the `kubernetesAlertingRules` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
+
+Note: Disabling provenance for this resource is not currently supported. Using this resource WILL set the provenance and prevent editing in the UI.
 
 ## Example Usage
 

--- a/docs/resources/apps_rules_recordingrule_v0alpha1.md
+++ b/docs/resources/apps_rules_recordingrule_v0alpha1.md
@@ -4,11 +4,17 @@ page_title: "grafana_apps_rules_recordingrule_v0alpha1 Resource - terraform-prov
 subcategory: "Alerting"
 description: |-
   Manages Grafana Recording Rules.
+  This resource is currently in alpha and is subject to change. Grafana 12.4+ users must enable the kubernetesAlertingRules feature toggle https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/.
+  Note: Disabling provenance for this resource is not currently supported. Using this resource WILL set the provenance and prevent editing in the UI.
 ---
 
 # grafana_apps_rules_recordingrule_v0alpha1 (Resource)
 
 Manages Grafana Recording Rules.
+
+This resource is currently in alpha and is subject to change. Grafana 12.4+ users must enable the `kubernetesAlertingRules` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
+
+Note: Disabling provenance for this resource is not currently supported. Using this resource WILL set the provenance and prevent editing in the UI.
 
 ## Example Usage
 

--- a/internal/resources/appplatform/alertrule_resource.go
+++ b/internal/resources/appplatform/alertrule_resource.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -88,6 +89,8 @@ func AlertRule() NamedResource {
 Manages Grafana Alert Rules.
 
 This resource is currently in alpha and is subject to change. Grafana 12.4+ users must enable the ` + "`kubernetesAlertingRules`" + ` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
+
+Note: Disabling provenance for this resource is not currently supported. Using this resource WILL set the provenance and prevent editing in the UI.
 `,
 				SpecAttributes: map[string]schema.Attribute{
 					"title": schema.StringAttribute{
@@ -359,6 +362,15 @@ func parseAlertRuleSpec(ctx context.Context, src types.Object, dst *v0alpha1.Ale
 			diag.NewErrorDiagnostic("failed to set spec", err.Error()),
 		}
 	}
+
+	// HACK: set the provenance explicitly for now till we sort the manager properties compatibility
+	meta, err := utils.MetaAccessor(dst)
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("failed to get metadata accessor", err.Error()),
+		}
+	}
+	meta.SetAnnotation(v0alpha1.ProvenanceStatusAnnotationKey, v0alpha1.ProvenanceStatusAPI)
 
 	return diag.Diagnostics{}
 }

--- a/internal/resources/appplatform/recordingrule_resource.go
+++ b/internal/resources/appplatform/recordingrule_resource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -46,6 +47,10 @@ func RecordingRule() NamedResource {
 				Description: "Manages Grafana Recording Rules.",
 				MarkdownDescription: `
 Manages Grafana Recording Rules.
+
+This resource is currently in alpha and is subject to change. Grafana 12.4+ users must enable the ` + "`kubernetesAlertingRules`" + ` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
+
+Note: Disabling provenance for this resource is not currently supported. Using this resource WILL set the provenance and prevent editing in the UI.
 `,
 				SpecAttributes: map[string]schema.Attribute{
 					"title": schema.StringAttribute{
@@ -170,6 +175,15 @@ func parseRecordingRuleSpec(ctx context.Context, src types.Object, dst *v0alpha1
 			diag.NewErrorDiagnostic("failed to set spec", err.Error()),
 		}
 	}
+
+	// HACK: set the provenance explicitly for now till we sort the manager properties compatibility
+	meta, err := utils.MetaAccessor(dst)
+	if err != nil {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic("failed to get metadata accessor", err.Error()),
+		}
+	}
+	meta.SetAnnotation(v0alpha1.ProvenanceStatusAnnotationKey, v0alpha1.ProvenanceStatusAPI)
 
 	return diag.Diagnostics{}
 }


### PR DESCRIPTION
Set the provenance annotation to maintain the existing behavior of rules created via terraform being not editable via the UI.

Note: For now we're not allowing users to disable this functionality in the new resources as AppPlatform resources have a different mechanism for the same that we're looking at unifying.
