### PR TITLE
fix(grafana_team): prevent mass member removal on ignore_externally_synced transition

### DIFF
--- a/internal/resources/grafana/resource_team.go
+++ b/internal/resources/grafana/resource_team.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -55,6 +54,51 @@ var (
 	resourceTeamName = "grafana_team"
 	resourceTeamID   = orgResourceIDInt("id")
 )
+
+// membersUseStateWhenUnconfigured returns a plan modifier for the members
+// attribute that preserves the prior state value when the attribute is not
+// set in config.
+//
+// This prevents accidental mass-removal of team members when a user manages a
+// team without specifying the members attribute (e.g., members are managed by
+// an external system like Okta team sync or SCIM).
+//
+// Behavior:
+//   - Config sets members (even to []): use the config value (enforced by the framework).
+//   - Config omits members, no prior state (create): default to empty set.
+//   - Config omits members, has prior state (update): preserve prior state.
+func membersUseStateWhenUnconfigured() planmodifier.Set {
+	return &membersPreserveStatePlanModifier{}
+}
+
+type membersPreserveStatePlanModifier struct{}
+
+func (m *membersPreserveStatePlanModifier) Description(_ context.Context) string {
+	return "Preserves the prior state value when members is not configured, preventing accidental removal of externally managed team members."
+}
+
+func (m *membersPreserveStatePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m *membersPreserveStatePlanModifier) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// If the attribute is explicitly set in config, let the framework handle it.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Config is null (attribute not in user's .tf file).
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		// Create path: no prior state. Default to empty set so a new team
+		// starts with zero members (matching prior SDKv2 behavior).
+		resp.PlanValue = types.SetValueMust(types.StringType, []attr.Value{})
+		return
+	}
+
+	// Update path: prior state exists. Preserve it so that members managed
+	// outside of Terraform (Okta, SCIM, team sync, UI) are not removed.
+	resp.PlanValue = req.StateValue
+}
 
 func makeResourceTeam() *common.Resource {
 	return common.NewResource(
@@ -139,9 +183,11 @@ func (r *teamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"members": schema.SetAttribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 				ElementType: types.StringType,
 				Description: "A set of email addresses corresponding to users who should be given membership to the team. Note: users specified here must already exist in Grafana.",
+				PlanModifiers: []planmodifier.Set{
+					membersUseStateWhenUnconfigured(),
+				},
 			},
 			"ignore_externally_synced_members": schema.BoolAttribute{
 				Optional: true,
@@ -333,6 +379,12 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	var configData resourceTeamModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	client, _, split, err := r.clientFromExistingOrgResource(resourceTeamID, planData.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to parse resource ID", err.Error())
@@ -405,11 +457,26 @@ func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 	}
 
-	readData, diags := r.read(ctx, planData.ID.ValueString(), planData.IgnoreExternallySyncedMembers.ValueBool(), len(planData.TeamSync) > 0)
+	// When members is not in config, the plan modifier preserved state members
+	// (which were read with the old ignore value). Use the same ignore value
+	// for the final read so the returned member list matches the plan.
+	// On the next Read() (refresh), the new ignore value will take effect and
+	// silently update the member list in state.
+	readIgnore := planData.IgnoreExternallySyncedMembers.ValueBool()
+	if configData.Members.IsNull() {
+		readIgnore = stateData.IgnoreExternallySyncedMembers.ValueBool()
+		if stateData.IgnoreExternallySyncedMembers.IsNull() || stateData.IgnoreExternallySyncedMembers.IsUnknown() {
+			readIgnore = defaultIgnoreExternallySyncedMembers
+		}
+	}
+
+	readData, diags := r.read(ctx, planData.ID.ValueString(), readIgnore, len(planData.TeamSync) > 0)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Override ignore to the plan value so state reflects the desired config.
+	readData.IgnoreExternallySyncedMembers = planData.IgnoreExternallySyncedMembers
 	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
 }
 

--- a/internal/resources/grafana/resource_team_mock_test.go
+++ b/internal/resources/grafana/resource_team_mock_test.go
@@ -1,0 +1,184 @@
+package grafana_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestUnitTeam_IgnoreExternallySyncedTransition_Mock tests the transition of
+// ignore_externally_synced_members from false to true when members are not in
+// config. It uses a mock Grafana API that returns members with external sync
+// labels (simulating LDAP/SAML/team sync).
+//
+// The bug (support escalation #21901): With the Default([]) on the members
+// attribute, removing members from config causes plan=[] which diffs against
+// state (has members) and triggers mass removal. The correct behavior is to
+// preserve members and silently clear them from state via Read() filtering.
+func TestUnitTeam_IgnoreExternallySyncedTransition_Mock(t *testing.T) {
+	// memberRemovals tracks how many times the mock received a DELETE request
+	// to remove a team member. The fix should result in zero removals.
+	var memberRemovals atomic.Int32
+
+	mux := http.NewServeMux()
+
+	// POST /api/teams — create team
+	mux.HandleFunc("/api/teams", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"teamId": 1})
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	// GET/PUT/DELETE /api/teams/1 — team CRUD
+	mux.HandleFunc("/api/teams/1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": 1, "orgId": 1, "name": "test-team",
+				"email": "test@example.com", "uid": "abc123",
+			})
+		case http.MethodPut:
+			json.NewEncoder(w).Encode(map[string]any{"message": "Team updated"})
+		case http.MethodDelete:
+			json.NewEncoder(w).Encode(map[string]any{"message": "Team deleted"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// GET/POST /api/teams/1/members — list/add members
+	// Always returns members WITH labels (externally synced).
+	mux.HandleFunc("/api/teams/1/members", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"userId": 10, "email": "user1@example.com", "login": "user1", "labels": []string{"ldap"}},
+				{"userId": 11, "email": "user2@example.com", "login": "user2", "labels": []string{"ldap"}},
+			})
+		case http.MethodPost:
+			json.NewEncoder(w).Encode(map[string]any{"message": "Member added"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// DELETE /api/teams/1/members/{userId} — remove member
+	mux.HandleFunc("/api/teams/1/members/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			memberRemovals.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"message": "Member removed"})
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	// GET/PUT /api/teams/1/preferences
+	mux.HandleFunc("/api/teams/1/preferences", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]any{})
+		case http.MethodPut:
+			json.NewEncoder(w).Encode(map[string]any{"message": "Preferences updated"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// GET /api/org/users — list org users (needed for member ID resolution)
+	mux.HandleFunc("/api/org/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"userId": 10, "email": "user1@example.com", "login": "user1", "role": "Viewer"},
+			{"userId": 11, "email": "user2@example.com", "login": "user2", "role": "Viewer"},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	t.Setenv("GRAFANA_URL", server.URL)
+	t.Setenv("GRAFANA_AUTH", "admin:admin")
+
+	// Step 1 config: ignore=false, explicit members.
+	// With ignore=false, labeled members are included in state.
+	configStep1 := `
+resource "grafana_team" "test" {
+	name                             = "test-team"
+	email                            = "test@example.com"
+	ignore_externally_synced_members = false
+	members                          = ["user1@example.com", "user2@example.com"]
+}`
+
+	// Step 2 config: ignore=true, NO members in config.
+	// This simulates the customer transitioning to "let external sync manage members".
+	configStep2 := `
+resource "grafana_team" "test" {
+	name                             = "test-team"
+	email                            = "test@example.com"
+	ignore_externally_synced_members = true
+}`
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configStep1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_team.test", "members.#", "2"),
+					resource.TestCheckResourceAttr("grafana_team.test", "ignore_externally_synced_members", "false"),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Reset removal counter before the transition step.
+					memberRemovals.Store(0)
+				},
+				Config: configStep2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_team.test", "ignore_externally_synced_members", "true"),
+					// Members are still in state after this apply because the
+					// Update read used the old ignore=false value to match the
+					// plan. They will be cleared on the next refresh cycle.
+					resource.TestCheckResourceAttr("grafana_team.test", "members.#", "2"),
+					func(_ *terraform.State) error {
+						if n := memberRemovals.Load(); n > 0 {
+							return fmt.Errorf("expected 0 member removal API calls, got %d", n)
+						}
+						return nil
+					},
+				),
+			},
+			// Step 3: Re-apply same config. The refresh (Read) now runs with
+			// ignore=true, filtering externally synced members from state.
+			// This is the "silent state clearing" — no diff, no API calls.
+			{
+				Config: configStep2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_team.test", "ignore_externally_synced_members", "true"),
+					// Members are now cleared from state (filtered by ignore=true).
+					resource.TestCheckResourceAttr("grafana_team.test", "members.#", "0"),
+					func(_ *terraform.State) error {
+						if n := memberRemovals.Load(); n > 0 {
+							return fmt.Errorf("expected 0 member removal API calls, got %d", n)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where transitioning `ignore_externally_synced_members` from `false` to `true` causes all externally synced team members to be removed via the API
- Replaces `Default([])` on `members` with a plan modifier that preserves prior state when members is not in config, preventing the empty-set diff that triggers mass removal
- Adjusts `Update()` to use the state's `ignore` value for the final read when members is unconfigured, so the returned member list matches the plan (preventing "inconsistent result after apply")

## Root Cause

The v4.31.1 migration added `Default: setdefault.StaticValue([])` on the `members` attribute. This means "members not in config" becomes `plan=[]`, which diffs against state (containing members) and triggers removal API calls. The old SDKv2 code had a `DiffSuppressFunc` that treated null and empty as equivalent, preventing this.

## The Fix

1. **Plan modifier** (`membersUseStateWhenUnconfigured`): When config members is null and prior state exists, preserve state. When null and no state (create), default to `[]`. When explicitly set (even to `[]`), let the framework handle it.
2. **Update() consistency**: When members is unconfigured, the final `r.read()` uses the **state's** `ignore` value (not the plan's) so the returned member list matches what the plan modifier predicted. The `ignore` field is then overridden to the plan value, taking effect on the next refresh cycle.

### Two-cycle convergence

When `ignore` transitions `false→true`:
- **Cycle 1**: Plan modifier preserves state members. Update makes no member API calls. Final read uses old `ignore=false` → members still in state. State saved with `ignore=true`.
- **Cycle 2**: Read refreshes with `ignore=true` → filters labeled members → state cleared. No diff, stable.

## Testing

Adds a mock unit test (`TestUnitTeam_IgnoreExternallySyncedTransition_Mock`) that:
1. Creates a team with `ignore=false` and explicit members (all externally synced via LDAP labels)
2. Transitions to `ignore=true` with no `members` in config — asserts 0 removal API calls and members preserved in state
3. Re-applies same config — asserts members are cleared from state (via Read filtering), still 0 removal API calls

The test **fails** on unfixed code (`expected members.# "2", got "0"`) and **passes** with the fix.

Relates to [support escalation #21901](https://github.com/grafana/support-escalations/issues/21901).