### PR TITLE
Update CODEOWNERS for grafana_report

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 /internal/resources/grafana/*library_panel*                    @grafana/dataviz-squad
 /internal/resources/grafana/*organization*                     @grafana/access-squad
 /internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad
-/internal/resources/grafana/resource_report*                   @grafana/sharing-squad
+/internal/resources/grafana/resource_report*                   @grafana/operator-experience-squad
 /internal/resources/grafana/*role*                             @grafana/access-squad
 /internal/resources/grafana/resource_team*                     @grafana/access-squad
 /internal/resources/grafana/*service_account*                  @grafana/identity-squad

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -295,7 +295,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/sharing-squad
+  owner: group:default/operator-experience-squad
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
**Changes Made**
- Updates the ownership of the `grafana_report` resource to `grafana/operator-experience-squad`
- [slack ref](https://raintank-corp.slack.com/archives/C05PEHHJTC5/p1775571324767349)