### PR TITLE
fix(cloud_stack): derive domain suffix for cloud_provider_url and connections_api_url

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -633,8 +633,18 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 		d.Set("influx_url", influxURL.Get())
 	}
 
-	d.Set("cloud_provider_url", fmt.Sprintf("https://cloud-provider-api-%s.grafana.net", stack.ClusterSlug))
-	d.Set("connections_api_url", fmt.Sprintf("https://connections-api-%s.grafana.net", stack.ClusterSlug))
+	// Derive the domain suffix from an API-returned URL so that both the old
+	// flat convention (*.grafana.net) and the new hierarchical convention
+	// (*.<csp>-<csp-region>-<counter>.grafana.net) produce correct URLs.
+	//
+	// NOTE: This is a stopgap. The plan is for the Grafana API to return
+	// these URLs directly, removing this derivation.
+	domainSuffix := "grafana.net"
+	if suffix, err := DomainSuffixFromURL(stack.HmInstancePromUrl); err == nil {
+		domainSuffix = suffix
+	}
+	d.Set("cloud_provider_url", fmt.Sprintf("https://cloud-provider-api-%s.%s", stack.ClusterSlug, domainSuffix))
+	d.Set("connections_api_url", fmt.Sprintf("https://connections-api-%s.%s", stack.ClusterSlug, domainSuffix))
 
 	return nil
 }
@@ -673,6 +683,24 @@ func addPrivateConnectivityInfo(d *schema.ResourceData, preffix string, info *gc
 	d.Set(fmt.Sprintf("%s_private_connectivity_info_regions", preffix), info.Regions)
 	d.Set(fmt.Sprintf("%s_private_connectivity_info_availability_zones", preffix), info.AvailabilityZones)
 	d.Set(fmt.Sprintf("%s_private_connectivity_info_availability_zone_ids", preffix), info.AvailabilityZoneIds)
+}
+
+// DomainSuffixFromURL extracts the domain suffix from a URL's hostname by
+// stripping the leftmost DNS label. For example:
+//
+//	"https://prometheus-prod-01-eu-west-0.grafana.net" → "grafana.net"
+//	"https://prometheus-prod-04.csp-region-1.grafana.net" → "csp-region-1.grafana.net"
+func DomainSuffixFromURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing URL: %w", err)
+	}
+	host := u.Hostname()
+	idx := strings.Index(host, ".")
+	if idx < 0 || idx >= len(host)-1 {
+		return "", fmt.Errorf("hostname %q has no domain suffix", host)
+	}
+	return host[idx+1:], nil
 }
 
 // Append path to baseurl

--- a/internal/resources/cloud/resource_cloud_stack_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_test.go
@@ -95,9 +95,9 @@ func TestResourceStack_Basic(t *testing.T) {
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "otlp_private_connectivity_info_availability_zone_ids"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "influx_url"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "cloud_provider_url"),
-		resource.TestMatchResourceAttr("grafana_cloud_stack.test", "cloud_provider_url", regexp.MustCompile(`^https://cloud-provider-api-.+\.grafana\.net$`)),
+		resource.TestMatchResourceAttr("grafana_cloud_stack.test", "cloud_provider_url", regexp.MustCompile(`^https://cloud-provider-api-.+\.(.+\.)?grafana\.net$`)),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "connections_api_url"),
-		resource.TestMatchResourceAttr("grafana_cloud_stack.test", "connections_api_url", regexp.MustCompile(`^https://connections-api-.+\.grafana\.net$`)),
+		resource.TestMatchResourceAttr("grafana_cloud_stack.test", "connections_api_url", regexp.MustCompile(`^https://connections-api-.+\.(.+\.)?grafana\.net$`)),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "cluster_slug"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "cluster_name"),
 		resource.TestCheckResourceAttrSet("grafana_cloud_stack.test", "pdc_api_private_connectivity_info_private_dns"),
@@ -341,4 +341,57 @@ func testAccStackConfigUpdate(name string, slug string, description string) stri
 // Prefix a character as stack name can't start with a number
 func GetRandomStackName(prefix string) string {
 	return prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+}
+
+func TestDomainSuffixFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "old flat convention",
+			url:  "https://prometheus-prod-01-eu-west-0.grafana.net",
+			want: "grafana.net",
+		},
+		{
+			name: "new hierarchical convention",
+			url:  "https://prometheus-prod-04.csp-region-1.grafana.net",
+			want: "csp-region-1.grafana.net",
+		},
+		{
+			name: "URL with path and port",
+			url:  "https://prometheus-prod-01.grafana.net:443/api/prom",
+			want: "grafana.net",
+		},
+		{
+			name:    "bare hostname",
+			url:     "https://localhost",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			url:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cloud.DomainSuffixFromURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`cloud_provider_url` and `connections_api_url` (added in #2679) hardcode `.grafana.net` as the domain suffix:

```go
fmt.Sprintf("https://cloud-provider-api-%s.grafana.net", stack.ClusterSlug)
```

Grafana Cloud regions now use a hierarchical DNS convention where the suffix is `<csp>-<csp-region>-<counter>.grafana.net` instead of plain `grafana.net`. These two fields produce wrong URLs for any stack in a new region.

## Fix

Extract the domain suffix from `prometheus_url` (which the Grafana API already returns correctly for all regions) and use it when constructing both URLs. Falls back to `grafana.net` if extraction fails.

This is a stopgap. The plan is for the Grafana API to return these URLs directly, removing the client-side derivation entirely.