### PR TITLE
fix(oncall): add inbound_email Attribute to Grafana OnCall Integration Resource

### DIFF
--- a/docs/resources/oncall_integration.md
+++ b/docs/resources/oncall_integration.md
@@ -102,6 +102,7 @@ resource "grafana_oncall_integration" "test-acc-integration" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `inbound_email` (String) The inbound email for the integration. Only available for integration type `inbound_email`.
 - `link` (String) The link for using in an integrated tool.
 
 <a id="nestedblock--default_route"></a>

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -158,6 +158,11 @@ func resourceIntegration() *common.Resource {
 				MaxItems:    1,
 				Description: "The Default route for all alerts from the given integration",
 			},
+			"inbound_email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The inbound email for the integration. Only available for integration type `inbound_email`.",
+			},
 			"link": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -386,6 +391,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, client
 	d.Set("name", integration.Name)
 	d.Set("type", integration.Type)
 	d.Set("templates", flattenTemplates(integration.Templates))
+	d.Set("inbound_email", integration.InboundEmail)
 	d.Set("link", integration.Link)
 	d.Set("labels", flattenLabels(integration.Labels))
 	d.Set("dynamic_labels", flattenLabels(integration.DynamicLabels))


### PR DESCRIPTION
This adds the `inbound_email` Attribute to the `grafana_oncall_integration` Resource, this was added previously to the Datasource.

Adding this here, means you don't need to use a datasource to lookup the email address of the integration created.