### PR TITLE
build(release): automate versioning with git-cliff

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Go module updates affect the compiled binary, use fix(deps) to trigger a patch release",
+      "matchManagers": ["gomod"],
+      "semanticCommitType": "fix"
+    }
+  ]
+}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,9 +58,7 @@ integration-test:
 	DOCKER_COMPOSE_ARGS="$(DOCKER_COMPOSE_ARGS)" GRAFANA_VERSION=$(GRAFANA_VERSION) ./testdata/integration/test.sh
 
 release:
-	@test $${RELEASE_VERSION?Please set environment variable RELEASE_VERSION}
-	@git tag $$RELEASE_VERSION
-	@git push origin $$RELEASE_VERSION
+	@./scripts/release.sh
 
 golangci-lint:
 	docker run \

--- a/README.md
+++ b/README.md
@@ -104,42 +104,6 @@ files are in `docs/` and *should not be updated manually*. They are derived from
 
 Use `go generate ./...` to update generated docs. This will be checked by CI on pull requests to ensure docs are in sync.
 
-## Versioning
-
-This project follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
-
-- **Major** (`vX.0.0`): Reserved for intentional breaking changes. This includes
-  removing or renaming existing resources/data sources, removing or renaming
-  attributes, changing attribute types, or changing provider configuration in
-  incompatible ways. Major releases should be rare and well-documented with an
-  upgrade guide.
-
-- **Minor** (`vX.Y.0`): New features and improvements that are
-  backwards-compatible. **This is the most common release type.** It includes adding
-  new resources or data sources, adding new optional attributes to existing
-  resources, refactoring internals, dependency updates, and removing resources
-  that are clearly marked as alpha, beta, or experimental.
-
-- **Patch** (`vX.Y.Z`): Backwards-compatible bug fixes. This includes fixing
-  incorrect API calls, correcting state handling, fixing documentation, and
-  other small targeted fixes.
-
 ## Releasing
 
-Builds and releases are automated with GitHub Actions and
-[GoReleaser](https://github.com/goreleaser/goreleaser/).
-
-Currently there are a few manual steps to this:
-
-1. Kick off the release:
-
-   ```sh
-   RELEASE_VERSION=v... \
-   make release
-   ```
-
-2. Publish release:
-
-   The Action creates the release, but leaves it in "draft" state. Open it up in
-   a [browser](https://github.com/grafana/terraform-provider-grafana/releases)
-   and if all looks well, publish the release. Release notes are generated automatically by git-cliff.
+See [RELEASING.md](RELEASING.md) for versioning policy, release process, and how the CI pipeline works.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,8 +3,9 @@
 ## Versioning
 
 This project follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
-Version bumps are determined automatically from conventional commit messages
-using [git-cliff](https://git-cliff.org).
+Version bumps are determined automatically from
+[conventional commit](https://www.conventionalcommits.org/) messages using
+[git-cliff](https://git-cliff.org).
 
 - **Major** (`vX.0.0`): Reserved for intentional breaking changes. Major releases
   should be rare and well-documented with an upgrade guide. Examples:
@@ -151,8 +152,8 @@ push matching `v*`. It runs the following steps:
    signs them with GPG.
 
 4. **Create draft release** — GoReleaser creates a GitHub Release in **draft**
-   state with the git-cliff changelog as release notes. A maintainer must
-   manually review and publish the release.
+   state with the git-cliff changelog as release notes. Someone with release
+   access must manually review and publish the release.
 
 ### Configuration files
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,165 @@
+# Releasing
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+Version bumps are determined automatically from conventional commit messages
+using [git-cliff](https://git-cliff.org).
+
+- **Major** (`vX.0.0`): Reserved for intentional breaking changes. Major releases
+  should be rare and well-documented with an upgrade guide. Examples:
+  - Removing or renaming existing resources or data sources
+  - Removing or renaming attributes
+  - Changing attribute types (e.g. string to list)
+  - Changing provider configuration in incompatible ways
+  - Any change that requires users to rewrite their Terraform configuration or
+    manually manipulate state
+
+- **Minor** (`vX.Y.0`): New features and improvements that are
+  backwards-compatible. **This is the most common release type.** Examples:
+  - Adding new resources or data sources
+  - Adding new optional attributes to existing resources
+  - Refactoring internals (e.g. migrating a resource from SDKv2 to Plugin Framework)
+  - Performance improvements
+  - Removing resources that are clearly marked as alpha, beta, or experimental
+    (these carry no stability guarantee)
+
+- **Patch** (`vX.Y.Z`): Backwards-compatible bug fixes and dependency updates.
+  These are typically follow-up releases after a minor release. Examples:
+  - Fixing incorrect API calls or state handling
+  - Correcting plan-time validation logic
+  - Fixing documentation typos in schema `Description` fields
+  - Go dependency updates (security patches, bug fixes)
+  - Other small, targeted fixes
+
+### Bump rules
+
+The version bump is computed by git-cliff from the conventional commit messages
+since the last tag. The rules are configured in [`cliff.toml`](cliff.toml) under
+the `[bump]` section.
+
+| Commit type(s) since last tag                             | Version bump          |
+|-----------------------------------------------------------|-----------------------|
+| Only `fix` (including `fix(deps)`)                        | **patch** (vX.Y.Z)   |
+| `feat`, `refactor`, or `perf` (with or without others)    | **minor** (vX.Y.0)   |
+| `BREAKING CHANGE` footer or `!` suffix on any commit type | **major** (vX.0.0)   |
+| Only `ci`, `docs`, `test`, `build`, `style`, `chore` | No bump (nothing to release) |
+
+### Commit types and release impact
+
+| Commit type | Affects binary? | Triggers release? | Bump    |
+|-------------|-----------------|-------------------|---------|
+| `feat`      | yes             | yes               | minor   |
+| `fix`       | yes             | yes               | patch   |
+| `refactor`  | yes             | yes               | minor   |
+| `perf`      | yes             | yes               | minor   |
+| `docs`      | no              | no                | —       |
+| `ci`        | no              | no                | —       |
+| `test`      | no              | no                | —       |
+| `build`     | no              | no                | —       |
+| `style`     | no              | no                | —       |
+| `chore`     | no              | no                | —       |
+
+### Dependency updates
+
+Go module dependency updates are managed by Renovate and use `fix(deps)` as
+their commit type, because changes to `go.mod`/`go.sum` affect the compiled
+provider binary. These trigger a **patch** release.
+
+GitHub Actions and other non-Go dependency updates use `chore(deps)` and do
+**not** trigger a release, since they have no effect on the shipped binary.
+
+This behavior is configured in [`.github/renovate.json5`](.github/renovate.json5).
+
+## Creating a release
+
+### Prerequisites
+
+- [git-cliff](https://git-cliff.org/docs/installation) installed locally
+- Push access to the repository
+
+### Steps
+
+1. Switch to the `main` branch:
+
+   ```sh
+   git checkout main
+   ```
+
+2. Run the release target:
+
+   ```sh
+   make release
+   ```
+
+   The target will:
+   - Verify you are on `main` (refuses to run from other branches)
+   - Fetch from origin and prompt to pull if your local branch is behind
+   - Compute the next version from conventional commits using git-cliff
+
+   To override the computed version:
+
+   ```sh
+   RELEASE_VERSION=v5.0.0 make release
+   ```
+
+3. The tag push triggers the [`release`](.github/workflows/release.yml) GitHub
+   Actions workflow (see [CI pipeline](#ci-pipeline) below).
+
+4. Open the [Releases page](https://github.com/grafana/terraform-provider-grafana/releases),
+   review the draft release, and publish it.
+
+### What `make release` does
+
+`make release` runs [`scripts/release.sh`](scripts/release.sh), which performs
+the following checks and actions:
+
+```
+scripts/release.sh
+  │
+  ├─ on main branch?       → error if not
+  ├─ fetch origin/main
+  │   └─ local behind?     → prompt to pull (--ff-only)
+  │
+  ├─ RELEASE_VERSION set?  → use it
+  ├─ git-cliff installed?  → compute version via `git cliff --bumped-version`
+  │   └─ version == latest tag?  → error: nothing to release
+  └─ neither?              → error: install git-cliff or set RELEASE_VERSION
+  │
+  ├─ git tag <version>
+  └─ git push origin <version>
+```
+
+## CI pipeline
+
+The [`release.yml`](.github/workflows/release.yml) workflow triggers on any tag
+push matching `v*`. It runs the following steps:
+
+1. **Generate changelog** — git-cliff produces release notes from conventional
+   commits since the previous tag (`--latest --strip header`).
+
+2. **Validate semver bump** — git-cliff computes the minimum required version
+   (`--bumped-version`) and compares it against the pushed tag. If the tag is
+   lower than what the commits require (e.g., tagging a patch when there are
+   `feat` commits), the workflow **fails** before building. This is a safety net
+   that catches incorrect manual overrides.
+
+3. **Build and sign** — [GoReleaser](https://goreleaser.com/) builds the
+   provider binary for all supported platforms (`linux`, `darwin`, `windows`,
+   `freebsd` on `amd64`, `arm64`, `arm`, `386`), creates a separate
+   `terraform-provider-grafana-generate` tool, computes SHA256 checksums, and
+   signs them with GPG.
+
+4. **Create draft release** — GoReleaser creates a GitHub Release in **draft**
+   state with the git-cliff changelog as release notes. A maintainer must
+   manually review and publish the release.
+
+### Configuration files
+
+| File                                  | Purpose                                    |
+|---------------------------------------|--------------------------------------------|
+| [`scripts/release.sh`](scripts/release.sh) | Local release script (branch check, pull prompt, version computation, tag + push) |
+| [`cliff.toml`](cliff.toml)           | Changelog format, commit parsing, bump rules |
+| [`.goreleaser.yml`](.goreleaser.yml)  | Build targets, archives, signing, release settings |
+| [`.github/workflows/release.yml`](.github/workflows/release.yml) | CI workflow that orchestrates the release |
+| [`.github/renovate.json5`](.github/renovate.json5) | Renovate config for dependency update commit types |

--- a/cliff.toml
+++ b/cliff.toml
@@ -43,3 +43,8 @@ sort_commits = "oldest"
 [remote.github]
 owner = "grafana"
 repo = "terraform-provider-grafana"
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = true
+custom_minor_increment_regex = "^(refactor|perf)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify we're on the main branch.
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+	echo "Error: releases must be created from the main branch (currently on '$branch')."
+	exit 1
+fi
+
+# Fetch latest state from origin.
+git fetch origin main --tags --quiet
+
+# Prompt to pull if local is behind.
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/main)
+if [ "$local_sha" != "$remote_sha" ]; then
+	echo "Local branch is behind origin/main."
+	printf "Pull latest changes? [y/N] "
+	read -r ans
+	if [ "$ans" = "y" ] || [ "$ans" = "Y" ]; then
+		git pull --ff-only origin main
+	else
+		echo "Continuing with local HEAD."
+	fi
+fi
+
+# Determine the release version.
+if [ -n "${RELEASE_VERSION:-}" ]; then
+	echo "Using provided version: $RELEASE_VERSION"
+elif command -v git-cliff >/dev/null 2>&1; then
+	RELEASE_VERSION=$(git cliff --bumped-version 2>/dev/null)
+	latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
+	if [ "$RELEASE_VERSION" = "$latest_tag" ]; then
+		echo "Error: no unreleased changes to bump. Nothing to release."
+		exit 1
+	fi
+	echo "Computed version from conventional commits: $RELEASE_VERSION"
+else
+	echo "Error: git-cliff is not installed and RELEASE_VERSION is not set."
+	echo "Install git-cliff: https://git-cliff.org/docs/installation"
+	exit 1
+fi
+
+# Create and push the tag.
+git tag "$RELEASE_VERSION"
+git push origin "$RELEASE_VERSION"


### PR DESCRIPTION
## Summary

Automate release version computation from conventional commits using git-cliff, replacing the manual `RELEASE_VERSION` requirement.

### What changed

- Auto-compute the next release version from conventional commits using git-cliff's `--bumped-version`, removing the need to manually set `RELEASE_VERSION`
- Add bump rules to `cliff.toml`: `feat`/`refactor`/`perf` bump minor, `fix` bumps patch, breaking bumps major, everything else (`ci`/`docs`/`test`/`build`/`style`/`chore`) does not trigger a release
- Extract release logic from GNUmakefile into `scripts/release.sh` with pre-flight checks: branch verification, fetch/pull prompt, version computation
- Add `.github/renovate.json5` to override Go module dependency updates to use `fix(deps)` (they change the compiled binary, so should trigger a patch release)
- Create `RELEASING.md` with versioning policy, bump rules, release steps, and CI pipeline docs
- Move versioning and releasing sections from `README.md` to `RELEASING.md`

## Changed files

| File | Change |
|---|---|
| `cliff.toml` | Added `[bump]` section with custom minor increment rules |
| `GNUmakefile` | Simplified `release` target to call `scripts/release.sh` |
| `scripts/release.sh` | New release script with branch check, pull prompt, version computation, tag + push |
| `.github/renovate.json5` | New Renovate override for Go module updates to use `fix(deps)` |
| `RELEASING.md` | New consolidated release documentation |
| `README.md` | Replaced Versioning + Releasing sections with link to `RELEASING.md` |

## Bump rules

| Commit type(s) since last tag | Version bump |
|---|---|
| Only `fix` (including `fix(deps)`) | **patch** |
| `feat`, `refactor`, or `perf` | **minor** |
| `BREAKING CHANGE` or `!` suffix | **major** |
| Only `ci`, `docs`, `test`, `build`, `style`, `chore` | No bump |