### PR TITLE
feat(ci): generate changelog from conventional commits and validate semver bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,11 @@ jobs:
     - name: Validate semver bump
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ github.ref_name }}
       run: |
         # Get the expected version from git-cliff based on conventional commits
         expected=$(git cliff --bumped-version)
-        actual="${{ github.ref_name }}"
+        actual="${TAG_NAME}"
 
         # Extract major.minor.patch (strip leading 'v')
         expected_ver="${expected#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,54 +48,35 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG_NAME: ${{ github.ref_name }}
       run: |
-        # Get the expected version from git-cliff based on conventional commits
+        # git-cliff computes the minimum required version based on conventional commits
         expected=$(git cliff --bumped-version)
         actual="${TAG_NAME}"
 
-        # Extract major.minor.patch (strip leading 'v')
-        expected_ver="${expected#v}"
-        actual_ver="${actual#v}"
-
-        # Parse version components
-        expected_major="${expected_ver%%.*}"
-        actual_major="${actual_ver%%.*}"
-        expected_rest="${expected_ver#*.}"
-        actual_rest="${actual_ver#*.}"
-        expected_minor="${expected_rest%%.*}"
-        actual_minor="${actual_rest%%.*}"
-
-        echo "Expected minimum version: $expected (based on conventional commits)"
+        echo "Minimum required version: $expected"
         echo "Actual tag: $actual"
 
-        # Determine the required bump level from git-cliff's suggestion
-        # Get the previous tag to compare against
-        prev_tag=$(git describe --tags --abbrev=0 "${actual}^" 2>/dev/null || echo "v0.0.0")
-        prev_ver="${prev_tag#v}"
-        prev_major="${prev_ver%%.*}"
-        prev_rest="${prev_ver#*.}"
-        prev_minor="${prev_rest%%.*}"
+        # Compare major.minor.patch — actual must be >= expected
+        IFS='.' read -r exp_major exp_minor exp_patch <<< "${expected#v}"
+        IFS='.' read -r act_major act_minor act_patch <<< "${actual#v}"
 
-        echo "Previous tag: $prev_tag"
-
-        # Determine what git-cliff thinks is needed
-        if [ "$expected_major" -gt "$prev_major" ]; then
-          required_bump="major"
-        elif [ "$expected_minor" -gt "$prev_minor" ]; then
-          required_bump="minor"
-        else
-          required_bump="patch"
-        fi
-
-        echo "Required bump level: $required_bump"
-
-        # Validate the actual tag meets the minimum requirement
-        if [ "$required_bump" = "major" ] && [ "$actual_major" -le "$prev_major" ]; then
-          echo "::error::Breaking changes detected — major version bump required (expected at least v$((prev_major + 1)).0.0, got $actual)"
+        if [ "$act_major" -gt "$exp_major" ]; then
+          echo "Semver validation passed (major exceeds minimum)."
+          exit 0
+        elif [ "$act_major" -lt "$exp_major" ]; then
+          echo "::error::Tag $actual does not meet minimum required version $expected (major version too low)"
           exit 1
         fi
 
-        if [ "$required_bump" = "minor" ] && [ "$actual_major" -eq "$prev_major" ] && [ "$actual_minor" -le "$prev_minor" ]; then
-          echo "::error::New features detected — at least minor version bump required (expected at least v${prev_major}.$((prev_minor + 1)).0, got $actual)"
+        if [ "$act_minor" -gt "$exp_minor" ]; then
+          echo "Semver validation passed (minor exceeds minimum)."
+          exit 0
+        elif [ "$act_minor" -lt "$exp_minor" ]; then
+          echo "::error::Tag $actual does not meet minimum required version $expected (minor version too low)"
+          exit 1
+        fi
+
+        if [ "$act_patch" -lt "$exp_patch" ]; then
+          echo "::error::Tag $actual does not meet minimum required version $expected (patch version too low)"
           exit 1
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,69 @@ jobs:
         persist-credentials: false
     - name: Unshallow
       run: git fetch --prune --unshallow
+    - name: Generate changelog
+      id: changelog
+      uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
+      with:
+        args: --latest --strip header
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Validate semver bump
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Get the expected version from git-cliff based on conventional commits
+        expected=$(git cliff --bumped-version)
+        actual="${{ github.ref_name }}"
+
+        # Extract major.minor.patch (strip leading 'v')
+        expected_ver="${expected#v}"
+        actual_ver="${actual#v}"
+
+        # Parse version components
+        expected_major="${expected_ver%%.*}"
+        actual_major="${actual_ver%%.*}"
+        expected_rest="${expected_ver#*.}"
+        actual_rest="${actual_ver#*.}"
+        expected_minor="${expected_rest%%.*}"
+        actual_minor="${actual_rest%%.*}"
+
+        echo "Expected minimum version: $expected (based on conventional commits)"
+        echo "Actual tag: $actual"
+
+        # Determine the required bump level from git-cliff's suggestion
+        # Get the previous tag to compare against
+        prev_tag=$(git describe --tags --abbrev=0 "${actual}^" 2>/dev/null || echo "v0.0.0")
+        prev_ver="${prev_tag#v}"
+        prev_major="${prev_ver%%.*}"
+        prev_rest="${prev_ver#*.}"
+        prev_minor="${prev_rest%%.*}"
+
+        echo "Previous tag: $prev_tag"
+
+        # Determine what git-cliff thinks is needed
+        if [ "$expected_major" -gt "$prev_major" ]; then
+          required_bump="major"
+        elif [ "$expected_minor" -gt "$prev_minor" ]; then
+          required_bump="minor"
+        else
+          required_bump="patch"
+        fi
+
+        echo "Required bump level: $required_bump"
+
+        # Validate the actual tag meets the minimum requirement
+        if [ "$required_bump" = "major" ] && [ "$actual_major" -le "$prev_major" ]; then
+          echo "::error::Breaking changes detected — major version bump required (expected at least v$((prev_major + 1)).0.0, got $actual)"
+          exit 1
+        fi
+
+        if [ "$required_bump" = "minor" ] && [ "$actual_major" -eq "$prev_major" ] && [ "$actual_minor" -le "$prev_minor" ]; then
+          echo "::error::New features detected — at least minor version bump required (expected at least v${prev_major}.$((prev_minor + 1)).0, got $actual)"
+          exit 1
+        fi
+
+        echo "Semver validation passed."
     - name: Free Disk Space
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
@@ -67,7 +130,7 @@ jobs:
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:
         version: latest
-        args: release --clean
+        args: release --clean --release-notes=${{ steps.changelog.outputs.changelog }}
       env:
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,7 +2,7 @@
 header = ""
 body = """
 {% macro pr_link(commit) %}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/grafana/terraform-provider-grafana/pull/{{ commit.remote.pr_number }})){% endif %}{% endmacro %}
-{% macro commit_line(commit) %}- {% if commit.scope and commit.scope != "_unscoped" %}**{{ commit.scope }}:** {% endif %}{{ commit.message }}{{ self::pr_link(commit=commit) }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% endmacro %}
+{% macro commit_line(commit) %}- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }}{{ self::pr_link(commit=commit) }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% endmacro %}
 
 {% for group, group_commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
@@ -22,17 +22,17 @@ commit_preprocessors = [
 filter_unconventional = false
 protect_breaking_commits = true
 commit_parsers = [
-    { message = "^feat", group = "Features", default_scope = "_unscoped" },
-    { message = "^fix", group = "Bug Fixes", default_scope = "_unscoped" },
-    { message = "^docs", group = "Documentation", default_scope = "_unscoped" },
-    { message = "^perf", group = "Performance", default_scope = "_unscoped" },
-    { message = "^refactor", group = "Refactoring", default_scope = "_unscoped" },
-    { message = "^style", group = "Styling", default_scope = "_unscoped" },
-    { message = "^test", group = "Testing", default_scope = "_unscoped" },
-    { message = "^chore", group = "Miscellaneous", default_scope = "_unscoped" },
-    { message = "^ci", group = "CI/CD", default_scope = "_unscoped" },
-    { message = "^build", group = "Build", default_scope = "_unscoped" },
-    { message = ".*", group = "Other Changes", default_scope = "_unscoped" },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+    { message = ".*", group = "Other Changes" },
 ]
 tag_pattern = "v[0-9].*"
 sort_commits = "oldest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,52 @@
+[changelog]
+header = ""
+body = """
+{%- macro commit_line(commit) -%}
+    - {{ commit.message }}\
+    {%- if commit.remote.pr_number %} \
+        ([#{{ commit.remote.pr_number }}](https://github.com/grafana/terraform-provider-grafana/pull/{{ commit.remote.pr_number }}))\
+    {%- endif %}
+{%- endmacro -%}
+
+{## Breaking changes section ##}
+{%- set breaking_commits = commits | filter(attribute="breaking", value=true) -%}
+{% if breaking_commits | length > 0 %}
+### Breaking Changes
+{% for commit in breaking_commits %}
+{{ self::commit_line(commit=commit) }}
+{%- endfor %}
+{% endif %}
+
+{## Grouped sections (excluding breaking commits) ##}
+{% for group, group_commits in commits | filter(attribute="breaking", value=false) | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in group_commits %}
+{{ self::commit_line(commit=commit) }}
+{%- endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+protect_breaking_commits = true
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+    { message = ".*", group = "Other Changes" },
+]
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"
+
+[remote.github]
+owner = "grafana"
+repo = "terraform-provider-grafana"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,57 +1,38 @@
 [changelog]
 header = ""
 body = """
-{%- macro commit_line(commit) -%}
-    - {{ commit.message }}\
-    {%- if commit.remote.pr_number %} \
-        ([#{{ commit.remote.pr_number }}](https://github.com/grafana/terraform-provider-grafana/pull/{{ commit.remote.pr_number }}))\
-    {%- endif %}
-{%- endmacro -%}
+{% macro pr_link(commit) %}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/grafana/terraform-provider-grafana/pull/{{ commit.remote.pr_number }})){% endif %}{% endmacro %}
+{% macro commit_line(commit) %}- {% if commit.scope and commit.scope != "_unscoped" %}**{{ commit.scope }}:** {% endif %}{{ commit.message }}{{ self::pr_link(commit=commit) }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% endmacro %}
 
-{## Breaking changes section ##}
-{%- set breaking_commits = commits | filter(attribute="breaking", value=true) -%}
-{% if breaking_commits | length > 0 %}
-### Breaking Changes
-{% for commit in breaking_commits %}
-{{ self::commit_line(commit=commit) }}
-{%- endfor %}
-{% endif %}
-
-{## Grouped sections (excluding breaking commits) ##}
-{% for group, group_commits in commits | filter(attribute="breaking", value=false) | group_by(attribute="group") %}
+{% for group, group_commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
-{%- for scope, scoped_commits in group_commits | group_by(attribute="scope") %}
-{% if scope != "" %}
-- **{{ scope }}:**
-{%- for commit in scoped_commits %}
-{{ self::commit_line(commit=commit) | indent(n=2) }}
-{%- endfor %}
-{%- else %}
-{%- for commit in scoped_commits %}
+{% for commit in group_commits -%}
 {{ self::commit_line(commit=commit) }}
-{%- endfor %}
-{%- endif %}
-{%- endfor %}
+{% endfor -%}
 {% endfor %}
 """
 trim = true
 
 [git]
 conventional_commits = true
+commit_preprocessors = [
+    { pattern = ' *\(#\d+\)', replace = "" },
+    { pattern = '\n.*', replace = "" },
+]
 filter_unconventional = false
 protect_breaking_commits = true
 commit_parsers = [
-    { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
-    { message = "^docs", group = "Documentation" },
-    { message = "^perf", group = "Performance" },
-    { message = "^refactor", group = "Refactoring" },
-    { message = "^style", group = "Styling" },
-    { message = "^test", group = "Testing" },
-    { message = "^chore", group = "Miscellaneous" },
-    { message = "^ci", group = "CI/CD" },
-    { message = "^build", group = "Build" },
-    { message = ".*", group = "Other Changes" },
+    { message = "^feat", group = "Features", default_scope = "_unscoped" },
+    { message = "^fix", group = "Bug Fixes", default_scope = "_unscoped" },
+    { message = "^docs", group = "Documentation", default_scope = "_unscoped" },
+    { message = "^perf", group = "Performance", default_scope = "_unscoped" },
+    { message = "^refactor", group = "Refactoring", default_scope = "_unscoped" },
+    { message = "^style", group = "Styling", default_scope = "_unscoped" },
+    { message = "^test", group = "Testing", default_scope = "_unscoped" },
+    { message = "^chore", group = "Miscellaneous", default_scope = "_unscoped" },
+    { message = "^ci", group = "CI/CD", default_scope = "_unscoped" },
+    { message = "^build", group = "Build", default_scope = "_unscoped" },
+    { message = ".*", group = "Other Changes", default_scope = "_unscoped" },
 ]
 tag_pattern = "v[0-9].*"
 sort_commits = "oldest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -20,8 +20,17 @@ body = """
 {## Grouped sections (excluding breaking commits) ##}
 {% for group, group_commits in commits | filter(attribute="breaking", value=false) | group_by(attribute="group") %}
 ### {{ group | upper_first }}
-{% for commit in group_commits %}
+{%- for scope, scoped_commits in group_commits | group_by(attribute="scope") %}
+{% if scope != "" %}
+- **{{ scope }}:**
+{%- for commit in scoped_commits %}
+{{ self::commit_line(commit=commit) | indent(n=2) }}
+{%- endfor %}
+{%- else %}
+{%- for commit in scoped_commits %}
 {{ self::commit_line(commit=commit) }}
+{%- endfor %}
+{%- endif %}
 {%- endfor %}
 {% endfor %}
 """


### PR DESCRIPTION
## Summary

- Add `cliff.toml` configuration for [git-cliff](https://git-cliff.org/) changelog generation from conventional commit messages
- Add a changelog generation step to the release workflow using `orhun/git-cliff-action`, replacing the manual GitHub "Generate release notes" button
- Add a semver validation step that fails the release workflow if:
  - Breaking changes are present without a **major** version bump
  - New features (`feat`) are present without at least a **minor** version bump
- Changelog output is passed to GoReleaser via `--release-notes` for the draft release body

## Changelog format

Each release groups commits by type (Features, Bug Fixes, etc.) with:
- Scope shown as an inline bold prefix (e.g. **grafana_dashboard:**)
- PR number linked to GitHub
- PR author attributed
- Non-conventional (historical) commits grouped under "Other Changes"
- Commit bodies stripped — only the first line is shown

<details>
<summary>Example: generated changelog for v4.31.0 (v4.30.0..v4.31.0)</summary>

### Bug Fixes
- reject full k8s envelope in dashboard v2 spec.json with a descriptive error ([#2677](https://github.com/grafana/terraform-provider-grafana/pull/2677)) by @ivanortegaalba
- **provider:** set User-Agent on clients that were missing it ([#2593](https://github.com/grafana/terraform-provider-grafana/pull/2593)) by @Duologic
- **deps:** update module github.com/hashicorp/hc-install to v0.9.3 ([#2682](https://github.com/grafana/terraform-provider-grafana/pull/2682)) by @renovate-sh-app[bot]

### Features
- **cloud_stack:** add cloud_provider_url, connections_api_url, sm_url and simplify provider docs ([#2679](https://github.com/grafana/terraform-provider-grafana/pull/2679)) by @Duologic

### Miscellaneous
- **deps:** update module go.opentelemetry.io/otel/sdk to v1.43.0 [security] ([#2672](https://github.com/grafana/terraform-provider-grafana/pull/2672)) by @renovate-sh-app[bot]
- **deps:** update module github.com/cloudflare/circl to v1.6.3 [security] ([#2554](https://github.com/grafana/terraform-provider-grafana/pull/2554)) by @renovate-sh-app[bot]

### Other Changes
- App Platform: Add extra documentation about how to use folder_uid ([#2675](https://github.com/grafana/terraform-provider-grafana/pull/2675)) by @spinillos
- Datasource Permissions: Skip lookup for global ([#2678](https://github.com/grafana/terraform-provider-grafana/pull/2678)) by @stephaniehingtgen
- Migrate disabled alert config ([#2668](https://github.com/grafana/terraform-provider-grafana/pull/2668)) by @rooneyshuman

</details>

## Semver validation

The release workflow now validates that the tag version matches the conventional commits:
- **Breaking change** (`!` or `BREAKING CHANGE:` footer) → requires major version bump
- **New feature** (`feat`) → requires at least minor version bump
- Bumping more than required is always allowed

## Depends on

- #2692 (conventional commits enforcement on PR titles)