### PR TITLE
fix(sm): Add validation for private probe labels

### DIFF
--- a/docs/resources/synthetic_monitoring_probe.md
+++ b/docs/resources/synthetic_monitoring_probe.md
@@ -47,7 +47,7 @@ resource "grafana_synthetic_monitoring_probe" "main" {
 
 - `disable_browser_checks` (Boolean) Disables browser checks for this probe. Defaults to `false`.
 - `disable_scripted_checks` (Boolean) Disables scripted checks for this probe. Defaults to `false`.
-- `labels` (Map of String) Custom labels to be included with collected metrics and logs.
+- `labels` (Map of String) Custom labels to be included with collected metrics and logs. The maximum number of labels for private probes is 3.
 - `public` (Boolean) Public probes are run by Grafana Labs and can be used by all users. Only Grafana Labs managed public probes will be set to `true`. Defaults to `false`.
 
 ### Read-Only

--- a/internal/resources/syntheticmonitoring/resource_probe.go
+++ b/internal/resources/syntheticmonitoring/resource_probe.go
@@ -78,7 +78,7 @@ Grafana Synthetic Monitoring Agent.
 				Required:    true,
 			},
 			"labels": {
-				Description: "Custom labels to be included with collected metrics and logs.",
+				Description: fmt.Sprintf("Custom labels to be included with collected metrics and logs. The maximum number of labels for private probes is %d.", sm.MaxProbeLabels),
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Elem: &schema.Schema{
@@ -147,7 +147,26 @@ func listProbes(ctx context.Context, client *common.Client, data any) ([]string,
 	return ids, nil
 }
 
+// ValidateProbeLabels checks that private probes do not exceed the maximum label count.
+func ValidateProbeLabels(public bool, labels map[string]string) diag.Diagnostics {
+	if !public && len(labels) > sm.MaxProbeLabels {
+		return diag.Errorf("private probes support a maximum of %d labels, but %d were provided", sm.MaxProbeLabels, len(labels))
+	}
+	return nil
+}
+
+func validateProbeLabelsFromResource(d *schema.ResourceData) diag.Diagnostics {
+	labels := make(map[string]string)
+	for k, v := range d.Get("labels").(map[string]any) {
+		labels[k] = v.(string)
+	}
+	return ValidateProbeLabels(d.Get("public").(bool), labels)
+}
+
 func resourceProbeCreate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {
+	if diags := validateProbeLabelsFromResource(d); diags.HasError() {
+		return diags
+	}
 	p := makeProbe(d)
 	res, token, err := c.AddProbe(ctx, *p)
 	if err != nil {
@@ -200,6 +219,9 @@ func resourceProbeRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 }
 
 func resourceProbeUpdate(ctx context.Context, d *schema.ResourceData, c *smapi.Client) diag.Diagnostics {
+	if diags := validateProbeLabelsFromResource(d); diags.HasError() {
+		return diags
+	}
 	p := makeProbe(d)
 	_, err := c.UpdateProbe(ctx, *p)
 	if err != nil {

--- a/internal/resources/syntheticmonitoring/resource_probe_test.go
+++ b/internal/resources/syntheticmonitoring/resource_probe_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	syntheticmonitoring "github.com/grafana/terraform-provider-grafana/v4/internal/resources/syntheticmonitoring"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -254,6 +255,50 @@ func TestAccResourceProbe_InvalidLabels(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps:                    steps,
 	})
+}
+
+func TestUnitProbe_TooManyLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		public    bool
+		labels    map[string]string
+		expectErr bool
+	}{
+		{
+			name:      "private probe with 3 labels is ok",
+			public:    false,
+			labels:    map[string]string{"a": "1", "b": "2", "c": "3"},
+			expectErr: false,
+		},
+		{
+			name:      "private probe with 4 labels is rejected",
+			public:    false,
+			labels:    map[string]string{"a": "1", "b": "2", "c": "3", "d": "4"},
+			expectErr: true,
+		},
+		{
+			name:      "public probe with 4 labels is ok",
+			public:    true,
+			labels:    map[string]string{"a": "1", "b": "2", "c": "3", "d": "4"},
+			expectErr: false,
+		},
+		{
+			name:      "private probe with 0 labels is ok",
+			public:    false,
+			labels:    map[string]string{},
+			expectErr: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := syntheticmonitoring.ValidateProbeLabels(tc.public, tc.labels)
+			if tc.expectErr && !diags.HasError() {
+				t.Errorf("expected error but got none")
+			}
+			if !tc.expectErr && diags.HasError() {
+				t.Errorf("expected no error but got: %v", diags)
+			}
+		})
+	}
 }
 
 func testSyntheticMonitoringProbeAndCheck(name, probeSuffix string) string {


### PR DESCRIPTION
Private probes should only have a max of 3 labels. This updates the behavior to provide this as an error the user during planning isntead of failing silently. It also updates the generated documentation to provide the maximum number of labels.

- fixes https://github.com/grafana/synthetic-monitoring/issues/535