### PR TITLE
chore(asserts_custom_model_rules): migrate to Terraform Framework SDK

### DIFF
--- a/docs/resources/asserts_custom_model_rules.md
+++ b/docs/resources/asserts_custom_model_rules.md
@@ -56,7 +56,10 @@ resource "grafana_asserts_custom_model_rules" "test" {
 ### Required
 
 - `name` (String) The name of the custom model rules.
-- `rules` (Block List, Min: 1, Max: 1) The rules configuration for the custom model rules. (see [below for nested schema](#nestedblock--rules))
+
+### Optional
+
+- `rules` (Block List) The rules configuration for the custom model rules. (see [below for nested schema](#nestedblock--rules))
 
 ### Read-Only
 
@@ -65,21 +68,21 @@ resource "grafana_asserts_custom_model_rules" "test" {
 <a id="nestedblock--rules"></a>
 ### Nested Schema for `rules`
 
-Required:
+Optional:
 
-- `entity` (Block List, Min: 1) List of entities to define in the custom model rules. (see [below for nested schema](#nestedblock--rules--entity))
+- `entity` (Block List) List of entities to define in the custom model rules. (see [below for nested schema](#nestedblock--rules--entity))
 
 <a id="nestedblock--rules--entity"></a>
 ### Nested Schema for `rules.entity`
 
 Required:
 
-- `defined_by` (Block List, Min: 1) List of queries that define this entity. (see [below for nested schema](#nestedblock--rules--entity--defined_by))
 - `name` (String) The name of the entity.
 - `type` (String) The type of the entity (e.g., Service, Pod, Namespace).
 
 Optional:
 
+- `defined_by` (Block List) List of queries that define this entity. (see [below for nested schema](#nestedblock--rules--entity--defined_by))
 - `disabled` (Boolean) Whether this entity is disabled.
 - `enriched_by` (List of String) List of enrichment sources for the entity.
 - `lookup` (Map of String) Lookup mappings for the entity.

--- a/internal/resources/asserts/resource_custom_model_rules.go
+++ b/internal/resources/asserts/resource_custom_model_rules.go
@@ -90,6 +90,13 @@ func (r *customModelRulesResource) Configure(_ context.Context, req resource.Con
 		)
 		return
 	}
+	if client.GrafanaStackID == 0 {
+		resp.Diagnostics.AddError(
+			"stack_id required for Asserts resources",
+			"stack_id must be set in the provider configuration for Asserts resources.",
+		)
+		return
+	}
 	r.client = client.AssertsAPIClient
 	r.stackID = client.GrafanaStackID
 }
@@ -116,6 +123,7 @@ func (r *customModelRulesResource) Schema(_ context.Context, _ resource.SchemaRe
 			"rules": schema.ListNestedBlock{
 				Description: "The rules configuration for the custom model rules.",
 				Validators: []validator.List{
+					listvalidator.IsRequired(),
 					listvalidator.SizeAtLeast(1),
 					listvalidator.SizeAtMost(1),
 				},
@@ -124,6 +132,7 @@ func (r *customModelRulesResource) Schema(_ context.Context, _ resource.SchemaRe
 						"entity": schema.ListNestedBlock{
 							Description: "List of entities to define in the custom model rules.",
 							Validators: []validator.List{
+								listvalidator.IsRequired(),
 								listvalidator.SizeAtLeast(1),
 							},
 							NestedObject: schema.NestedBlockObject{
@@ -160,6 +169,7 @@ func (r *customModelRulesResource) Schema(_ context.Context, _ resource.SchemaRe
 									"defined_by": schema.ListNestedBlock{
 										Description: "List of queries that define this entity.",
 										Validators: []validator.List{
+											listvalidator.IsRequired(),
 											listvalidator.SizeAtLeast(1),
 										},
 										NestedObject: schema.NestedBlockObject{

--- a/internal/resources/asserts/resource_custom_model_rules.go
+++ b/internal/resources/asserts/resource_custom_model_rules.go
@@ -3,335 +3,186 @@ package asserts
 import (
 	"context"
 	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"math"
+	"math/rand"
+	"time"
 
 	assertsapi "github.com/grafana/grafana-asserts-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// convertStringMap converts a map[string]interface{} to map[string]string
-func convertStringMap(input map[string]interface{}) map[string]string {
-	result := make(map[string]string)
-	for k, v := range input {
-		if str, ok := v.(string); ok {
-			result[k] = str
-		}
-	}
-	return result
+var (
+	_ resource.Resource                = &customModelRulesResource{}
+	_ resource.ResourceWithConfigure   = &customModelRulesResource{}
+	_ resource.ResourceWithImportState = &customModelRulesResource{}
+)
+
+type customModelRulesModel struct {
+	ID    types.String `tfsdk:"id"`
+	Name  types.String `tfsdk:"name"`
+	Rules []rulesModel `tfsdk:"rules"`
 }
 
-// convertPropertyRule converts Terraform defined_by data to PropertyRuleDto
-func convertPropertyRule(definedByItem map[string]interface{}) assertsapi.PropertyRuleDto {
-	query := definedByItem["query"].(string)
-	propertyRule := assertsapi.PropertyRuleDto{
-		Query: &query,
-	}
-
-	// Handle optional fields - only set disabled when it's explicitly true
-	if disabled, ok := definedByItem["disabled"].(bool); ok && disabled {
-		propertyRule.Disabled = &disabled
-	}
-
-	// Handle labelValues map
-	if labelValues, ok := definedByItem["label_values"].(map[string]interface{}); ok && len(labelValues) > 0 {
-		labelValuesMap := convertStringMap(labelValues)
-		if len(labelValuesMap) > 0 {
-			propertyRule.LabelValues = labelValuesMap
-		}
-	}
-
-	// Handle literals map
-	if literals, ok := definedByItem["literals"].(map[string]interface{}); ok && len(literals) > 0 {
-		literalsMap := convertStringMap(literals)
-		if len(literalsMap) > 0 {
-			propertyRule.Literals = literalsMap
-		}
-	}
-
-	// Handle metricValue field
-	if metricValue, ok := definedByItem["metric_value"].(string); ok && metricValue != "" {
-		propertyRule.MetricValue = &metricValue
-	}
-
-	return propertyRule
+type rulesModel struct {
+	Entity []entityModel `tfsdk:"entity"`
 }
 
-// convertDefinedBy converts Terraform defined_by list to PropertyRuleDto slice
-func convertDefinedBy(definedByList []interface{}) []assertsapi.PropertyRuleDto {
-	var definedBy []assertsapi.PropertyRuleDto
-	for _, definedByData := range definedByList {
-		definedByItem := definedByData.(map[string]interface{})
-		propertyRule := convertPropertyRule(definedByItem)
-		definedBy = append(definedBy, propertyRule)
-	}
-	return definedBy
+type entityModel struct {
+	Type       types.String     `tfsdk:"type"`
+	Name       types.String     `tfsdk:"name"`
+	Scope      types.Map        `tfsdk:"scope"`
+	Lookup     types.Map        `tfsdk:"lookup"`
+	EnrichedBy types.List       `tfsdk:"enriched_by"`
+	Disabled   types.Bool       `tfsdk:"disabled"`
+	DefinedBy  []definedByModel `tfsdk:"defined_by"`
 }
 
-// convertEnrichedBy converts Terraform enriched_by list to PropertyRuleDto slice
-func convertEnrichedBy(enrichedByList []interface{}) []assertsapi.PropertyRuleDto {
-	var result []assertsapi.PropertyRuleDto
-	for _, item := range enrichedByList {
-		if str, ok := item.(string); ok {
-			result = append(result, assertsapi.PropertyRuleDto{
-				Query: &str,
-			})
-		}
-	}
-	return result
+type definedByModel struct {
+	Query       types.String `tfsdk:"query"`
+	Disabled    types.Bool   `tfsdk:"disabled"`
+	LabelValues types.Map    `tfsdk:"label_values"`
+	Literals    types.Map    `tfsdk:"literals"`
+	MetricValue types.String `tfsdk:"metric_value"`
 }
 
-// convertEntityRule converts Terraform entity data to EntityRuleDto
-func convertEntityRule(entity map[string]interface{}) assertsapi.EntityRuleDto {
-	entityType := entity["type"].(string)
-	entityName := entity["name"].(string)
-	definedByList := entity["defined_by"].([]interface{})
-
-	entityRule := assertsapi.EntityRuleDto{
-		Type:      &entityType,
-		Name:      &entityName,
-		DefinedBy: convertDefinedBy(definedByList),
-	}
-
-	// Handle optional entity fields
-	if scope, ok := entity["scope"].(map[string]interface{}); ok && len(scope) > 0 {
-		scopeMap := convertStringMap(scope)
-		if len(scopeMap) > 0 {
-			entityRule.Scope = scopeMap
-		}
-	}
-
-	if lookup, ok := entity["lookup"].(map[string]interface{}); ok && len(lookup) > 0 {
-		lookupMap := convertStringMap(lookup)
-		if len(lookupMap) > 0 {
-			entityRule.Lookup = lookupMap
-		}
-	}
-
-	if enrichedBy, ok := entity["enriched_by"].([]interface{}); ok && len(enrichedBy) > 0 {
-		enrichedByList := convertEnrichedBy(enrichedBy)
-		if len(enrichedByList) > 0 {
-			entityRule.EnrichedBy = enrichedByList
-		}
-	}
-
-	// Handle entity-level disabled field
-	if disabled, ok := entity["disabled"].(bool); ok && disabled {
-		entityRule.Disabled = &disabled
-	}
-
-	return entityRule
-}
-
-// convertTerraformToModelRules converts Terraform structured data to ModelRulesDto
-func convertTerraformToModelRules(d *schema.ResourceData) (*assertsapi.ModelRulesDto, error) {
-	rulesList := d.Get("rules").([]interface{})
-	if len(rulesList) == 0 {
-		return nil, fmt.Errorf("rules block is required")
-	}
-
-	rulesData := rulesList[0].(map[string]interface{})
-	entitiesList := rulesData["entity"].([]interface{})
-
-	var entities []assertsapi.EntityRuleDto
-	for _, entityData := range entitiesList {
-		entity := entityData.(map[string]interface{})
-		entityRule := convertEntityRule(entity)
-		entities = append(entities, entityRule)
-	}
-
-	return &assertsapi.ModelRulesDto{
-		Entities: entities,
-	}, nil
-}
-
-// convertModelRulesToTerraform converts ModelRulesDto to Terraform structured data
-func convertModelRulesToTerraform(rules *assertsapi.ModelRulesDto) ([]interface{}, error) {
-	if rules == nil || rules.Entities == nil {
-		return []interface{}{}, nil
-	}
-
-	var entities []interface{}
-	for _, entity := range rules.Entities {
-		var definedBy []interface{}
-		for _, db := range entity.DefinedBy {
-			query := ""
-			if db.Query != nil {
-				query = *db.Query
-			}
-
-			definedByItem := map[string]interface{}{
-				"query": query,
-			}
-
-			// Add optional fields if they exist
-			if db.Disabled != nil {
-				definedByItem["disabled"] = *db.Disabled
-			}
-
-			if len(db.LabelValues) > 0 {
-				definedByItem["label_values"] = db.LabelValues
-			}
-
-			if len(db.Literals) > 0 {
-				definedByItem["literals"] = db.Literals
-			}
-
-			if db.MetricValue != nil {
-				definedByItem["metric_value"] = *db.MetricValue
-			}
-
-			definedBy = append(definedBy, definedByItem)
-		}
-
-		entityType := ""
-		if entity.Type != nil {
-			entityType = *entity.Type
-		}
-		entityName := ""
-		if entity.Name != nil {
-			entityName = *entity.Name
-		}
-
-		entityMap := map[string]interface{}{
-			"type":       entityType,
-			"name":       entityName,
-			"defined_by": definedBy,
-		}
-
-		// Add optional entity fields if they exist
-		if len(entity.Scope) > 0 {
-			entityMap["scope"] = entity.Scope
-		}
-
-		if len(entity.Lookup) > 0 {
-			entityMap["lookup"] = entity.Lookup
-		}
-
-		if len(entity.EnrichedBy) > 0 {
-			var enrichedByList []string
-			for _, enrichedBy := range entity.EnrichedBy {
-				if enrichedBy.Query != nil {
-					enrichedByList = append(enrichedByList, *enrichedBy.Query)
-				}
-			}
-			if len(enrichedByList) > 0 {
-				entityMap["enriched_by"] = enrichedByList
-			}
-		}
-
-		if entity.Disabled != nil {
-			entityMap["disabled"] = *entity.Disabled
-		}
-
-		entities = append(entities, entityMap)
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"entity": entities,
-		},
-	}, nil
+type customModelRulesResource struct {
+	client  *assertsapi.APIClient
+	stackID int64
 }
 
 func makeResourceCustomModelRules() *common.Resource {
-	sch := &schema.Resource{
+	return common.NewResource(
+		common.CategoryAsserts,
+		"grafana_asserts_custom_model_rules",
+		common.NewResourceID(common.StringIDField("name")),
+		&customModelRulesResource{},
+	).WithLister(assertsListerFunction(listCustomModelRules))
+}
+
+func (r *customModelRulesResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "grafana_asserts_custom_model_rules"
+}
+
+func (r *customModelRulesResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil || r.client != nil {
+		return
+	}
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Configure Type",
+			fmt.Sprintf("Expected *common.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	if client.AssertsAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Asserts API client not configured",
+			"The Grafana provider is missing a configuration for the Asserts API. Ensure stack_id is set in the provider configuration.",
+		)
+		return
+	}
+	r.client = client.AssertsAPIClient
+	r.stackID = client.GrafanaStackID
+}
+
+func (r *customModelRulesResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
 		Description: "Manages Knowledge Graph Custom Model Rules through the Grafana API.",
-
-		CreateContext: resourceCustomModelRulesCreate,
-		ReadContext:   resourceCustomModelRulesRead,
-		UpdateContext: resourceCustomModelRulesUpdate,
-		DeleteContext: resourceCustomModelRulesDelete,
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The name of the custom model rules.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"rules": {
-				Type:        schema.TypeList,
+			"name": schema.StringAttribute{
 				Required:    true,
-				MaxItems:    1,
+				Description: "The name of the custom model rules.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"rules": schema.ListNestedBlock{
 				Description: "The rules configuration for the custom model rules.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"entity": {
-							Type:        schema.TypeList,
-							Required:    true,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"entity": schema.ListNestedBlock{
 							Description: "List of entities to define in the custom model rules.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"type": {
-										Type:        schema.TypeString,
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"type": schema.StringAttribute{
 										Required:    true,
 										Description: "The type of the entity (e.g., Service, Pod, Namespace).",
 									},
-									"name": {
-										Type:        schema.TypeString,
+									"name": schema.StringAttribute{
 										Required:    true,
 										Description: "The name of the entity.",
 									},
-									"scope": {
-										Type:        schema.TypeMap,
+									"scope": schema.MapAttribute{
 										Optional:    true,
 										Description: "Scope labels for the entity.",
-										Elem:        &schema.Schema{Type: schema.TypeString},
+										ElementType: types.StringType,
 									},
-									"lookup": {
-										Type:        schema.TypeMap,
+									"lookup": schema.MapAttribute{
 										Optional:    true,
 										Description: "Lookup mappings for the entity.",
-										Elem:        &schema.Schema{Type: schema.TypeString},
+										ElementType: types.StringType,
 									},
-									"enriched_by": {
-										Type:        schema.TypeList,
+									"enriched_by": schema.ListAttribute{
 										Optional:    true,
 										Description: "List of enrichment sources for the entity.",
-										Elem:        &schema.Schema{Type: schema.TypeString},
+										ElementType: types.StringType,
 									},
-									"disabled": {
-										Type:        schema.TypeBool,
+									"disabled": schema.BoolAttribute{
 										Optional:    true,
 										Description: "Whether this entity is disabled.",
 									},
-									"defined_by": {
-										Type:        schema.TypeList,
-										Required:    true,
+								},
+								Blocks: map[string]schema.Block{
+									"defined_by": schema.ListNestedBlock{
 										Description: "List of queries that define this entity.",
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"query": {
-													Type:        schema.TypeString,
+										Validators: []validator.List{
+											listvalidator.SizeAtLeast(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"query": schema.StringAttribute{
 													Required:    true,
 													Description: "The Prometheus query that defines this entity.",
 												},
-												"disabled": {
-													Type:        schema.TypeBool,
+												"disabled": schema.BoolAttribute{
 													Optional:    true,
 													Description: "Whether this rule is disabled. When true, only the 'query' field is used to match an existing rule to disable; other fields are ignored.",
 												},
-												"label_values": {
-													Type:        schema.TypeMap,
+												"label_values": schema.MapAttribute{
 													Optional:    true,
 													Description: "Label value mappings for the query.",
-													Elem:        &schema.Schema{Type: schema.TypeString},
+													ElementType: types.StringType,
 												},
-												"literals": {
-													Type:        schema.TypeMap,
+												"literals": schema.MapAttribute{
 													Optional:    true,
 													Description: "Literal value mappings for the query.",
-													Elem:        &schema.Schema{Type: schema.TypeString},
+													ElementType: types.StringType,
 												},
-												"metric_value": {
-													Type:        schema.TypeString,
+												"metric_value": schema.StringAttribute{
 													Optional:    true,
 													Description: "Metric value for the query.",
 												},
@@ -346,135 +197,453 @@ func makeResourceCustomModelRules() *common.Resource {
 			},
 		},
 	}
-
-	return common.NewLegacySDKResource(
-		common.CategoryAsserts,
-		"grafana_asserts_custom_model_rules",
-		common.NewResourceID(common.StringIDField("name")),
-		sch,
-	).WithLister(assertsListerFunction(listCustomModelRules))
 }
 
-func resourceCustomModelRulesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, stackID, diags := validateAssertsClient(meta)
-	if diags.HasError() {
-		return diags
+func (r *customModelRulesResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data customModelRulesModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	name := d.Get("name").(string)
-
-	rules, err := convertTerraformToModelRules(d)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to convert rules: %w", err))
+	rules, diags := modelToAPIRules(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
+	name := data.Name.ValueString()
 	rules.Name = &name
 	rules.SetManagedBy(getManagedByTerraformValue())
 
-	req := client.ModelRulesConfigurationAPI.PutModelRules(ctx).ModelRulesDto(*rules).XScopeOrgID(fmt.Sprintf("%d", stackID))
-	_, err = req.Execute()
+	stackID := fmt.Sprintf("%d", r.stackID)
+	_, err := r.client.ModelRulesConfigurationAPI.PutModelRules(ctx).ModelRulesDto(*rules).XScopeOrgID(stackID).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create custom model rules: %w", err))
+		resp.Diagnostics.AddError("Failed to create custom model rules", err.Error())
+		return
 	}
 
-	d.SetId(name)
+	data.ID = types.StringValue(name)
 
-	return resourceCustomModelRulesRead(ctx, d, meta)
+	readData, diags := r.readModelWithRetry(ctx, name)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if readData == nil {
+		resp.Diagnostics.AddError("Resource not found after create",
+			fmt.Sprintf("custom model rules %q was not found after creation", name))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
 }
 
-func resourceCustomModelRulesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, stackID, diags := validateAssertsClient(meta)
-	if diags.HasError() {
-		return diags
+func (r *customModelRulesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data customModelRulesModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	name := d.Id()
 
-	// Retry logic for read operation to handle eventual consistency
-	var rules *assertsapi.ModelRulesDto
-	err := withRetryRead(ctx, func(retryCount, maxRetries int) *retry.RetryError {
-		req := client.ModelRulesConfigurationAPI.GetModelRules(ctx, name).XScopeOrgID(fmt.Sprintf("%d", stackID))
-		rulesResult, _, err := req.Execute()
-		if err != nil {
-			// If the error indicates "not found", check if we should retry or give up
-			if _, ok := err.(*assertsapi.GenericOpenAPIError); ok {
-				if retryCount >= maxRetries {
-					return createNonRetryableError("custom model rules", name, retryCount)
-				}
-				return createRetryableError("custom model rules", name, retryCount, maxRetries)
-			}
+	readData, diags := r.readModelWithRetry(ctx, data.ID.ValueString())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if readData == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
 
-			// Other API errors
-			return createAPIError("get custom model rules", retryCount, maxRetries, err)
+func (r *customModelRulesResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data customModelRulesModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rules, diags := modelToAPIRules(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+	rules.Name = &name
+	rules.SetManagedBy(getManagedByTerraformValue())
+
+	stackID := fmt.Sprintf("%d", r.stackID)
+	_, err := r.client.ModelRulesConfigurationAPI.PutModelRules(ctx).ModelRulesDto(*rules).XScopeOrgID(stackID).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to update custom model rules", err.Error())
+		return
+	}
+
+	readData, diags := r.readModelWithRetry(ctx, name)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if readData == nil {
+		resp.Diagnostics.AddError("Resource not found after update",
+			fmt.Sprintf("custom model rules %q was not found after update", name))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
+
+func (r *customModelRulesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data customModelRulesModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.ID.ValueString()
+	stackID := fmt.Sprintf("%d", r.stackID)
+	_, err := r.client.ModelRulesConfigurationAPI.DeleteModelRules(ctx, name).XScopeOrgID(stackID).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to delete custom model rules", err.Error())
+	}
+}
+
+func (r *customModelRulesResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	readData, diags := r.readModelWithRetry(ctx, req.ID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if readData == nil {
+		resp.Diagnostics.AddError("Resource not found",
+			fmt.Sprintf("custom model rules %q not found during import", req.ID))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
+}
+
+// readModelWithRetry fetches the custom model rules from the API with retry/backoff
+// to handle eventual consistency after write operations.
+func (r *customModelRulesResource) readModelWithRetry(ctx context.Context, name string) (*customModelRulesModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	maxRetries := 40
+	deadline := time.Now().Add(600 * time.Second)
+	stackID := fmt.Sprintf("%d", r.stackID)
+	var lastErrMsg string
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if time.Now().After(deadline) {
+			diags.AddError("Timeout reading custom model rules",
+				fmt.Sprintf("timed out waiting for custom model rules %q after 600s", name))
+			return nil, diags
+		}
+		select {
+		case <-ctx.Done():
+			diags.AddError("Context cancelled", ctx.Err().Error())
+			return nil, diags
+		default:
 		}
 
-		rules = rulesResult
-		return nil
-	})
+		result, _, err := r.client.ModelRulesConfigurationAPI.GetModelRules(ctx, name).XScopeOrgID(stackID).Execute()
+		if err == nil {
+			if result == nil {
+				return nil, diags
+			}
+			return apiRulesToModel(ctx, name, result)
+		}
 
-	if err != nil {
-		return diag.FromErr(err)
+		if _, ok := err.(*assertsapi.GenericOpenAPIError); ok {
+			lastErrMsg = fmt.Sprintf("custom model rules %q not found (attempt %d/%d)", name, attempt, maxRetries)
+			if attempt >= maxRetries {
+				diags.AddError("Custom model rules not found",
+					fmt.Sprintf("giving up after %d attempt(s): %s", attempt, lastErrMsg))
+				return nil, diags
+			}
+		} else {
+			lastErrMsg = fmt.Sprintf("API error: %s", err)
+			if attempt >= maxRetries {
+				diags.AddError("Failed to read custom model rules",
+					fmt.Sprintf("giving up after %d attempt(s): %s", attempt, lastErrMsg))
+				return nil, diags
+			}
+		}
+
+		customModelRulesBackoff(ctx, attempt)
 	}
+
+	diags.AddError("Failed to read custom model rules",
+		fmt.Sprintf("giving up after %d attempt(s): %s", maxRetries, lastErrMsg))
+	return nil, diags
+}
+
+func customModelRulesBackoff(ctx context.Context, attempt int) {
+	var baseSleep time.Duration
+	if attempt == 1 {
+		baseSleep = 1 * time.Second
+	} else {
+		baseSleep = time.Duration(1<<int(math.Min(float64(attempt-2), 4))) * time.Second
+	}
+	minSleep := baseSleep / 2
+	maxJitter := baseSleep - minSleep
+	var sleepDuration time.Duration
+	if maxJitter > 0 {
+		//nolint:gosec
+		j := time.Duration(rand.Int63n(int64(maxJitter)))
+		sleepDuration = minSleep + j
+	} else {
+		sleepDuration = baseSleep
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(sleepDuration):
+	}
+}
+
+// apiRulesToModel converts an API ModelRulesDto to the Terraform Framework model.
+func apiRulesToModel(ctx context.Context, name string, rules *assertsapi.ModelRulesDto) (*customModelRulesModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
 
 	if rules == nil {
-		d.SetId("")
-		return nil
+		return nil, diags
 	}
 
+	modelName := name
 	if rules.Name != nil {
-		d.Set("name", *rules.Name)
+		modelName = *rules.Name
 	}
 
-	// Convert API response to Terraform structured data
-	rulesCopy := *rules
-	rulesCopy.Name = nil // Don't include name in the rules structure
-
-	terraformRules, err := convertModelRulesToTerraform(&rulesCopy)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to convert rules to Terraform format: %w", err))
+	model := &customModelRulesModel{
+		ID:   types.StringValue(name),
+		Name: types.StringValue(modelName),
 	}
 
-	d.Set("rules", terraformRules)
-
-	return nil
+	var entities []entityModel
+	for _, entity := range rules.Entities {
+		em, d := apiEntityToModel(ctx, entity)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		entities = append(entities, em)
+	}
+	if entities == nil {
+		entities = []entityModel{}
+	}
+	model.Rules = []rulesModel{{Entity: entities}}
+	return model, diags
 }
 
-func resourceCustomModelRulesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, stackID, diags := validateAssertsClient(meta)
-	if diags.HasError() {
-		return diags
+func apiEntityToModel(ctx context.Context, entity assertsapi.EntityRuleDto) (entityModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	em := entityModel{}
+
+	if entity.Type != nil {
+		em.Type = types.StringValue(*entity.Type)
+	}
+	if entity.Name != nil {
+		em.Name = types.StringValue(*entity.Name)
 	}
 
-	name := d.Get("name").(string)
-
-	rules, err := convertTerraformToModelRules(d)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to convert rules: %w", err))
+	if len(entity.Scope) > 0 {
+		scopeMap, d := types.MapValueFrom(ctx, types.StringType, entity.Scope)
+		diags.Append(d...)
+		em.Scope = scopeMap
+	} else {
+		em.Scope = types.MapNull(types.StringType)
 	}
 
-	rules.Name = &name
-	rules.SetManagedBy(getManagedByTerraformValue())
-
-	req := client.ModelRulesConfigurationAPI.PutModelRules(ctx).ModelRulesDto(*rules).XScopeOrgID(fmt.Sprintf("%d", stackID))
-	_, err = req.Execute()
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update custom model rules: %w", err))
+	if len(entity.Lookup) > 0 {
+		lookupMap, d := types.MapValueFrom(ctx, types.StringType, entity.Lookup)
+		diags.Append(d...)
+		em.Lookup = lookupMap
+	} else {
+		em.Lookup = types.MapNull(types.StringType)
 	}
 
-	return resourceCustomModelRulesRead(ctx, d, meta)
+	if len(entity.EnrichedBy) > 0 {
+		queries := make([]string, 0, len(entity.EnrichedBy))
+		for _, eb := range entity.EnrichedBy {
+			if eb.Query != nil {
+				queries = append(queries, *eb.Query)
+			}
+		}
+		enrichedByList, d := types.ListValueFrom(ctx, types.StringType, queries)
+		diags.Append(d...)
+		em.EnrichedBy = enrichedByList
+	} else {
+		em.EnrichedBy = types.ListNull(types.StringType)
+	}
+
+	if entity.Disabled != nil {
+		em.Disabled = types.BoolValue(*entity.Disabled)
+	} else {
+		em.Disabled = types.BoolNull()
+	}
+
+	var definedBy []definedByModel
+	for _, db := range entity.DefinedBy {
+		dm, d := apiDefinedByToModel(ctx, db)
+		diags.Append(d...)
+		if diags.HasError() {
+			return em, diags
+		}
+		definedBy = append(definedBy, dm)
+	}
+	if definedBy == nil {
+		definedBy = []definedByModel{}
+	}
+	em.DefinedBy = definedBy
+
+	return em, diags
 }
 
-func resourceCustomModelRulesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, stackID, diags := validateAssertsClient(meta)
-	if diags.HasError() {
-		return diags
-	}
-	name := d.Id()
+func apiDefinedByToModel(ctx context.Context, db assertsapi.PropertyRuleDto) (definedByModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	dm := definedByModel{}
 
-	req := client.ModelRulesConfigurationAPI.DeleteModelRules(ctx, name).XScopeOrgID(fmt.Sprintf("%d", stackID))
-	_, err := req.Execute()
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete custom model rules: %w", err))
+	if db.Query != nil {
+		dm.Query = types.StringValue(*db.Query)
 	}
 
-	return nil
+	if db.Disabled != nil {
+		dm.Disabled = types.BoolValue(*db.Disabled)
+	} else {
+		dm.Disabled = types.BoolNull()
+	}
+
+	if len(db.LabelValues) > 0 {
+		lvMap, d := types.MapValueFrom(ctx, types.StringType, db.LabelValues)
+		diags.Append(d...)
+		dm.LabelValues = lvMap
+	} else {
+		dm.LabelValues = types.MapNull(types.StringType)
+	}
+
+	if len(db.Literals) > 0 {
+		litMap, d := types.MapValueFrom(ctx, types.StringType, db.Literals)
+		diags.Append(d...)
+		dm.Literals = litMap
+	} else {
+		dm.Literals = types.MapNull(types.StringType)
+	}
+
+	if db.MetricValue != nil && *db.MetricValue != "" {
+		dm.MetricValue = types.StringValue(*db.MetricValue)
+	} else {
+		dm.MetricValue = types.StringNull()
+	}
+
+	return dm, diags
+}
+
+// modelToAPIRules converts the Terraform Framework model to an API ModelRulesDto.
+func modelToAPIRules(ctx context.Context, data *customModelRulesModel) (*assertsapi.ModelRulesDto, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if len(data.Rules) == 0 {
+		diags.AddError("rules block is required", "at least one rules block must be specified")
+		return nil, diags
+	}
+
+	rulesData := data.Rules[0]
+	var entities []assertsapi.EntityRuleDto
+	for _, entityData := range rulesData.Entity {
+		entity, d := modelEntityToAPI(ctx, entityData)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		entities = append(entities, entity)
+	}
+
+	return &assertsapi.ModelRulesDto{Entities: entities}, diags
+}
+
+func modelEntityToAPI(ctx context.Context, em entityModel) (assertsapi.EntityRuleDto, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	entityType := em.Type.ValueString()
+	entityName := em.Name.ValueString()
+
+	var definedBy []assertsapi.PropertyRuleDto
+	for _, dm := range em.DefinedBy {
+		prop, d := modelDefinedByToAPI(ctx, dm)
+		diags.Append(d...)
+		if diags.HasError() {
+			return assertsapi.EntityRuleDto{}, diags
+		}
+		definedBy = append(definedBy, prop)
+	}
+
+	entity := assertsapi.EntityRuleDto{
+		Type:      &entityType,
+		Name:      &entityName,
+		DefinedBy: definedBy,
+	}
+
+	if !em.Scope.IsNull() && !em.Scope.IsUnknown() {
+		scopeMap := make(map[string]string)
+		diags.Append(em.Scope.ElementsAs(ctx, &scopeMap, false)...)
+		entity.Scope = scopeMap
+	}
+
+	if !em.Lookup.IsNull() && !em.Lookup.IsUnknown() {
+		lookupMap := make(map[string]string)
+		diags.Append(em.Lookup.ElementsAs(ctx, &lookupMap, false)...)
+		entity.Lookup = lookupMap
+	}
+
+	if !em.EnrichedBy.IsNull() && !em.EnrichedBy.IsUnknown() {
+		var queries []string
+		diags.Append(em.EnrichedBy.ElementsAs(ctx, &queries, false)...)
+		for _, q := range queries {
+			qCopy := q
+			entity.EnrichedBy = append(entity.EnrichedBy, assertsapi.PropertyRuleDto{Query: &qCopy})
+		}
+	}
+
+	// Only set disabled when explicitly true, matching original behavior.
+	if !em.Disabled.IsNull() && em.Disabled.ValueBool() {
+		disabled := true
+		entity.Disabled = &disabled
+	}
+
+	return entity, diags
+}
+
+func modelDefinedByToAPI(ctx context.Context, dm definedByModel) (assertsapi.PropertyRuleDto, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	query := dm.Query.ValueString()
+	prop := assertsapi.PropertyRuleDto{Query: &query}
+
+	// Only set disabled when explicitly true, matching original behavior.
+	if !dm.Disabled.IsNull() && dm.Disabled.ValueBool() {
+		disabled := true
+		prop.Disabled = &disabled
+	}
+
+	if !dm.LabelValues.IsNull() && !dm.LabelValues.IsUnknown() {
+		labelMap := make(map[string]string)
+		diags.Append(dm.LabelValues.ElementsAs(ctx, &labelMap, false)...)
+		if len(labelMap) > 0 {
+			prop.LabelValues = labelMap
+		}
+	}
+
+	if !dm.Literals.IsNull() && !dm.Literals.IsUnknown() {
+		litMap := make(map[string]string)
+		diags.Append(dm.Literals.ElementsAs(ctx, &litMap, false)...)
+		if len(litMap) > 0 {
+			prop.Literals = litMap
+		}
+	}
+
+	if !dm.MetricValue.IsNull() && !dm.MetricValue.IsUnknown() && dm.MetricValue.ValueString() != "" {
+		mv := dm.MetricValue.ValueString()
+		prop.MetricValue = &mv
+	}
+
+	return prop, diags
 }

--- a/internal/resources/asserts/resource_custom_model_rules.go
+++ b/internal/resources/asserts/resource_custom_model_rules.go
@@ -595,13 +595,17 @@ func modelEntityToAPI(ctx context.Context, em entityModel) (assertsapi.EntityRul
 	if !em.Scope.IsNull() && !em.Scope.IsUnknown() {
 		scopeMap := make(map[string]string)
 		diags.Append(em.Scope.ElementsAs(ctx, &scopeMap, false)...)
-		entity.Scope = scopeMap
+		if len(scopeMap) > 0 {
+			entity.Scope = scopeMap
+		}
 	}
 
 	if !em.Lookup.IsNull() && !em.Lookup.IsUnknown() {
 		lookupMap := make(map[string]string)
 		diags.Append(em.Lookup.ElementsAs(ctx, &lookupMap, false)...)
-		entity.Lookup = lookupMap
+		if len(lookupMap) > 0 {
+			entity.Lookup = lookupMap
+		}
 	}
 
 	if !em.EnrichedBy.IsNull() && !em.EnrichedBy.IsUnknown() {

--- a/internal/resources/asserts/resource_custom_model_rules.go
+++ b/internal/resources/asserts/resource_custom_model_rules.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -162,6 +163,8 @@ func (r *customModelRulesResource) Schema(_ context.Context, _ resource.SchemaRe
 									},
 									"disabled": schema.BoolAttribute{
 										Optional:    true,
+										Computed:    true,
+										Default:     booldefault.StaticBool(false),
 										Description: "Whether this entity is disabled.",
 									},
 								},
@@ -180,6 +183,8 @@ func (r *customModelRulesResource) Schema(_ context.Context, _ resource.SchemaRe
 												},
 												"disabled": schema.BoolAttribute{
 													Optional:    true,
+													Computed:    true,
+													Default:     booldefault.StaticBool(false),
 													Description: "Whether this rule is disabled. When true, only the 'query' field is used to match an existing rule to disable; other fields are ignored.",
 												},
 												"label_values": schema.MapAttribute{
@@ -488,7 +493,7 @@ func apiEntityToModel(ctx context.Context, entity assertsapi.EntityRuleDto) (ent
 	if entity.Disabled != nil {
 		em.Disabled = types.BoolValue(*entity.Disabled)
 	} else {
-		em.Disabled = types.BoolNull()
+		em.Disabled = types.BoolValue(false)
 	}
 
 	var definedBy []definedByModel
@@ -519,7 +524,7 @@ func apiDefinedByToModel(ctx context.Context, db assertsapi.PropertyRuleDto) (de
 	if db.Disabled != nil {
 		dm.Disabled = types.BoolValue(*db.Disabled)
 	} else {
-		dm.Disabled = types.BoolNull()
+		dm.Disabled = types.BoolValue(false)
 	}
 
 	if len(db.LabelValues) > 0 {

--- a/internal/resources/asserts/resource_custom_model_rules_unit_test.go
+++ b/internal/resources/asserts/resource_custom_model_rules_unit_test.go
@@ -1,0 +1,417 @@
+package asserts
+
+import (
+	"context"
+	"testing"
+
+	assertsapi "github.com/grafana/grafana-asserts-public-clients/go/gcom"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitCustomModelRules_Metadata(t *testing.T) {
+	r := &customModelRulesResource{}
+	var resp resource.MetadataResponse
+	r.Metadata(context.Background(), resource.MetadataRequest{}, &resp)
+	assert.Equal(t, "grafana_asserts_custom_model_rules", resp.TypeName)
+}
+
+func TestUnitCustomModelRules_Schema(t *testing.T) {
+	r := &customModelRulesResource{}
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	require.False(t, resp.Diagnostics.HasError(), "schema should be valid: %v", resp.Diagnostics)
+
+	attrs := resp.Schema.Attributes
+	assert.Contains(t, attrs, "id")
+	assert.Contains(t, attrs, "name")
+
+	blocks := resp.Schema.Blocks
+	assert.Contains(t, blocks, "rules")
+	assert.NotNil(t, blocks["rules"])
+}
+
+// TestUnitCustomModelRules_APIToModel_Basic verifies that a minimal API response converts correctly.
+func TestUnitCustomModelRules_APIToModel_Basic(t *testing.T) {
+	ctx := context.Background()
+	name := "test-rules"
+	query := "up{job!=''}"
+	entityType := "Service"
+	entityName := "Service"
+
+	apiRules := &assertsapi.ModelRulesDto{
+		Name: &name,
+		Entities: []assertsapi.EntityRuleDto{
+			{
+				Type: &entityType,
+				Name: &entityName,
+				DefinedBy: []assertsapi.PropertyRuleDto{
+					{Query: &query},
+				},
+			},
+		},
+	}
+
+	model, diags := apiRulesToModel(ctx, name, apiRules)
+	require.False(t, diags.HasError(), "unexpected diags: %v", diags)
+	require.NotNil(t, model)
+
+	assert.Equal(t, name, model.ID.ValueString())
+	assert.Equal(t, name, model.Name.ValueString())
+	require.Len(t, model.Rules, 1)
+	require.Len(t, model.Rules[0].Entity, 1)
+
+	entity := model.Rules[0].Entity[0]
+	assert.Equal(t, entityType, entity.Type.ValueString())
+	assert.Equal(t, entityName, entity.Name.ValueString())
+	assert.True(t, entity.Scope.IsNull(), "absent scope should be null")
+	assert.True(t, entity.Lookup.IsNull(), "absent lookup should be null")
+	assert.True(t, entity.EnrichedBy.IsNull(), "absent enriched_by should be null")
+	assert.True(t, entity.Disabled.IsNull(), "absent disabled should be null")
+
+	require.Len(t, entity.DefinedBy, 1)
+	db := entity.DefinedBy[0]
+	assert.Equal(t, query, db.Query.ValueString())
+	assert.True(t, db.Disabled.IsNull())
+	assert.True(t, db.LabelValues.IsNull())
+	assert.True(t, db.Literals.IsNull())
+	assert.True(t, db.MetricValue.IsNull())
+}
+
+// TestUnitCustomModelRules_APIToModel_AllOptionalFields verifies optional fields convert correctly.
+func TestUnitCustomModelRules_APIToModel_AllOptionalFields(t *testing.T) {
+	ctx := context.Background()
+	name := "test-rules"
+	query := "up{job!=''}"
+	entityType := "Service"
+	entityName := "workload"
+	enrichedQuery := "kube_pod_info"
+	metricVal := "value"
+	disabled := true
+
+	apiRules := &assertsapi.ModelRulesDto{
+		Name: &name,
+		Entities: []assertsapi.EntityRuleDto{
+			{
+				Type:     &entityType,
+				Name:     &entityName,
+				Scope:    map[string]string{"namespace": "ns", "env": "prod"},
+				Lookup:   map[string]string{"workload": "workload"},
+				Disabled: &disabled,
+				EnrichedBy: []assertsapi.PropertyRuleDto{
+					{Query: &enrichedQuery},
+				},
+				DefinedBy: []assertsapi.PropertyRuleDto{
+					{
+						Query:       &query,
+						Disabled:    &disabled,
+						LabelValues: map[string]string{"job": "job"},
+						Literals:    map[string]string{"_src": "test"},
+						MetricValue: &metricVal,
+					},
+				},
+			},
+		},
+	}
+
+	model, diags := apiRulesToModel(ctx, name, apiRules)
+	require.False(t, diags.HasError())
+	require.NotNil(t, model)
+
+	entity := model.Rules[0].Entity[0]
+
+	// scope map
+	require.False(t, entity.Scope.IsNull())
+	scopeElems := entity.Scope.Elements()
+	assert.Len(t, scopeElems, 2)
+	assert.Equal(t, types.StringValue("ns"), scopeElems["namespace"])
+
+	// lookup map
+	require.False(t, entity.Lookup.IsNull())
+	lookupElems := entity.Lookup.Elements()
+	assert.Equal(t, types.StringValue("workload"), lookupElems["workload"])
+
+	// enriched_by list
+	require.False(t, entity.EnrichedBy.IsNull())
+	enrichedElems := entity.EnrichedBy.Elements()
+	assert.Len(t, enrichedElems, 1)
+	assert.Equal(t, types.StringValue(enrichedQuery), enrichedElems[0])
+
+	// entity disabled
+	assert.Equal(t, types.BoolValue(true), entity.Disabled)
+
+	// defined_by fields
+	db := entity.DefinedBy[0]
+	assert.Equal(t, types.BoolValue(true), db.Disabled)
+	assert.Equal(t, types.StringValue(metricVal), db.MetricValue)
+
+	lvElems := db.LabelValues.Elements()
+	assert.Equal(t, types.StringValue("job"), lvElems["job"])
+	litElems := db.Literals.Elements()
+	assert.Equal(t, types.StringValue("test"), litElems["_src"])
+}
+
+// TestUnitCustomModelRules_APIToModel_NilInput verifies nil API response returns nil model.
+func TestUnitCustomModelRules_APIToModel_NilInput(t *testing.T) {
+	model, diags := apiRulesToModel(context.Background(), "name", nil)
+	require.False(t, diags.HasError())
+	assert.Nil(t, model)
+}
+
+// TestUnitCustomModelRules_ModelToAPI_Basic verifies a minimal model converts correctly.
+func TestUnitCustomModelRules_ModelToAPI_Basic(t *testing.T) {
+	ctx := context.Background()
+	data := &customModelRulesModel{
+		ID:   types.StringValue("test-rules"),
+		Name: types.StringValue("test-rules"),
+		Rules: []rulesModel{
+			{
+				Entity: []entityModel{
+					{
+						Type:       types.StringValue("Service"),
+						Name:       types.StringValue("Service"),
+						Scope:      types.MapNull(types.StringType),
+						Lookup:     types.MapNull(types.StringType),
+						EnrichedBy: types.ListNull(types.StringType),
+						Disabled:   types.BoolNull(),
+						DefinedBy: []definedByModel{
+							{
+								Query:       types.StringValue("up{job!=''}"),
+								Disabled:    types.BoolNull(),
+								LabelValues: types.MapNull(types.StringType),
+								Literals:    types.MapNull(types.StringType),
+								MetricValue: types.StringNull(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	apiRules, diags := modelToAPIRules(ctx, data)
+	require.False(t, diags.HasError())
+	require.NotNil(t, apiRules)
+	require.Len(t, apiRules.Entities, 1)
+
+	entity := apiRules.Entities[0]
+	assert.Equal(t, "Service", *entity.Type)
+	assert.Equal(t, "Service", *entity.Name)
+	assert.Nil(t, entity.Scope)
+	assert.Nil(t, entity.Lookup)
+	assert.Nil(t, entity.EnrichedBy)
+	assert.Nil(t, entity.Disabled)
+	require.Len(t, entity.DefinedBy, 1)
+	assert.Equal(t, "up{job!=''}", *entity.DefinedBy[0].Query)
+	assert.Nil(t, entity.DefinedBy[0].Disabled)
+}
+
+// TestUnitCustomModelRules_ModelToAPI_DisabledOnlySetWhenTrue verifies the original behavior
+// that disabled is only sent to the API when explicitly true (not when false).
+func TestUnitCustomModelRules_ModelToAPI_DisabledOnlySetWhenTrue(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		entityDisabled  types.Bool
+		definedDisabled types.Bool
+		wantEntityNil   bool
+		wantDBNil       bool
+	}{
+		{
+			name:            "null disabled → nil in API",
+			entityDisabled:  types.BoolNull(),
+			definedDisabled: types.BoolNull(),
+			wantEntityNil:   true,
+			wantDBNil:       true,
+		},
+		{
+			name:            "false disabled → nil in API",
+			entityDisabled:  types.BoolValue(false),
+			definedDisabled: types.BoolValue(false),
+			wantEntityNil:   true,
+			wantDBNil:       true,
+		},
+		{
+			name:            "true disabled → set in API",
+			entityDisabled:  types.BoolValue(true),
+			definedDisabled: types.BoolValue(true),
+			wantEntityNil:   false,
+			wantDBNil:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := &customModelRulesModel{
+				ID:   types.StringValue("r"),
+				Name: types.StringValue("r"),
+				Rules: []rulesModel{{Entity: []entityModel{{
+					Type:       types.StringValue("Service"),
+					Name:       types.StringValue("Service"),
+					Scope:      types.MapNull(types.StringType),
+					Lookup:     types.MapNull(types.StringType),
+					EnrichedBy: types.ListNull(types.StringType),
+					Disabled:   tc.entityDisabled,
+					DefinedBy: []definedByModel{{
+						Query:       types.StringValue("up{}"),
+						Disabled:    tc.definedDisabled,
+						LabelValues: types.MapNull(types.StringType),
+						Literals:    types.MapNull(types.StringType),
+						MetricValue: types.StringNull(),
+					}},
+				}}}},
+			}
+
+			apiRules, diags := modelToAPIRules(ctx, data)
+			require.False(t, diags.HasError())
+
+			entity := apiRules.Entities[0]
+			if tc.wantEntityNil {
+				assert.Nil(t, entity.Disabled)
+			} else {
+				require.NotNil(t, entity.Disabled)
+				assert.True(t, *entity.Disabled)
+			}
+
+			db := entity.DefinedBy[0]
+			if tc.wantDBNil {
+				assert.Nil(t, db.Disabled)
+			} else {
+				require.NotNil(t, db.Disabled)
+				assert.True(t, *db.Disabled)
+			}
+		})
+	}
+}
+
+// TestUnitCustomModelRules_RoundTrip verifies that API→model→API produces the same API payload.
+func TestUnitCustomModelRules_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	name := "test-rules"
+	query := "up{job!=''}"
+	entityType := "Service"
+	entityName := "workload"
+	enrichedQuery := "kube_pod_info"
+	disabled := true
+
+	originalAPI := &assertsapi.ModelRulesDto{
+		Name: &name,
+		Entities: []assertsapi.EntityRuleDto{
+			{
+				Type:     &entityType,
+				Name:     &entityName,
+				Scope:    map[string]string{"namespace": "ns"},
+				Lookup:   map[string]string{"workload": "workload"},
+				Disabled: &disabled,
+				EnrichedBy: []assertsapi.PropertyRuleDto{
+					{Query: &enrichedQuery},
+				},
+				DefinedBy: []assertsapi.PropertyRuleDto{
+					{
+						Query:       &query,
+						LabelValues: map[string]string{"job": "job"},
+						Literals:    map[string]string{"_src": "test"},
+					},
+				},
+			},
+		},
+	}
+
+	// API → model
+	model, diags := apiRulesToModel(ctx, name, originalAPI)
+	require.False(t, diags.HasError())
+	require.NotNil(t, model)
+
+	// model → API
+	roundTripped, diags := modelToAPIRules(ctx, model)
+	require.False(t, diags.HasError())
+	require.NotNil(t, roundTripped)
+
+	require.Len(t, roundTripped.Entities, 1)
+	entity := roundTripped.Entities[0]
+
+	assert.Equal(t, entityType, *entity.Type)
+	assert.Equal(t, entityName, *entity.Name)
+	assert.Equal(t, map[string]string{"namespace": "ns"}, entity.Scope)
+	assert.Equal(t, map[string]string{"workload": "workload"}, entity.Lookup)
+	require.NotNil(t, entity.Disabled)
+	assert.True(t, *entity.Disabled)
+
+	require.Len(t, entity.EnrichedBy, 1)
+	assert.Equal(t, enrichedQuery, *entity.EnrichedBy[0].Query)
+
+	require.Len(t, entity.DefinedBy, 1)
+	db := entity.DefinedBy[0]
+	assert.Equal(t, query, *db.Query)
+	assert.Equal(t, map[string]string{"job": "job"}, db.LabelValues)
+	assert.Equal(t, map[string]string{"_src": "test"}, db.Literals)
+}
+
+// TestUnitCustomModelRules_RoundTrip_WithDisabled verifies the disabled field round-trips correctly.
+func TestUnitCustomModelRules_RoundTrip_WithDisabled(t *testing.T) {
+	ctx := context.Background()
+	name := "test-rules"
+	query := "up{}"
+	entityType := "Service"
+	entityName := "Service"
+	disabled := true
+
+	originalAPI := &assertsapi.ModelRulesDto{
+		Name: &name,
+		Entities: []assertsapi.EntityRuleDto{
+			{
+				Type:     &entityType,
+				Name:     &entityName,
+				Disabled: &disabled,
+				DefinedBy: []assertsapi.PropertyRuleDto{
+					{Query: &query, Disabled: &disabled},
+				},
+			},
+		},
+	}
+
+	model, diags := apiRulesToModel(ctx, name, originalAPI)
+	require.False(t, diags.HasError())
+
+	roundTripped, diags := modelToAPIRules(ctx, model)
+	require.False(t, diags.HasError())
+
+	entity := roundTripped.Entities[0]
+	require.NotNil(t, entity.Disabled)
+	assert.True(t, *entity.Disabled)
+
+	db := entity.DefinedBy[0]
+	require.NotNil(t, db.Disabled)
+	assert.True(t, *db.Disabled)
+}
+
+// TestUnitCustomModelRules_EmptyEntities verifies an empty entities list produces a valid model.
+func TestUnitCustomModelRules_EmptyEntities(t *testing.T) {
+	ctx := context.Background()
+	name := "test-rules"
+
+	apiRules := &assertsapi.ModelRulesDto{
+		Name:     &name,
+		Entities: []assertsapi.EntityRuleDto{},
+	}
+
+	model, diags := apiRulesToModel(ctx, name, apiRules)
+	require.False(t, diags.HasError())
+	require.NotNil(t, model)
+	require.Len(t, model.Rules, 1)
+	assert.Empty(t, model.Rules[0].Entity)
+}
+
+// TestUnitCustomModelRules_ModelToAPI_EmptyRules verifies error on empty rules.
+func TestUnitCustomModelRules_ModelToAPI_EmptyRules(t *testing.T) {
+	data := &customModelRulesModel{
+		ID:    types.StringValue("r"),
+		Name:  types.StringValue("r"),
+		Rules: []rulesModel{},
+	}
+	_, diags := modelToAPIRules(context.Background(), data)
+	assert.True(t, diags.HasError())
+}

--- a/internal/resources/asserts/resource_custom_model_rules_unit_test.go
+++ b/internal/resources/asserts/resource_custom_model_rules_unit_test.go
@@ -5,7 +5,12 @@ import (
 	"testing"
 
 	assertsapi "github.com/grafana/grafana-asserts-public-clients/go/gcom"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -419,4 +424,80 @@ func TestUnitCustomModelRules_ModelToAPI_EmptyRules(t *testing.T) {
 	}
 	_, diags := modelToAPIRules(context.Background(), data)
 	assert.True(t, diags.HasError())
+}
+
+// TestUnitCustomModelRules_Configure_MissingStackID verifies that Configure rejects a zero stack_id.
+func TestUnitCustomModelRules_Configure_MissingStackID(t *testing.T) {
+	r := &customModelRulesResource{}
+	req := resource.ConfigureRequest{
+		ProviderData: &common.Client{
+			AssertsAPIClient: assertsapi.NewAPIClient(assertsapi.NewConfiguration()),
+			GrafanaStackID:   0,
+		},
+	}
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), req, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "stack_id")
+	assert.Nil(t, r.client, "client must not be set when stack_id is missing")
+}
+
+// TestUnitCustomModelRules_Configure_MissingClient verifies that Configure rejects a nil AssertsAPIClient.
+func TestUnitCustomModelRules_Configure_MissingClient(t *testing.T) {
+	r := &customModelRulesResource{}
+	req := resource.ConfigureRequest{
+		ProviderData: &common.Client{
+			AssertsAPIClient: nil,
+			GrafanaStackID:   42,
+		},
+	}
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), req, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	assert.Nil(t, r.client)
+}
+
+// TestUnitCustomModelRules_Configure_Valid verifies that Configure succeeds with both fields set.
+func TestUnitCustomModelRules_Configure_Valid(t *testing.T) {
+	r := &customModelRulesResource{}
+	apiClient := assertsapi.NewAPIClient(assertsapi.NewConfiguration())
+	req := resource.ConfigureRequest{
+		ProviderData: &common.Client{
+			AssertsAPIClient: apiClient,
+			GrafanaStackID:   99,
+		},
+	}
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), req, &resp)
+
+	require.False(t, resp.Diagnostics.HasError())
+	assert.Equal(t, apiClient, r.client)
+	assert.Equal(t, int64(99), r.stackID)
+}
+
+// TestUnitCustomModelRules_IsRequired_NullBlock verifies that IsRequired() fires on a null block,
+// which SizeAtLeast(1) would silently skip.
+func TestUnitCustomModelRules_IsRequired_NullBlock(t *testing.T) {
+	ctx := context.Background()
+	v := listvalidator.IsRequired()
+
+	// Null list (block completely absent from config) must produce an error.
+	nullReq := validator.ListRequest{
+		Path:        path.Root("rules"),
+		ConfigValue: types.ListNull(types.ObjectType{}),
+	}
+	var nullResp validator.ListResponse
+	v.ValidateList(ctx, nullReq, &nullResp)
+	assert.True(t, nullResp.Diagnostics.HasError(), "IsRequired must error on null block")
+
+	// Empty (but non-null) list must pass IsRequired — SizeAtLeast catches the empty case.
+	emptyReq := validator.ListRequest{
+		Path:        path.Root("rules"),
+		ConfigValue: types.ListValueMust(types.ObjectType{}, []attr.Value{}),
+	}
+	var emptyResp validator.ListResponse
+	v.ValidateList(ctx, emptyReq, &emptyResp)
+	assert.False(t, emptyResp.Diagnostics.HasError(), "IsRequired must pass on empty (non-null) list")
 }

--- a/internal/resources/asserts/resource_custom_model_rules_unit_test.go
+++ b/internal/resources/asserts/resource_custom_model_rules_unit_test.go
@@ -426,6 +426,45 @@ func TestUnitCustomModelRules_ModelToAPI_EmptyRules(t *testing.T) {
 	assert.True(t, diags.HasError())
 }
 
+// TestUnitCustomModelRules_ModelToAPI_EmptyCollectionsOmitted verifies that empty (non-null) scope,
+// lookup, and enriched_by are not sent to the API. The read-path normalises absent API fields back to
+// null, so sending an empty collection would cause a perpetual null-vs-empty plan diff.
+func TestUnitCustomModelRules_ModelToAPI_EmptyCollectionsOmitted(t *testing.T) {
+	ctx := context.Background()
+
+	emptyScope, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+	emptyLookup, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+	emptyEnrichedBy, _ := types.ListValueFrom(ctx, types.StringType, []string{})
+
+	data := &customModelRulesModel{
+		ID:   types.StringValue("r"),
+		Name: types.StringValue("r"),
+		Rules: []rulesModel{{Entity: []entityModel{{
+			Type:       types.StringValue(testEntityTypeServ),
+			Name:       types.StringValue(testEntityTypeServ),
+			Scope:      emptyScope,
+			Lookup:     emptyLookup,
+			EnrichedBy: emptyEnrichedBy,
+			Disabled:   types.BoolNull(),
+			DefinedBy: []definedByModel{{
+				Query:       types.StringValue("up{}"),
+				Disabled:    types.BoolNull(),
+				LabelValues: types.MapNull(types.StringType),
+				Literals:    types.MapNull(types.StringType),
+				MetricValue: types.StringNull(),
+			}},
+		}}}},
+	}
+
+	apiRules, diags := modelToAPIRules(ctx, data)
+	require.False(t, diags.HasError())
+
+	entity := apiRules.Entities[0]
+	assert.Nil(t, entity.Scope, "empty scope must not be sent to avoid null-vs-empty diff")
+	assert.Nil(t, entity.Lookup, "empty lookup must not be sent to avoid null-vs-empty diff")
+	assert.Nil(t, entity.EnrichedBy, "empty enriched_by must not be sent to avoid null-vs-empty diff")
+}
+
 // TestUnitCustomModelRules_Configure_MissingStackID verifies that Configure rejects a zero stack_id.
 func TestUnitCustomModelRules_Configure_MissingStackID(t *testing.T) {
 	r := &customModelRulesResource{}

--- a/internal/resources/asserts/resource_custom_model_rules_unit_test.go
+++ b/internal/resources/asserts/resource_custom_model_rules_unit_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testRulesName      = "test-rules"
+	testEntityTypeServ = "Service"
+)
+
 func TestUnitCustomModelRules_Metadata(t *testing.T) {
 	r := &customModelRulesResource{}
 	var resp resource.MetadataResponse
@@ -36,10 +41,10 @@ func TestUnitCustomModelRules_Schema(t *testing.T) {
 // TestUnitCustomModelRules_APIToModel_Basic verifies that a minimal API response converts correctly.
 func TestUnitCustomModelRules_APIToModel_Basic(t *testing.T) {
 	ctx := context.Background()
-	name := "test-rules"
+	name := testRulesName
 	query := "up{job!=''}"
-	entityType := "Service"
-	entityName := "Service"
+	entityType := testEntityTypeServ
+	entityName := testEntityTypeServ
 
 	apiRules := &assertsapi.ModelRulesDto{
 		Name: &name,
@@ -83,9 +88,9 @@ func TestUnitCustomModelRules_APIToModel_Basic(t *testing.T) {
 // TestUnitCustomModelRules_APIToModel_AllOptionalFields verifies optional fields convert correctly.
 func TestUnitCustomModelRules_APIToModel_AllOptionalFields(t *testing.T) {
 	ctx := context.Background()
-	name := "test-rules"
+	name := testRulesName
 	query := "up{job!=''}"
-	entityType := "Service"
+	entityType := testEntityTypeServ
 	entityName := "workload"
 	enrichedQuery := "kube_pod_info"
 	metricVal := "value"
@@ -164,14 +169,14 @@ func TestUnitCustomModelRules_APIToModel_NilInput(t *testing.T) {
 func TestUnitCustomModelRules_ModelToAPI_Basic(t *testing.T) {
 	ctx := context.Background()
 	data := &customModelRulesModel{
-		ID:   types.StringValue("test-rules"),
-		Name: types.StringValue("test-rules"),
+		ID:   types.StringValue(testRulesName),
+		Name: types.StringValue(testRulesName),
 		Rules: []rulesModel{
 			{
 				Entity: []entityModel{
 					{
-						Type:       types.StringValue("Service"),
-						Name:       types.StringValue("Service"),
+						Type:       types.StringValue(testEntityTypeServ),
+						Name:       types.StringValue(testEntityTypeServ),
 						Scope:      types.MapNull(types.StringType),
 						Lookup:     types.MapNull(types.StringType),
 						EnrichedBy: types.ListNull(types.StringType),
@@ -197,8 +202,8 @@ func TestUnitCustomModelRules_ModelToAPI_Basic(t *testing.T) {
 	require.Len(t, apiRules.Entities, 1)
 
 	entity := apiRules.Entities[0]
-	assert.Equal(t, "Service", *entity.Type)
-	assert.Equal(t, "Service", *entity.Name)
+	assert.Equal(t, testEntityTypeServ, *entity.Type)
+	assert.Equal(t, testEntityTypeServ, *entity.Name)
 	assert.Nil(t, entity.Scope)
 	assert.Nil(t, entity.Lookup)
 	assert.Nil(t, entity.EnrichedBy)
@@ -249,8 +254,8 @@ func TestUnitCustomModelRules_ModelToAPI_DisabledOnlySetWhenTrue(t *testing.T) {
 				ID:   types.StringValue("r"),
 				Name: types.StringValue("r"),
 				Rules: []rulesModel{{Entity: []entityModel{{
-					Type:       types.StringValue("Service"),
-					Name:       types.StringValue("Service"),
+					Type:       types.StringValue(testEntityTypeServ),
+					Name:       types.StringValue(testEntityTypeServ),
 					Scope:      types.MapNull(types.StringType),
 					Lookup:     types.MapNull(types.StringType),
 					EnrichedBy: types.ListNull(types.StringType),
@@ -290,9 +295,9 @@ func TestUnitCustomModelRules_ModelToAPI_DisabledOnlySetWhenTrue(t *testing.T) {
 // TestUnitCustomModelRules_RoundTrip verifies that API→model→API produces the same API payload.
 func TestUnitCustomModelRules_RoundTrip(t *testing.T) {
 	ctx := context.Background()
-	name := "test-rules"
+	name := testRulesName
 	query := "up{job!=''}"
-	entityType := "Service"
+	entityType := testEntityTypeServ
 	entityName := "workload"
 	enrichedQuery := "kube_pod_info"
 	disabled := true
@@ -353,10 +358,10 @@ func TestUnitCustomModelRules_RoundTrip(t *testing.T) {
 // TestUnitCustomModelRules_RoundTrip_WithDisabled verifies the disabled field round-trips correctly.
 func TestUnitCustomModelRules_RoundTrip_WithDisabled(t *testing.T) {
 	ctx := context.Background()
-	name := "test-rules"
+	name := testRulesName
 	query := "up{}"
-	entityType := "Service"
-	entityName := "Service"
+	entityType := testEntityTypeServ
+	entityName := testEntityTypeServ
 	disabled := true
 
 	originalAPI := &assertsapi.ModelRulesDto{
@@ -391,7 +396,7 @@ func TestUnitCustomModelRules_RoundTrip_WithDisabled(t *testing.T) {
 // TestUnitCustomModelRules_EmptyEntities verifies an empty entities list produces a valid model.
 func TestUnitCustomModelRules_EmptyEntities(t *testing.T) {
 	ctx := context.Background()
-	name := "test-rules"
+	name := testRulesName
 
 	apiRules := &assertsapi.ModelRulesDto{
 		Name:     &name,

--- a/internal/resources/asserts/resource_custom_model_rules_unit_test.go
+++ b/internal/resources/asserts/resource_custom_model_rules_unit_test.go
@@ -79,12 +79,12 @@ func TestUnitCustomModelRules_APIToModel_Basic(t *testing.T) {
 	assert.True(t, entity.Scope.IsNull(), "absent scope should be null")
 	assert.True(t, entity.Lookup.IsNull(), "absent lookup should be null")
 	assert.True(t, entity.EnrichedBy.IsNull(), "absent enriched_by should be null")
-	assert.True(t, entity.Disabled.IsNull(), "absent disabled should be null")
+	assert.Equal(t, types.BoolValue(false), entity.Disabled, "absent disabled should default to false")
 
 	require.Len(t, entity.DefinedBy, 1)
 	db := entity.DefinedBy[0]
 	assert.Equal(t, query, db.Query.ValueString())
-	assert.True(t, db.Disabled.IsNull())
+	assert.Equal(t, types.BoolValue(false), db.Disabled)
 	assert.True(t, db.LabelValues.IsNull())
 	assert.True(t, db.Literals.IsNull())
 	assert.True(t, db.MetricValue.IsNull())
@@ -517,6 +517,102 @@ func TestUnitCustomModelRules_Configure_Valid(t *testing.T) {
 }
 
 // TestUnitCustomModelRules_IsRequired_NullBlock verifies that IsRequired() fires on a null block,
+// TestUnitCustomModelRules_DisabledFalse_APIReturnsNil verifies that when the API omits the disabled
+// field (returns nil), the read path stores false rather than null. This prevents a perpetual plan
+// diff when config sets disabled = false: apply sends nothing, API returns nil, state must match.
+func TestUnitCustomModelRules_DisabledFalse_APIReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	name := testRulesName
+	query := "up{}"
+	entityType := testEntityTypeServ
+	entityName := testEntityTypeServ
+
+	// API response omits Disabled entirely (nil pointer).
+	apiRules := &assertsapi.ModelRulesDto{
+		Name: &name,
+		Entities: []assertsapi.EntityRuleDto{
+			{
+				Type:     &entityType,
+				Name:     &entityName,
+				Disabled: nil,
+				DefinedBy: []assertsapi.PropertyRuleDto{
+					{Query: &query, Disabled: nil},
+				},
+			},
+		},
+	}
+
+	model, diags := apiRulesToModel(ctx, name, apiRules)
+	require.False(t, diags.HasError())
+	require.Len(t, model.Rules, 1)
+	require.Len(t, model.Rules[0].Entity, 1)
+
+	entity := model.Rules[0].Entity[0]
+	assert.Equal(t, types.BoolValue(false), entity.Disabled, "entity.Disabled must be false (not null) when API omits the field")
+
+	require.Len(t, entity.DefinedBy, 1)
+	assert.Equal(t, types.BoolValue(false), entity.DefinedBy[0].Disabled, "defined_by.Disabled must be false (not null) when API omits the field")
+}
+
+// TestUnitCustomModelRules_DisabledFalse_RoundTrip verifies idempotency when disabled=false is in config:
+// model→API does NOT send the field (omit-when-false), API returns nil, read path produces false.
+// After a second apply the model and API are consistent.
+func TestUnitCustomModelRules_DisabledFalse_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	disabledFalse := false
+
+	// Simulate a model with disabled explicitly set to false (typical config state).
+	data := &customModelRulesModel{
+		ID:   types.StringValue(testRulesName),
+		Name: types.StringValue(testRulesName),
+		Rules: []rulesModel{{Entity: []entityModel{{
+			Type:      types.StringValue(testEntityTypeServ),
+			Name:      types.StringValue(testEntityTypeServ),
+			Scope:     types.MapNull(types.StringType),
+			Lookup:    types.MapNull(types.StringType),
+			EnrichedBy: types.ListNull(types.StringType),
+			Disabled:  types.BoolValue(false),
+			DefinedBy: []definedByModel{{
+				Query:       types.StringValue("up{}"),
+				Disabled:    types.BoolValue(false),
+				LabelValues: types.MapNull(types.StringType),
+				Literals:    types.MapNull(types.StringType),
+				MetricValue: types.StringNull(),
+			}},
+		}}}},
+	}
+
+	apiPayload, diags := modelToAPIRules(ctx, data)
+	require.False(t, diags.HasError())
+
+	entity := apiPayload.Entities[0]
+	// disabled=false must NOT be sent to the API (API uses omit-zero semantics).
+	assert.Nil(t, entity.Disabled, "disabled=false must be omitted from the API payload")
+	assert.Nil(t, entity.DefinedBy[0].Disabled, "defined_by.disabled=false must be omitted from the API payload")
+
+	// Now simulate the API returning nil for disabled (typical API behaviour for false).
+	entity.Disabled = nil
+	entity.DefinedBy[0].Disabled = nil
+	apiPayload.Entities[0] = entity
+
+	// Read the API response back into a model.
+	apiRules := &assertsapi.ModelRulesDto{
+		Name:     &[]string{testRulesName}[0],
+		Entities: apiPayload.Entities,
+	}
+	readModel, diags := apiRulesToModel(ctx, testRulesName, apiRules)
+	require.False(t, diags.HasError())
+
+	readEntity := readModel.Rules[0].Entity[0]
+	// State must record false, matching the original config value — no perpetual diff.
+	assert.Equal(t, types.BoolValue(false), readEntity.Disabled)
+	assert.Equal(t, types.BoolValue(false), readEntity.DefinedBy[0].Disabled)
+
+	// Verify the original model and the round-tripped model agree on disabled.
+	originalDisabled := disabledFalse
+	_ = originalDisabled // false, matches what the read path now returns
+}
+
 // which SizeAtLeast(1) would silently skip.
 func TestUnitCustomModelRules_IsRequired_NullBlock(t *testing.T) {
 	ctx := context.Background()

--- a/internal/resources/asserts/resource_custom_model_rules_unit_test.go
+++ b/internal/resources/asserts/resource_custom_model_rules_unit_test.go
@@ -566,12 +566,12 @@ func TestUnitCustomModelRules_DisabledFalse_RoundTrip(t *testing.T) {
 		ID:   types.StringValue(testRulesName),
 		Name: types.StringValue(testRulesName),
 		Rules: []rulesModel{{Entity: []entityModel{{
-			Type:      types.StringValue(testEntityTypeServ),
-			Name:      types.StringValue(testEntityTypeServ),
-			Scope:     types.MapNull(types.StringType),
-			Lookup:    types.MapNull(types.StringType),
+			Type:       types.StringValue(testEntityTypeServ),
+			Name:       types.StringValue(testEntityTypeServ),
+			Scope:      types.MapNull(types.StringType),
+			Lookup:     types.MapNull(types.StringType),
 			EnrichedBy: types.ListNull(types.StringType),
-			Disabled:  types.BoolValue(false),
+			Disabled:   types.BoolValue(false),
 			DefinedBy: []definedByModel{{
 				Query:       types.StringValue("up{}"),
 				Disabled:    types.BoolValue(false),


### PR DESCRIPTION
Migrates `grafana_asserts_custom_model_rules` from the legacy Terraform Plugin SDK v2 to the Terraform Plugin
  Framework.

  - Replaces `map[string]interface{}` data handling with typed Go structs (`customModelRulesModel`,
  `rulesModel`, `entityModel`, `definedByModel`).
  - Implements `resource.Resource`, `resource.ResourceWithConfigure`, and `resource.ResourceWithImportState`
  interfaces.
  - Replaces the SDK-coupled `withRetryRead` helper with a Framework-compatible `readModelWithRetry` method
  using exponential backoff with jitter, to handle eventual consistency after write operations.
  - Preserves all existing behavioral semantics, including the `disabled`-only-when-true API contract.
  - Adds comprehensive unit tests covering API↔model conversion, round-trips, disabled field edge cases, and
  error paths.

Fixes https://github.com/grafana/deployment_tools/issues/547404