### PR TITLE
ci(release): fix GoReleaser failing on dirty git tree from git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,22 @@ jobs:
       with:
         gpg_private_key: ${{ env.GPG_PRIVATE_KEY }}
         passphrase: ${{ env.PASSPHRASE }}
+    # git-cliff-action writes under git-cliff/ (untracked). GoReleaser refuses to run when git is dirty.
+    - name: Prepare release notes outside repo for GoReleaser
+      run: |
+        set -euo pipefail
+        notes="${{ steps.changelog.outputs.changelog }}"
+        if [ ! -f "$notes" ]; then
+          echo "::error::Changelog file not found at $notes"
+          exit 1
+        fi
+        cp "$notes" /tmp/goreleaser-release-notes.md
+        rm -rf git-cliff/
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:
         version: latest
-        args: release --clean --release-notes=${{ steps.changelog.outputs.changelog }}
+        args: release --clean --release-notes=/tmp/goreleaser-release-notes.md
       env:
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Seeing another issue with the [workflow](https://github.com/grafana/terraform-provider-grafana/actions/runs/24518244217/job/71668345700).

[Thread](https://raintank-corp.slack.com/archives/C09TK4TSNKU/p1776348222393089?thread_ts=1776288820.822609&cid=C09TK4TSNKU).