### PR TITLE
ci: add full changelog comparison link to release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -10,6 +10,9 @@ body = """
 {{ self::commit_line(commit=commit) }}
 {% endfor -%}
 {% endfor %}
+{% if previous.version %}
+**Full Changelog**: [{{ previous.version }}...{{ version }}](https://github.com/grafana/terraform-provider-grafana/compare/{{ previous.version }}...{{ version }})
+{% endif %}
 """
 trim = true
 


### PR DESCRIPTION
## Summary

- Adds a "Full Changelog" comparison link at the bottom of generated release notes, matching the format GitHub's auto-generated release notes use
- Uses git-cliff's `previous.version` and `version` template variables to build the link

Follow-up to #2693.