### PR TITLE
ci: add policy-bot config for path-based CI requirements

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -1,6 +1,12 @@
 name: acceptance tests
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'templates/**'
+      - 'LICENSE'
+      - '.policy.yml'
   push:
     branches:
       - main

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -1,12 +1,14 @@
 name: acceptance tests
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'templates/**'
-      - 'LICENSE'
-      - '.policy.yml'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'examples/**'
+      - 'GNUmakefile'
+      - '.goreleaser.yml'
+      - '.github/workflows/acc-tests.yml'
   push:
     branches:
       - main

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -2,6 +2,12 @@ name: pr comment
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'templates/**'
+      - 'LICENSE'
+      - '.policy.yml'
 
 jobs:
   info-comment:

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -2,12 +2,12 @@ name: pr comment
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'templates/**'
-      - 'LICENSE'
-      - '.policy.yml'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'examples/**'
+      - 'GNUmakefile'
 
 jobs:
   info-comment:

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -10,6 +10,7 @@ on:
       - 'templates/**'
       - 'GNUmakefile'
       - '.goreleaser.yml'
+      - '.github/workflows/comment-on-pr.yml'
 
 jobs:
   info-comment:

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -7,7 +7,9 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'examples/**'
+      - 'templates/**'
       - 'GNUmakefile'
+      - '.goreleaser.yml'
 
 jobs:
   info-comment:

--- a/.github/workflows/sdkv2-migration-check.yml
+++ b/.github/workflows/sdkv2-migration-check.yml
@@ -1,6 +1,12 @@
 name: SDKv2 migration check
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'templates/**'
+      - 'LICENSE'
+      - '.policy.yml'
   push:
     branches:
       - main

--- a/.github/workflows/sdkv2-migration-check.yml
+++ b/.github/workflows/sdkv2-migration-check.yml
@@ -1,12 +1,9 @@
 name: SDKv2 migration check
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'templates/**'
-      - 'LICENSE'
-      - '.policy.yml'
+    paths:
+      - 'internal/resources/**'
+      - '.github/workflows/sdkv2-migration-check.yml'
   push:
     branches:
       - main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,12 +1,14 @@
 name: unit tests
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'examples/**'
       - 'templates/**'
-      - 'LICENSE'
-      - '.policy.yml'
+      - 'GNUmakefile'
+      - '.github/workflows/unit-tests.yml'
   push:
     branches:
       - main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,12 @@
 name: unit tests
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'templates/**'
+      - 'LICENSE'
+      - '.policy.yml'
   push:
     branches:
       - main

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,6 +1,12 @@
 name: Validate catalog
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'templates/**'
+      - 'LICENSE'
+      - '.policy.yml'
 
 jobs:
   validate-catalog:

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,12 +1,12 @@
 name: Validate catalog
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'templates/**'
-      - 'LICENSE'
-      - '.policy.yml'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/validate-catalog.yml'
+      - '.github/actions/validate-catalog/**'
 
 jobs:
   validate-catalog:

--- a/.policy.yml
+++ b/.policy.yml
@@ -4,6 +4,10 @@
 # in a pull request. If only non-code files change (e.g. docs, markdown),
 # the policy passes without waiting for CI.
 #
+# IMPORTANT: The `changed_files` paths below must stay aligned with the
+# `paths` trigger filters in the corresponding workflow files. Both use the
+# same set of paths — policy-bot uses regex, workflows use glob patterns.
+#
 # See https://github.com/palantir/policy-bot for documentation.
 
 policy:

--- a/.policy.yml
+++ b/.policy.yml
@@ -4,9 +4,20 @@
 # in a pull request. If only non-code files change (e.g. docs, markdown),
 # the policy passes without waiting for CI.
 #
-# IMPORTANT: The `changed_files` paths below must stay aligned with the
-# `paths` trigger filters in the corresponding workflow files. Both use the
-# same set of paths — policy-bot uses regex, workflows use glob patterns.
+# How it works:
+#   Each approval_rule has an `if.changed_files` predicate and a
+#   `requires.has_workflow_result` condition. When a PR doesn't touch any
+#   files matching the predicate, the rule is inactive — it auto-satisfies
+#   without checking for a workflow result. The corresponding workflow also
+#   won't trigger (its `paths:` filter is aligned with these predicates).
+#   The `has_workflow_result` condition is only evaluated when matching files
+#   changed, at which point the workflow will have been triggered.
+#
+# IMPORTANT: The `changed_files` regex paths below must stay aligned with
+# the `paths:` glob filters in the corresponding workflow files. A mismatch
+# could cause policy-bot to require a workflow that didn't trigger (regex
+# wider than glob) or a workflow to run without being required (glob wider
+# than regex).
 #
 # See https://github.com/palantir/policy-bot for documentation.
 

--- a/.policy.yml
+++ b/.policy.yml
@@ -82,13 +82,15 @@ approval_rules:
 
   - name: override policies
     description: >
-      Emergency override. A user with write access can post a comment
-      containing "policy-bot override" to bypass all policy checks.
+      Emergency override. A Grafana org member with write access can post
+      a comment containing "policy-bot override" to bypass all policy checks.
     options:
       methods:
         comment_patterns:
           - "^(?:policy-bot override|Policy-Bot Override)"
     requires:
       count: 1
+      organizations:
+        - "grafana"
       permissions:
         - write

--- a/.policy.yml
+++ b/.policy.yml
@@ -17,6 +17,7 @@ policy:
             - unit-tests workflow succeeded or skipped
             - acc-tests workflow succeeded or skipped
             - validate-catalog workflow succeeded or skipped
+            - sdkv2-migration-check workflow succeeded or skipped
         - override policies
 
 approval_rules:
@@ -83,6 +84,24 @@ approval_rules:
             - skipped
           workflows:
             - .github/workflows/validate-catalog.yml
+
+  - name: sdkv2-migration-check workflow succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - "^internal/resources/"
+          - "^\\.github/workflows/sdkv2-migration-check\\.yml$"
+      file_not_deleted:
+        paths:
+          - "^\\.github/workflows/sdkv2-migration-check\\.yml$"
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - success
+            - skipped
+          workflows:
+            - .github/workflows/sdkv2-migration-check.yml
 
   - name: override policies
     description: >

--- a/.policy.yml
+++ b/.policy.yml
@@ -1,0 +1,94 @@
+# Policy Bot configuration for terraform-provider-grafana
+#
+# This file defines which CI checks are required based on the files changed
+# in a pull request. If only non-code files change (e.g. docs, markdown),
+# the policy passes without waiting for CI.
+#
+# See https://github.com/palantir/policy-bot for documentation.
+
+policy:
+  approval:
+    - or:
+        - and:
+            - unit-tests workflow succeeded or skipped
+            - acc-tests workflow succeeded or skipped
+            - validate-catalog workflow succeeded or skipped
+        - override policies
+
+approval_rules:
+  - name: unit-tests workflow succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - "^.*\\.go$"
+          - "^go\\.(mod|sum)$"
+          - "^examples/"
+          - "^templates/"
+          - "^GNUmakefile$"
+          - "^\\.github/workflows/unit-tests\\.yml$"
+      file_not_deleted:
+        paths:
+          - "^\\.github/workflows/unit-tests\\.yml$"
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - success
+            - skipped
+          workflows:
+            - .github/workflows/unit-tests.yml
+
+  - name: acc-tests workflow succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - "^.*\\.go$"
+          - "^go\\.(mod|sum)$"
+          - "^examples/"
+          - "^GNUmakefile$"
+          - "^\\.goreleaser\\.yml$"
+          - "^\\.github/workflows/acc-tests\\.yml$"
+      file_not_deleted:
+        paths:
+          - "^\\.github/workflows/acc-tests\\.yml$"
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - success
+            - skipped
+          workflows:
+            - .github/workflows/acc-tests.yml
+
+  - name: validate-catalog workflow succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - "^.*\\.go$"
+          - "^go\\.(mod|sum)$"
+          - "^\\.github/workflows/validate-catalog\\.yml$"
+          - "^\\.github/actions/validate-catalog/"
+      file_not_deleted:
+        paths:
+          - "^\\.github/workflows/validate-catalog\\.yml$"
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - success
+            - skipped
+          workflows:
+            - .github/workflows/validate-catalog.yml
+
+  - name: override policies
+    description: >
+      Emergency override. A user with write access can post a comment
+      containing "policy-bot override" to bypass all policy checks.
+    options:
+      methods:
+        comment_patterns:
+          - "^(?:policy-bot override|Policy-Bot Override)"
+    requires:
+      count: 1
+      permissions:
+        - write


### PR DESCRIPTION
## Why

Currently all CI workflows run on every PR regardless of what changed. A docs-only or markdown change triggers the full acceptance test matrix (30+ jobs), wasting CI resources and making contributors wait unnecessarily.

## Summary

Two complementary changes:

### 1. Policy-bot config (`.policy.yml`)

Uses [policy-bot](https://github.com/palantir/policy-bot) file-based predicates to conditionally require CI workflows based on changed files:

- **`unit-tests.yml`** — required when Go, go.mod/sum, examples, templates, GNUmakefile, or its own workflow file changes
- **`acc-tests.yml`** — required when Go, go.mod/sum, examples, GNUmakefile, .goreleaser.yml, or its own workflow file changes
- **`validate-catalog.yml`** — required when Go, go.mod/sum, validate-catalog action, or its own workflow file changes
- **`sdkv2-migration-check.yml`** — required when files under `internal/resources/` or its own workflow file change

When only non-code files change (docs, markdown, LICENSE, etc.), policy-bot passes immediately without waiting for CI.

Includes an **override rule** — Grafana org members with write access can post `policy-bot override` as a comment to bypass all policy checks in emergencies.

### 2. `paths:` triggers on workflow files

Added positive `paths:` filters to 5 workflows so they don't trigger on non-code changes:

| Workflow | Paths |
|---|---|
| `unit-tests.yml` | `**.go`, `go.mod`, `go.sum`, `examples/**`, `templates/**`, `GNUmakefile`, own workflow |
| `acc-tests.yml` | `**.go`, `go.mod`, `go.sum`, `examples/**`, `GNUmakefile`, `.goreleaser.yml`, own workflow |
| `validate-catalog.yml` | `**.go`, `go.mod`, `go.sum`, `.github/actions/validate-catalog/**`, own workflow |
| `sdkv2-migration-check.yml` | `internal/resources/**`, own workflow |
| `comment-on-pr.yml` | Union of unit-tests + acc-tests code paths (excludes their workflow self-references, includes own workflow) |

The `paths:` filters are aligned with the `changed_files` regex predicates in `.policy.yml` — same set of paths, different syntax (glob vs regex).

Policy-bot ensures the missing required checks don't block merge. The workflows save CI resources by not running at all.

Note: `Validate PR title` and `pr-title.yml` are intentionally not affected — PR title validation should always run regardless of which files changed.

## Action items before merging

- [ ] **Verify policy-bot is enabled** on the `grafana/terraform-provider-grafana` repo (the GitHub App with integration ID `942795` must be installed and configured for this repo)

## Action items after merging

- [ ] **Add `policy-bot: main` as a required status check** in the `main` branch ruleset (integration ID `942795`)
- [ ] **Remove the 6 individual required status checks** from the ruleset: `unit tests`, `docs`, `golangci-lint`, `terraform fmt`, `integration`, `cloudinstance` (keep `Validate PR title`)
- [ ] Keep the approval requirement (`required_approving_review_count = 1`) in the ruleset as-is