### PR TITLE
fix(dashboard_permission): normalize team_id/user_id '0' to null in plan

### DIFF
--- a/internal/resources/grafana/common_plugin_framework.go
+++ b/internal/resources/grafana/common_plugin_framework.go
@@ -215,13 +215,17 @@ func (d *orgScopedAttributePlanModifier) PlanModifyString(ctx context.Context, r
 	}
 }
 
-// stripOrgScopedIDPlanModifier unconditionally strips the org prefix from plan values,
-// normalizing "orgID:localID" to "localID". Used in bulk permission blocks where
-// referenced resources may return either format.
+// stripOrgScopedIDPlanModifier normalizes team_id/user_id plan values for bulk
+// permission blocks:
+//   - Strips the org prefix: "orgID:localID" → "localID"
+//   - Normalizes "0" → null: zero means "not set", matching what readBulkPermissions
+//     returns (types.StringNull) when the API returns TeamID/UserID == 0. This
+//     prevents "inconsistent result after apply" errors when users carry over the
+//     legacy SDKv2 pattern of explicitly setting team_id = "0" or user_id = "0".
 type stripOrgScopedIDPlanModifier struct{}
 
 func (d *stripOrgScopedIDPlanModifier) Description(_ context.Context) string {
-	return "Strips the org ID prefix from resource IDs, normalizing to the local ID."
+	return "Strips the org ID prefix from resource IDs and normalizes \"0\" to null."
 }
 
 func (d *stripOrgScopedIDPlanModifier) MarkdownDescription(ctx context.Context) string {
@@ -233,6 +237,10 @@ func (d *stripOrgScopedIDPlanModifier) PlanModifyString(_ context.Context, req p
 		return
 	}
 	_, localID := SplitOrgResourceID(resp.PlanValue.ValueString())
+	if localID == "0" {
+		resp.PlanValue = types.StringNull()
+		return
+	}
 	if localID != "" {
 		resp.PlanValue = types.StringValue(localID)
 	}

--- a/internal/resources/grafana/resource_dashboard_permission_test.go
+++ b/internal/resources/grafana/resource_dashboard_permission_test.go
@@ -11,6 +11,44 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+// TestAccDashboardPermission_legacyZeroIDs verifies that team_id = "0" and
+// user_id = "0" — the legacy SDKv2 pattern where "0" meant "not set" — are
+// normalized to null by the plan modifier and do not cause a
+// "provider produced inconsistent result after apply" error.
+func TestAccDashboardPermission_legacyZeroIDs(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "grafana_dashboard" "test" {
+  config_json = jsonencode({ title = "Test", uid = "legacy-zero-ids-test" })
+}
+resource "grafana_dashboard_permission" "test" {
+  dashboard_uid = grafana_dashboard.test.uid
+  permissions {
+    role       = "Viewer"
+    permission = "View"
+    team_id    = "0"
+    user_id    = "0"
+  }
+}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_dashboard_permission.test", "permissions.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("grafana_dashboard_permission.test", "permissions.*", map[string]string{
+						"role":       "Viewer",
+						"permission": "View",
+						"team_id":    "",
+						"user_id":    "",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDashboardPermission_basic(t *testing.T) {
 	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
 

--- a/pkg/generate/postprocessing/replace_references.go
+++ b/pkg/generate/postprocessing/replace_references.go
@@ -58,6 +58,7 @@ var knownReferences = []string{
 	"grafana_dashboard.uid=grafana_library_panel.uid",
 	"grafana_dashboard_permission.dashboard_uid=grafana_dashboard.uid",
 	"grafana_dashboard_permission.team_id=grafana_team.id",
+	"grafana_dashboard_permission.user_id=grafana_service_account.id",
 	"grafana_dashboard_permission.user_id=grafana_user.id",
 	"grafana_dashboard_permission_item.dashboard_uid=grafana_dashboard.uid",
 	"grafana_dashboard_permission_item.team=grafana_team.id",


### PR DESCRIPTION
### **Changes Made**
**Root cause**

The SDKv2 version of `grafana_dashboard_permission` (and `grafana_folder_permission`) defaulted `team_id`/`user_id` to `"0"`. Many users carried `team_id = "0"` / `user_id = "0"` into their configs to mean "not set".

After the Framework migration in #2653, `readBulkPermissions` correctly returns `types.StringNull()` for zero IDs:

```go
if perm.TeamID > 0 {
    item.TeamID = types.StringValue(...)
} else {
    item.TeamID = types.StringNull()  // "0" becomes null
}
```

But the plan preserved the literal `"0"` from config. Since `permissions` is a `SetNestedBlock`, elements are matched by their full value — `{team_id="0"}` ≠ `{team_id=null}` → **"provider produced inconsistent result after apply"** (support escalation grafana/support-escalations#21762).

**Fix**

Extend `stripOrgScopedIDPlanModifier` (already applied to both fields) to normalize `"0"` → `null` at plan time, so plan and Read agree. `applyBulkPermissions` already handles null and `"0"` identically (`if teamID > 0` guard), so apply behaviour is unchanged.

Affects both `grafana_dashboard_permission` and `grafana_folder_permission` since both share `bulkPermissionsSchemaAttribute`.

### **Testing**
Built a dev version of the provider and used it to reproduce the steps outlined in the support issue using the same defined `main.tf` file. After the change, verified that the resources were able to be created without the `inconsistent result` errors.
```
❯ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - grafana/grafana in /Users/belen/repos/terraform-provider-grafana
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
│ published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # grafana_dashboard.home_dashboard will be created
  + resource "grafana_dashboard" "home_dashboard" {
      + config_json  = jsonencode(
            {
              + panels        = []
              + schemaVersion = 16
              + tags          = []
              + title         = "Home Dashboard"
              + uid           = null
            }
        )
      + dashboard_id = (known after apply)
      + folder       = (known after apply)
      + id           = (known after apply)
      + uid          = (known after apply)
      + url          = (known after apply)
      + version      = (known after apply)
    }

  # grafana_dashboard_permission.home_dashboard_permission will be created
  + resource "grafana_dashboard_permission" "home_dashboard_permission" {
      + dashboard_uid = (known after apply)
      + id            = (known after apply)
      + org_id        = (known after apply)

      + permissions {
          + permission = "View"
          + role       = "Viewer"
        }
    }

  # grafana_folder.bam_standard_dashboards will be created
  + resource "grafana_folder" "bam_standard_dashboards" {
      + id                           = (known after apply)
      + prevent_destroy_if_not_empty = false
      + title                        = "BAM Standard Dashboards"
      + uid                          = (known after apply)
      + url                          = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

grafana_folder.bam_standard_dashboards: Creating...
grafana_folder.bam_standard_dashboards: Creation complete after 0s [id=0:bfj39v12n9b7kd]
grafana_dashboard.home_dashboard: Creating...
grafana_dashboard.home_dashboard: Creation complete after 1s [id=0:3ae8f2cb-9d57-4105-8301-994a345e833d]
grafana_dashboard_permission.home_dashboard_permission: Creating...
grafana_dashboard_permission.home_dashboard_permission: Creation complete after 0s [id=0:3ae8f2cb-9d57-4105-8301-994a345e833d]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```