### PR TITLE
fix(ci): fix workflow failures for label syncing and issue labeling

### DIFF
--- a/.github/workflows/issue-label-resources.yml
+++ b/.github/workflows/issue-label-resources.yml
@@ -15,12 +15,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          # Skip issues that are not bug reports (e.g. Renovate Dependency Dashboard)
-          if [ "$ISSUE_TITLE" = "Dependency Dashboard" ]; then
-            echo "Skipping Dependency Dashboard issue"
+          # Skip the Renovate Dependency Dashboard issue
+          if [ "$ISSUE_NUMBER" = "2389" ]; then
+            echo "Skipping Dependency Dashboard issue (#2389)"
             exit 0
           fi
 

--- a/.github/workflows/issue-label-resources.yml
+++ b/.github/workflows/issue-label-resources.yml
@@ -13,9 +13,17 @@ jobs:
       - name: Extract affected resources and apply labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
+          # Skip issues that are not bug reports (e.g. Renovate Dependency Dashboard)
+          if [ "$ISSUE_TITLE" = "Dependency Dashboard" ]; then
+            echo "Skipping Dependency Dashboard issue"
+            exit 0
+          fi
+
           # Extract the "Affected Resource(s)" section from the issue body.
           # GitHub issue forms render multi-select dropdowns as a comma-separated
           # list under a markdown heading matching the field label.
@@ -25,7 +33,7 @@ jobs:
 
           # Remove any existing resource/data-source labels on the issue first
           # so that edits to the dropdown are reflected accurately.
-          existing=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name | select(startswith("resource/") or startswith("data-source/"))] | join(",")')
+          existing=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name | select(startswith("r/") or startswith("ds/"))] | join(",")')
           if [ -n "$existing" ]; then
             echo "Removing stale labels: $existing"
             gh issue edit "$ISSUE_NUMBER" --remove-label "$existing"
@@ -37,6 +45,7 @@ jobs:
           fi
 
           # Split comma-separated values and map to labels
+          # Labels use short prefixes (r/, ds/) with grafana_ prefix stripped.
           labels=()
           while IFS= read -r entry; do
             entry=$(echo "$entry" | xargs) # trim whitespace
@@ -49,11 +58,11 @@ jobs:
 
             # Parse entries like "grafana_dashboard (resource)" or "grafana_dashboard (data source)"
             if [[ "$entry" =~ ^(.+)\ \(resource\)$ ]]; then
-              name="${BASH_REMATCH[1]}"
-              labels+=("resource/${name}")
+              name="${BASH_REMATCH[1]#grafana_}"
+              labels+=("r/${name}")
             elif [[ "$entry" =~ ^(.+)\ \(data\ source\)$ ]]; then
-              name="${BASH_REMATCH[1]}"
-              labels+=("data-source/${name}")
+              name="${BASH_REMATCH[1]#grafana_}"
+              labels+=("ds/${name}")
             fi
           done < <(echo "$section" | tr ',' '\n')
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -21,19 +21,19 @@ jobs:
           SCHEMA="provider_schema.json"
           PROVIDER_KEY="registry.terraform.io/grafana/grafana"
 
-          # Extract desired labels from schema
+          # Extract desired labels from schema (short prefixes, strip grafana_ prefix)
           jq -r ".provider_schemas[\"$PROVIDER_KEY\"].resource_schemas | keys[]" "$SCHEMA" \
-            | sed 's/^/resource\//' > /tmp/desired_labels.txt
+            | sed 's/^grafana_//' | sed 's/^/r\//' > /tmp/desired_labels.txt
           jq -r ".provider_schemas[\"$PROVIDER_KEY\"].data_source_schemas | keys[]" "$SCHEMA" \
-            | sed 's/^/data-source\//' >> /tmp/desired_labels.txt
+            | sed 's/^grafana_//' | sed 's/^/ds\//' >> /tmp/desired_labels.txt
 
           # Get existing prefixed labels
           gh label list --limit 1000 --json name --jq '.[].name' \
-            | grep -E '^(resource|data-source)/' | sort > /tmp/existing_labels.txt
+            | grep -E '^(r|ds)/' | sort > /tmp/existing_labels.txt
 
           # Create missing labels
           comm -23 <(sort /tmp/desired_labels.txt) /tmp/existing_labels.txt | while read -r label; do
-            if [[ "$label" == resource/* ]]; then
+            if [[ "$label" == r/* ]]; then
               gh label create "$label" --color "0075ca" --description "Terraform resource" --force
             else
               gh label create "$label" --color "e4e669" --description "Terraform data source" --force

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -101,10 +101,19 @@ jobs:
           committer: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
           author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
 
-      - name: Approve and enable auto-merge
+      - name: Approve PR
         if: steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review "${{ steps.create-pr.outputs.pull-request-number }}" --approve
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          # Use the app token so the merge push triggers downstream workflows
+          # (e.g. sync-labels). GITHUB_TOKEN pushes are suppressed by GitHub's
+          # anti-recursion rule.
+          GH_TOKEN: ${{ steps.generate_github_token.outputs.token }}
+        run: |
           gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash


### PR DESCRIPTION
## Summary

- **sync-labels**: Use shorter label prefixes (`r/`, `ds/`) and strip `grafana_` prefix to fit GitHub's 50-character label limit (was failing with `HTTP 422: name is too long`)
- **issue-label-resources**: Skip Dependency Dashboard issue (#2389) explicitly, use `GH_REPO` env var so `gh` doesn't need a git checkout, and align label prefixes with sync-labels
- **update-schema**: Use app token for auto-merge so the resulting push to main triggers downstream workflows (e.g. sync-labels). The approve step keeps using `GITHUB_TOKEN` to maintain different identities for author vs approver.

Fixes https://github.com/grafana/terraform-provider-grafana/actions/runs/24746634210
Fixes https://github.com/grafana/terraform-provider-grafana/actions/runs/24743569018