### PR TITLE
fix(cloud): Update cloud wake path to grafana_com login page

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -666,7 +666,7 @@ func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL 
 	if joinErr != nil {
 		return diag.FromErr(joinErr)
 	}
-	wakePath, joinErr := url.JoinPath(stackURL, "login")
+	wakePath, joinErr := url.JoinPath(stackURL, "/login/grafana_com")
 	if joinErr != nil {
 		return diag.FromErr(joinErr)
 	}


### PR DESCRIPTION
Since the mt-fe service is now at 100% rollout, `/login` no longer wakes stacks, as those calls are proxied to that service. Instead, we can trigger an instance wake-up by selecting the `grafana_com` provider. These calls are routed directly to the stack, triggering a wake-up.