### PR TITLE
SLO: Add alert enrichment support to fastburn and slowburn alerting

### DIFF
--- a/docs/data-sources/slos.md
+++ b/docs/data-sources/slos.md
@@ -124,6 +124,7 @@ Read-Only:
 Read-Only:
 
 - `annotation` (List of Object) (see [below for nested schema](#nestedobjatt--slos--alerting--fastburn--annotation))
+- `enrichment` (List of Object) (see [below for nested schema](#nestedobjatt--slos--alerting--fastburn--enrichment))
 - `label` (List of Object) (see [below for nested schema](#nestedobjatt--slos--alerting--fastburn--label))
 
 <a id="nestedobjatt--slos--alerting--fastburn--annotation"></a>
@@ -133,6 +134,14 @@ Read-Only:
 
 - `key` (String)
 - `value` (String)
+
+
+<a id="nestedobjatt--slos--alerting--fastburn--enrichment"></a>
+### Nested Schema for `slos.alerting.fastburn.enrichment`
+
+Read-Only:
+
+- `type` (String)
 
 
 <a id="nestedobjatt--slos--alerting--fastburn--label"></a>
@@ -160,6 +169,7 @@ Read-Only:
 Read-Only:
 
 - `annotation` (List of Object) (see [below for nested schema](#nestedobjatt--slos--alerting--slowburn--annotation))
+- `enrichment` (List of Object) (see [below for nested schema](#nestedobjatt--slos--alerting--slowburn--enrichment))
 - `label` (List of Object) (see [below for nested schema](#nestedobjatt--slos--alerting--slowburn--label))
 
 <a id="nestedobjatt--slos--alerting--slowburn--annotation"></a>
@@ -169,6 +179,14 @@ Read-Only:
 
 - `key` (String)
 - `value` (String)
+
+
+<a id="nestedobjatt--slos--alerting--slowburn--enrichment"></a>
+### Nested Schema for `slos.alerting.slowburn.enrichment`
+
+Read-Only:
+
+- `type` (String)
 
 
 <a id="nestedobjatt--slos--alerting--slowburn--label"></a>

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -101,6 +101,9 @@ resource "grafana_slo" "test" {
         key   = "description"
         value = "Error budget is burning too fast"
       }
+      enrichment {
+        type = "assistantInvestigation"
+      }
     }
 
     slowburn {
@@ -111,6 +114,9 @@ resource "grafana_slo" "test" {
       annotation {
         key   = "description"
         value = "Error budget is burning too fast"
+      }
+      enrichment {
+        type = "assistantInvestigation"
       }
     }
   }

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -320,6 +320,7 @@ Required:
 Optional:
 
 - `annotation` (Block List) Annotations to attach only to Fast Burn alerts. (see [below for nested schema](#nestedblock--alerting--fastburn--annotation))
+- `enrichment` (Block List) Enrichments to attach only to Fast Burn alerts. (see [below for nested schema](#nestedblock--alerting--fastburn--enrichment))
 - `label` (Block List) Labels to attach only to Fast Burn alerts. (see [below for nested schema](#nestedblock--alerting--fastburn--label))
 
 <a id="nestedblock--alerting--fastburn--annotation"></a>
@@ -329,6 +330,14 @@ Required:
 
 - `key` (String) Key for filtering and identification
 - `value` (String) Templatable value
+
+
+<a id="nestedblock--alerting--fastburn--enrichment"></a>
+### Nested Schema for `alerting.fastburn.enrichment`
+
+Required:
+
+- `type` (String) Type of the alert enrichment. Currently only "assistantInvestigation" is supported.
 
 
 <a id="nestedblock--alerting--fastburn--label"></a>
@@ -356,6 +365,7 @@ Required:
 Optional:
 
 - `annotation` (Block List) Annotations to attach only to Slow Burn alerts. (see [below for nested schema](#nestedblock--alerting--slowburn--annotation))
+- `enrichment` (Block List) Enrichments to attach only to Slow Burn alerts. (see [below for nested schema](#nestedblock--alerting--slowburn--enrichment))
 - `label` (Block List) Labels to attach only to Slow Burn alerts. (see [below for nested schema](#nestedblock--alerting--slowburn--label))
 
 <a id="nestedblock--alerting--slowburn--annotation"></a>
@@ -365,6 +375,14 @@ Required:
 
 - `key` (String) Key for filtering and identification
 - `value` (String) Templatable value
+
+
+<a id="nestedblock--alerting--slowburn--enrichment"></a>
+### Nested Schema for `alerting.slowburn.enrichment`
+
+Required:
+
+- `type` (String) Type of the alert enrichment. Currently only "assistantInvestigation" is supported.
 
 
 <a id="nestedblock--alerting--slowburn--label"></a>

--- a/examples/resources/grafana_slo/resource.tf
+++ b/examples/resources/grafana_slo/resource.tf
@@ -28,6 +28,9 @@ resource "grafana_slo" "test" {
         key   = "description"
         value = "Error budget is burning too fast"
       }
+      enrichment {
+        type = "assistantInvestigation"
+      }
     }
 
     slowburn {
@@ -38,6 +41,9 @@ resource "grafana_slo" "test" {
       annotation {
         key   = "description"
         value = "Error budget is burning too fast"
+      }
+      enrichment {
+        type = "assistantInvestigation"
       }
     }
   }

--- a/examples/resources/grafana_slo/resource_complex.tf
+++ b/examples/resources/grafana_slo/resource_complex.tf
@@ -34,6 +34,9 @@ resource "grafana_slo" "test" {
         key   = "type"
         value = "slo"
       }
+      enrichment {
+        type = "assistantInvestigation"
+      }
     }
 
     slowburn {
@@ -48,6 +51,9 @@ resource "grafana_slo" "test" {
       label {
         key   = "type"
         value = "slo"
+      }
+      enrichment {
+        type = "assistantInvestigation"
       }
     }
   }

--- a/examples/resources/grafana_slo/resource_ratio_enrichments.tf
+++ b/examples/resources/grafana_slo/resource_ratio_enrichments.tf
@@ -1,0 +1,52 @@
+resource "grafana_slo" "ratio_enrichments" {
+  name        = "Terraform Testing - Ratio Query"
+  description = "Terraform Description - Ratio Query"
+  query {
+    ratio {
+      success_metric  = "kubelet_http_requests_total{status!~\"5..\"}"
+      total_metric    = "kubelet_http_requests_total"
+      group_by_labels = ["job", "instance"]
+    }
+    type = "ratio"
+  }
+  objectives {
+    value  = 0.995
+    window = "30d"
+  }
+  destination_datasource {
+    uid = "grafanacloud-prom"
+  }
+  label {
+    key   = "slo"
+    value = "terraform"
+  }
+  alerting {
+    fastburn {
+      annotation {
+        key   = "name"
+        value = "SLO Burn Rate Very High"
+      }
+      annotation {
+        key   = "description"
+        value = "Error budget is burning too fast"
+      }
+      enrichment {
+        type = "assistantInvestigation"
+      }
+    }
+
+    slowburn {
+      annotation {
+        key   = "name"
+        value = "SLO Burn Rate High"
+      }
+      annotation {
+        key   = "description"
+        value = "Error budget is burning too fast"
+      }
+      enrichment {
+        type = "assistantInvestigation"
+      }
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/grafana/k6-cloud-openapi-client-go v0.0.0-20251022100644-dd6cfbb68f85
 	github.com/grafana/machine-learning-go-client v0.8.2
 	github.com/grafana/river v0.3.0
-	github.com/grafana/slo-openapi-client/go/slo v0.0.0-20250218172929-ab9cae090da6
+	github.com/grafana/slo-openapi-client/go/slo v0.0.0-20260327172536-7bee3b953aed
 	github.com/grafana/synthetic-monitoring-agent v0.43.1
 	github.com/grafana/synthetic-monitoring-api-go-client v0.17.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/river v0.3.0 h1:6TsaR/vkkcppUM9I0muGbPIUedCtpPu6OWreE5+CE6g=
 github.com/grafana/river v0.3.0/go.mod h1:icSidCSHYXJUYy6TjGAi/D+X7FsP7Gc7cxvBUIwYMmY=
-github.com/grafana/slo-openapi-client/go/slo v0.0.0-20250218172929-ab9cae090da6 h1:7jbuz2MCqHlIc+vC3geOEzMZolm30v3K1bFTaTJ4mGI=
-github.com/grafana/slo-openapi-client/go/slo v0.0.0-20250218172929-ab9cae090da6/go.mod h1:a9idYds6valDrBwBdcFTIp+QzlERgf2CFDZgEfmp9pA=
+github.com/grafana/slo-openapi-client/go/slo v0.0.0-20260327172536-7bee3b953aed h1:M30lANVDmd+7KlDpLkFdYCQAq9lpDPI66ACd8XcecOY=
+github.com/grafana/slo-openapi-client/go/slo v0.0.0-20260327172536-7bee3b953aed/go.mod h1:QO+DOKYQzwHcJKsemop2s5XEjyUVBdjeazwSkioPLbw=
 github.com/grafana/synthetic-monitoring-agent v0.43.1 h1:Qejsuf25yZzdImVLZ6K1f5cbEIYVw0gMU8dob3JTzEc=
 github.com/grafana/synthetic-monitoring-agent v0.43.1/go.mod h1:HO4es33UF/5b3i4JdUhVcvs9abUXESMjFxnWP8y6KG0=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1 h1:6ZQoQVD0sASxe5OVEk/T/YEOYOuilSA434bX4n3SJLQ=

--- a/internal/resources/slo/data_source_slos.go
+++ b/internal/resources/slo/data_source_slos.go
@@ -225,8 +225,23 @@ func unpackAlertingMetadata(metaData slo.SloV00AlertingMetadata) []map[string]an
 		labelsAnnotsStruct["label"] = retLabels
 	}
 
+	if metaData.Enrichments != nil {
+		retEnrichments := unpackEnrichments(metaData.Enrichments)
+		labelsAnnotsStruct["enrichment"] = retEnrichments
+	}
+
 	retAlertMetaData = append(retAlertMetaData, labelsAnnotsStruct)
 	return retAlertMetaData
+}
+
+func unpackEnrichments(enrichments []slo.SloV00AlertEnrichment) []map[string]any {
+	retEnrichments := []map[string]any{}
+	for _, enrichment := range enrichments {
+		retEnrichment := make(map[string]any)
+		retEnrichment["type"] = enrichment.Type
+		retEnrichments = append(retEnrichments, retEnrichment)
+	}
+	return retEnrichments
 }
 
 func unpackAdvancedOptions(options slo.SloV00AdvancedOptions) []map[string]any {

--- a/internal/resources/slo/resource_slo.go
+++ b/internal/resources/slo/resource_slo.go
@@ -262,6 +262,12 @@ Resource manages Grafana SLOs (Service Level Objectives).
 										Description: "Annotations to attach only to Fast Burn alerts.",
 										Elem:        keyvalueSchema,
 									},
+									"enrichment": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "Enrichments to attach only to Fast Burn alerts.",
+										Elem:        enrichmentSchema,
+									},
 								},
 							},
 						},
@@ -283,6 +289,12 @@ Resource manages Grafana SLOs (Service Level Objectives).
 										Optional:    true,
 										Description: "Annotations to attach only to Slow Burn alerts.",
 										Elem:        keyvalueSchema,
+									},
+									"enrichment": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: "Enrichments to attach only to Slow Burn alerts.",
+										Elem:        enrichmentSchema,
 									},
 								},
 							},
@@ -335,6 +347,17 @@ var keyvalueSchema = &schema.Resource{
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: `Templatable value`,
+		},
+	},
+}
+
+var enrichmentSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"type": {
+			Type:         schema.TypeString,
+			Required:     true,
+			Description:  `Type of the alert enrichment. Currently only "assistantInvestigation" is supported.`,
+			ValidateFunc: validation.StringInSlice([]string{"assistantInvestigation"}, false),
 		},
 	},
 }
@@ -822,6 +845,7 @@ func packAlerting(tfAlerting map[string]any) (slo.SloV00Alerting, error) {
 func packAlertMetadata(metadata []any) (slo.SloV00AlertingMetadata, error) {
 	var tflabels []slo.SloV00Label
 	var tfannots []slo.SloV00Label
+	var tfenrichments []slo.SloV00AlertEnrichment
 
 	if len(metadata) > 0 {
 		meta, ok := metadata[0].(map[string]any)
@@ -843,15 +867,45 @@ func packAlertMetadata(metadata []any) (slo.SloV00AlertingMetadata, error) {
 					return slo.SloV00AlertingMetadata{}, err
 				}
 			}
+
+			enrichments, ok := meta["enrichment"].([]any)
+			if ok {
+				var err error
+				tfenrichments, err = packEnrichments(enrichments)
+				if err != nil {
+					return slo.SloV00AlertingMetadata{}, err
+				}
+			}
 		}
 	}
 
 	apiMetadata := slo.SloV00AlertingMetadata{
 		Labels:      tflabels,
 		Annotations: tfannots,
+		Enrichments: tfenrichments,
 	}
 
 	return apiMetadata, nil
+}
+
+func packEnrichments(tfEnrichments []any) ([]slo.SloV00AlertEnrichment, error) {
+	enrichments := []slo.SloV00AlertEnrichment{}
+
+	for ind := range tfEnrichments {
+		currEnrichment, ok := tfEnrichments[ind].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("enrichment[%d]: unexpected type — check your Terraform configuration", ind)
+		}
+		enrichmentType, ok := currEnrichment["type"].(string)
+		if !ok {
+			return nil, fmt.Errorf("enrichment[%d].type: expected string type — check your Terraform configuration", ind)
+		}
+		enrichments = append(enrichments, slo.SloV00AlertEnrichment{
+			Type: enrichmentType,
+		})
+	}
+
+	return enrichments, nil
 }
 
 func setTerraformState(d *schema.ResourceData, slo slo.SloV00Slo) {

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -129,6 +129,22 @@ func TestAccResourceSlo(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				// Tests Enrichments
+				Config: testutils.TestAccExample(t, "resources/grafana_slo/resource_ratio_enrichments.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSloCheckExists("grafana_slo.ratio_enrichments", &slo),
+					testAlertingExists(true, "grafana_slo.ratio_enrichments", &slo),
+					resource.TestCheckResourceAttr("grafana_slo.ratio_enrichments", "alerting.0.fastburn.0.enrichment.0.type", "assistantInvestigation"),
+					resource.TestCheckResourceAttr("grafana_slo.ratio_enrichments", "alerting.0.slowburn.0.enrichment.0.type", "assistantInvestigation"),
+				),
+			},
+			{
+				// Import test (this tests that all fields are read correctly)
+				ResourceName:      "grafana_slo.ratio_enrichments",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				// Tests the Search Expression
 				Config: testutils.TestAccExample(t, "resources/grafana_slo/resource_search_expression.tf"),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -51,6 +51,8 @@ func TestAccResourceSlo(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_slo.test", "objectives.0.value", "0.995"),
 					resource.TestCheckResourceAttr("grafana_slo.test", "objectives.0.window", "30d"),
 					resource.TestCheckNoResourceAttr("grafana_slo.test", "folder_uid"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "alerting.0.fastburn.0.enrichment.0.type", "assistantInvestigation"),
+					resource.TestCheckResourceAttr("grafana_slo.test", "alerting.0.slowburn.0.enrichment.0.type", "assistantInvestigation"),
 					testutils.CheckLister("grafana_slo.test"),
 				),
 			},


### PR DESCRIPTION
Add the enrichment block to fastburn and slowburn alerting metadata, allowing users to configure alert enrichments (e.g., assistantInvestigation) on SLO alert rules. Updates the slo-openapi-client dependency to include the new AlertEnrichment model.