### PR TITLE
App Platform: Add extra documentation about how to use folder_uid

### DIFF
--- a/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
+++ b/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
@@ -191,7 +191,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_dashboard_dashboard_v1beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v1beta1.md
@@ -56,7 +56,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_dashboard_dashboard_v2.md
+++ b/docs/resources/apps_dashboard_dashboard_v2.md
@@ -65,7 +65,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_dashboard_dashboard_v2beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v2beta1.md
@@ -65,7 +65,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_notifications_inhibitionrule_v1beta1.md
+++ b/docs/resources/apps_notifications_inhibitionrule_v1beta1.md
@@ -65,7 +65,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_playlist_playlist_v0alpha1.md
+++ b/docs/resources/apps_playlist_playlist_v0alpha1.md
@@ -58,7 +58,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_playlist_playlist_v1.md
+++ b/docs/resources/apps_playlist_playlist_v1.md
@@ -58,7 +58,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_productactivation_appo11yconfig_v1alpha1.md
+++ b/docs/resources/apps_productactivation_appo11yconfig_v1alpha1.md
@@ -52,7 +52,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_productactivation_k8so11yconfig_v1alpha1.md
+++ b/docs/resources/apps_productactivation_k8so11yconfig_v1alpha1.md
@@ -52,7 +52,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_provisioning_connection_v0alpha1.md
+++ b/docs/resources/apps_provisioning_connection_v0alpha1.md
@@ -65,7 +65,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_provisioning_repository_v0alpha1.md
+++ b/docs/resources/apps_provisioning_repository_v0alpha1.md
@@ -277,7 +277,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_rules_alertrule_v0alpha1.md
+++ b/docs/resources/apps_rules_alertrule_v0alpha1.md
@@ -134,7 +134,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_rules_recordingrule_v0alpha1.md
+++ b/docs/resources/apps_rules_recordingrule_v0alpha1.md
@@ -82,7 +82,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_secret_keeper_v1beta1.md
+++ b/docs/resources/apps_secret_keeper_v1beta1.md
@@ -34,7 +34,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/docs/resources/apps_secret_securevalue_v1beta1.md
+++ b/docs/resources/apps_secret_securevalue_v1beta1.md
@@ -36,7 +36,7 @@ Required:
 
 Optional:
 
-- `folder_uid` (String) The UID of the folder to save the resource in.
+- `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
 
 Read-Only:
 

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -163,8 +163,9 @@ func (r *Resource[T, L]) Schema(ctx context.Context, req resource.SchemaRequest,
 					},
 				},
 				"folder_uid": schema.StringAttribute{
-					Optional:    true,
-					Description: "The UID of the folder to save the resource in.",
+					Optional: true,
+					Description: "The UID of the folder to save the resource in. " +
+						"For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.",
 				},
 				//
 				// TODO: add labels


### PR DESCRIPTION
It improves `folder_uid` information to indicate that not all resources support it.