### PR TITLE
ci: enforce conventional commits on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -16,7 +16,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,8 +40,9 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             should not start with an uppercase character.
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        continue-on-error: true
         with:
           header: pr-title-lint-error
           message: |
@@ -72,8 +73,9 @@ jobs:
 
             </details>
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        continue-on-error: true
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -65,6 +65,8 @@ jobs:
             - `chore: update Go dependencies`
             - `docs: regenerate resource documentation`
 
+            See [CONTRIBUTING.md](https://github.com/grafana/terraform-provider-grafana/blob/main/CONTRIBUTING.md#pr-title-format) for full details.
+
             <details><summary>Error details</summary>
 
             ```

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,79 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+            build
+          scopes: |
+            [a-z][a-z0-9_-]*
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            should not start with an uppercase character.
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Pull request titles must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, because this repository uses squash merges and the PR title becomes the commit message.
+
+            **Format:** `<type>(<scope>): <subject>`
+
+            **Valid types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`
+
+            **Scope** is optional but recommended — use the affected resource name, e.g. `feat(grafana_dashboard): add uid attribute`.
+
+            **Subject** should be lowercase and use imperative mood (e.g. "add" not "added").
+
+            **Breaking changes:** append `!` after the type/scope, e.g. `feat(grafana_folder)!: rename uid to folder_uid`. Explain the breaking change in the PR description.
+
+            **Examples:**
+            - `feat(grafana_dashboard): add uid attribute`
+            - `fix(grafana_folder): handle missing parent on import`
+            - `feat(grafana_folder)!: rename uid to folder_uid`
+            - `chore: update Go dependencies`
+            - `docs: regenerate resource documentation`
+
+            <details><summary>Error details</summary>
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+            </details>
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,10 @@ Always call the appropriate `testutils.CheckOSSTestsEnabled(t)` / `CheckEnterpri
 - Example files prefixed with `_acc_` are also used as acceptance test configs via `testutils.TestAccExample(t, "resources/grafana_foo/_acc_basic.tf")`
 - After any schema or example change, run `make docs` and commit the updated `docs/` files
 
+### Commit conventions
+
+This repository uses squash merges with [Conventional Commits](https://www.conventionalcommits.org/). PR titles must follow the format `<type>(<scope>): <subject>`. See [CONTRIBUTING.md](./CONTRIBUTING.md#pr-title-format) for the full list of types, scope guidance, and breaking change conventions.
+
 ### Concurrency
 
 Some resources use mutexes on the shared `common.Client` to avoid race conditions during parallel applies. Wrap CRUD functions with the appropriate helper:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,69 @@ We welcome contributions. Here’s how to get changes merged.
    - OSS acceptance tests (needs Grafana): see [README – Running Tests](README.md#running-tests), e.g. `make testacc-oss-docker`.
 4. **Run the linter** before opening a PR: `make golangci-lint` (runs `golangci-lint run ./... -v` in Docker with the same version CI uses). If you have [golangci-lint](https://golangci-lint.run/) v2 installed locally, you can run `golangci-lint run ./... -v` from the repo root instead.
 5. **Update generated docs** if you changed resource/datasource schema or examples: run `go generate ./...` (or `make docs`). CI will fail if `docs/` is out of sync.
-6. **Open a pull request** against `main` with a clear description of the change.
+6. **Open a pull request** against `main` — see [PR title format](#pr-title-format) below.
+
+## PR title format
+
+This repository uses **squash merges**, so all commits in a PR are combined into a single commit when merged. The **PR title becomes the commit message**, so it must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
+
+```
+<type>(<scope>): <subject>
+```
+
+A CI check validates the PR title and will block merging if it doesn't conform.
+
+### Types
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no logic change |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `build` | Build system or external dependencies |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance tasks, dependency updates, housekeeping |
+
+### Scope
+
+Scope is optional but recommended. Use the affected resource name when applicable. Scopes must be lowercase with no spaces.
+
+### Subject
+
+The subject should be lowercase, use imperative mood ("add" not "added"), and not end with a period.
+
+### Breaking changes
+
+Breaking changes should be avoided whenever possible. Terraform users depend on stable resource schemas, and breaking changes force manual state manipulation or configuration rewrites. Prefer deprecating attributes over removing them, and add new attributes alongside old ones when feasible.
+
+When a breaking change is unavoidable, append `!` after the type (and scope, if present):
+
+```
+feat(grafana_folder)!: rename uid to folder_uid
+```
+
+Breaking changes must be explained in the PR description body. When squash merging, expand the commit message body to include a `BREAKING CHANGE:` footer describing what changed and how users should migrate. For example:
+
+```
+feat(grafana_folder)!: rename uid to folder_uid
+
+BREAKING CHANGE: The `uid` attribute on `grafana_folder` has been renamed
+to `folder_uid`. Update your configuration and state accordingly.
+```
+
+### Examples
+
+- `feat(grafana_dashboard): add uid attribute`
+- `fix(grafana_folder): handle missing parent on import`
+- `refactor(grafana_team): migrate to Plugin Framework`
+- `feat(grafana_folder)!: rename uid to folder_uid`
+- `chore: update Go dependencies`
+- `docs: regenerate resource documentation`
+
+## Questions
 
 For questions or discussion, use the [Grafana #terraform Slack channel](https://grafana.slack.com/archives/C017MUCFJUT). The Grafana Slack is public—anyone can join at [slack.grafana.com](https://slack.grafana.com/).


### PR DESCRIPTION
## Why

Adopting conventional commits gives us:

- **Consistency** — the commit log becomes easier to parse by both humans and machines
- **Structured changelogs** — release notes can be automatically generated and grouped by type (features, bug fixes, etc.) — see #2693
- **Semver enforcement** — breaking changes can require a major version bump, new features a minor bump — see #2693

Since we use squash merges, the PR title becomes the commit message. Enforcing conventional commits on PR titles is the natural place to do this.

## Summary

- Add a GitHub Actions workflow (`.github/workflows/pr-title.yml`) that validates PR titles against the [Conventional Commits](https://www.conventionalcommits.org/) spec using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request)
- Posts a sticky PR comment with format guidance when validation fails, auto-deletes when fixed
- Update `CONTRIBUTING.md` with a new section on PR title format, squash merge workflow, and breaking change conventions

## Action items after merging

- [x] **Change repo setting:** update `squash_merge_commit_title` from `COMMIT_OR_PR_TITLE` to `PR_TITLE` (Settings > General > Pull Requests, or via API: `gh api --method PATCH /repos/grafana/terraform-provider-grafana -f squash_merge_commit_title=PR_TITLE`). This ensures the PR title is always used as the squash commit title, even for single-commit PRs.
- [x] **Mark `Validate PR title` as a required status check** in branch protection rules so PRs cannot merge without it passing.