### PR TITLE
maint: Update CODEOWNERS and catalogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,29 +8,29 @@
 /internal/resources/grafana/*_organization_user*               @grafana/identity-squad
 /internal/resources/grafana/resource_dashboard_public*         @grafana/grafana-operator-experience-squad
 /internal/resources/grafana/resource_dashboard_permission*     @grafana/access-squad
-# /internal/resources/grafana/resource_dashboard.go              @grafana/dashboards-squad  # unknown team handle
-# /internal/resources/grafana/*data_source_cache*                @grafana/grafana-operator-experience-squad  # unknown team handle
+/internal/resources/grafana/resource_dashboard.go              @grafana/dashboards-squad
+/internal/resources/grafana/*data_source_cache*                @grafana/grafana-operator-experience-squad
 /internal/resources/grafana/*data_source_permission*           @grafana/access-squad
 /internal/resources/grafana/*data_source_config_lbac*          @grafana/access-squad
-# /internal/resources/grafana/resource_data_source.go            @grafana/data-sources  # unknown team handle
-# /internal/resources/grafana/resource_data_source_config.go     @grafana/data-sources  # unknown team handle
+/internal/resources/grafana/resource_data_source.go            @grafana/data-sources
+/internal/resources/grafana/resource_data_source_config.go     @grafana/data-sources
 /internal/resources/grafana/*folder_permission*                @grafana/access-squad
-# /internal/resources/grafana/resource_folder*                   @grafana/grafana-search-and-storage  # unknown team handle
-# /internal/resources/grafana/resource_annotation*               @grafana/grafana-search-and-storage  # unknown team handle
-# /internal/resources/grafana/*library_panel*                    @grafana/dataviz-squad  # unknown team handle
+/internal/resources/grafana/resource_folder*                   @grafana/grafana-search-and-storage
+/internal/resources/grafana/resource_annotation*               @grafana/grafana-search-and-storage
+/internal/resources/grafana/*library_panel*                    @grafana/dataviz-squad
 /internal/resources/grafana/*organization*                     @grafana/access-squad
-# /internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad  # unknown team handle
-# /internal/resources/grafana/resource_report*                   @grafana/sharing-squad  # unknown team handle
+/internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad
+/internal/resources/grafana/resource_report*                   @grafana/sharing-squad
 /internal/resources/grafana/*role*                             @grafana/access-squad
 /internal/resources/grafana/resource_team*                     @grafana/access-squad
 /internal/resources/grafana/*service_account*                  @grafana/identity-squad
 /internal/resources/grafana/*sso*                              @grafana/identity-squad
 /internal/resources/grafana/*scim*                             @grafana/identity-squad
 /internal/resources/grafana/resource_user*                     @grafana/identity-squad
-# /internal/resources/grafana/data_source_dashboard*             @grafana/dashboards-squad  # unknown team handle
-# /internal/resources/grafana/data_source_data_source*           @grafana/data-sources  # unknown team handle
-# /internal/resources/grafana/data_source_folder*                @grafana/grafana-search-and-storage  # unknown team handle
-# /internal/resources/grafana/data_source_library_panel*         @grafana/dataviz-squad  # unknown team handle
+/internal/resources/grafana/data_source_dashboard*             @grafana/dashboards-squad
+/internal/resources/grafana/data_source_data_source*           @grafana/data-sources
+/internal/resources/grafana/data_source_folder*                @grafana/grafana-search-and-storage
+/internal/resources/grafana/data_source_library_panel*         @grafana/dataviz-squad
 /internal/resources/grafana/data_source_organization*          @grafana/access-squad
 /internal/resources/grafana/data_source_role*                  @grafana/access-squad
 /internal/resources/grafana/data_source_service_account*       @grafana/identity-squad
@@ -40,8 +40,8 @@
 # internal/resources/cloud
 /internal/resources/cloud/*_access_policy_*                    @grafana/identity-squad
 /internal/resources/cloud/*org_member*                         @grafana/identity-squad
-# /internal/resources/cloud/*plugin_installation*                @grafana/plugins-platform-backend  # unknown team handle
-# /internal/resources/cloud/*private_data_source_connect*        @grafana/grafana-datasources-core-services  # unknown team handle
+/internal/resources/cloud/*plugin_installation*                @grafana/plugins-platform-backend
+/internal/resources/cloud/*private_data_source_connect*        @grafana/grafana-datasources-core-services
 /internal/resources/cloud/*k6_installation*                    @grafana/k6-cloud-provisioning
 /internal/resources/cloud/*synthetic_monitoring_installation*  @grafana/synthetic-monitoring
 /internal/resources/cloud/*stack_service_account*              @grafana/identity-squad
@@ -53,15 +53,15 @@
 /internal/resources/appplatform/*inhibitionrule*               @grafana/alerting-squad
 /internal/resources/appplatform/*alertrule*                    @grafana/alerting-squad
 /internal/resources/appplatform/*recordingrule*                @grafana/alerting-squad
-# /internal/resources/appplatform/*appo11yconfig*                @grafana/app-o11y  # unknown team handle
-# /internal/resources/appplatform/*k8so11yconfig*                @grafana/app-o11y  # unknown team handle
-# /internal/resources/appplatform/*secret*                       @grafana/grafana-operator-experience-squad  # unknown team handle
+/internal/resources/appplatform/*appo11yconfig*                @grafana/app-o11y-visualizations
+/internal/resources/appplatform/*k8so11yconfig*                @grafana/app-o11y-visualizations
+/internal/resources/appplatform/*secret*                       @grafana/grafana-operator-experience-squad
 /internal/resources/appplatform/*                              @grafana/grafana-app-platform-squad
 
 # Other packages
-# /internal/resources/asserts/*                                  @grafana/asserts  # unknown team handle
-# /internal/resources/cloudprovider/*                            @grafana/middleware-apps  # unknown team handle
-# /internal/resources/connections/*                              @grafana/middleware-apps  # unknown team handle
+/internal/resources/asserts/*                                  @grafana/asserts-team
+/internal/resources/cloudprovider/*                            @grafana/o11y-apps-backend
+/internal/resources/connections/*                              @grafana/o11y-apps-backend
 /internal/resources/fleetmanagement/*                          @grafana/fleet-management-backend
 /internal/resources/frontendo11y/*                             @grafana/frontend-o11y
 /internal/resources/k6/*                                       @grafana/k6-cloud-provisioning

--- a/internal/resources/appplatform/catalog-resource.yaml
+++ b/internal/resources/appplatform/catalog-resource.yaml
@@ -152,7 +152,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:backstage-catalog/app-o11y
+  owner: group:default/app-o11y-visualizations
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -204,5 +204,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:backstage-catalog/app-o11y
+  owner: group:default/app-o11y-visualizations
   lifecycle: production

--- a/internal/resources/cloudprovider/catalog-data-source.yaml
+++ b/internal/resources/cloudprovider/catalog-data-source.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -22,7 +22,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -35,7 +35,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -48,5 +48,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production

--- a/internal/resources/cloudprovider/catalog-resource.yaml
+++ b/internal/resources/cloudprovider/catalog-resource.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -22,7 +22,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -35,7 +35,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -48,5 +48,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production

--- a/internal/resources/connections/catalog-data-source.yaml
+++ b/internal/resources/connections/catalog-data-source.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production

--- a/internal/resources/connections/catalog-resource.yaml
+++ b/internal/resources/connections/catalog-resource.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/middleware-apps
+  owner: group:default/o11y-apps-backend
   lifecycle: production


### PR DESCRIPTION
### Changes Made

- **`.github/CODEOWNERS`**: Uncomment 16 entries that were disabled due to unknown team handles; use correct/current handles:
  - `@grafana/app-o11y` → `@grafana/app-o11y-visualizations` (appplatform)
  - `@grafana/middleware-apps` → `@grafana/o11y-apps-backend` (cloudprovider, connections)
<img width="388" height="71" alt="image" src="https://github.com/user-attachments/assets/565624f0-5288-4eea-8cb2-2cf2aa015bd1" />

  - `@grafana/asserts` → `@grafana/asserts-team`
  - All other previously-unknown handles confirmed and uncommented

- **`internal/resources/appplatform/catalog-resource.yaml`**: Update owner from `group:backstage-catalog/app-o11y` → `group:default/app-o11y-visualizations`

- **`internal/resources/cloudprovider/catalog-*.yaml`** and
  **`internal/resources/connections/catalog-*.yaml`**: Update owner from `group:default/middleware-apps` → `group:default/o11y-apps-backend`

Follow-up to: https://github.com/grafana/terraform-provider-grafana/pull/2603