### PR TITLE
Roles: Enforce auto-incrementing and creating with version 1

### DIFF
--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -62,7 +62,7 @@ data "grafana_role" "from_name" {
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `permissions` (Set of Object) Specific set of actions granted by the role. (see [below for nested schema](#nestedatt--permissions))
 - `uid` (String) Unique identifier of the role. Used for assignments.
-- `version` (Number) Version of the role. A role is updated only on version increase. This field or `auto_increment_version` should be set.
+- `version` (Number) Version of the role. On create, must be `1`. On update, must be exactly one greater than the previous state. This field or `auto_increment_version` should be set; `auto_increment_version` is recommended.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -48,7 +48,7 @@ resource "grafana_role" "super_user" {
 
 ### Optional
 
-- `auto_increment_version` (Boolean) Whether the role version should be incremented automatically on updates (and set to 1 on creation). This field or `version` should be set.
+- `auto_increment_version` (Boolean) Whether the role version should be incremented automatically on updates (and set to 1 on creation). Recommended for most configurations. This field or `version` should be set.
 - `description` (String) Description of the role.
 - `display_name` (String) Display name of the role. Available with Grafana 8.5+.
 - `global` (Boolean) Boolean to state whether the role is available across all organizations or not. Defaults to `false`.
@@ -57,7 +57,7 @@ resource "grafana_role" "super_user" {
 - `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
 - `permissions` (Block Set) Specific set of actions granted by the role. (see [below for nested schema](#nestedblock--permissions))
 - `uid` (String) Unique identifier of the role. Used for assignments.
-- `version` (Number) Version of the role. A role is updated only on version increase. This field or `auto_increment_version` should be set.
+- `version` (Number) Version of the role. On create, must be `1`. On update, must be exactly one greater than the previous state. This field or `auto_increment_version` should be set; `auto_increment_version` is recommended.
 
 ### Read-Only
 

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -28,6 +29,7 @@ func resourceRole() *common.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: roleCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"org_id": orgIDAttribute(),
 			"uid": {
@@ -39,7 +41,7 @@ func resourceRole() *common.Resource {
 			},
 			"version": {
 				Type:         schema.TypeInt,
-				Description:  "Version of the role. A role is updated only on version increase. This field or `auto_increment_version` should be set.",
+				Description:  "Version of the role. On create, must be `1`. On update, must be exactly one greater than the previous state. This field or `auto_increment_version` should be set; `auto_increment_version` is recommended.",
 				Optional:     true,
 				ExactlyOneOf: []string{"version", "auto_increment_version"},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -48,7 +50,7 @@ func resourceRole() *common.Resource {
 			},
 			"auto_increment_version": {
 				Type:         schema.TypeBool,
-				Description:  "Whether the role version should be incremented automatically on updates (and set to 1 on creation). This field or `version` should be set.",
+				Description:  "Whether the role version should be incremented automatically on updates (and set to 1 on creation). Recommended for most configurations. This field or `version` should be set.",
 				Optional:     true,
 				ExactlyOneOf: []string{"version", "auto_increment_version"},
 			},
@@ -123,6 +125,41 @@ func resourceRole() *common.Resource {
 	)
 }
 
+// roleCustomizeDiff requires explicit version to be 1 on create and to increase by
+// exactly one on update whenever version changes. Skipped while auto_increment_version is true.
+func roleCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
+	if d.Get("auto_increment_version").(bool) {
+		return nil
+	}
+	if d.Id() == "" {
+		return validateExplicitRoleVersionDiff(true, true, 0, d.Get("version").(int))
+	}
+	if !d.HasChange("version") {
+		return nil
+	}
+	oldV, newV := d.GetChange("version")
+	return validateExplicitRoleVersionDiff(false, true, oldV.(int), newV.(int))
+}
+
+// validateExplicitRoleVersionDiff enforces explicit versioning rules (caller must skip when
+// auto_increment_version is true). On create, newVer must be 1. On update when version changes,
+// newVer must be oldVer+1.
+func validateExplicitRoleVersionDiff(isCreate, versionChanged bool, oldVer, newVer int) error {
+	if isCreate {
+		if newVer != 1 {
+			return fmt.Errorf("when creating a role with explicit version, version must be 1 (got %d)", newVer)
+		}
+		return nil
+	}
+	if !versionChanged {
+		return nil
+	}
+	if newVer != oldVer+1 {
+		return fmt.Errorf("version must increase by exactly 1 on update when using explicit versioning (expected %d, got %d)", oldVer+1, newVer)
+	}
+	return nil
+}
+
 func CreateRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, orgID := OAPIClientFromNewOrgResource(meta, d)
 	if d.Get("global").(bool) {
@@ -135,6 +172,9 @@ func CreateRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 		version = 1
 	} else {
 		version = d.Get("version").(int)
+		if version != 1 {
+			return diag.Errorf("when creating a role with explicit version, version must be 1 (got %d)", version)
+		}
 	}
 
 	role := models.CreateRoleForm{

--- a/internal/resources/grafana/resource_role_test.go
+++ b/internal/resources/grafana/resource_role_test.go
@@ -2,6 +2,7 @@ package grafana_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -121,6 +122,109 @@ func TestAccRole_GlobalCanBeManagedInGrafanaCloud(t *testing.T) {
 	})
 }
 
+func TestAccRole_explicitVersion_createMustBeOne_plan(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=9.0.0")
+
+	name := acctest.RandomWithPrefix("role-ver-create")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_role" "test" {
+  name   = "%[1]s"
+  uid    = "%[1]s"
+  global = false
+  version = 2
+}
+`, name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`when creating a role with explicit version, version must be 1`),
+			},
+		},
+	})
+}
+
+func TestAccRole_explicitVersion_updateMustIncrementByOne_plan(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=9.0.0")
+
+	var role models.RoleDTO
+	name := acctest.RandomWithPrefix("role-ver-inc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             roleCheckExists.destroyed(&role, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_role" "test" {
+  name    = "%[1]s"
+  uid     = "%[1]s"
+  global  = false
+  version = 1
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					roleCheckExists.exists("grafana_role.test", &role),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_role" "test" {
+  name    = "%[1]s"
+  uid     = "%[1]s"
+  global  = false
+  version = 3
+}
+`, name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`version must increase by exactly 1 on update when using explicit versioning`),
+			},
+		},
+	})
+}
+
+func TestAccRole_explicitVersion_autoToExplicitSkipRejected_plan(t *testing.T) {
+	testutils.CheckEnterpriseTestsEnabled(t, ">=9.0.0")
+
+	var role models.RoleDTO
+	name := acctest.RandomWithPrefix("role-ver-auto")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             roleCheckExists.destroyed(&role, nil),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_role" "test" {
+  name                   = "%[1]s"
+  uid                    = "%[1]s"
+  global                 = false
+  auto_increment_version = true
+}
+`, name),
+				Check: resource.ComposeTestCheckFunc(
+					roleCheckExists.exists("grafana_role.test", &role),
+					resource.TestCheckResourceAttr("grafana_role.test", "version", "1"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "grafana_role" "test" {
+  name    = "%[1]s"
+  uid     = "%[1]s"
+  global  = false
+  version = 7
+}
+`, name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`version must increase by exactly 1 on update when using explicit versioning \(expected 2, got 7\)`),
+			},
+		},
+	})
+}
+
 func TestAccRoleVersioning(t *testing.T) {
 	testutils.CheckEnterpriseTestsEnabled(t, ">=9.0.0")
 
@@ -149,12 +253,12 @@ func TestAccRoleVersioning(t *testing.T) {
 				resource "grafana_role" "test" {
 					name  = "%s"
 					description = "desc 2"
-					version = 5
+					version = 2
 				}`, name),
 				Check: resource.ComposeTestCheckFunc(
 					roleCheckExists.exists("grafana_role.test", &role),
 					resource.TestCheckResourceAttr("grafana_role.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_role.test", "version", "5"),
+					resource.TestCheckResourceAttr("grafana_role.test", "version", "2"),
 				),
 			},
 			{
@@ -167,7 +271,7 @@ func TestAccRoleVersioning(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					roleCheckExists.exists("grafana_role.test", &role),
 					resource.TestCheckResourceAttr("grafana_role.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_role.test", "version", "6"),
+					resource.TestCheckResourceAttr("grafana_role.test", "version", "3"),
 				),
 			},
 			{
@@ -180,7 +284,7 @@ func TestAccRoleVersioning(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					roleCheckExists.exists("grafana_role.test", &role),
 					resource.TestCheckResourceAttr("grafana_role.test", "name", name),
-					resource.TestCheckResourceAttr("grafana_role.test", "version", "7"),
+					resource.TestCheckResourceAttr("grafana_role.test", "version", "4"),
 				),
 			},
 		},

--- a/internal/resources/grafana/resource_role_version_diff_test.go
+++ b/internal/resources/grafana/resource_role_version_diff_test.go
@@ -1,0 +1,90 @@
+package grafana
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateExplicitRoleVersionDiff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		isCreate       bool
+		versionChanged bool
+		oldVer         int
+		newVer         int
+		wantErr        string
+	}{
+		{
+			name:           "create explicit version 1",
+			isCreate:       true,
+			versionChanged: true,
+			newVer:         1,
+		},
+		{
+			name:           "create explicit version not 1",
+			isCreate:       true,
+			versionChanged: true,
+			newVer:         2,
+			wantErr:        "version must be 1",
+		},
+		{
+			name:           "update no version change",
+			isCreate:       false,
+			versionChanged: false,
+			oldVer:         3,
+			newVer:         3,
+		},
+		{
+			name:           "update increment by 1",
+			isCreate:       false,
+			versionChanged: true,
+			oldVer:         4,
+			newVer:         5,
+		},
+		{
+			name:           "update skip version",
+			isCreate:       false,
+			versionChanged: true,
+			oldVer:         5,
+			newVer:         7,
+			wantErr:        "increase by exactly 1",
+		},
+		{
+			name:           "update same version when changed flag set but equal values edge",
+			isCreate:       false,
+			versionChanged: true,
+			oldVer:         2,
+			newVer:         2,
+			wantErr:        "increase by exactly 1",
+		},
+		{
+			name:           "auto to explicit would be old 5 new 7",
+			isCreate:       false,
+			versionChanged: true,
+			oldVer:         5,
+			newVer:         7,
+			wantErr:        "expected 6, got 7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateExplicitRoleVersionDiff(tt.isCreate, tt.versionChanged, tt.oldVer, tt.newVer)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In Grafana 13, setting a `version` in roles is deprecated (see https://github.com/grafana/grafana/pull/120538 and https://github.com/grafana/grafana-enterprise/pull/11348). Grafana now sets version to 1 on creates and increments by 1 on updates. **The value sent is not written as is.**

Terraform impact: If a user increments the role by more than 1 (e.g. currently file has 5, and then they set it to 7), more than one terraform apply will be needed before the plan is clean, because Grafana will only increment by 1.

This PR adds validation so users only bump version by one to avoid confusion. It also recommends instead moving to the auto increment setting.


----------------------------
Creation errors look like:
```
│ Error: when creating a role with explicit version, version must be 1 (got 0)
│ 
│   with grafana_role.local,
│   on main.tf line 49, in resource "grafana_role" "local":
│   49: resource "grafana_role" "local" {
│ 
```

Update errors look like:
```
Planning failed. Terraform encountered an error while generating this plan.

│ Error: version must increase by exactly 1 on update when using explicit versioning (expected 2, got 5)
│ 
│   with grafana_role.local,
│   on main.tf line 49, in resource "grafana_role" "local":
│   49: resource "grafana_role" "local" {
│ 
```

Successful update:
```
Terraform will perform the following actions:

  # grafana_role.local will be updated in-place
  ~ resource "grafana_role" "local" {
        id           = "1:terraform-local-role"
        name         = "terraform-local-role"
      ~ version      = 2 -> 3
        # (6 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

grafana_role.local: Modifying... [id=1:terraform-local-role]
grafana_role.local: Modifications complete after 0s [id=1:terraform-local-role]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

role_id = "1:terraform-local-role"
role_uid = "terraform-local-role"
```