### PR TITLE
fix(release): force lightweight tags to prevent empty release notes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,5 +43,9 @@ else
 fi
 
 # Create and push the tag.
-git tag "$RELEASE_VERSION"
+# Use --no-sign to ensure a lightweight tag regardless of user's
+# tag.gpgSign config. Annotated tags cause GitHub/GoReleaser to use the
+# tag message as release notes instead of the git-cliff changelog
+# generated in the release workflow.
+git tag --no-sign "$RELEASE_VERSION"
 git push origin "$RELEASE_VERSION"


### PR DESCRIPTION
## Summary

- Force lightweight tags in `scripts/release.sh` by adding `--no-sign` to `git tag`
- Fixes the v4.33.0 release having empty release notes

## Root Cause

When `tag.gpgSign = true` is set in git config, `git tag <version>` silently creates an **annotated + signed** tag instead of a lightweight one. GitHub/GoReleaser then uses the tag annotation body for release notes instead of the git-cliff changelog generated by the release workflow, resulting in empty or incorrect release notes on the GitHub release.

v4.32.0 was a lightweight tag and worked correctly. v4.33.0 was an annotated tag and had empty release notes.

## Fix

Use `git tag --no-sign` to ensure a lightweight tag regardless of the user's git config.