### PR TITLE
CI: Switch to hard failure for SDKv2 CI check

### DIFF
--- a/.github/workflows/sdkv2-migration-check.yml
+++ b/.github/workflows/sdkv2-migration-check.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   sdkv2_migration_check:
@@ -19,7 +18,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check for new SDKv2 resource/datasource usage
-        id: check
         run: |
           # Compare against base: for PRs use the base ref, for push use the previous commit
           if [ -n "${GITHUB_BASE_REF:-}" ]; then
@@ -36,39 +34,21 @@ jobs:
           # Look for added lines that register a new SDKv2 resource or datasource
           ADDED_LEGACY=$(echo "$DIFF" | grep -E '^\+.*NewLegacySDK(Resource|DataSource)' || true)
           if [ -n "$ADDED_LEGACY" ]; then
-            echo "sdkv2_detected=true" >> "$GITHUB_OUTPUT"
-            {
-              echo '**SDKv2 migration notice**'
-              echo ''
-              echo 'This PR adds new SDKv2 (legacy) resource or datasource registration. This codebase is migrating to the Terraform Plugin Framework; **new resources and data sources must use the Framework**, not SDKv2.'
-              echo ''
-              echo '- Use **`common.NewResource`** (with a type implementing `resource.ResourceWithConfigure`) for new resources.'
-              echo '- Use the Framework datasource pattern for new data sources (not `NewLegacySDKDataSource`).'
-              echo ''
-              echo 'See **AGENTS.md** (Three-Layer Resource Architecture) for details. See https://github.com/grafana/deployment_tools/issues/475444, https://github.com/grafana/terraform-provider-grafana/issues/2580 and https://github.com/grafana/terraform-provider-grafana/issues/2216 for more context and examples of how to use the Plugin Framework.'
-              echo ''
-              echo 'This is currently a warning only; the job remains green. It will begin failing in April.'
-              echo ''
-              echo 'Added lines that triggered this check:'
-              echo '```'
-              echo "$ADDED_LEGACY"
-              echo '```'
-            } > sdkv2_comment_body.md
-            echo "::warning::New SDKv2 (legacy) resource or datasource registration detected."
-            cat sdkv2_comment_body.md
-            # WARNING ONLY: exit 0. Change to exit 1 to fail the job once migration policy is strict.
-            exit 0
+            echo "::error::New SDKv2 (legacy) resource or datasource registration detected."
+            echo ''
+            echo '**SDKv2 migration**'
+            echo ''
+            echo 'This change adds new SDKv2 (legacy) resource or datasource registration. This codebase is migrating to the Terraform Plugin Framework; **new resources and data sources must use the Framework**, not SDKv2.'
+            echo ''
+            echo '- Use **`common.NewResource`** (with a type implementing `resource.ResourceWithConfigure`) for new resources.'
+            echo '- Use the Framework datasource pattern for new data sources (not `NewLegacySDKDataSource`).'
+            echo ''
+            echo 'See **AGENTS.md** (Three-Layer Resource Architecture) for details. See https://github.com/grafana/deployment_tools/issues/475444, https://github.com/grafana/terraform-provider-grafana/issues/2580 and https://github.com/grafana/terraform-provider-grafana/issues/2216 for more context and examples of how to use the Plugin Framework.'
+            echo ''
+            echo 'Added lines that triggered this check:'
+            echo '```'
+            echo "$ADDED_LEGACY"
+            echo '```'
+            exit 1
           fi
           echo "No new SDKv2 resource/datasource registration found."
-      - name: Write comment body to output
-        id: comment-body
-        if: github.event_name == 'pull_request' && steps.check.outputs.sdkv2_detected == 'true'
-        run: |
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          cat sdkv2_comment_body.md >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-      - uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
-        if: github.event_name == 'pull_request' && steps.check.outputs.sdkv2_detected == 'true'
-        with:
-          message: ${{ steps.comment-body.outputs.body }}
-          message-id: sdkv2-migration-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ Both rely on `ResourceListIDsFunc` lister functions attached via `.WithLister(fn
 
 ### SDKv2 migration CI check
 
-The **SDKv2 migration check** workflow (`.github/workflows/sdkv2-migration-check.yml`) runs a job that warns when a PR (or push to main) adds new SDKv2 resource or datasource registration in `internal/resources/` (i.e. new `NewLegacySDKResource` or `NewLegacySDKDataSource` calls). New resources/datasources must use the Plugin Framework (`common.NewResource` / Framework datasource pattern). The check is **warning-only** (job does not fail). When the check triggers on a pull request, it also posts a **PR comment** with the migration notice and the added lines that triggered it. To make the check fail the job once the migration policy is strict, change the step in that workflow from `exit 0` to `exit 1` in the "Check for new SDKv2 resource/datasource usage" step.
+The **SDKv2 migration check** workflow (`.github/workflows/sdkv2-migration-check.yml`) runs a job that **fails** when a PR (or push to main) adds new SDKv2 resource or datasource registration in `internal/resources/` (i.e. new `NewLegacySDKResource` or `NewLegacySDKDataSource` calls). New resources/datasources must use the Plugin Framework (`common.NewResource` / Framework datasource pattern). The job log prints the offending added lines and links to migration context.
 
 ### Migrating a resource or datasource to the Plugin Framework
 

--- a/agent-docs/resources/sdkv2-to-framework-migration.md
+++ b/agent-docs/resources/sdkv2-to-framework-migration.md
@@ -8,7 +8,7 @@ Reference migrations that shaped this doc: **`grafana_annotation`** ([PR #2546](
 
 ### New `NewLegacySDK*` registrations and CI
 
-New `NewLegacySDKResource` / `NewLegacySDKDataSource` registrations under `internal/resources/` trip the [SDKv2 migration check](../../.github/workflows/sdkv2-migration-check.yml) workflow (warning-only for now; it may comment on the PR with the offending lines). Prefer Framework registration for new work. (See also `AGENTS.md` § “SDKv2 migration CI check”.)
+New `NewLegacySDKResource` / `NewLegacySDKDataSource` registrations under `internal/resources/` trip the [SDKv2 migration check](../../.github/workflows/sdkv2-migration-check.yml) workflow and **fail CI**; the job log lists the offending lines. Prefer Framework registration for new work. (See also `AGENTS.md` “SDKv2 migration CI check”.)
 
 ---
 


### PR DESCRIPTION
For https://github.com/grafana/deployment_tools/issues/511486

Follows up on https://github.com/grafana/terraform-provider-grafana/pull/2577

Adds a CI check that fails when a PR or push to main adds new SDKv2 resource or datasource registration in internal/resources/. AGENTS.md is updated to describe the check.