### PR TITLE
fix(docs): update docs links

### DIFF
--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -3,13 +3,13 @@
 page_title: "grafana_folder Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/
 ---
 
 # grafana_folder (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/)
 
 ## Example Usage
 

--- a/docs/data-sources/folders.md
+++ b/docs/data-sources/folders.md
@@ -3,13 +3,13 @@
 page_title: "grafana_folders Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/
 ---
 
 # grafana_folders (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/)
 
 ## Example Usage
 

--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -3,13 +3,13 @@
 page_title: "grafana_organization Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/org/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/
 ---
 
 # grafana_organization (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/)
 
 ## Example Usage
 

--- a/docs/data-sources/organization_preferences.md
+++ b/docs/data-sources/organization_preferences.md
@@ -3,13 +3,13 @@
 page_title: "grafana_organization_preferences Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/#get-current-org-prefs
 ---
 
 # grafana_organization_preferences (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/#get-current-org-prefs)
 
 ## Example Usage
 

--- a/docs/data-sources/organization_user.md
+++ b/docs/data-sources/organization_user.md
@@ -3,13 +3,13 @@
 page_title: "grafana_organization_user Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-all-users-within-the-current-organization-lookup
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/#get-all-users-within-the-current-organization-lookup
 ---
 
 # grafana_organization_user (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-all-users-within-the-current-organization-lookup)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/#get-all-users-within-the-current-organization-lookup)
 
 ## Example Usage
 

--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -4,7 +4,7 @@ page_title: "grafana_role Data Source - terraform-provider-grafana"
 subcategory: "Grafana Enterprise"
 description: |-
   Note: This resource is available only with Grafana Enterprise 8.+.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/access_control/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/
 ---
 
 # grafana_role (Data Source)
@@ -12,7 +12,7 @@ description: |-
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/)
 
 ## Example Usage
 

--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -4,13 +4,13 @@ page_title: "grafana_service_account Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-  	* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+  	* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 ---
 
 # grafana_service_account (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-		* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+		* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 ## Example Usage
 

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -3,13 +3,13 @@
 page_title: "grafana_team Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/team-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/team/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/team-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/
 ---
 
 # grafana_team (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/)
 
 ## Example Usage
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -3,7 +3,7 @@
 page_title: "grafana_user Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/user/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/
   This data source uses Grafana's admin APIs for reading users which
   does not currently work with API Tokens. You must use basic auth.
   This data source is also not compatible with Grafana Cloud, as it does not allow basic auth.
@@ -12,7 +12,7 @@ description: |-
 # grafana_user (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/)
 
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -3,7 +3,7 @@
 page_title: "grafana_users Data Source - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/user/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/
   This data source uses Grafana's admin APIs for reading users which
   does not currently work with API Tokens. You must use basic auth.
   This data source is also not compatible with Grafana Cloud, as it does not allow basic auth.
@@ -12,7 +12,7 @@ description: |-
 # grafana_users (Data Source)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/)
 		
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/docs/resources/annotation.md
+++ b/docs/resources/annotation.md
@@ -4,7 +4,7 @@ page_title: "grafana_annotation Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana annotations.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/annotations/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/annotations/
 ---
 
 # grafana_annotation (Resource)
@@ -12,7 +12,7 @@ description: |-
 Manages Grafana annotations.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/annotations/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/annotations/)
 
 ## Example Usage
 

--- a/docs/resources/cloud_stack_service_account.md
+++ b/docs/resources/cloud_stack_service_account.md
@@ -5,7 +5,7 @@ subcategory: "Cloud"
 description: |-
   Manages service accounts of a Grafana Cloud stack using the Cloud API
   This can be used to bootstrap a management service account for a new stack
-  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api
+  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api
   Required access policy scopes:
   stacks:readstack-service-accounts:write
 ---
@@ -16,7 +16,7 @@ Manages service accounts of a Grafana Cloud stack using the Cloud API
 This can be used to bootstrap a management service account for a new stack
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 Required access policy scopes:
 

--- a/docs/resources/cloud_stack_service_account_rotating_token.md
+++ b/docs/resources/cloud_stack_service_account_rotating_token.md
@@ -5,7 +5,7 @@ subcategory: "Cloud"
 description: |-
   Manages and rotates service account tokens of a Grafana Cloud stack using the Cloud API
   This can be used to bootstrap a management service account token for a new stack
-  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api
+  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api
   Required access policy scopes:
   stack-service-accounts:write
 ---
@@ -16,7 +16,7 @@ Manages and rotates service account tokens of a Grafana Cloud stack using the Cl
 This can be used to bootstrap a management service account token for a new stack
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 Required access policy scopes:
 

--- a/docs/resources/cloud_stack_service_account_token.md
+++ b/docs/resources/cloud_stack_service_account_token.md
@@ -5,7 +5,7 @@ subcategory: "Cloud"
 description: |-
   Manages service account tokens of a Grafana Cloud stack using the Cloud API
   This can be used to bootstrap a management service account token for a new stack
-  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api
+  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api
   Required access policy scopes:
   stack-service-accounts:write
 ---
@@ -16,7 +16,7 @@ Manages service account tokens of a Grafana Cloud stack using the Cloud API
 This can be used to bootstrap a management service account token for a new stack
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 Required access policy scopes:
 

--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -4,7 +4,7 @@ page_title: "grafana_contact_point Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting contact points.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#contact-points
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -13,7 +13,7 @@ description: |-
 Manages Grafana Alerting contact points.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/dashboard_permission.md
+++ b/docs/resources/dashboard_permission.md
@@ -4,14 +4,14 @@ page_title: "grafana_dashboard_permission Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages the entire set of permissions for a dashboard. Permissions that aren't specified when applying this resource will be removed.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions/
 ---
 
 # grafana_dashboard_permission (Resource)
 
 Manages the entire set of permissions for a dashboard. Permissions that aren't specified when applying this resource will be removed.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/dashboard_public.md
+++ b/docs/resources/dashboard_public.md
@@ -5,7 +5,7 @@ subcategory: "Grafana OSS"
 description: |-
   Manages Grafana public dashboards.
   Note: This resource is available only with Grafana 10.2+.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/HTTP API https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_public/
 ---
 
 # grafana_dashboard_public (Resource)
@@ -15,7 +15,7 @@ Manages Grafana public dashboards.
 **Note:** This resource is available only with Grafana 10.2+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_public/)
 
 ## Example Usage
 

--- a/docs/resources/data_source.md
+++ b/docs/resources/data_source.md
@@ -3,7 +3,7 @@
 page_title: "grafana_data_source Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/datasources/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/data_source/
+  Official documentation https://grafana.com/docs/grafana/latest/datasources/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/
   The required arguments for this resource vary depending on the type of data
   source selected (via the 'type' argument).
 ---
@@ -11,7 +11,7 @@ description: |-
 # grafana_data_source (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/datasources/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/)
 
 The required arguments for this resource vary depending on the type of data
 source selected (via the 'type' argument).

--- a/docs/resources/data_source_config.md
+++ b/docs/resources/data_source_config.md
@@ -3,7 +3,7 @@
 page_title: "grafana_data_source_config Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/datasources/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/data_source/
+  Official documentation https://grafana.com/docs/grafana/latest/datasources/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/
   The required arguments for this resource vary depending on the type of data
   source selected (via the 'type' argument).
   Use this resource for configuring multiple datasources, when that configuration (json_data_encoded field) requires circular references like in the example below.
@@ -13,7 +13,7 @@ description: |-
 # grafana_data_source_config (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/datasources/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/)
 
 The required arguments for this resource vary depending on the type of data
 source selected (via the 'type' argument).

--- a/docs/resources/data_source_config_lbac_rules.md
+++ b/docs/resources/data_source_config_lbac_rules.md
@@ -5,7 +5,7 @@ subcategory: "Grafana Enterprise"
 description: |-
   Manages LBAC rules for a data source.
   !> Warning: The resource is experimental and will be subject to change. This resource manages the entire LBAC rules tree, and will overwrite any existing rules.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/datasource_lbac_rules/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules/
   This resource requires Grafana >=11.5.0.
 ---
 
@@ -16,7 +16,7 @@ Manages LBAC rules for a data source.
 !> Warning: The resource is experimental and will be subject to change. This resource manages the entire LBAC rules tree, and will overwrite any existing rules.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_lbac_rules/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules/)
 
 This resource requires Grafana >=11.5.0.
 

--- a/docs/resources/data_source_permission.md
+++ b/docs/resources/data_source_permission.md
@@ -4,13 +4,13 @@ page_title: "grafana_data_source_permission Resource - terraform-provider-grafan
 subcategory: "Grafana Enterprise"
 description: |-
   Manages the entire set of permissions for a datasource. Permissions that aren't specified when applying this resource will be removed.
-  HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/
+  HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_permissions/
 ---
 
 # grafana_data_source_permission (Resource)
 
 Manages the entire set of permissions for a datasource. Permissions that aren't specified when applying this resource will be removed.
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -3,13 +3,13 @@
 page_title: "grafana_folder Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/
 ---
 
 # grafana_folder (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/)
 
 ## Example Usage
 

--- a/docs/resources/folder_permission.md
+++ b/docs/resources/folder_permission.md
@@ -4,14 +4,14 @@ page_title: "grafana_folder_permission Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages the entire set of permissions for a folder. Permissions that aren't specified when applying this resource will be removed.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/
 ---
 
 # grafana_folder_permission (Resource)
 
 Manages the entire set of permissions for a folder. Permissions that aren't specified when applying this resource will be removed.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/folder_permission_item.md
+++ b/docs/resources/folder_permission_item.md
@@ -5,14 +5,14 @@ subcategory: "Grafana OSS"
 description: |-
   Manages a single permission item for a folder. Conflicts with the "grafana_folder_permission" resource which manages the entire set of permissions for a folder.
   * Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/
-  * HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/
+  * HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/
 ---
 
 # grafana_folder_permission_item (Resource)
 
 Manages a single permission item for a folder. Conflicts with the "grafana_folder_permission" resource which manages the entire set of permissions for a folder.
 		* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-		* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)
+		* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/)
 
 ## Example Usage
 

--- a/docs/resources/library_panel.md
+++ b/docs/resources/library_panel.md
@@ -4,7 +4,7 @@ page_title: "grafana_library_panel Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana library panels.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/library_element/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/library_element/
 ---
 
 # grafana_library_panel (Resource)
@@ -12,7 +12,7 @@ description: |-
 Manages Grafana library panels.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/library_element/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/library_element/)
 
 ## Example Usage
 

--- a/docs/resources/message_template.md
+++ b/docs/resources/message_template.md
@@ -4,7 +4,7 @@ page_title: "grafana_message_template Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting notification template groups, including notification templates.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-template-groups
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#notification-template-groups
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -13,7 +13,7 @@ description: |-
 Manages Grafana Alerting notification template groups, including notification templates.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-template-groups)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#notification-template-groups)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/mute_timing.md
+++ b/docs/resources/mute_timing.md
@@ -4,7 +4,7 @@ page_title: "grafana_mute_timing Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting mute timings.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#mute-timings
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#mute-timings
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -13,7 +13,7 @@ description: |-
 Manages Grafana Alerting mute timings.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#mute-timings)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#mute-timings)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -5,7 +5,7 @@ subcategory: "Alerting"
 description: |-
   Sets the global notification policy for Grafana.
   !> This resource manages the entire notification policy tree and overwrites its policies. However, it does not overwrite internal policies created when alert rules directly set a contact point for notifications.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-policies
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#notification-policies
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -16,7 +16,7 @@ Sets the global notification policy for Grafana.
 !> This resource manages the entire notification policy tree and overwrites its policies. However, it does not overwrite internal policies created when alert rules directly set a contact point for notifications.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-policies)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#notification-policies)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -3,7 +3,7 @@
 page_title: "grafana_organization Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/org/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/
   This resource represents an instance-scoped resource and uses Grafana's admin APIs.
   It does not work with API tokens or service accounts which are org-scoped.
   You must use basic auth.
@@ -13,7 +13,7 @@ description: |-
 # grafana_organization (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/)
 
 This resource represents an instance-scoped resource and uses Grafana's admin APIs.
 It does not work with API tokens or service accounts which are org-scoped.

--- a/docs/resources/organization_preferences.md
+++ b/docs/resources/organization_preferences.md
@@ -3,13 +3,13 @@
 page_title: "grafana_organization_preferences Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs
+  Official documentation https://grafana.com/docs/grafana/latest/administration/organization-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/#get-current-org-prefs
 ---
 
 # grafana_organization_preferences (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/#get-current-org-prefs)
 
 ## Example Usage
 

--- a/docs/resources/playlist.md
+++ b/docs/resources/playlist.md
@@ -4,7 +4,7 @@ page_title: "grafana_playlist Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana playlists.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/playlist/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/playlist/
 ---
 
 # grafana_playlist (Resource)
@@ -12,7 +12,7 @@ description: |-
 Manages Grafana playlists.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/playlist/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/playlist/)
 
 ## Example Usage
 

--- a/docs/resources/report.md
+++ b/docs/resources/report.md
@@ -4,7 +4,7 @@ page_title: "grafana_report Resource - terraform-provider-grafana"
 subcategory: "Grafana Enterprise"
 description: |-
   Note: This resource is available only with Grafana Enterprise 7.+.
-  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-reports/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/reporting/
+  Official documentation https://grafana.com/docs/grafana/latest/dashboards/create-reports/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/reporting/
 ---
 
 # grafana_report (Resource)
@@ -12,7 +12,7 @@ description: |-
 **Note:** This resource is available only with Grafana Enterprise 7.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-reports/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/reporting/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/reporting/)
 
 ## Example Usage
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -4,7 +4,7 @@ page_title: "grafana_role Resource - terraform-provider-grafana"
 subcategory: "Grafana Enterprise"
 description: |-
   Note: This resource is available only with Grafana Enterprise 8.+.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/access_control/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/
 ---
 
 # grafana_role (Resource)
@@ -12,7 +12,7 @@ description: |-
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/)
 
 ## Example Usage
 

--- a/docs/resources/role_assignment.md
+++ b/docs/resources/role_assignment.md
@@ -5,7 +5,7 @@ subcategory: "Grafana Enterprise"
 description: |-
   Manages the entire set of assignments for a role. Assignments that aren't specified when applying this resource will be removed.
   Note: This resource is available only with Grafana Enterprise 9.2+.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/access_control/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/
 ---
 
 # grafana_role_assignment (Resource)
@@ -13,7 +13,7 @@ description: |-
 Manages the entire set of assignments for a role. Assignments that aren't specified when applying this resource will be removed.
 **Note:** This resource is available only with Grafana Enterprise 9.2+.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/)
 
 ## Example Usage
 

--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -4,7 +4,7 @@ page_title: "grafana_rule_group Resource - terraform-provider-grafana"
 subcategory: "Alerting"
 description: |-
   Manages Grafana Alerting rule groups.
-  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules
+  Official documentation https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#alert-rules
   This resource requires Grafana 9.1.0 or later.
 ---
 
@@ -13,7 +13,7 @@ description: |-
 Manages Grafana Alerting rule groups.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#alert-rules)
 
 This resource requires Grafana 9.1.0 or later.
 

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -4,7 +4,7 @@ page_title: "grafana_service_account Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Note: This resource is available only with Grafana 9.1+.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api
+  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api
 ---
 
 # grafana_service_account (Resource)
@@ -12,7 +12,7 @@ description: |-
 **Note:** This resource is available only with Grafana 9.1+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 ## Example Usage
 

--- a/docs/resources/service_account_rotating_token.md
+++ b/docs/resources/service_account_rotating_token.md
@@ -4,7 +4,7 @@ page_title: "grafana_service_account_rotating_token Resource - terraform-provide
 subcategory: "Grafana OSS"
 description: |-
   Note: This resource is available only with Grafana 9.1+.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api
+  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api
 ---
 
 # grafana_service_account_rotating_token (Resource)
@@ -12,7 +12,7 @@ description: |-
 **Note:** This resource is available only with Grafana 9.1+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 ## Example Usage
 

--- a/docs/resources/service_account_token.md
+++ b/docs/resources/service_account_token.md
@@ -4,7 +4,7 @@ page_title: "grafana_service_account_token Resource - terraform-provider-grafana
 subcategory: "Grafana OSS"
 description: |-
   Note: This resource is available only with Grafana 9.1+.
-  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api
+  Official documentation https://grafana.com/docs/grafana/latest/administration/service-accounts/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api
 ---
 
 # grafana_service_account_token (Resource)
@@ -12,7 +12,7 @@ description: |-
 **Note:** This resource is available only with Grafana 9.1+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 ## Example Usage
 

--- a/docs/resources/sso_settings.md
+++ b/docs/resources/sso_settings.md
@@ -4,7 +4,7 @@ page_title: "grafana_sso_settings Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
   Manages Grafana SSO Settings for OAuth2, SAML and LDAP. Support for LDAP is currently in preview, it will be available in Grafana starting with v11.3.
-  Official documentation https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/sso-settings/
+  Official documentation https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/sso-settings/
 ---
 
 # grafana_sso_settings (Resource)
@@ -12,7 +12,7 @@ description: |-
 Manages Grafana SSO Settings for OAuth2, SAML and LDAP. Support for LDAP is currently in preview, it will be available in Grafana starting with v11.3.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/sso-settings/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/sso-settings/)
 
 ## Example Usage
 

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -3,13 +3,13 @@
 page_title: "grafana_team Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/team-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/team/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/team-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/
 ---
 
 # grafana_team (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/)
 
 ## Example Usage
 
@@ -46,7 +46,7 @@ resource "grafana_team" "test-team" {
 - `preferences` (Block List) (see [below for nested schema](#nestedblock--preferences))
 - `team_sync` (Block List) Sync external auth provider groups with this Grafana team. Only available in Grafana Enterprise.
 * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team_sync/) (see [below for nested schema](#nestedblock--team_sync))
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team_sync/) (see [below for nested schema](#nestedblock--team_sync))
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,7 +3,7 @@
 page_title: "grafana_user Resource - terraform-provider-grafana"
 subcategory: "Grafana OSS"
 description: |-
-  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developers/http_api/user/
+  Official documentation https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/HTTP API https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/
   This resource represents an instance-scoped resource and uses Grafana's admin APIs.
   It does not work with API tokens or service accounts which are org-scoped.
   You must use basic auth.
@@ -13,7 +13,7 @@ description: |-
 # grafana_user (Resource)
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/)
 
 This resource represents an instance-scoped resource and uses Grafana's admin APIs.
 It does not work with API tokens or service accounts which are org-scoped. 

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -30,7 +30,7 @@ Manages service accounts of a Grafana Cloud stack using the Cloud API
 This can be used to bootstrap a management service account for a new stack
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 Required access policy scopes:
 

--- a/internal/resources/cloud/resource_cloud_stack_service_account_rotating_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_rotating_token.go
@@ -20,7 +20,7 @@ Manages and rotates service account tokens of a Grafana Cloud stack using the Cl
 This can be used to bootstrap a management service account token for a new stack
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 Required access policy scopes:
 

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -20,7 +20,7 @@ Manages service account tokens of a Grafana Cloud stack using the Cloud API
 This can be used to bootstrap a management service account token for a new stack
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 
 Required access policy scopes:
 

--- a/internal/resources/grafana/data_source_folder.go
+++ b/internal/resources/grafana/data_source_folder.go
@@ -17,7 +17,7 @@ func datasourceFolder() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/)
 `,
 		ReadContext: dataSourceFolderRead,
 		Schema: common.CloneResourceSchemaForDatasource(resourceFolder().Schema, map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_folders.go
+++ b/internal/resources/grafana/data_source_folders.go
@@ -19,7 +19,7 @@ func datasourceFolders() *common.DataSource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/)
 `,
 
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_organization.go
+++ b/internal/resources/grafana/data_source_organization.go
@@ -15,7 +15,7 @@ func datasourceOrganization() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/)
 `,
 		ReadContext: dataSourceOrganizationRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_organization_preferences.go
+++ b/internal/resources/grafana/data_source_organization_preferences.go
@@ -13,7 +13,7 @@ func datasourceOrganizationPreferences() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/#get-current-org-prefs)
 `,
 		ReadContext: dataSourceOrganizationPreferencesRead,
 		Schema: common.CloneResourceSchemaForDatasource(resourceOrganizationPreferences().Schema, map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_organization_user.go
+++ b/internal/resources/grafana/data_source_organization_user.go
@@ -14,7 +14,7 @@ func datasourceOrganizationUser() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-all-users-within-the-current-organization-lookup)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/#get-all-users-within-the-current-organization-lookup)
 `,
 		ReadContext: dataSourceOrganizationUserRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_role.go
+++ b/internal/resources/grafana/data_source_role.go
@@ -16,7 +16,7 @@ func datasourceRole() *common.DataSource {
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/)
 `,
 		ReadContext: dataSourceRoleRead,
 		Schema: common.CloneResourceSchemaForDatasource(resourceRole().Schema, map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_service_account.go
+++ b/internal/resources/grafana/data_source_service_account.go
@@ -17,7 +17,7 @@ func datasourceServiceAccount() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 		* [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-		* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+		* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 `,
 		ReadContext: datasourceServiceAccountRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/resources/grafana/data_source_team.go
+++ b/internal/resources/grafana/data_source_team.go
@@ -59,7 +59,7 @@ func (d *teamDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/grafana/data_source_user.go
+++ b/internal/resources/grafana/data_source_user.go
@@ -14,7 +14,7 @@ func datasourceUser() *common.DataSource {
 	schema := &schema.Resource{
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/)
 
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/internal/resources/grafana/data_source_users.go
+++ b/internal/resources/grafana/data_source_users.go
@@ -20,7 +20,7 @@ func datasourceUsers() *common.DataSource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/)
 		
 This data source uses Grafana's admin APIs for reading users which
 does not currently work with API Tokens. You must use basic auth.

--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -54,7 +54,7 @@ func resourceContactPoint() *common.Resource {
 Manages Grafana Alerting contact points.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#contact-points)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#contact-points)
 
 This resource requires Grafana 9.1.0 or later.
 `,

--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -63,7 +63,7 @@ func (r *messageTemplateResource) Schema(_ context.Context, _ resource.SchemaReq
 Manages Grafana Alerting notification template groups, including notification templates.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-template-groups)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#notification-template-groups)
 
 This resource requires Grafana 9.1.0 or later.
 `,

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -23,7 +23,7 @@ func resourceMuteTiming() *common.Resource {
 Manages Grafana Alerting mute timings.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#mute-timings)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#mute-timings)
 
 This resource requires Grafana 9.1.0 or later.
 `,

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -25,7 +25,7 @@ Sets the global notification policy for Grafana.
 !> This resource manages the entire notification policy tree and overwrites its policies. However, it does not overwrite internal policies created when alert rules directly set a contact point for notifications.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#notification-policies)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#notification-policies)
 
 This resource requires Grafana 9.1.0 or later.
 `,

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -35,7 +35,7 @@ func resourceRuleGroup() *common.Resource {
 Manages Grafana Alerting rule groups.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/terraform-provisioning/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#alert-rules)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/#alert-rules)
 
 This resource requires Grafana 9.1.0 or later.
 `,

--- a/internal/resources/grafana/resource_annotation.go
+++ b/internal/resources/grafana/resource_annotation.go
@@ -87,7 +87,7 @@ func (r *annotationResource) Schema(ctx context.Context, req resource.SchemaRequ
 Manages Grafana annotations.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/annotations/)`,
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/annotations/)`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,

--- a/internal/resources/grafana/resource_dashboard_permission.go
+++ b/internal/resources/grafana/resource_dashboard_permission.go
@@ -50,7 +50,7 @@ func (r *resourceDashboardPermission) Schema(ctx context.Context, req resource.S
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Manages the entire set of permissions for a dashboard. Permissions that aren't specified when applying this resource will be removed.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard_permissions/)`,
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions/)`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/resources/grafana/resource_dashboard_public.go
+++ b/internal/resources/grafana/resource_dashboard_public.go
@@ -67,7 +67,7 @@ Manages Grafana public dashboards.
 **Note:** This resource is available only with Grafana 10.2+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/shared-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/next/developers/http_api/dashboard_public/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_public/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/grafana/resource_data_source.go
+++ b/internal/resources/grafana/resource_data_source.go
@@ -24,7 +24,7 @@ func resourceDataSource() *common.Resource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/datasources/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/)
 
 The required arguments for this resource vary depending on the type of data
 source selected (via the 'type' argument).

--- a/internal/resources/grafana/resource_data_source_config.md
+++ b/internal/resources/grafana/resource_data_source_config.md
@@ -1,5 +1,5 @@
 * [Official documentation](https://grafana.com/docs/grafana/latest/datasources/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/data_source/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/)
 
 The required arguments for this resource vary depending on the type of data
 source selected (via the 'type' argument).

--- a/internal/resources/grafana/resource_data_source_config_lbac_rules.go
+++ b/internal/resources/grafana/resource_data_source_config_lbac_rules.go
@@ -63,7 +63,7 @@ Manages LBAC rules for a data source.
 !> Warning: The resource is experimental and will be subject to change. This resource manages the entire LBAC rules tree, and will overwrite any existing rules.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_lbac_rules/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules/)
 
 This resource requires Grafana >=11.5.0.
 `,

--- a/internal/resources/grafana/resource_data_source_permission.go
+++ b/internal/resources/grafana/resource_data_source_permission.go
@@ -36,7 +36,7 @@ func resourceDatasourcePermission() *common.Resource {
 	schema := &schema.Resource{
 		Description: `
 Manages the entire set of permissions for a datasource. Permissions that aren't specified when applying this resource will be removed.
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/datasource_permissions/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_permissions/)
 `,
 
 		CreateContext: crudHelper.updatePermissions,

--- a/internal/resources/grafana/resource_folder.go
+++ b/internal/resources/grafana/resource_folder.go
@@ -26,7 +26,7 @@ func resourceFolder() *common.Resource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboards/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/)
 `,
 
 		CreateContext: common.WithFolderMutex[schema.CreateContextFunc](CreateFolder),

--- a/internal/resources/grafana/resource_folder_permission.go
+++ b/internal/resources/grafana/resource_folder_permission.go
@@ -53,7 +53,7 @@ func (r *resourceFolderPermission) Schema(ctx context.Context, req resource.Sche
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Manages the entire set of permissions for a folder. Permissions that aren't specified when applying this resource will be removed.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)`,
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/)`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/resources/grafana/resource_folder_permission_item.go
+++ b/internal/resources/grafana/resource_folder_permission_item.go
@@ -76,7 +76,7 @@ func (r *resourceFolderPermissionItem) Schema(ctx context.Context, req resource.
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Manages a single permission item for a folder. Conflicts with the "grafana_folder_permission" resource which manages the entire set of permissions for a folder.
 		* [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-		* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_permissions/)`,
+		* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/)`,
 		Attributes: r.addInSchemaAttributes(map[string]schema.Attribute{
 			"folder_uid": schema.StringAttribute{
 				Required:    true,

--- a/internal/resources/grafana/resource_library_panel.go
+++ b/internal/resources/grafana/resource_library_panel.go
@@ -23,7 +23,7 @@ func resourceLibraryPanel() *common.Resource {
 Manages Grafana library panels.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-library-panels/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/library_element/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/library_element/)
 `,
 
 		CreateContext: createLibraryPanel,

--- a/internal/resources/grafana/resource_organization.go
+++ b/internal/resources/grafana/resource_organization.go
@@ -42,7 +42,7 @@ func resourceOrganization() *common.Resource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/)
 
 This resource represents an instance-scoped resource and uses Grafana's admin APIs.
 It does not work with API tokens or service accounts which are org-scoped.

--- a/internal/resources/grafana/resource_organization_preferences.go
+++ b/internal/resources/grafana/resource_organization_preferences.go
@@ -17,7 +17,7 @@ func resourceOrganizationPreferences() *common.Resource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/organization-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/preferences/#get-current-org-prefs)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/#get-current-org-prefs)
 `,
 
 		CreateContext: CreateOrganizationPreferences,

--- a/internal/resources/grafana/resource_playlist.go
+++ b/internal/resources/grafana/resource_playlist.go
@@ -92,7 +92,7 @@ func (r *playlistResource) Schema(ctx context.Context, req resource.SchemaReques
 Manages Grafana playlists.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-manage-playlists/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/playlist/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/playlist/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/grafana/resource_report.go
+++ b/internal/resources/grafana/resource_report.go
@@ -139,7 +139,7 @@ func (r *reportResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 **Note:** This resource is available only with Grafana Enterprise 7.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/dashboards/create-reports/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/reporting/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/reporting/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/grafana/resource_role.go
+++ b/internal/resources/grafana/resource_role.go
@@ -20,7 +20,7 @@ func resourceRole() *common.Resource {
 **Note:** This resource is available only with Grafana Enterprise 8.+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/)
 `,
 		CreateContext: CreateRole,
 		UpdateContext: UpdateRole,

--- a/internal/resources/grafana/resource_role_assignment.go
+++ b/internal/resources/grafana/resource_role_assignment.go
@@ -16,7 +16,7 @@ func resourceRoleAssignment() *common.Resource {
 Manages the entire set of assignments for a role. Assignments that aren't specified when applying this resource will be removed.
 **Note:** This resource is available only with Grafana Enterprise 9.2+.
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/)
 `,
 		CreateContext: UpdateRoleAssignments,
 		UpdateContext: UpdateRoleAssignments,

--- a/internal/resources/grafana/resource_service_account.go
+++ b/internal/resources/grafana/resource_service_account.go
@@ -100,7 +100,7 @@ func (r *serviceAccountResource) Schema(ctx context.Context, req resource.Schema
 **Note:** This resource is available only with Grafana 9.1+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/resources/grafana/resource_service_account_rotating_token.go
+++ b/internal/resources/grafana/resource_service_account_rotating_token.go
@@ -18,7 +18,7 @@ func resourceServiceAccountRotatingToken() *common.Resource {
 **Note:** This resource is available only with Grafana 9.1+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)`,
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)`,
 
 		// We use the same function for Read and Update because fields are only updated in the Terraform state,
 		// not in Grafana, for this resource.

--- a/internal/resources/grafana/resource_service_account_token.go
+++ b/internal/resources/grafana/resource_service_account_token.go
@@ -18,7 +18,7 @@ func resourceServiceAccountToken() *common.Resource {
 **Note:** This resource is available only with Grafana 9.1+.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/service-accounts/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/serviceaccount/#service-account-api)`,
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/#service-account-api)`,
 
 		CreateContext: serviceAccountTokenCreate,
 		ReadContext:   serviceAccountTokenRead,

--- a/internal/resources/grafana/resource_sso_settings.go
+++ b/internal/resources/grafana/resource_sso_settings.go
@@ -31,7 +31,7 @@ func resourceSSOSettings() *common.Resource {
 Manages Grafana SSO Settings for OAuth2, SAML and LDAP. Support for LDAP is currently in preview, it will be available in Grafana starting with v11.3.
 
 * [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/sso-settings/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/sso-settings/)
 `,
 
 		CreateContext: UpdateSSOSettings,

--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -97,7 +97,7 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/team-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/)
 `,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -186,7 +186,7 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"team_sync": schema.ListNestedBlock{
 				MarkdownDescription: "Sync external auth provider groups with this Grafana team. Only available in Grafana Enterprise.\n" +
 					"* [Official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-team-sync/)\n" +
-					"* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/team_sync/)",
+					"* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team_sync/)",
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},

--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -20,7 +20,7 @@ func resourceUser() *common.Resource {
 
 		Description: `
 * [Official documentation](https://grafana.com/docs/grafana/latest/administration/user-management/server-user-management/)
-* [HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/)
+* [HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/)
 
 This resource represents an instance-scoped resource and uses Grafana's admin APIs.
 It does not work with API tokens or service accounts which are org-scoped. 


### PR DESCRIPTION
**Changes Made**
- The Grafana docs site reorganized its HTTP API reference pages. This caused 18 URLs across the provider docs to
  return 404, failing the linkchecker step in CI.
- This commit updates all broken URLs to the new path.