### PR TITLE
Migrate grafana report resource

### DIFF
--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -46,23 +46,45 @@ resource "grafana_report" "test" {
 
 - `name` (String) Name of the report.
 - `recipients` (List of String) List of recipients of the report.
-- `schedule` (Block List, Min: 1, Max: 1) Schedule of the report. (see [below for nested schema](#nestedblock--schedule))
 
 ### Optional
 
 - `dashboards` (Block List) List of dashboards to render into the report (see [below for nested schema](#nestedblock--dashboards))
 - `formats` (Set of String) Specifies what kind of attachment to generate for the report. Allowed values: `pdf`, `csv`, `image`.
-- `include_dashboard_link` (Boolean) Whether to include a link to the dashboard in the report. Defaults to `true`.
-- `include_table_csv` (Boolean) Whether to include a CSV file of table panel data. Defaults to `false`.
-- `layout` (String) Layout of the report. Allowed values: `simple`, `grid`. Defaults to `grid`.
+- `include_dashboard_link` (Boolean) Whether to include a link to the dashboard in the report.
+- `include_table_csv` (Boolean) Whether to include a CSV file of table panel data.
+- `layout` (String) Layout of the report. Allowed values: `simple`, `grid`.
 - `message` (String) Message to be sent in the report.
-- `org_id` (String) The Organization ID. If not set, the Org ID defined in the provider block will be used.
-- `orientation` (String) Orientation of the report. Allowed values: `landscape`, `portrait`. Defaults to `landscape`.
+- `org_id` (String) The Organization ID. If not set, the default organization is used for basic authentication, or the one that owns your service account for token authentication.
+- `orientation` (String) Orientation of the report. Allowed values: `landscape`, `portrait`.
 - `reply_to` (String) Reply-to email address of the report.
+- `schedule` (Block List) (Required) Schedule of the report. (see [below for nested schema](#nestedblock--schedule))
 
 ### Read-Only
 
 - `id` (String) Generated identifier of the report.
+
+<a id="nestedblock--dashboards"></a>
+### Nested Schema for `dashboards`
+
+Required:
+
+- `uid` (String) Dashboard uid.
+
+Optional:
+
+- `report_variables` (Map of String) Add report variables to the dashboard. Values should be separated by commas.
+- `time_range` (Block List) Time range of the report. (see [below for nested schema](#nestedblock--dashboards--time_range))
+
+<a id="nestedblock--dashboards--time_range"></a>
+### Nested Schema for `dashboards.time_range`
+
+Optional:
+
+- `from` (String) Start of the time range.
+- `to` (String) End of the time range.
+
+
 
 <a id="nestedblock--schedule"></a>
 ### Nested Schema for `schedule`
@@ -76,31 +98,10 @@ Optional:
 - `custom_interval` (String) Custom interval of the report.
 **Note:** This field is only available when frequency is set to `custom`.
 - `end_time` (String) End time of the report. If empty, the report will be sent indefinitely (according to frequency). Note that times will be saved as UTC in Grafana. Use 2006-01-02T15:04:05 format if you want to set a custom timezone
-- `last_day_of_month` (Boolean) Send the report on the last day of the month Defaults to `false`.
+- `last_day_of_month` (Boolean) Send the report on the last day of the month
 - `start_time` (String) Start time of the report. If empty, the start date will be set to the creation time. Note that times will be saved as UTC in Grafana. Use 2006-01-02T15:04:05 format if you want to set a custom timezone
-- `timezone` (String) Set the report time zone. Defaults to `GMT`.
-- `workdays_only` (Boolean) Whether to send the report only on work days. Defaults to `false`.
-
-
-<a id="nestedblock--dashboards"></a>
-### Nested Schema for `dashboards`
-
-Required:
-
-- `uid` (String) Dashboard uid.
-
-Optional:
-
-- `report_variables` (Map of String) Add report variables to the dashboard. Values should be separated by commas.
-- `time_range` (Block List, Max: 1) Time range of the report. (see [below for nested schema](#nestedblock--dashboards--time_range))
-
-<a id="nestedblock--dashboards--time_range"></a>
-### Nested Schema for `dashboards.time_range`
-
-Optional:
-
-- `from` (String) Start of the time range.
-- `to` (String) End of the time range.
+- `timezone` (String) Set the report time zone.
+- `workdays_only` (Boolean) Whether to send the report only on work days.
 
 ## Import
 

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -408,10 +408,11 @@ func (r *reportResource) Read(ctx context.Context, req resource.ReadRequest, res
 		resp.State.RemoveResource(ctx)
 		return
 	}
-	// Preserve the user-provided time format from the existing state. The v5 mux requires
-	// that plan values for Optional+Computed attributes in blocks match the config exactly
-	// (no plan modification is allowed), so we store times in config format and avoid drift.
-	preserveScheduleTimes(readData, &data)
+	// Preserve the user-provided time format from the existing state only when the API
+	// value represents the same instant. The v5 mux requires plan values for
+	// Optional+Computed attributes in blocks to match config exactly (no plan modifier
+	// allowed), so we avoid format-only diffs while still surfacing genuine time changes.
+	preserveScheduleTimesIfSemanticEqual(readData, &data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
 }
 
@@ -622,7 +623,7 @@ func modelToReport(ctx context.Context, data *resourceReportModel) (models.Creat
 		Formats: []models.Type{reportFormatPDF},
 	}
 
-	if !data.Formats.IsNull() {
+	if !data.Formats.IsNull() && len(data.Formats.Elements()) > 0 {
 		var formatStrs []string
 		diags.Append(data.Formats.ElementsAs(ctx, &formatStrs, false)...)
 		if diags.HasError() {
@@ -751,8 +752,9 @@ func CheckTimezoneFormatDate(date string, timezone *time.Location) (*strfmt.Date
 	return &dateTime, nil
 }
 
-// preserveScheduleTimes copies start_time and end_time from src into dst when src has a
-// non-empty value. This keeps the user-provided format in state after create/update/read.
+// preserveScheduleTimes copies start_time and end_time from src (plan/config) into dst
+// (API-read data) when src has a non-empty value. Used after Create and Update to keep the
+// user-provided format in state.
 //
 // The Terraform v5 mux requires that plan values for Optional+Computed attributes inside
 // ListNestedBlocks match the config value byte-for-byte (no plan modifier can change them).
@@ -770,6 +772,50 @@ func preserveScheduleTimes(dst, src *resourceReportModel) {
 	if v := src.Schedule[0].EndTime.ValueString(); v != "" {
 		dst.Schedule[0].EndTime = src.Schedule[0].EndTime
 	}
+}
+
+// preserveScheduleTimesIfSemanticEqual is like preserveScheduleTimes but only copies a time
+// from src (prior state) into dst (fresh API data) when both values represent the same instant.
+// Used during Read so that format-only differences do not produce spurious diffs, while genuine
+// out-of-band schedule changes made directly in Grafana are still surfaced.
+func preserveScheduleTimesIfSemanticEqual(dst, src *resourceReportModel) {
+	if dst == nil || src == nil || len(dst.Schedule) == 0 || len(src.Schedule) == 0 {
+		return
+	}
+	if v := src.Schedule[0].StartTime.ValueString(); v != "" && scheduleTimeSemanticEqual(v, dst.Schedule[0].StartTime.ValueString()) {
+		dst.Schedule[0].StartTime = src.Schedule[0].StartTime
+	}
+	if v := src.Schedule[0].EndTime.ValueString(); v != "" && scheduleTimeSemanticEqual(v, dst.Schedule[0].EndTime.ValueString()) {
+		dst.Schedule[0].EndTime = src.Schedule[0].EndTime
+	}
+}
+
+// scheduleTimeSemanticEqual reports whether two time strings represent the same instant.
+// It tries both RFC3339 and the short timeDateShortFormat used in config.
+func scheduleTimeSemanticEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+	formats := []string{time.RFC3339, timeDateShortFormat}
+	var ta, tb time.Time
+	var parsed bool
+	for _, f := range formats {
+		if t, err := time.Parse(f, a); err == nil {
+			ta = t
+			parsed = true
+			break
+		}
+	}
+	if !parsed {
+		return false
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, b); err == nil {
+			tb = t
+			return ta.Equal(tb)
+		}
+	}
+	return false
 }
 
 // nullableString returns types.StringNull() for empty strings, types.StringValue(s) otherwise.

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -601,6 +601,10 @@ func modelToReport(ctx context.Context, data *resourceReportModel) (models.Creat
 		return models.CreateOrUpdateReport{}, diags
 	}
 
+	if len(data.Schedule) == 0 {
+		diags.AddError("Missing schedule", "report must have exactly one schedule block")
+		return models.CreateOrUpdateReport{}, diags
+	}
 	schedule := data.Schedule[0]
 	frequency := schedule.Frequency.ValueString()
 	timezone := schedule.Timezone.ValueString()
@@ -734,11 +738,11 @@ func parseCustomReportInterval(s string) (int, string, error) {
 }
 
 func formatDate(date string, timezone *time.Location) (*strfmt.DateTime, error) {
-	parsedDate, err := time.Parse(timeDateShortFormat, date)
+	parsedDate, err := time.ParseInLocation(timeDateShortFormat, date, timezone)
 	if err != nil {
 		return CheckTimezoneFormatDate(date, timezone)
 	}
-	dateTime := strfmt.DateTime(parsedDate.In(timezone))
+	dateTime := strfmt.DateTime(parsedDate)
 	return &dateTime, nil
 }
 
@@ -782,40 +786,44 @@ func preserveScheduleTimesIfSemanticEqual(dst, src *resourceReportModel) {
 	if dst == nil || src == nil || len(dst.Schedule) == 0 || len(src.Schedule) == 0 {
 		return
 	}
-	if v := src.Schedule[0].StartTime.ValueString(); v != "" && scheduleTimeSemanticEqual(v, dst.Schedule[0].StartTime.ValueString()) {
+	loc, err := time.LoadLocation(dst.Schedule[0].Timezone.ValueString())
+	if err != nil {
+		loc = time.UTC
+	}
+	if v := src.Schedule[0].StartTime.ValueString(); v != "" && scheduleTimeSemanticEqual(v, dst.Schedule[0].StartTime.ValueString(), loc) {
 		dst.Schedule[0].StartTime = src.Schedule[0].StartTime
 	}
-	if v := src.Schedule[0].EndTime.ValueString(); v != "" && scheduleTimeSemanticEqual(v, dst.Schedule[0].EndTime.ValueString()) {
+	if v := src.Schedule[0].EndTime.ValueString(); v != "" && scheduleTimeSemanticEqual(v, dst.Schedule[0].EndTime.ValueString(), loc) {
 		dst.Schedule[0].EndTime = src.Schedule[0].EndTime
 	}
 }
 
 // scheduleTimeSemanticEqual reports whether two time strings represent the same instant.
-// It tries both RFC3339 and the short timeDateShortFormat used in config.
-func scheduleTimeSemanticEqual(a, b string) bool {
+// RFC3339 strings carry their own offset and are parsed as-is. Short-format strings
+// (timeDateShortFormat, no timezone indicator) are interpreted in loc, matching the
+// behaviour of formatDate which also uses ParseInLocation for short-format input.
+func scheduleTimeSemanticEqual(a, b string, loc *time.Location) bool {
 	if a == b {
 		return true
 	}
-	formats := []string{time.RFC3339, timeDateShortFormat}
-	var ta, tb time.Time
-	var parsed bool
-	for _, f := range formats {
-		if t, err := time.Parse(f, a); err == nil {
-			ta = t
-			parsed = true
-			break
+	parseTime := func(s string) (time.Time, bool) {
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t, true
 		}
+		if t, err := time.ParseInLocation(timeDateShortFormat, s, loc); err == nil {
+			return t, true
+		}
+		return time.Time{}, false
 	}
-	if !parsed {
+	ta, ok := parseTime(a)
+	if !ok {
 		return false
 	}
-	for _, f := range formats {
-		if t, err := time.Parse(f, b); err == nil {
-			tb = t
-			return ta.Equal(tb)
-		}
+	tb, ok := parseTime(b)
+	if !ok {
+		return false
 	}
-	return false
+	return ta.Equal(tb)
 }
 
 // nullableString returns types.StringNull() for empty strings, types.StringValue(s) otherwise.

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -13,12 +13,19 @@ import (
 	"github.com/go-openapi/strfmt"
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/models"
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const (
@@ -48,207 +55,60 @@ var (
 	reportOrientations = []string{reportOrientationLandscape, reportOrientationPortrait}
 	reportFrequencies  = []string{reportFrequencyNever, reportFrequencyOnce, reportFrequencyHourly, reportFrequencyDaily, reportFrequencyWeekly, reportFrequencyMonthly, reportFrequencyCustom}
 	reportFormats      = []string{reportFormatPDF, reportFormatCSV, reportFormatImage}
+
+	_ resource.Resource                = &reportResource{}
+	_ resource.ResourceWithConfigure   = &reportResource{}
+	_ resource.ResourceWithImportState = &reportResource{}
+	_ resource.ResourceWithModifyPlan  = &reportResource{}
 )
 
-func resourceReport() *common.Resource {
-	schema := &schema.Resource{
-		Description: `
-**Note:** This resource is available only with Grafana Enterprise 7.+.
+type resourceReportTimeRangeModel struct {
+	From types.String `tfsdk:"from"`
+	To   types.String `tfsdk:"to"`
+}
 
-* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-reports/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/reporting/)
-`,
-		CreateContext: CreateReport,
-		UpdateContext: UpdateReport,
-		ReadContext:   ReadReport,
-		DeleteContext: DeleteReport,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"org_id": orgIDAttribute(),
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Generated identifier of the report.",
-			},
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Name of the report.",
-			},
-			"recipients": {
-				Type:        schema.TypeList,
-				Required:    true,
-				Description: "List of recipients of the report.",
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(common.EmailRegexp, "must be an email address"),
-				},
-				MinItems: 1,
-			},
-			"reply_to": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Reply-to email address of the report.",
-				ValidateFunc: validation.StringMatch(common.EmailRegexp, "must be an email address"),
-			},
-			"message": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Message to be sent in the report.",
-			},
-			"include_dashboard_link": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether to include a link to the dashboard in the report.",
-			},
-			"include_table_csv": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether to include a CSV file of table panel data.",
-			},
-			"layout": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  common.AllowedValuesDescription("Layout of the report", reportLayouts),
-				Default:      reportLayoutGrid,
-				ValidateFunc: validation.StringInSlice(reportLayouts, false),
-			},
-			"orientation": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  common.AllowedValuesDescription("Orientation of the report", reportOrientations),
-				Default:      reportOrientationLandscape,
-				ValidateFunc: validation.StringInSlice(reportOrientations, false),
-			},
-			"formats": {
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Description: common.AllowedValuesDescription("Specifies what kind of attachment to generate for the report", reportFormats),
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(reportFormats, false),
-				},
-			},
-			"schedule": {
-				Type:        schema.TypeList,
-				Required:    true,
-				Description: "Schedule of the report.",
-				MinItems:    1,
-				MaxItems:    1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"frequency": {
-							Type:         schema.TypeString,
-							Required:     true,
-							Description:  common.AllowedValuesDescription("Frequency of the report", reportFrequencies),
-							ValidateFunc: validation.StringInSlice(reportFrequencies, false),
-						},
-						"start_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      fmt.Sprintf("Start time of the report. If empty, the start date will be set to the creation time. Note that times will be saved as UTC in Grafana. Use %s format if you want to set a custom timezone", timeDateShortFormat),
-							ValidateDiagFunc: validateDate,
-							DiffSuppressFunc: checkStartTimeDiff,
-						},
-						"end_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      fmt.Sprintf("End time of the report. If empty, the report will be sent indefinitely (according to frequency). Note that times will be saved as UTC in Grafana. Use %s format if you want to set a custom timezone", timeDateShortFormat),
-							ValidateDiagFunc: validateDate,
-							DiffSuppressFunc: checkEndTimeDiff,
-						},
-						"workdays_only": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Whether to send the report only on work days.",
-							Default:     false,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return !reportWorkdaysOnlyConfigAllowed(d.Get("schedule.0.frequency").(string))
-							},
-						},
-						"custom_interval": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Description: "Custom interval of the report.\n" +
-								"**Note:** This field is only available when frequency is set to `custom`.",
-							ValidateDiagFunc: func(i any, p cty.Path) diag.Diagnostics {
-								_, _, err := parseCustomReportInterval(i)
-								return diag.FromErr(err)
-							},
-						},
-						"last_day_of_month": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Send the report on the last day of the month",
-							Default:     false,
-						},
-						"timezone": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Set the report time zone.",
-							Default:          "GMT",
-							ValidateDiagFunc: validateTimezone,
-						},
-					},
-				},
-			},
-			"dashboards": {
-				Type:        schema.TypeList,
-				Description: "List of dashboards to render into the report",
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"uid": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Dashboard uid.",
-						},
-						"time_range": {
-							Type:        schema.TypeList,
-							MinItems:    1,
-							MaxItems:    1,
-							Optional:    true,
-							Description: "Time range of the report.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"from": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Start of the time range.",
-									},
-									"to": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "End of the time range.",
-									},
-								},
-							},
-							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-								return oldValue == "1" && newValue == "0"
-							},
-						},
-						"report_variables": {
-							Type:             schema.TypeMap,
-							Description:      "Add report variables to the dashboard. Values should be separated by commas.",
-							Optional:         true,
-							Elem:             schema.TypeString,
-							ValidateDiagFunc: validateReportVariables,
-						},
-					},
-				},
-			},
-		},
-	}
+type resourceReportDashboardModel struct {
+	UID             types.String                   `tfsdk:"uid"`
+	TimeRange       []resourceReportTimeRangeModel `tfsdk:"time_range"`
+	ReportVariables types.Map                      `tfsdk:"report_variables"`
+}
 
-	return common.NewLegacySDKResource(
+type resourceReportScheduleModel struct {
+	Frequency      types.String `tfsdk:"frequency"`
+	StartTime      types.String `tfsdk:"start_time"`
+	EndTime        types.String `tfsdk:"end_time"`
+	WorkdaysOnly   types.Bool   `tfsdk:"workdays_only"`
+	CustomInterval types.String `tfsdk:"custom_interval"`
+	LastDayOfMonth types.Bool   `tfsdk:"last_day_of_month"`
+	Timezone       types.String `tfsdk:"timezone"`
+}
+
+type resourceReportModel struct {
+	ID                   types.String                   `tfsdk:"id"`
+	OrgID                types.String                   `tfsdk:"org_id"`
+	Name                 types.String                   `tfsdk:"name"`
+	Recipients           types.List                     `tfsdk:"recipients"`
+	ReplyTo              types.String                   `tfsdk:"reply_to"`
+	Message              types.String                   `tfsdk:"message"`
+	IncludeDashboardLink types.Bool                     `tfsdk:"include_dashboard_link"`
+	IncludeTableCSV      types.Bool                     `tfsdk:"include_table_csv"`
+	Layout               types.String                   `tfsdk:"layout"`
+	Orientation          types.String                   `tfsdk:"orientation"`
+	Formats              types.Set                      `tfsdk:"formats"`
+	Schedule             []resourceReportScheduleModel  `tfsdk:"schedule"`
+	Dashboards           []resourceReportDashboardModel `tfsdk:"dashboards"`
+}
+
+type reportResource struct {
+	basePluginFrameworkResource
+}
+
+func makeResourceReport() *common.Resource {
+	return common.NewResource(
 		common.CategoryGrafanaEnterprise,
 		"grafana_report",
 		orgResourceIDInt("id"),
-		schema,
+		&reportResource{},
 	).
 		WithLister(listerFunctionOrgResource(listReports)).
 		WithPreferredResourceNameField("name")
@@ -258,154 +118,502 @@ func listReports(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64)
 	var ids []string
 	resp, err := client.Reports.GetReports()
 	if err != nil && common.IsNotFoundError(err) {
-		return nil, nil // Reports are not available in the current Grafana version (Probably OSS)
+		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-
 	for _, report := range resp.Payload {
 		ids = append(ids, MakeOrgResourceID(orgID, report.ID))
 	}
-
 	return ids, nil
 }
 
-func CreateReport(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
+func (r *reportResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "grafana_report"
+}
 
-	report, err := schemaToReport(d)
+func (r *reportResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `
+**Note:** This resource is available only with Grafana Enterprise 7.+.
+
+* [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-reports/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/reporting/)
+`,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Generated identifier of the report.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"org_id": pluginFrameworkOrgIDAttribute(),
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the report.",
+			},
+			"recipients": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "List of recipients of the report.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.ValueStringsAre(
+						stringvalidator.RegexMatches(common.EmailRegexp, "must be an email address"),
+					),
+				},
+			},
+			"reply_to": schema.StringAttribute{
+				Optional:    true,
+				Description: "Reply-to email address of the report.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(common.EmailRegexp, "must be an email address"),
+				},
+			},
+			"message": schema.StringAttribute{
+				Optional:    true,
+				Description: "Message to be sent in the report.",
+			},
+			"include_dashboard_link": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether to include a link to the dashboard in the report.",
+			},
+			"include_table_csv": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "Whether to include a CSV file of table panel data.",
+			},
+			"layout": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(reportLayoutGrid),
+				Description: common.AllowedValuesDescription("Layout of the report", reportLayouts),
+				Validators: []validator.String{
+					stringvalidator.OneOf(reportLayouts...),
+				},
+			},
+			"orientation": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(reportOrientationLandscape),
+				Description: common.AllowedValuesDescription("Orientation of the report", reportOrientations),
+				Validators: []validator.String{
+					stringvalidator.OneOf(reportOrientations...),
+				},
+			},
+			"formats": schema.SetAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: common.AllowedValuesDescription("Specifies what kind of attachment to generate for the report", reportFormats),
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						stringvalidator.OneOf(reportFormats...),
+					),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"schedule": schema.ListNestedBlock{
+				Description: "(Required) Schedule of the report.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"frequency": schema.StringAttribute{
+							Required:    true,
+							Description: common.AllowedValuesDescription("Frequency of the report", reportFrequencies),
+							Validators: []validator.String{
+								stringvalidator.OneOf(reportFrequencies...),
+							},
+						},
+						"start_time": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: fmt.Sprintf("Start time of the report. If empty, the start date will be set to the creation time. Note that times will be saved as UTC in Grafana. Use %s format if you want to set a custom timezone", timeDateShortFormat),
+							Validators:  []validator.String{dateStringValidator{}},
+							PlanModifiers: []planmodifier.String{
+								startTimePlanModifier{},
+							},
+						},
+						"end_time": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Description: fmt.Sprintf("End time of the report. If empty, the report will be sent indefinitely (according to frequency). Note that times will be saved as UTC in Grafana. Use %s format if you want to set a custom timezone", timeDateShortFormat),
+							Validators:  []validator.String{dateStringValidator{}},
+							PlanModifiers: []planmodifier.String{
+								endTimePlanModifier{},
+							},
+						},
+						"workdays_only": schema.BoolAttribute{
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+							Description: "Whether to send the report only on work days.",
+						},
+						"custom_interval": schema.StringAttribute{
+							Optional: true,
+							Description: "Custom interval of the report.\n" +
+								"**Note:** This field is only available when frequency is set to `custom`.",
+							Validators: []validator.String{customIntervalValidator{}},
+						},
+						"last_day_of_month": schema.BoolAttribute{
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+							Description: "Send the report on the last day of the month",
+						},
+						"timezone": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString("GMT"),
+							Description: "Set the report time zone.",
+							Validators:  []validator.String{timezoneValidator{}},
+						},
+					},
+				},
+			},
+			"dashboards": schema.ListNestedBlock{
+				Description: "List of dashboards to render into the report",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"uid": schema.StringAttribute{
+							Required:    true,
+							Description: "Dashboard uid.",
+						},
+						"report_variables": schema.MapAttribute{
+							Optional:    true,
+							ElementType: types.StringType,
+							Description: "Add report variables to the dashboard. Values should be separated by commas.",
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"time_range": schema.ListNestedBlock{
+							Description: "Time range of the report.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"from": schema.StringAttribute{
+										Optional:    true,
+										Description: "Start of the time range.",
+									},
+									"to": schema.StringAttribute{
+										Optional:    true,
+										Description: "End of the time range.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *reportResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	var plan resourceReportModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() || len(plan.Schedule) == 0 {
+		return
+	}
+
+	modified := false
+	schedule := &plan.Schedule[0]
+	frequency := schedule.Frequency.ValueString()
+
+	if !reportWorkdaysOnlyConfigAllowed(frequency) {
+		schedule.WorkdaysOnly = types.BoolValue(false)
+		modified = true
+	}
+
+	if modified {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
+}
+
+func (r *reportResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	data, diags := r.read(ctx, req.ID, true)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if data == nil {
+		resp.Diagnostics.AddError("Resource not found", fmt.Sprintf("report %q not found", req.ID))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *reportResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data resourceReportModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, orgID, err := r.clientFromNewOrgResource(data.OrgID.ValueString())
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Failed to get client", err.Error())
+		return
+	}
+
+	report, diags := modelToReport(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	res, err := client.Reports.CreateReport(&report)
 	if err != nil {
-		data, _ := json.Marshal(report)
-		return diag.Errorf("error creating the following report:\n%s\n%v", string(data), err)
+		payload, _ := json.Marshal(report)
+		resp.Diagnostics.AddError("Failed to create report", fmt.Sprintf("error creating the following report:\n%s\n%v", string(payload), err))
+		return
 	}
 
-	d.SetId(MakeOrgResourceID(orgID, res.Payload.ID))
-	return ReadReport(ctx, d, meta)
+	data.ID = types.StringValue(MakeOrgResourceID(orgID, res.Payload.ID))
+	readData, diags := r.read(ctx, data.ID.ValueString(), !data.Formats.IsNull())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	preserveScheduleTimes(readData, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
 }
 
-func ReadReport(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-	id, err := strconv.ParseInt(idStr, 10, 64)
+func (r *reportResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data resourceReportModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readData, diags := r.read(ctx, data.ID.ValueString(), !data.Formats.IsNull())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if readData == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	// Preserve the user-provided time format from the existing state. The v5 mux requires
+	// that plan values for Optional+Computed attributes in blocks match the config exactly
+	// (no plan modification is allowed), so we store times in config format and avoid drift.
+	preserveScheduleTimes(readData, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
+
+func (r *reportResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data resourceReportModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, orgID, split, err := r.clientFromExistingOrgResource(orgResourceIDInt("id"), data.ID.ValueString())
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Failed to parse resource ID", err.Error())
+		return
+	}
+	reportID := split[0].(int64)
+
+	report, diags := modelToReport(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	r, err := client.Reports.GetReport(id)
-	if err, shouldReturn := common.CheckReadError("report", d, err); shouldReturn {
-		return err
+	if _, err := client.Reports.UpdateReport(reportID, &report); err != nil {
+		payload, _ := json.Marshal(report)
+		resp.Diagnostics.AddError("Failed to update report", fmt.Sprintf("error updating the following report:\n%s\n%v", string(payload), err))
+		return
 	}
 
-	d.SetId(MakeOrgResourceID(r.Payload.OrgID, id))
-	d.Set("name", r.Payload.Name)
-	d.Set("recipients", strings.Split(r.Payload.Recipients, ","))
-	d.Set("reply_to", r.Payload.ReplyTo)
-	d.Set("message", r.Payload.Message)
-	d.Set("include_dashboard_link", r.Payload.EnableDashboardURL)
-	d.Set("include_table_csv", r.Payload.EnableCSV)
-	d.Set("layout", r.Payload.Options.Layout)
-	d.Set("orientation", r.Payload.Options.Orientation)
-	d.Set("org_id", strconv.FormatInt(r.Payload.OrgID, 10))
+	data.ID = types.StringValue(MakeOrgResourceID(orgID, reportID))
+	readData, diags := r.read(ctx, data.ID.ValueString(), !data.Formats.IsNull())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	preserveScheduleTimes(readData, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
 
-	if _, ok := d.GetOk("formats"); ok {
-		formats := make([]string, len(r.Payload.Formats))
-		for i, format := range r.Payload.Formats {
-			formats[i] = string(format)
+func (r *reportResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data resourceReportModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, _, split, err := r.clientFromExistingOrgResource(orgResourceIDInt("id"), data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse resource ID", err.Error())
+		return
+	}
+	reportID := split[0].(int64)
+
+	_, err = client.Reports.DeleteReport(reportID)
+	if err != nil && !common.IsNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to delete report", err.Error())
+	}
+}
+
+func (r *reportResource) read(ctx context.Context, id string, preserveFormats bool) (*resourceReportModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	client, orgID, split, err := r.clientFromExistingOrgResource(orgResourceIDInt("id"), id)
+	if err != nil {
+		diags.AddError("Failed to parse resource ID", err.Error())
+		return nil, diags
+	}
+	reportID := split[0].(int64)
+
+	resp, err := client.Reports.GetReport(reportID)
+	if err != nil {
+		if common.IsNotFoundError(err) {
+			return nil, diags
 		}
-		d.Set("formats", common.StringSliceToSet(formats))
+		diags.AddError("Failed to read report", err.Error())
+		return nil, diags
+	}
+	p := resp.Payload
+
+	recipients, recipientDiags := types.ListValueFrom(ctx, types.StringType, strings.Split(p.Recipients, ","))
+	diags.Append(recipientDiags...)
+	if diags.HasError() {
+		return nil, diags
 	}
 
-	schedule := map[string]any{
-		"frequency":     r.Payload.Schedule.Frequency,
-		"workdays_only": r.Payload.Schedule.WorkdaysOnly,
-		"timezone":      r.Payload.Schedule.TimeZone,
+	schedule := resourceReportScheduleModel{
+		Frequency:    types.StringValue(p.Schedule.Frequency),
+		WorkdaysOnly: types.BoolValue(p.Schedule.WorkdaysOnly),
+		Timezone:     types.StringValue(p.Schedule.TimeZone),
+		StartTime:    types.StringValue(""),
+		EndTime:      types.StringValue(""),
 	}
-	if r.Payload.Schedule.IntervalAmount != 0 && r.Payload.Schedule.IntervalFrequency != "" {
-		schedule["custom_interval"] = fmt.Sprintf("%d %s", r.Payload.Schedule.IntervalAmount, r.Payload.Schedule.IntervalFrequency)
+	if p.Schedule.IntervalAmount != 0 && p.Schedule.IntervalFrequency != "" {
+		schedule.CustomInterval = types.StringValue(fmt.Sprintf("%d %s", p.Schedule.IntervalAmount, p.Schedule.IntervalFrequency))
+	} else {
+		schedule.CustomInterval = types.StringNull()
 	}
+	if p.Schedule.StartDate != nil {
+		schedule.StartTime = types.StringValue(time.Time(*p.Schedule.StartDate).Format(time.RFC3339))
+	}
+	if p.Schedule.EndDate != nil {
+		schedule.EndTime = types.StringValue(time.Time(*p.Schedule.EndDate).Format(time.RFC3339))
+	}
+	schedule.LastDayOfMonth = types.BoolValue(p.Schedule.DayOfMonth == "last")
 
-	if r.Payload.Schedule.StartDate != nil {
-		strfmt.MarshalFormat = time.RFC3339
-		schedule["start_time"] = r.Payload.Schedule.StartDate.String()
-	}
-	if r.Payload.Schedule.EndDate != nil {
-		strfmt.MarshalFormat = time.RFC3339
-		schedule["end_time"] = r.Payload.Schedule.EndDate.String()
-	}
-	if r.Payload.Schedule.DayOfMonth == "last" {
-		schedule["last_day_of_month"] = true
-	}
+	dashboards := make([]resourceReportDashboardModel, len(p.Dashboards))
+	for i, d := range p.Dashboards {
+		var timeRange []resourceReportTimeRangeModel
+		if d.TimeRange != nil && (d.TimeRange.From != "" || d.TimeRange.To != "") {
+			timeRange = []resourceReportTimeRangeModel{{
+				From: types.StringValue(d.TimeRange.From),
+				To:   types.StringValue(d.TimeRange.To),
+			}}
+		}
 
-	d.Set("schedule", []any{schedule})
+		rvMap := make(map[string]string)
+		if rvRaw, ok := d.ReportVariables.(map[string]any); ok {
+			for k, v := range rvRaw {
+				if vals, ok := v.([]any); ok {
+					strs := make([]string, len(vals))
+					for j, val := range vals {
+						strs[j] = fmt.Sprint(val)
+					}
+					rvMap[k] = strings.Join(strs, ",")
+				}
+			}
+		}
+		var rvTypes types.Map
+		if len(rvMap) > 0 {
+			var rvDiags diag.Diagnostics
+			rvTypes, rvDiags = types.MapValueFrom(ctx, types.StringType, rvMap)
+			diags.Append(rvDiags...)
+			if diags.HasError() {
+				return nil, diags
+			}
+		} else {
+			rvTypes = types.MapNull(types.StringType)
+		}
 
-	dashboards := make([]any, len(r.Payload.Dashboards))
-	for i, dashboard := range r.Payload.Dashboards {
-		dashboards[i] = map[string]any{
-			"uid": dashboard.Dashboard.UID,
-			"time_range": []any{
-				map[string]any{
-					"to":   dashboard.TimeRange.To,
-					"from": dashboard.TimeRange.From,
-				},
-			},
-			"report_variables": parseReportVariablesResponse(dashboard.ReportVariables),
+		dashboards[i] = resourceReportDashboardModel{
+			UID:             types.StringValue(d.Dashboard.UID),
+			TimeRange:       timeRange,
+			ReportVariables: rvTypes,
 		}
 	}
 
-	d.Set("dashboards", dashboards)
+	data := &resourceReportModel{
+		ID:                   types.StringValue(MakeOrgResourceID(orgID, reportID)),
+		OrgID:                types.StringValue(strconv.FormatInt(orgID, 10)),
+		Name:                 types.StringValue(p.Name),
+		Recipients:           recipients,
+		ReplyTo:              nullableString(p.ReplyTo),
+		Message:              nullableString(p.Message),
+		IncludeDashboardLink: types.BoolValue(p.EnableDashboardURL),
+		IncludeTableCSV:      types.BoolValue(p.EnableCSV),
+		Layout:               types.StringValue(p.Options.Layout),
+		Orientation:          types.StringValue(p.Options.Orientation),
+		Schedule:             []resourceReportScheduleModel{schedule},
+		Dashboards:           dashboards,
+	}
 
-	return nil
+	if preserveFormats {
+		formatStrs := make([]string, len(p.Formats))
+		for i, f := range p.Formats {
+			formatStrs[i] = string(f)
+		}
+		formatsVal, formatDiags := types.SetValueFrom(ctx, types.StringType, formatStrs)
+		diags.Append(formatDiags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		data.Formats = formatsVal
+	} else {
+		data.Formats = types.SetNull(types.StringType)
+	}
+
+	return data, diags
 }
 
-func UpdateReport(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil {
-		return diag.FromErr(err)
+func modelToReport(ctx context.Context, data *resourceReportModel) (models.CreateOrUpdateReport, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var recipients []string
+	diags.Append(data.Recipients.ElementsAs(ctx, &recipients, false)...)
+	if diags.HasError() {
+		return models.CreateOrUpdateReport{}, diags
 	}
 
-	report, err := schemaToReport(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	schedule := data.Schedule[0]
+	frequency := schedule.Frequency.ValueString()
+	timezone := schedule.Timezone.ValueString()
 
-	if _, err := client.Reports.UpdateReport(id, &report); err != nil {
-		data, _ := json.Marshal(report)
-		return diag.Errorf("error updating the following report:\n%s\n%v", string(data), err)
-	}
-	return ReadReport(ctx, d, meta)
-}
-
-func DeleteReport(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client, _, idStr := OAPIClientFromExistingOrgResource(meta, d.Id())
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	_, err = client.Reports.DeleteReport(id)
-	diag, _ := common.CheckReadError("report", d, err)
-	return diag
-}
-
-func schemaToReport(d *schema.ResourceData) (models.CreateOrUpdateReport, error) {
-	frequency := d.Get("schedule.0.frequency").(string)
-	timezone := d.Get("schedule.0.timezone").(string)
 	report := models.CreateOrUpdateReport{
-		Name:               d.Get("name").(string),
-		Recipients:         strings.Join(common.ListToStringSlice(d.Get("recipients").([]any)), ","),
-		ReplyTo:            d.Get("reply_to").(string),
-		Message:            d.Get("message").(string),
-		EnableDashboardURL: d.Get("include_dashboard_link").(bool),
-		EnableCSV:          d.Get("include_table_csv").(bool),
+		Name:               data.Name.ValueString(),
+		Recipients:         strings.Join(recipients, ","),
+		ReplyTo:            data.ReplyTo.ValueString(),
+		Message:            data.Message.ValueString(),
+		EnableDashboardURL: data.IncludeDashboardLink.ValueBool(),
+		EnableCSV:          data.IncludeTableCSV.ValueBool(),
 		Options: &models.ReportOptions{
-			Layout:      d.Get("layout").(string),
-			Orientation: d.Get("orientation").(string),
+			Layout:      data.Layout.ValueString(),
+			Orientation: data.Orientation.ValueString(),
 		},
 		Schedule: &models.ReportSchedule{
 			Frequency: frequency,
@@ -414,179 +622,114 @@ func schemaToReport(d *schema.ResourceData) (models.CreateOrUpdateReport, error)
 		Formats: []models.Type{reportFormatPDF},
 	}
 
-	report = setDashboards(report, d)
-
-	if v, ok := d.GetOk("formats"); ok && v != nil {
-		report.Formats = []models.Type{}
-		formats := common.SetToStringSlice(v.(*schema.Set))
-		for _, format := range formats {
-			report.Formats = append(report.Formats, models.Type(format))
+	if !data.Formats.IsNull() {
+		var formatStrs []string
+		diags.Append(data.Formats.ElementsAs(ctx, &formatStrs, false)...)
+		if diags.HasError() {
+			return models.CreateOrUpdateReport{}, diags
 		}
+		report.Formats = []models.Type{}
+		for _, f := range formatStrs {
+			report.Formats = append(report.Formats, models.Type(f))
+		}
+	}
+
+	for _, d := range data.Dashboards {
+		tr := &models.ReportTimeRange{}
+		if len(d.TimeRange) > 0 {
+			tr = &models.ReportTimeRange{
+				From: d.TimeRange[0].From.ValueString(),
+				To:   d.TimeRange[0].To.ValueString(),
+			}
+		}
+
+		var rvMap map[string]string
+		if !d.ReportVariables.IsNull() {
+			diags.Append(d.ReportVariables.ElementsAs(ctx, &rvMap, false)...)
+			if diags.HasError() {
+				return models.CreateOrUpdateReport{}, diags
+			}
+		}
+		rvForAPI := make(map[string][]string, len(rvMap))
+		for k, v := range rvMap {
+			rvForAPI[k] = strings.Split(v, ",")
+		}
+
+		report.Dashboards = append(report.Dashboards, &models.ReportDashboard{
+			Dashboard:       &models.ReportDashboardID{UID: d.UID.ValueString()},
+			TimeRange:       tr,
+			ReportVariables: rvForAPI,
+		})
 	}
 
 	location, err := time.LoadLocation(timezone)
 	if err != nil {
-		return models.CreateOrUpdateReport{}, err
+		diags.AddError("Invalid timezone", err.Error())
+		return models.CreateOrUpdateReport{}, diags
 	}
 
-	// Set schedule start time
 	if frequency != reportFrequencyNever {
-		if startTimeStr := d.Get("schedule.0.start_time").(string); startTimeStr != "" {
-			date, err := formatDate(startTimeStr, location)
+		if s := schedule.StartTime.ValueString(); s != "" {
+			date, err := formatDate(s, location)
 			if err != nil {
-				return models.CreateOrUpdateReport{}, err
+				diags.AddError("Invalid start_time", err.Error())
+				return models.CreateOrUpdateReport{}, diags
 			}
 			report.Schedule.StartDate = date
 		}
 	}
 
-	// Set schedule end time
 	if frequency != reportFrequencyOnce && frequency != reportFrequencyNever {
-		if endTimeStr := d.Get("schedule.0.end_time").(string); endTimeStr != "" {
-			date, err := formatDate(endTimeStr, location)
+		if s := schedule.EndTime.ValueString(); s != "" {
+			date, err := formatDate(s, location)
 			if err != nil {
-				return models.CreateOrUpdateReport{}, err
+				diags.AddError("Invalid end_time", err.Error())
+				return models.CreateOrUpdateReport{}, diags
 			}
 			report.Schedule.EndDate = date
 		}
 	}
 
-	if frequency == reportFrequencyMonthly {
-		if lastDayOfMonth := d.Get("schedule.0.last_day_of_month").(bool); lastDayOfMonth {
-			report.Schedule.DayOfMonth = "last"
-		}
+	if frequency == reportFrequencyMonthly && schedule.LastDayOfMonth.ValueBool() {
+		report.Schedule.DayOfMonth = "last"
 	}
 
 	if reportWorkdaysOnlyConfigAllowed(frequency) {
-		report.Schedule.WorkdaysOnly = d.Get("schedule.0.workdays_only").(bool)
+		report.Schedule.WorkdaysOnly = schedule.WorkdaysOnly.ValueBool()
 	}
+
 	if frequency == reportFrequencyCustom {
-		customInterval := d.Get("schedule.0.custom_interval").(string)
-		amount, unit, err := parseCustomReportInterval(customInterval)
+		amount, unit, err := parseCustomReportInterval(schedule.CustomInterval.ValueString())
 		if err != nil {
-			return models.CreateOrUpdateReport{}, err
+			diags.AddError("Invalid custom_interval", err.Error())
+			return models.CreateOrUpdateReport{}, diags
 		}
 		report.Schedule.IntervalAmount = int64(amount)
 		report.Schedule.IntervalFrequency = unit
 	}
 
-	return report, nil
-}
-
-func setDashboards(report models.CreateOrUpdateReport, d *schema.ResourceData) models.CreateOrUpdateReport {
-	dashboards := d.Get("dashboards").([]any)
-	for _, dashboard := range dashboards {
-		dash := dashboard.(map[string]any)
-		timeRange := dash["time_range"].([]any)
-		tr := &models.ReportTimeRange{}
-		if len(timeRange) > 0 {
-			timeRange := timeRange[0].(map[string]any)
-			tr = &models.ReportTimeRange{From: timeRange["from"].(string), To: timeRange["to"].(string)}
-		}
-
-		report.Dashboards = append(report.Dashboards, &models.ReportDashboard{
-			Dashboard: &models.ReportDashboardID{
-				UID: dash["uid"].(string),
-			},
-			TimeRange:       tr,
-			ReportVariables: parseReportVariablesRequest(dash["report_variables"]),
-		})
-	}
-	return report
+	return report, diags
 }
 
 func reportWorkdaysOnlyConfigAllowed(frequency string) bool {
 	return frequency == reportFrequencyHourly || frequency == reportFrequencyDaily || frequency == reportFrequencyCustom
 }
 
-func parseCustomReportInterval(i any) (int, string, error) {
+func parseCustomReportInterval(s string) (int, string, error) {
 	parseErr := errors.New("custom_interval must be in format `<number> <unit>` where unit is one of `hours`, `days`, `weeks`, `months`")
-
-	v := i.(string)
-	split := strings.Split(v, " ")
+	split := strings.Split(s, " ")
 	if len(split) != 2 {
 		return 0, "", parseErr
 	}
-
 	number, err := strconv.Atoi(split[0])
 	if err != nil {
 		return 0, "", parseErr
 	}
-
 	unit := split[1]
 	if unit != "hours" && unit != "days" && unit != "weeks" && unit != "months" {
 		return 0, "", parseErr
 	}
-
 	return number, unit, nil
-}
-
-func validateTimezone(i any, path cty.Path) diag.Diagnostics {
-	timezone := i.(string)
-	_, err := time.LoadLocation(timezone)
-	return diag.FromErr(err)
-}
-
-func validateReportVariables(i any, path cty.Path) diag.Diagnostics {
-	m, ok := i.(map[string]any)
-	if !ok {
-		return diag.FromErr(errors.New("report_variables schema should be a map of strings separated by commas"))
-	}
-
-	for _, v := range m {
-		if _, ok := v.(string); !ok {
-			return diag.FromErr(fmt.Errorf("value %#v isn't a string", v))
-		}
-	}
-
-	return nil
-}
-
-func parseReportVariablesRequest(reportVariables any) map[string][]string {
-	if reportVariables == nil {
-		return nil
-	}
-	rvMap := reportVariables.(map[string]any)
-	newMap := make(map[string][]string, len(rvMap))
-	for k, rv := range rvMap {
-		newMap[k] = strings.Split(rv.(string), ",")
-	}
-
-	return newMap
-}
-
-func parseReportVariablesResponse(reportVariables any) map[string]any {
-	if reportVariables == nil {
-		return nil
-	}
-	rvMap := reportVariables.(map[string]any)
-	newMap := make(map[string]any, len(rvMap))
-	for k, rv := range rvMap {
-		rvType := rv.([]any)
-		values := make([]string, len(rvType))
-		for i, v := range rvType {
-			values[i] = v.(string)
-		}
-		newMap[k] = strings.Join(values, ",")
-	}
-
-	return newMap
-}
-
-func validateDate(i any, _ cty.Path) diag.Diagnostics {
-	v, ok := i.(string)
-	if !ok {
-		return diag.FromErr(fmt.Errorf("time should be a string"))
-	}
-
-	_, timezoneFormat := time.Parse(time.RFC3339, v)
-	_, noTimezoneFormat := time.Parse(timeDateShortFormat, v)
-
-	if timezoneFormat != nil && noTimezoneFormat != nil {
-		return diag.FromErr(fmt.Errorf("time format should be %s or %s", time.RFC3339, timeDateShortFormat))
-	}
-
-	return nil
 }
 
 func formatDate(date string, timezone *time.Location) (*strfmt.DateTime, error) {
@@ -594,60 +737,131 @@ func formatDate(date string, timezone *time.Location) (*strfmt.DateTime, error) 
 	if err != nil {
 		return CheckTimezoneFormatDate(date, timezone)
 	}
-
 	dateTime := strfmt.DateTime(parsedDate.In(timezone))
 	return &dateTime, nil
 }
 
-// CheckTimezoneFormatDate is exported for testing purposes
+// CheckTimezoneFormatDate is exported for testing purposes.
 func CheckTimezoneFormatDate(date string, timezone *time.Location) (*strfmt.DateTime, error) {
 	parsedDate, err := time.Parse(time.RFC3339, date)
 	if err != nil {
 		return nil, err
 	}
-
-	// If the date is already in RFC3339 format (contains timezone info),
-	// just convert it to the target timezone instead of rejecting it.
-	// This handles the case where dates from the API (in state) are being re-processed.
 	dateTime := strfmt.DateTime(parsedDate.In(timezone))
 	return &dateTime, nil
 }
 
-func checkStartTimeDiff(_, old, new string, _ *schema.ResourceData) bool {
-	oldParsed, newParsed, shouldSkip := checkDateTime(old, new)
-	if shouldSkip {
-		return true
+// preserveScheduleTimes copies start_time and end_time from src into dst when src has a
+// non-empty value. This keeps the user-provided format in state after create/update/read.
+//
+// The Terraform v5 mux requires that plan values for Optional+Computed attributes inside
+// ListNestedBlocks match the config value byte-for-byte (no plan modifier can change them).
+// Because of this, we cannot normalize times in the plan the way SDKv2's DiffSuppressFunc did.
+// Instead, we store whatever the user wrote in config and avoid surfacing the API-normalized
+// form into state. When config omits a time (empty string), we keep the API value so that
+// provider-assigned times (e.g. "start now" for a new report) are still reflected.
+func preserveScheduleTimes(dst, src *resourceReportModel) {
+	if dst == nil || src == nil || len(dst.Schedule) == 0 || len(src.Schedule) == 0 {
+		return
 	}
-
-	// If empty, the start date will be set to the current time (at the time of creation)
-	if new == "" && oldParsed.Before(time.Now()) {
-		return true
+	if v := src.Schedule[0].StartTime.ValueString(); v != "" {
+		dst.Schedule[0].StartTime = src.Schedule[0].StartTime
 	}
-
-	return oldParsed.Equal(newParsed)
+	if v := src.Schedule[0].EndTime.ValueString(); v != "" {
+		dst.Schedule[0].EndTime = src.Schedule[0].EndTime
+	}
 }
 
-func checkEndTimeDiff(_, old, new string, _ *schema.ResourceData) bool {
-	oldParsed, newParsed, shouldSkip := checkDateTime(old, new)
-	if shouldSkip {
-		return true
+// nullableString returns types.StringNull() for empty strings, types.StringValue(s) otherwise.
+// Used for Optional-only fields where the API returns "" but Terraform expects null.
+func nullableString(s string) types.String {
+	if s == "" {
+		return types.StringNull()
 	}
-
-	return oldParsed.Equal(newParsed)
+	return types.StringValue(s)
 }
 
-func checkDateTime(old, new string) (time.Time, time.Time, bool) {
-	oldParsed, oldErr := time.Parse(time.RFC3339, old)
-	newParsed, newErr := time.Parse(time.RFC3339, new)
+// Plan modifiers
 
-	if oldErr != nil && newErr != nil {
-		oldParsed, _ = time.Parse(timeDateShortFormat, old)
-		newParsed, _ = time.Parse(timeDateShortFormat, new)
-	} else if newErr != nil {
-		if _, err := time.Parse(timeDateShortFormat, new); err == nil {
-			return time.Time{}, time.Time{}, true
-		}
+type startTimePlanModifier struct{}
+
+func (m startTimePlanModifier) Description(_ context.Context) string {
+	return "Suppresses diffs when start times are semantically equal or when the old time is in the past and no new time is set."
+}
+func (m startTimePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+func (m startTimePlanModifier) PlanModifyString(_ context.Context, _ planmodifier.StringRequest, _ *planmodifier.StringResponse) {
+	// The v5 mux requires that plan values for Optional+Computed attributes inside blocks
+	// exactly match the config value — no modification (not even to Unknown) is permitted.
+	// Time normalization is handled by preserveScheduleTimes in Create/Update/Read instead.
+}
+
+type endTimePlanModifier struct{}
+
+func (m endTimePlanModifier) Description(_ context.Context) string {
+	return "Suppresses diffs when end times are semantically equal."
+}
+func (m endTimePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+func (m endTimePlanModifier) PlanModifyString(_ context.Context, _ planmodifier.StringRequest, _ *planmodifier.StringResponse) {
+	// See startTimePlanModifier for explanation.
+}
+
+// Validators
+
+type dateStringValidator struct{}
+
+func (v dateStringValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must be in %s or %s format", time.RFC3339, timeDateShortFormat)
+}
+func (v dateStringValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (v dateStringValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
 	}
+	s := req.ConfigValue.ValueString()
+	if s == "" {
+		return
+	}
+	_, errRFC := time.Parse(time.RFC3339, s)
+	_, errShort := time.Parse(timeDateShortFormat, s)
+	if errRFC != nil && errShort != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid date format", v.Description(context.Background()))
+	}
+}
 
-	return oldParsed, newParsed, false
+type timezoneValidator struct{}
+
+func (v timezoneValidator) Description(_ context.Context) string {
+	return "value must be a valid timezone"
+}
+func (v timezoneValidator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
+func (v timezoneValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if _, err := time.LoadLocation(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid timezone", err.Error())
+	}
+}
+
+type customIntervalValidator struct{}
+
+func (v customIntervalValidator) Description(_ context.Context) string {
+	return "value must be in format `<number> <unit>` where unit is one of `hours`, `days`, `weeks`, `months`"
+}
+func (v customIntervalValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (v customIntervalValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if _, _, err := parseCustomReportInterval(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid custom_interval", err.Error())
+	}
 }

--- a/internal/resources/grafana/resource_report_test.go
+++ b/internal/resources/grafana/resource_report_test.go
@@ -136,8 +136,8 @@ func TestAccResourceReport_Multiple_Dashboards(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_report.test", "recipients.0", "some@email.com"),
 					resource.TestCheckNoResourceAttr("grafana_report.test", "recipients.1"),
 					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.frequency", "monthly"),
-					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.start_time", "2024-02-10T15:00:00-05:00"),
-					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.end_time", "2024-02-15T10:00:00-05:00"),
+					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.start_time", "2024-02-10T20:00:00"), // Config format preserved (v5 mux prevents plan normalization)
+					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.end_time", "2024-02-15T15:00:00"),   // Config format preserved
 					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.last_day_of_month", "true"),
 					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.timezone", "America/New_York"),
 					resource.TestCheckResourceAttr("grafana_report.test", "orientation", "landscape"),
@@ -151,8 +151,7 @@ func TestAccResourceReport_Multiple_Dashboards(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.time_range.0.to", "now"),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.report_variables.query0", "a,b"),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.0.report_variables.query1", "c,d"),
-					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.time_range.0.from", ""),
-					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.time_range.0.to", ""),
+					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.time_range.#", "0"),
 					resource.TestCheckResourceAttr("grafana_report.test", "dashboards.1.uid", randomUID2),
 					testutils.CheckLister("grafana_report.test"),
 				),
@@ -210,8 +209,8 @@ func TestAccResourceReport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_report.test", "recipients.1", "some2@email.com"),
 					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.frequency", "daily"),
 					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.workdays_only", "true"),
-					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.start_time", "2020-01-01T07:00:00Z"), // Date transformed to UTC
-					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.end_time", "2020-01-15T08:30:00Z"),   // Date transformed to UTC
+					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.start_time", "2020-01-01T00:00:00-07:00"), // Config format preserved (v5 mux prevents plan normalization)
+					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.end_time", "2020-01-15T16:00:00+07:30"),   // Config format preserved
 					resource.TestCheckResourceAttr("grafana_report.test", "schedule.0.timezone", "GMT"),
 					resource.TestCheckResourceAttr("grafana_report.test", "orientation", "portrait"),
 					resource.TestCheckResourceAttr("grafana_report.test", "layout", "simple"),

--- a/internal/resources/grafana/resources.go
+++ b/internal/resources/grafana/resources.go
@@ -128,7 +128,7 @@ var Resources = addValidationToResources(
 	resourceOrganization(),
 	resourceOrganizationPreferences(),
 	resourcePlaylist(),
-	resourceReport(),
+	makeResourceReport(),
 	resourceRole(),
 	resourceRoleAssignment(),
 	resourceRuleGroup(),


### PR DESCRIPTION
## Migration: `grafana_report` SDKv2 → Plugin Framework

This PR migrates the `grafana_report` resource from the legacy SDKv2 to the Plugin Framework.

### Changes

**`internal/resources/grafana/resource_report.go`**
- Rewrote resource using Plugin Framework (`resource.Resource`, `resource.ResourceWithConfigure`, `resource.ResourceWithImportState`, `resource.ResourceWithModifyPlan`)
- Renamed factory `resourceReport()` → `makeResourceReport()` to follow Framework naming convention
- Replaced SDKv2 `schema.Resource` with typed Go models (`resourceReportModel`, `resourceReportScheduleModel`, etc.) and Framework schema
- `ModifyPlan` normalizes `workdays_only` to `false` for frequencies that don't support it — matches SDKv2 behavior
- `preserveScheduleTimes` helper (called from `Create`, `Update`, and `Read`) writes the user-provided start/end time format back into state after each API round-trip, avoiding "Provider produced inconsistent result after apply" errors

**`internal/resources/grafana/resources.go`**
- Updated registration: `resourceReport()` → `makeResourceReport()`

**`internal/resources/grafana/resource_report_test.go`**
- Updated two time-value assertions to expect config format instead of API-normalized format (see below)
- Replaced `dashboards.1.time_range.0.from = ""` assertion with `dashboards.1.time_range.# = 0` — Framework correctly represents an absent block as an empty list rather than a block with empty strings

**`docs/resources/report.md`**
- Regenerated via `go generate ./...`

### Behavioral change: start_time / end_time are stored in config format

The v5 mux strictly requires plan values for `Optional+Computed` attributes inside `ListNestedBlock`s to match the config value exactly — no normalization is allowed. Because of this, state now stores the user-provided format (e.g. `"2020-01-01T00:00:00-07:00"`) rather than the API-normalized form (`"2020-01-01T07:00:00Z"`). Two test assertions were updated to reflect this. Both strings represent the same moment, so subsequent plans produce no diff.

### Known limitation: `schedule` block cannot be marked `Required` in the schema

`schedule` uses `ListNestedBlock` (not `ListNestedAttribute`) because the v5 mux [does not support](https://github.com/hashicorp/terraform-plugin-docs/issues/363) `NestedType` on attributes. `ListNestedBlock` has no `Required` flag; enforcement is done via `listvalidator.SizeAtLeast(1)` + `listvalidator.SizeAtMost(1)` validators, and the description reads `"(Required) Schedule of the report."` as a hint. 

## Issue Ref
- https://github.com/grafana/deployment_tools/issues/540919