### PR TITLE
fix: reject full k8s envelope in dashboard v2 spec.json with a descriptive error

### DIFF
--- a/docs/resources/apps_dashboard_dashboard_v2.md
+++ b/docs/resources/apps_dashboard_dashboard_v2.md
@@ -89,7 +89,7 @@ Optional:
 
 Required:
 
-- `json` (String) The JSON representation of the dashboard v2 spec.
+- `json` (String) The JSON representation of the dashboard v2 spec. Must be the spec object only — not the full Kubernetes envelope. Use: json = jsonencode(jsondecode(file("dashboard.json")).spec)
 
 Optional:
 

--- a/docs/resources/apps_dashboard_dashboard_v2beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v2beta1.md
@@ -89,7 +89,7 @@ Optional:
 
 Required:
 
-- `json` (String) The JSON representation of the dashboard v2beta1 spec.
+- `json` (String) The JSON representation of the dashboard v2beta1 spec. Must be the spec object only — not the full Kubernetes envelope. Use: json = jsonencode(jsondecode(file("dashboard.json")).spec)
 
 Optional:
 

--- a/internal/resources/appplatform/dashboard_envelope.go
+++ b/internal/resources/appplatform/dashboard_envelope.go
@@ -1,0 +1,36 @@
+package appplatform
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// extractSpecIfEnvelope detects if the given JSON is a full Kubernetes-style envelope
+// (i.e. has an "apiVersion" field, as produced by the Grafana UI dashboard export).
+// If so, it extracts and returns only the "spec" field, so the caller can unmarshal
+// it directly into a DashboardSpec without having to manually unwrap it.
+//
+// This allows users to pass the full exported dashboard JSON to spec.json instead of
+// having to extract .spec themselves:
+//
+//	spec { json = jsonencode(jsondecode(file("dashboard.json"))) }        # now works
+//	spec { json = jsonencode(jsondecode(file("dashboard.json")).spec) }   # still works
+//
+// If the JSON is not an envelope, it is returned unchanged.
+func extractSpecIfEnvelope(normalized jsontypes.Normalized) jsontypes.Normalized {
+	var envelope struct {
+		APIVersion string          `json:"apiVersion"`
+		Spec       json.RawMessage `json:"spec"`
+	}
+
+	if err := json.Unmarshal([]byte(normalized.ValueString()), &envelope); err != nil {
+		return normalized
+	}
+
+	if envelope.APIVersion == "" || len(envelope.Spec) == 0 {
+		return normalized
+	}
+
+	return jsontypes.NewNormalizedValue(string(envelope.Spec))
+}

--- a/internal/resources/appplatform/dashboard_envelope.go
+++ b/internal/resources/appplatform/dashboard_envelope.go
@@ -2,35 +2,46 @@ package appplatform
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
-// extractSpecIfEnvelope detects if the given JSON is a full Kubernetes-style envelope
-// (i.e. has an "apiVersion" field, as produced by the Grafana UI dashboard export).
-// If so, it extracts and returns only the "spec" field, so the caller can unmarshal
-// it directly into a DashboardSpec without having to manually unwrap it.
+// rejectIfEnvelope detects if the given JSON is a full Kubernetes-style envelope
+// (i.e. has an "apiVersion" field at the top level). If so, it returns an error
+// diagnostic explaining that only the spec is expected.
 //
-// This allows users to pass the full exported dashboard JSON to spec.json instead of
-// having to extract .spec themselves:
+// The json field expects the dashboard spec object only:
 //
-//	spec { json = jsonencode(jsondecode(file("dashboard.json"))) }        # now works
-//	spec { json = jsonencode(jsondecode(file("dashboard.json")).spec) }   # still works
-//
-// If the JSON is not an envelope, it is returned unchanged.
-func extractSpecIfEnvelope(normalized jsontypes.Normalized) jsontypes.Normalized {
-	var envelope struct {
-		APIVersion string          `json:"apiVersion"`
-		Spec       json.RawMessage `json:"spec"`
+//	spec { json = jsonencode(jsondecode(file("dashboard.json")).spec) }  # correct
+//	spec { json = jsonencode(jsondecode(file("dashboard.json")))       }  # wrong — full envelope
+func rejectIfEnvelope(normalized jsontypes.Normalized) diag.Diagnostics {
+	var probe struct {
+		APIVersion string `json:"apiVersion"`
 	}
 
-	if err := json.Unmarshal([]byte(normalized.ValueString()), &envelope); err != nil {
-		return normalized
+	if err := json.Unmarshal([]byte(normalized.ValueString()), &probe); err != nil {
+		return nil
 	}
 
-	if envelope.APIVersion == "" || len(envelope.Spec) == 0 {
-		return normalized
+	if probe.APIVersion == "" {
+		return nil
 	}
 
-	return jsontypes.NewNormalizedValue(string(envelope.Spec))
+	return diag.Diagnostics{
+		diag.NewErrorDiagnostic(
+			"Full Kubernetes envelope passed to spec.json",
+			fmt.Sprintf(
+				"The `json` field expects only the dashboard spec object, not the full Kubernetes envelope.\n\n"+
+					"The value you provided has `apiVersion: %q` at the top level, which means it is the full "+
+					"envelope (apiVersion + kind + metadata + spec) as exported by the Grafana UI.\n\n"+
+					"Fix: extract the spec before encoding:\n\n"+
+					"  json = jsonencode(jsondecode(file(\"dashboard.json\")).spec)\n\n"+
+					"Accepting the full envelope is intentionally unsupported — metadata fields "+
+					"(name, namespace, labels) are managed by Terraform, not the spec.",
+				probe.APIVersion,
+			),
+		),
+	}
 }

--- a/internal/resources/appplatform/dashboard_v2_resource.go
+++ b/internal/resources/appplatform/dashboard_v2_resource.go
@@ -38,7 +38,7 @@ Manages Grafana dashboards using the v2beta1 (Dynamic Dashboards) schema.
 				SpecAttributes: map[string]schema.Attribute{
 					"json": schema.StringAttribute{
 						Required:    true,
-						Description: "The JSON representation of the dashboard v2beta1 spec. Accepts either the inner spec object or the full Kubernetes envelope (apiVersion + kind + metadata + spec) as exported by the Grafana UI — the envelope is automatically unwrapped.",
+						Description: "The JSON representation of the dashboard v2beta1 spec. Must be the spec object only — not the full Kubernetes envelope. Use: json = jsonencode(jsondecode(file(\"dashboard.json\")).spec)",
 						CustomType:  jsontypes.NormalizedType{},
 					},
 					"title": schema.StringAttribute{
@@ -67,10 +67,9 @@ Manages Grafana dashboards using the v2beta1 (Dynamic Dashboards) schema.
 					return diag
 				}
 
-				// If the user passed the full k8s envelope (apiVersion + kind + metadata + spec),
-				// extract just the spec field. This allows using the JSON exported directly
-				// from the Grafana UI without manually unwrapping it.
-				data.JSON = extractSpecIfEnvelope(data.JSON)
+				if diags := rejectIfEnvelope(data.JSON); diags.HasError() {
+					return diags
+				}
 
 				var res v2beta1.DashboardSpec
 				if diag := data.JSON.Unmarshal(&res); diag.HasError() {

--- a/internal/resources/appplatform/dashboard_v2_resource.go
+++ b/internal/resources/appplatform/dashboard_v2_resource.go
@@ -38,7 +38,7 @@ Manages Grafana dashboards using the v2beta1 (Dynamic Dashboards) schema.
 				SpecAttributes: map[string]schema.Attribute{
 					"json": schema.StringAttribute{
 						Required:    true,
-						Description: "The JSON representation of the dashboard v2beta1 spec.",
+						Description: "The JSON representation of the dashboard v2beta1 spec. Accepts either the inner spec object or the full Kubernetes envelope (apiVersion + kind + metadata + spec) as exported by the Grafana UI — the envelope is automatically unwrapped.",
 						CustomType:  jsontypes.NormalizedType{},
 					},
 					"title": schema.StringAttribute{
@@ -66,6 +66,11 @@ Manages Grafana dashboards using the v2beta1 (Dynamic Dashboards) schema.
 				}); diag.HasError() {
 					return diag
 				}
+
+				// If the user passed the full k8s envelope (apiVersion + kind + metadata + spec),
+				// extract just the spec field. This allows using the JSON exported directly
+				// from the Grafana UI without manually unwrapping it.
+				data.JSON = extractSpecIfEnvelope(data.JSON)
 
 				var res v2beta1.DashboardSpec
 				if diag := data.JSON.Unmarshal(&res); diag.HasError() {

--- a/internal/resources/appplatform/dashboard_v2stable_resource.go
+++ b/internal/resources/appplatform/dashboard_v2stable_resource.go
@@ -38,7 +38,7 @@ Manages Grafana dashboards using the v2 (Dynamic Dashboards) schema.
 				SpecAttributes: map[string]schema.Attribute{
 					"json": schema.StringAttribute{
 						Required:    true,
-						Description: "The JSON representation of the dashboard v2 spec. Accepts either the inner spec object or the full Kubernetes envelope (apiVersion + kind + metadata + spec) as exported by the Grafana UI — the envelope is automatically unwrapped.",
+						Description: "The JSON representation of the dashboard v2 spec. Must be the spec object only — not the full Kubernetes envelope. Use: json = jsonencode(jsondecode(file(\"dashboard.json\")).spec)",
 						CustomType:  jsontypes.NormalizedType{},
 					},
 					"title": schema.StringAttribute{
@@ -67,10 +67,9 @@ Manages Grafana dashboards using the v2 (Dynamic Dashboards) schema.
 					return diag
 				}
 
-				// If the user passed the full k8s envelope (apiVersion + kind + metadata + spec),
-				// extract just the spec field. This allows using the JSON exported directly
-				// from the Grafana UI without manually unwrapping it.
-				data.JSON = extractSpecIfEnvelope(data.JSON)
+				if diags := rejectIfEnvelope(data.JSON); diags.HasError() {
+					return diags
+				}
 
 				var res v2.DashboardSpec
 				if diag := data.JSON.Unmarshal(&res); diag.HasError() {

--- a/internal/resources/appplatform/dashboard_v2stable_resource.go
+++ b/internal/resources/appplatform/dashboard_v2stable_resource.go
@@ -38,7 +38,7 @@ Manages Grafana dashboards using the v2 (Dynamic Dashboards) schema.
 				SpecAttributes: map[string]schema.Attribute{
 					"json": schema.StringAttribute{
 						Required:    true,
-						Description: "The JSON representation of the dashboard v2 spec.",
+						Description: "The JSON representation of the dashboard v2 spec. Accepts either the inner spec object or the full Kubernetes envelope (apiVersion + kind + metadata + spec) as exported by the Grafana UI — the envelope is automatically unwrapped.",
 						CustomType:  jsontypes.NormalizedType{},
 					},
 					"title": schema.StringAttribute{
@@ -66,6 +66,11 @@ Manages Grafana dashboards using the v2 (Dynamic Dashboards) schema.
 				}); diag.HasError() {
 					return diag
 				}
+
+				// If the user passed the full k8s envelope (apiVersion + kind + metadata + spec),
+				// extract just the spec field. This allows using the JSON exported directly
+				// from the Grafana UI without manually unwrapping it.
+				data.JSON = extractSpecIfEnvelope(data.JSON)
 
 				var res v2.DashboardSpec
 				if diag := data.JSON.Unmarshal(&res); diag.HasError() {


### PR DESCRIPTION
## What

`grafana_apps_dashboard_dashboard_v2beta1` and `grafana_apps_dashboard_dashboard_v2` now return a clear error when `spec.json` is passed the full Kubernetes envelope instead of the spec object.

## Why

The Grafana UI exports dashboards as a full k8s envelope (`apiVersion + kind + metadata + spec`). Passing that JSON directly to `spec.json` was silently broken: the provider unmarshalled the envelope into `DashboardSpec`, which only recognises top-level spec fields. Everything else (`layout`, `elements`, `variables`) was nested inside an unrecognised `spec` key and got silently dropped, producing a blank dashboard.

An earlier version of this PR silently unwrapped the envelope. Per feedback from Igor and Artur: we don't want to accept the full payload format — metadata fields (name, namespace, labels) are managed by Terraform, and silently accepting the envelope gives users the wrong mental model about what fields are in scope.

The right fix is a descriptive error that tells the user exactly what to change.

## Error message

```
Error: Full Kubernetes envelope passed to spec.json

The `json` field expects only the dashboard spec object, not the full
Kubernetes envelope.

The value you provided has `apiVersion: "dashboard.grafana.app/v2beta1"`
at the top level, which means it is the full envelope (apiVersion + kind
+ metadata + spec) as exported by the Grafana UI.

Fix: extract the spec before encoding:

  json = jsonencode(jsondecode(file("dashboard.json")).spec)

Accepting the full envelope is intentionally unsupported — metadata fields
(name, namespace, labels) are managed by Terraform, not the spec.
```

## How

`rejectIfEnvelope` in `dashboard_envelope.go` — detects `apiVersion` at the top level and returns a diagnostic error. Called in both resource `SpecParser` functions before unmarshalling.

Fixes: https://github.com/grafana/support-escalations/issues/21520