### PR TITLE
Dashboards: Update config_json documentation to include k8s-style schemas

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -39,11 +39,11 @@ resource "grafana_dashboard" "test" {
 
 - `config_json` (String) The complete dashboard model JSON.
 
-Starting with Grafana v13, it is recommended to use the "grafana_apps_dashboard_dashboard_v2" resource for Kubernetes-style dashboards.
+Starting with Grafana v13, use the resource corresponding to the API version they are using for Kubernetes-style dashboards.
 
-If using this legacy resource with a v2 dashboard definition:
-- In Grafana v12, only the "spec" field of the dashboard definition should be provided.
-- In Grafana v13 and later, the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec") can be provided.
+If you decide to use this legacy resource with a k8s-style dashboard definition:
+- In Grafana v12, provide the "spec" field of the dashboard definition.
+- In Grafana v13 and later, provide the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec").
 
 ### Optional
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -39,9 +39,9 @@ resource "grafana_dashboard" "test" {
 
 - `config_json` (String) The complete dashboard model JSON.
 
-Starting with Grafana v13, use the resource corresponding to the API version they are using for Kubernetes-style dashboards.
+Starting with Grafana v13, use the resource corresponding to your dashboard's API version for Kubernetes-style dashboards.
 
-If you decide to use this legacy resource with a k8s-style dashboard definition:
+If you decide to use this legacy resource with a Kubernetes-style dashboard definition:
 - In Grafana v12, provide the "spec" field of the dashboard definition.
 - In Grafana v13 and later, provide the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec").
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -4,7 +4,7 @@ page_title: "grafana_dashboard Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana dashboards.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/HTTP API (legacy API, recommended for Grafana 12 or earlier) https://grafana.com/docs/grafana/v11.6/developers/http_api/dashboard/HTTP API (new Kubernetes-style API, recommended for Grafana 13 and later) https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/
 ---
 
 # grafana_dashboard (Resource)
@@ -12,7 +12,8 @@ description: |-
 Manages Grafana dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
+* [HTTP API (legacy API, recommended for Grafana 12 or earlier)](https://grafana.com/docs/grafana/v11.6/developers/http_api/dashboard/)
+* [HTTP API (new Kubernetes-style API, recommended for Grafana 13 and later)](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 
 ## Example Usage
 
@@ -37,6 +38,12 @@ resource "grafana_dashboard" "test" {
 ### Required
 
 - `config_json` (String) The complete dashboard model JSON.
+
+Starting with Grafana v13, it is recommended to use the "grafana_apps_dashboard_dashboard_v2" resource for Kubernetes-style dashboards.
+
+If using this legacy resource with a v2 dashboard definition:
+- In Grafana v12, only the "spec" field of the dashboard definition should be provided.
+- In Grafana v13 and later, the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec") can be provided.
 
 ### Optional
 

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -97,9 +97,9 @@ Manages Grafana dashboards.
 				ValidateFunc: validateDashboardConfigJSON,
 				Description: `The complete dashboard model JSON.
 
-Starting with Grafana v13, use the resource corresponding to the API version they are using for Kubernetes-style dashboards.
+Starting with Grafana v13, use the resource corresponding to your dashboard's API version for Kubernetes-style dashboards.
 
-If you decide to use this legacy resource with a k8s-style dashboard definition:
+If you decide to use this legacy resource with a Kubernetes-style dashboard definition:
 - In Grafana v12, provide the "spec" field of the dashboard definition.
 - In Grafana v13 and later, provide the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec").
 `,

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -96,11 +96,11 @@ Manages Grafana dashboards.
 				ValidateFunc: validateDashboardConfigJSON,
 				Description: `The complete dashboard model JSON.
 
-For Kubernetes-style dashboards, it is recommended to use the "grafana_apps_dashboard_dashboard_v2" resource.
+Starting with Grafana v13, it is recommended to use the "grafana_apps_dashboard_dashboard_v2" resource for Kubernetes-style dashboards.
 
-When using this resource with Kubernetes-style dashboards:
-* In Grafana v12, only the "spec" field of the dashboard definition must be provided.
-* In Grafana v13 and later, the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec") can be provided.
+If using this legacy resource with a v2 dashboard definition:
+- In Grafana v12, only the "spec" field of the dashboard definition should be provided.
+- In Grafana v13 and later, the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec") can be provided.
 `,
 			},
 			"overwrite": {

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -33,7 +33,8 @@ func resourceDashboard() *common.Resource {
 Manages Grafana dashboards.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
+* [HTTP API (legacy API, recommended for Grafana 12 or earlier)](https://grafana.com/docs/grafana/v11.6/developers/http_api/dashboard/)
+* [HTTP API (new Kubernetes-style API, recommended for Grafana 13 and later)](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/)
 `,
 
 		CreateContext: common.WithDashboardMutex[schema.CreateContextFunc](CreateDashboard),

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -97,11 +97,11 @@ Manages Grafana dashboards.
 				ValidateFunc: validateDashboardConfigJSON,
 				Description: `The complete dashboard model JSON.
 
-Starting with Grafana v13, it is recommended to use the "grafana_apps_dashboard_dashboard_v2" resource for Kubernetes-style dashboards.
+Starting with Grafana v13, use the resource corresponding to the API version they are using for Kubernetes-style dashboards.
 
-If using this legacy resource with a v2 dashboard definition:
-- In Grafana v12, only the "spec" field of the dashboard definition should be provided.
-- In Grafana v13 and later, the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec") can be provided.
+If you decide to use this legacy resource with a k8s-style dashboard definition:
+- In Grafana v12, provide the "spec" field of the dashboard definition.
+- In Grafana v13 and later, provide the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec").
 `,
 			},
 			"overwrite": {

--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -94,7 +94,14 @@ Manages Grafana dashboards.
 				Required:     true,
 				StateFunc:    NormalizeDashboardConfigJSON,
 				ValidateFunc: validateDashboardConfigJSON,
-				Description:  "The complete dashboard model JSON.",
+				Description: `The complete dashboard model JSON.
+
+For Kubernetes-style dashboards, it is recommended to use the "grafana_apps_dashboard_dashboard_v2" resource.
+
+When using this resource with Kubernetes-style dashboards:
+* In Grafana v12, only the "spec" field of the dashboard definition must be provided.
+* In Grafana v13 and later, the full Kubernetes-style dashboard JSON (including "apiVersion", "kind", "metadata", and "spec") can be provided.
+`,
 			},
 			"overwrite": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
It adds extra information about how to use new resources using legacy API for dashboards.