### PR TITLE
fix(grafana_team): restore DiffSuppressFunc behavior after Framework migration

### DIFF
--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -41,6 +41,10 @@ type ChangeMemberType int8
 const (
 	AddMember ChangeMemberType = iota
 	RemoveMember
+
+	// defaultIgnoreExternallySyncedMembers matches the schema Default for ignore_externally_synced_members.
+	// Used in Read() to handle null state after SDKv2 → Framework migration.
+	defaultIgnoreExternallySyncedMembers = true
 )
 
 var (
@@ -301,7 +305,7 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	// old="" and new="true".
 	ignoreExternallySynced := data.IgnoreExternallySyncedMembers.ValueBool()
 	if data.IgnoreExternallySyncedMembers.IsNull() || data.IgnoreExternallySyncedMembers.IsUnknown() {
-		ignoreExternallySynced = true
+		ignoreExternallySynced = defaultIgnoreExternallySyncedMembers
 	}
 
 	readData, diags := r.read(ctx, data.ID.ValueString(), ignoreExternallySynced, len(data.TeamSync) > 0)

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -12,12 +12,14 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -133,6 +135,7 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"members": schema.SetAttribute{
 				Optional:    true,
 				Computed:    true,
+				Default:     setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 				ElementType: types.StringType,
 				Description: "A set of email addresses corresponding to users who should be given membership to the team. Note: users specified here must already exist in Grafana.",
 			},

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -135,6 +135,9 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "A set of email addresses corresponding to users who should be given membership to the team. Note: users specified here must already exist in Grafana.",
+				PlanModifiers: []planmodifier.Set{
+					nullEmptySetEquivalent{},
+				},
 			},
 			"ignore_externally_synced_members": schema.BoolAttribute{
 				Optional: true,
@@ -292,7 +295,16 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	readData, diags := r.read(ctx, data.ID.ValueString(), data.IgnoreExternallySyncedMembers.ValueBool(), len(data.TeamSync) > 0)
+	// Default to true when state is null (e.g. after SDKv2 → Framework migration
+	// or for resources created before this attribute existed). This matches the
+	// behavior of the old SDKv2 DiffSuppressFunc which suppressed diffs when
+	// old="" and new="true".
+	ignoreExternallySynced := data.IgnoreExternallySyncedMembers.ValueBool()
+	if data.IgnoreExternallySyncedMembers.IsNull() || data.IgnoreExternallySyncedMembers.IsUnknown() {
+		ignoreExternallySynced = true
+	}
+
+	readData, diags := r.read(ctx, data.ID.ValueString(), ignoreExternallySynced, len(data.TeamSync) > 0)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -653,4 +665,28 @@ func getTeamByID(client *goapi.GrafanaHTTPAPI, teamID int64) (*models.TeamDTO, e
 		return nil, err
 	}
 	return resp.GetPayload(), nil
+}
+
+// nullEmptySetEquivalent is a plan modifier that suppresses diffs between null
+// and empty sets. This replaces the SDKv2 DiffSuppressFunc that treated
+// "[]" and "" as equivalent for the members attribute.
+type nullEmptySetEquivalent struct{}
+
+var _ planmodifier.Set = nullEmptySetEquivalent{}
+
+func (m nullEmptySetEquivalent) Description(_ context.Context) string {
+	return "Treats null and empty sets as equivalent to suppress unnecessary diffs."
+}
+
+func (m nullEmptySetEquivalent) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m nullEmptySetEquivalent) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	stateIsNullOrEmpty := req.StateValue.IsNull() || len(req.StateValue.Elements()) == 0
+	planIsNullOrEmpty := resp.PlanValue.IsNull() || len(resp.PlanValue.Elements()) == 0
+
+	if stateIsNullOrEmpty && planIsNullOrEmpty {
+		resp.PlanValue = req.StateValue
+	}
 }

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -135,9 +135,6 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "A set of email addresses corresponding to users who should be given membership to the team. Note: users specified here must already exist in Grafana.",
-				PlanModifiers: []planmodifier.Set{
-					nullEmptySetEquivalent{},
-				},
 			},
 			"ignore_externally_synced_members": schema.BoolAttribute{
 				Optional: true,
@@ -665,28 +662,4 @@ func getTeamByID(client *goapi.GrafanaHTTPAPI, teamID int64) (*models.TeamDTO, e
 		return nil, err
 	}
 	return resp.GetPayload(), nil
-}
-
-// nullEmptySetEquivalent is a plan modifier that suppresses diffs between null
-// and empty sets. This replaces the SDKv2 DiffSuppressFunc that treated
-// "[]" and "" as equivalent for the members attribute.
-type nullEmptySetEquivalent struct{}
-
-var _ planmodifier.Set = nullEmptySetEquivalent{}
-
-func (m nullEmptySetEquivalent) Description(_ context.Context) string {
-	return "Treats null and empty sets as equivalent to suppress unnecessary diffs."
-}
-
-func (m nullEmptySetEquivalent) MarkdownDescription(ctx context.Context) string {
-	return m.Description(ctx)
-}
-
-func (m nullEmptySetEquivalent) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
-	stateIsNullOrEmpty := req.StateValue.IsNull() || len(req.StateValue.Elements()) == 0
-	planIsNullOrEmpty := resp.PlanValue.IsNull() || len(resp.PlanValue.Elements()) == 0
-
-	if stateIsNullOrEmpty && planIsNullOrEmpty {
-		resp.PlanValue = req.StateValue
-	}
 }


### PR DESCRIPTION
## Summary

The SDKv2 → Framework migration in #2530 dropped two `DiffSuppressFunc` handlers and changed `members` from `Optional` to `Optional + Computed` without a `Default`. This PR restores the original SDKv2 semantics.

### Changes

**`ignore_externally_synced_members` — null-safety in `Read()`**

The old SDKv2 `DiffSuppressFunc` suppressed diffs when `old="" new="true"` (state unset, default applied). The Framework `Default: booldefault.StaticBool(true)` handles the plan side, but `Read()` calls `ValueBool()` on the state which returns `false` when null — incorrectly including externally synced members in the read result and causing spurious diffs on `members`. Now defaults to `true` when the state value is null/unknown.

**`members` — add `Default: []` to restore SDKv2 semantics**

The migration added `Computed` to handle unknown values at plan time (e.g. `members` referencing another resource's output). However, `Optional + Computed` without a `Default` changes the plan behavior: when config is null, the plan uses the prior state instead of empty. This means not configuring `members` no longer means "no members" — instead, externally added members silently become part of the Terraform state without the user being aware.

Adding `Default: []` (empty set) restores the SDKv2 behavior: config null produces `plan = []`, so the Terraform config remains authoritative.

### Behavior comparison

| Scenario | SDKv2 (`Optional` + DiffSuppressFunc) | Framework without fix (`Optional + Computed`, no Default) | Framework with fix (`Optional + Computed + Default: []`) |
|---|---|---|---|
| **Create, config null** | plan = null → Create → Read returns `[]` → state `[]` | plan = unknown → Create → Read returns `[]` → state `[]` | plan = `[]` → Create → Read returns `[]` → state `[]` |
| **Create, config = `["u@..."]`** | plan = `["u@..."]` → state `["u@..."]` | plan = `["u@..."]` → state `["u@..."]` | plan = `["u@..."]` → state `["u@..."]` |
| **Create, config references unknown** | plan = unknown (implicit) → Read → state `[]` | plan = unknown → Read → state `[]` | plan = unknown (Default skipped) → Read → state `[]` |
| **Existing, config null, state `[]`** | DiffSuppressFunc → **no diff** | plan = `[]` (prior state) → **no diff** | plan = `[]` (Default) → **no diff** |
| **Existing, config null, members added externally** | plan = null, state `["ext@..."]` → **diff → removes members** | plan = `["ext@..."]` (prior state) → **no diff, external members silently accepted** | plan = `[]` (Default) → **diff → removes members** |
| **Existing, config = `["u@..."]`** | diff if state differs | diff if state differs | diff if state differs |

The key row is "members added externally" — SDKv2 removes them, current Framework silently accepts them, proposed fix restores the SDKv2 behavior.

### Context

- Original migration: #2530
- Open revert PR: #2685 — this fix is a less invasive alternative to a full revert