### PR TITLE
fix(release): remove changelog.disable to allow --release-notes to work

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,5 +74,4 @@ signs:
 release:
   # If you want to manually examine the release before it's live, uncomment this line:
   draft: true
-changelog:
-  disable: true
+

--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ Currently there are a few manual steps to this:
 
    The Action creates the release, but leaves it in "draft" state. Open it up in
    a [browser](https://github.com/grafana/terraform-provider-grafana/releases)
-   and if all looks well, click the `Auto-generate release notes` button and mash the publish button.
+   and if all looks well, publish the release. Release notes are generated automatically by git-cliff.


### PR DESCRIPTION
## Summary

- Remove `changelog.disable: true` from `.goreleaser.yml` because it suppresses `--release-notes` content, resulting in empty draft release bodies.

`changelog.disable: true` skips the entire changelog pipe ([source](https://github.com/goreleaser/goreleaser/blob/main/internal/pipe/changelog/changelog.go#L45-L51)), which means `--release-notes` file loading never executes. Without `disable`, `--release-notes` still skips GoReleaser's own changelog generation via an early return ([source](https://github.com/goreleaser/goreleaser/blob/main/internal/pipe/changelog/changelog.go#L73-L74)), so only the git-cliff content is used.