### PR TITLE
maint: Update the owners of dashboard_public resource

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # internal/resources/grafana
 /internal/resources/grafana/*_alerting_*                       @grafana/alerting-squad
 /internal/resources/grafana/*_organization_user*               @grafana/identity-squad
-# /internal/resources/grafana/resource_dashboard_public*         @grafana/sharing-squad  # unknown team handle
+/internal/resources/grafana/resource_dashboard_public*         @grafana/grafana-operator-experience-squad
 /internal/resources/grafana/resource_dashboard_permission*     @grafana/access-squad
 # /internal/resources/grafana/resource_dashboard.go              @grafana/dashboards-squad  # unknown team handle
 # /internal/resources/grafana/*data_source_cache*                @grafana/grafana-operator-experience-squad  # unknown team handle

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -74,7 +74,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/sharing-squad
+  owner: group:default/grafana-operator-experience-squad
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
**Changes in this PR**
- Updates the CODEOWNERS and enghub page for this resource to point to the correct owner @grafana/grafana-operator-experience-squad 

**Ref**
- Slack [thread](https://raintank-corp.slack.com/archives/C05PEHHJTC5/p1775217912485459?thread_ts=1775168666.187899&cid=C05PEHHJTC5)