### PR TITLE
maint: add UpgradeState passthrough handlers to 7 Framework resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ terraform-provider-grafana-generate
 
 .vscode
 vendor/
+tmp/

--- a/agent-docs/resources/sdkv2-to-framework-migration.md
+++ b/agent-docs/resources/sdkv2-to-framework-migration.md
@@ -17,6 +17,7 @@ New `NewLegacySDKResource` / `NewLegacySDKDataSource` registrations under `inter
 - [ ] Rewrite `resource_<name>.go` using Plugin Framework patterns
 - [ ] **For every `DiffSuppressFunc` in the SDKv2 source: explicitly translate it or document why it is safe to drop** (see [DiffSuppressFunc handling](#diffsuppressfunc-handling) below)
 - [ ] **For every non-zero `Default:` field: add a null guard if the value is read from state and used to control behavior in `Read`** (see [DiffSuppressFunc + Default as a signal for null-in-Read bugs](#diffsuppressfunc--default-as-a-signal-for-null-in-read-bugs))
+- [ ] **Add an `UpgradeState` passthrough handler for version 0** (see [UpgradeState for SDKv2→Framework migrations](#upgradestate-for-sdkv2framework-migrations))
 - [ ] Update `resources.go`: rename factory call, change `addValidationToResources` entry if org-scoped
 - [ ] Run `make docs` (`go generate ./...`) and commit updated `docs/resources/<name>.md`
 - [ ] Check `pkg/generate/testdata/**/*.tf.tmpl` for this resource — update if `Computed` defaults changed
@@ -417,6 +418,62 @@ If the SDKv2 resource had no `.WithLister(...)`, omit it in the Framework versio
 ### Enterprise-only resources
 
 Enterprise resources use `common.CategoryGrafanaEnterprise`. Tests must call `testutils.CheckEnterpriseTestsEnabled(t)` as the first line.
+
+### UpgradeState for SDKv2→Framework migrations
+
+When Terraform or OpenTofu calls `plan` or `apply`, it invokes the `UpgradeResourceState` RPC for every resource in state. The Framework handles same-version (v0→v0) transitions with a built-in passthrough: it deserializes the raw JSON into the current schema type without calling any custom handler. **The version 0 handler registered here is therefore not invoked during the initial SDKv2→Framework upgrade** — it exists as defensive scaffolding for future schema version bumps.
+
+#### Why add it now anyway
+
+If the schema is later bumped from `Version: 0` to `Version: 1` (or higher), users who still have pre-bump v0 state need a registered upgrader at version 0. Without it, the Framework returns:
+
+```
+│ Error: Unable to Upgrade Resource State
+│ Provider does not support upgrading to version 0 of this resource.
+```
+
+Adding the handler proactively — while the v0 schema is fresh and fully captured in `r.Schema()` — prevents this breakage regardless of how much later the schema version is bumped.
+
+#### Standard passthrough pattern (no structural schema changes)
+
+Add the interface assertion and the method to the resource file:
+
+```go
+var (
+    _ resource.Resource                 = &fooResource{}
+    _ resource.ResourceWithConfigure    = &fooResource{}
+    _ resource.ResourceWithImportState  = &fooResource{}
+    _ resource.ResourceWithUpgradeState = &fooResource{}  // ← add this line
+)
+
+// UpgradeState registers a no-op passthrough for version 0 state.
+// The Framework handles v0→v0 transitions natively; this handler fires only
+// if the schema is later bumped beyond v0 and a user still has v0 state.
+func (r *fooResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+    var schemaResp resource.SchemaResponse
+    r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+    return map[int64]resource.StateUpgrader{
+        0: {
+            PriorSchema: &schemaResp.Schema,
+            StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+                var state resourceFooModel
+                resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+                resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+            },
+        },
+    }
+}
+```
+
+#### When you later bump the schema version
+
+If you later add `Version: 1` to the schema with **structural changes** (renamed field, type change, nested block added/removed), the pattern above is no longer safe because `r.Schema()` now returns the *new* schema, not the v0 one. Instead:
+
+1. Copy the version 0 schema definition verbatim into the handler as a literal `schema.Schema{...}` value for `PriorSchema`.
+2. Write migration logic in the `StateUpgrader` body to translate old field values to new field values.
+3. Increment `schema.Schema.Version` in `r.Schema(...)` to 1.
+
+If the schema change is additive only (new optional field, no field removed or renamed), the passthrough is still safe as long as new fields have appropriate defaults or are Computed+Optional.
 
 ---
 

--- a/internal/resources/grafana/resource_dashboard_permission.go
+++ b/internal/resources/grafana/resource_dashboard_permission.go
@@ -17,7 +17,8 @@ var (
 	resourceDashboardPermissionID   = orgResourceIDString("dashboardUID")
 
 	// Check interface
-	_ resource.ResourceWithImportState = (*resourceDashboardPermission)(nil)
+	_ resource.ResourceWithImportState  = (*resourceDashboardPermission)(nil)
+	_ resource.ResourceWithUpgradeState = (*resourceDashboardPermission)(nil)
 )
 
 func makeResourceDashboardPermission() *common.Resource {
@@ -232,4 +233,24 @@ func (r *resourceDashboardPermission) Delete(ctx context.Context, req resource.D
 	dashboardUID := split[0].(string)
 
 	resp.Diagnostics.Append(r.applyBulkPermissions(client, dashboardUID, nil)...)
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *resourceDashboardPermission) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state resourceDashboardPermissionModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
+	}
 }

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &publicDashboardResource{}
-	_ resource.ResourceWithConfigure   = &publicDashboardResource{}
-	_ resource.ResourceWithImportState = &publicDashboardResource{}
+	_ resource.Resource                  = &publicDashboardResource{}
+	_ resource.ResourceWithConfigure     = &publicDashboardResource{}
+	_ resource.ResourceWithImportState   = &publicDashboardResource{}
+	_ resource.ResourceWithUpgradeState  = &publicDashboardResource{}
 
 	resourcePublicDashboardName = "grafana_dashboard_public"
 	resourcePublicDashboardID   = common.NewResourceID(
@@ -296,5 +297,25 @@ func publicDashboardFromModel(data *resourcePublicDashboardModel) *models.Public
 		IsEnabled:            data.IsEnabled.ValueBool(),
 		AnnotationsEnabled:   data.AnnotationsEnabled.ValueBool(),
 		Share:                models.ShareType(data.Share.ValueString()),
+	}
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *publicDashboardResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state resourcePublicDashboardModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
 	}
 }

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -20,7 +20,8 @@ var (
 	resourceFolderPermissionID   = orgResourceIDString("folderUID")
 
 	// Check interface
-	_ resource.ResourceWithImportState = (*resourceFolderPermission)(nil)
+	_ resource.ResourceWithImportState  = (*resourceFolderPermission)(nil)
+	_ resource.ResourceWithUpgradeState = (*resourceFolderPermission)(nil)
 )
 
 func makeResourceFolderPermission() *common.Resource {
@@ -237,4 +238,24 @@ func (r *resourceFolderPermission) Delete(ctx context.Context, req resource.Dele
 	folderUID := split[0].(string)
 
 	resp.Diagnostics.Append(r.applyBulkPermissions(client, folderUID, nil)...)
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *resourceFolderPermission) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state resourceFolderPermissionModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
+	}
 }

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -56,10 +56,11 @@ var (
 	reportFrequencies  = []string{reportFrequencyNever, reportFrequencyOnce, reportFrequencyHourly, reportFrequencyDaily, reportFrequencyWeekly, reportFrequencyMonthly, reportFrequencyCustom}
 	reportFormats      = []string{reportFormatPDF, reportFormatCSV, reportFormatImage}
 
-	_ resource.Resource                = &reportResource{}
-	_ resource.ResourceWithConfigure   = &reportResource{}
-	_ resource.ResourceWithImportState = &reportResource{}
-	_ resource.ResourceWithModifyPlan  = &reportResource{}
+	_ resource.Resource                  = &reportResource{}
+	_ resource.ResourceWithConfigure     = &reportResource{}
+	_ resource.ResourceWithImportState   = &reportResource{}
+	_ resource.ResourceWithModifyPlan    = &reportResource{}
+	_ resource.ResourceWithUpgradeState  = &reportResource{}
 )
 
 type resourceReportTimeRangeModel struct {
@@ -917,5 +918,25 @@ func (v customIntervalValidator) ValidateString(_ context.Context, req validator
 	}
 	if _, _, err := parseCustomReportInterval(req.ConfigValue.ValueString()); err != nil {
 		resp.Diagnostics.AddAttributeError(req.Path, "Invalid custom_interval", err.Error())
+	}
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *reportResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state resourceReportModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
 	}
 }

--- a/internal/resources/grafana/resource_scim_config.go
+++ b/internal/resources/grafana/resource_scim_config.go
@@ -41,9 +41,10 @@ type SCIMConfigSpec struct {
 }
 
 var (
-	_ resource.Resource                = &scimConfigResource{}
-	_ resource.ResourceWithConfigure   = &scimConfigResource{}
-	_ resource.ResourceWithImportState = &scimConfigResource{}
+	_ resource.Resource                  = &scimConfigResource{}
+	_ resource.ResourceWithConfigure     = &scimConfigResource{}
+	_ resource.ResourceWithImportState   = &scimConfigResource{}
+	_ resource.ResourceWithUpgradeState  = &scimConfigResource{}
 
 	resourceSCIMConfigName = "grafana_scim_config"
 	resourceSCIMConfigID   = common.NewResourceID(common.OptionalIntIDField("orgID"))
@@ -413,5 +414,25 @@ func setAuthHeaders(req *http.Request, transportConfig *goapi.TransportConfig) {
 		username := transportConfig.BasicAuth.Username()
 		password, _ := transportConfig.BasicAuth.Password()
 		req.SetBasicAuth(username, password)
+	}
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *scimConfigResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state resourceSCIMConfigModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
 	}
 }

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &serviceAccountResource{}
-	_ resource.ResourceWithConfigure   = &serviceAccountResource{}
-	_ resource.ResourceWithImportState = &serviceAccountResource{}
+	_ resource.Resource                  = &serviceAccountResource{}
+	_ resource.ResourceWithConfigure     = &serviceAccountResource{}
+	_ resource.ResourceWithImportState   = &serviceAccountResource{}
+	_ resource.ResourceWithUpgradeState  = &serviceAccountResource{}
 
 	resourceServiceAccountName = "grafana_service_account"
 	resourceServiceAccountID   = orgResourceIDInt("id")
@@ -332,4 +333,24 @@ func (r *serviceAccountResource) read(ctx context.Context, id string) (*serviceA
 		Role:       types.StringValue(sa.Role),
 		IsDisabled: types.BoolValue(sa.IsDisabled),
 	}, diags
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *serviceAccountResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state serviceAccountResourceModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
+	}
 }

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -48,9 +48,10 @@ const (
 )
 
 var (
-	_ resource.Resource                = &teamResource{}
-	_ resource.ResourceWithConfigure   = &teamResource{}
-	_ resource.ResourceWithImportState = &teamResource{}
+	_ resource.Resource                  = &teamResource{}
+	_ resource.ResourceWithConfigure     = &teamResource{}
+	_ resource.ResourceWithImportState   = &teamResource{}
+	_ resource.ResourceWithUpgradeState  = &teamResource{}
 
 	resourceTeamName = "grafana_team"
 	resourceTeamID   = orgResourceIDInt("id")
@@ -669,4 +670,24 @@ func getTeamByID(client *goapi.GrafanaHTTPAPI, teamID int64) (*models.TeamDTO, e
 		return nil, err
 	}
 	return resp.GetPayload(), nil
+}
+
+// UpgradeState registers a passthrough for version 0 state (written by the SDKv2 sub-provider).
+// The Framework handles v0→v0 transitions natively and does NOT call this handler during the
+// initial SDKv2→Framework upgrade. The handler exists so that if the schema is later bumped
+// to version 1+, users who still have v0 state can migrate without hitting
+// "Provider does not support upgrading to version 0 of this resource."
+func (r *teamResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &schemaResp.Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var state resourceTeamModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			},
+		},
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `ResourceWithUpgradeState` implementations to the 7 resources migrated from SDKv2 to Plugin Framework in v4.30.0: `grafana_team`, `grafana_service_account`, `grafana_scim_config`, `grafana_public_dashboard`, `grafana_folder_permission`, `grafana_report`, `grafana_dashboard_permission`.
- These handlers are **not invoked** during the initial SDKv2→Framework upgrade — the Framework handles v0→v0 transitions with a built-in passthrough. They exist so that if a schema is later bumped to `Version: 1+`, users who still have v0 state can migrate instead of hitting _"Provider does not support upgrading to version 0 of this resource."_
- Adds an `UpgradeState for SDKv2→Framework migrations` section to the migration playbook explaining when the handler fires, why to register it proactively, and what to do if a future structural schema change makes the simple passthrough unsafe.
- Fixes misleading comments in all 7 files (previously said "prevent a provider crash" which implied the handler was called during the upgrade; it is not).

## Test plan

- [ ] `go build ./...` passes (no new compilation errors)
- [ ] No new `ResourceWithUpgradeState` implementations needed — these cover all resources migrated in v4.29.2/v4.30.0
- [ ] Spot-check: `go test ./internal/resources/grafana/... -run TestUnit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)