### PR TITLE
Datasource Permissions: Skip lookup for global

### DIFF
--- a/internal/resources/grafana/resource_data_source_permission.go
+++ b/internal/resources/grafana/resource_data_source_permission.go
@@ -78,6 +78,9 @@ func resourceDatasourcePermissionGet(d *schema.ResourceData, meta any) (string, 
 	if d.Id() != "" {
 		client, _, id = OAPIClientFromExistingOrgResource(meta, d.Id())
 	}
+	if id == "*" {
+		return "*", nil
+	}
 	resp, err := client.Datasources.GetDataSourceByUID(id)
 	if err != nil {
 		return "", err
@@ -95,6 +98,9 @@ func resourceDatasourcePermissionGetType(d *schema.ResourceData, meta any) (stri
 	_, id := SplitOrgResourceID(d.Get("datasource_uid").(string))
 	if d.Id() != "" {
 		client, _, id = OAPIClientFromExistingOrgResource(meta, d.Id())
+	}
+	if id == "*" {
+		return "", nil
 	}
 	resp, err := client.Datasources.GetDataSourceByUID(id)
 	if err != nil {

--- a/internal/resources/grafana/resource_data_source_permission_item.go
+++ b/internal/resources/grafana/resource_data_source_permission_item.go
@@ -204,15 +204,22 @@ func (r *resourceDatasourcePermissionItem) Delete(ctx context.Context, req resou
 }
 
 func (r *resourceDatasourcePermissionItem) datasourceQuery(client *client.GrafanaHTTPAPI, datasourceUID string) error {
+	if datasourceUID == "*" {
+		return nil
+	}
 	_, err := client.Datasources.GetDataSourceByUID(datasourceUID)
 	return err
 }
 
 // resolveWriteOpts returns the ds_type client option for write operations.
 // if dsType is provided it is used directly; otherwise GetDataSourceByUID is called to look it up.
+// Wildcard UIDs ("*") skip the lookup entirely since they represent all datasources.
 func (r *resourceDatasourcePermissionItem) resolveWriteOpts(orgIDStr, dsUID string, dsType types.String) ([]access_control.ClientOption, error) {
 	if !dsType.IsNull() && dsType.ValueString() != "" {
 		return []access_control.ClientOption{withQueryParam("ds_type", dsType.ValueString())}, nil
+	}
+	if dsUID == "*" {
+		return nil, nil
 	}
 	c, _, err := r.clientFromNewOrgResource(orgIDStr)
 	if err != nil {


### PR DESCRIPTION
Skip lookups if the scope is `datasources:uid:*`, not just `datasources:*`