### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 /internal/resources/grafana/resource_playlist*                 @grafana/sharing-squad
 /internal/resources/grafana/resource_report*                   @grafana/operator-experience-squad
 /internal/resources/grafana/*role*                             @grafana/access-squad
-/internal/resources/grafana/resource_team*                     @grafana/access-squad
+/internal/resources/grafana/resource_team*                     @grafana/identity-squad
 /internal/resources/grafana/*service_account*                  @grafana/identity-squad
 /internal/resources/grafana/*sso*                              @grafana/identity-squad
 /internal/resources/grafana/*scim*                             @grafana/identity-squad
@@ -34,7 +34,7 @@
 /internal/resources/grafana/data_source_organization*          @grafana/access-squad
 /internal/resources/grafana/data_source_role*                  @grafana/access-squad
 /internal/resources/grafana/data_source_service_account*       @grafana/identity-squad
-/internal/resources/grafana/data_source_team*                  @grafana/access-squad
+/internal/resources/grafana/data_source_team*                  @grafana/identity-squad
 /internal/resources/grafana/data_source_user*                  @grafana/identity-squad
 
 # internal/resources/cloud

--- a/internal/resources/grafana/catalog-data-source.yaml
+++ b/internal/resources/grafana/catalog-data-source.yaml
@@ -165,7 +165,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/access-squad
+  owner: group:default/identity-squad
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -438,7 +438,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/access-squad
+  owner: group:default/identity-squad
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -451,7 +451,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/access-squad
+  owner: group:default/identity-squad
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
It seems that the Identity Squad owns all things **Team**, so update CODEOWNERS to reflect this.