### PR TITLE
fix(slo): allow empty fastburn {} / slowburn {} blocks to round-trip without drift

### DIFF
--- a/internal/resources/slo/data_source_slos.go
+++ b/internal/resources/slo/data_source_slos.go
@@ -501,13 +501,11 @@ func convertAlertingToModel(apiAlerting *slo.SloV00Alerting) []alertingModel {
 		Annotation: convertLabelsToModel(apiAlerting.Annotations),
 	}
 
-	// Convert FastBurn — treat API-returned empty metadata as absent to avoid phantom blocks
-	if apiAlerting.FastBurn != nil && !isAlertingMetadataEmpty(apiAlerting.FastBurn) {
+	if apiAlerting.FastBurn != nil {
 		alerting.FastBurn = convertAlertingMetadataToModel(apiAlerting.FastBurn)
 	}
 
-	// Convert SlowBurn — same treatment as FastBurn
-	if apiAlerting.SlowBurn != nil && !isAlertingMetadataEmpty(apiAlerting.SlowBurn) {
+	if apiAlerting.SlowBurn != nil {
 		alerting.SlowBurn = convertAlertingMetadataToModel(apiAlerting.SlowBurn)
 	}
 
@@ -521,17 +519,6 @@ func convertAlertingToModel(apiAlerting *slo.SloV00Alerting) []alertingModel {
 	}
 
 	return []alertingModel{alerting}
-}
-
-// isAlertingMetadataEmpty returns true when the API-returned metadata contains
-// no user-visible data (no labels, annotations, or enrichments). The SLO API
-// always returns non-nil fastburn/slowburn objects even when the user's config
-// did not specify them, so we need to treat those empty shells as absent.
-func isAlertingMetadataEmpty(meta *slo.SloV00AlertingMetadata) bool {
-	if meta == nil {
-		return true
-	}
-	return len(meta.Labels) == 0 && len(meta.Annotations) == 0 && len(meta.Enrichments) == 0
 }
 
 func convertAlertingMetadataToModel(meta *slo.SloV00AlertingMetadata) []alertingMetadataModel {

--- a/internal/resources/slo/resource_slo_test.go
+++ b/internal/resources/slo/resource_slo_test.go
@@ -93,6 +93,25 @@ func TestAccResourceSlo(t *testing.T) {
 				),
 			},
 			{
+				// Tests that empty fastburn {} / slowburn {} blocks round-trip cleanly.
+				// Regression coverage for the "block count changed from 1 to 0" error
+				// that occurred when the unpack stripped API-returned empty metadata
+				// shells out of state while the user's HCL still declared the blocks.
+				Config: emptyBurnAlert(randomName + " - Empty Burn Alerting Check"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccSloCheckExists("grafana_slo.empty_burn_alert", &slo),
+					testAlertingExists(true, "grafana_slo.empty_burn_alert", &slo),
+					resource.TestCheckResourceAttrSet("grafana_slo.empty_burn_alert", "id"),
+					resource.TestCheckResourceAttr("grafana_slo.empty_burn_alert", "alerting.0.fastburn.#", "1"),
+					resource.TestCheckResourceAttr("grafana_slo.empty_burn_alert", "alerting.0.slowburn.#", "1"),
+				),
+			},
+			{
+				// Same config, plan-only — asserts no drift on the next plan.
+				Config:   emptyBurnAlert(randomName + " - Empty Burn Alerting Check"),
+				PlanOnly: true,
+			},
+			{
 				// Tests Create
 				Config: testutils.TestAccExample(t, "resources/grafana_slo/resource_ratio.tf"),
 				Check: resource.ComposeTestCheckFunc(
@@ -516,6 +535,32 @@ func emptyAlert(name string) string {
 		}
 	  }
 	  alerting {}
+	}
+	`, name)
+}
+
+func emptyBurnAlert(name string) string {
+	return fmt.Sprintf(`
+	resource "grafana_slo" "empty_burn_alert" {
+	  description = "%[1]s"
+	  name        = "%[1]s"
+	  objectives {
+		value  = 0.995
+		window = "28d"
+	  }
+	  destination_datasource {
+		uid = "grafanacloud-prom"
+	  }
+	  query {
+		type = "freeform"
+		freeform {
+		  query = "sum(rate(apiserver_request_total{code!=\"500\"}[$__rate_interval])) / sum(rate(apiserver_request_total[$__rate_interval]))"
+		}
+	  }
+	  alerting {
+		fastburn {}
+		slowburn {}
+	  }
 	}
 	`, name)
 }


### PR DESCRIPTION
### Summary
  - Removes the `isAlertingMetadataEmpty` filter from `convertAlertingToModel` so the resource's READ no longer strips API-returned empty `fastburn` / `slowburn` shells out of state.
  - Restores pre-#2527 behavior for users whose HCL contains alerting `{ fastburn {} slowburn {} }` — apply succeeds again, no more block count changed from 1 to 0 consistency error.   
  - Adds an acceptance-test step exercising the previously-broken shape, plus a follow-up PlanOnly step that asserts no drift on the next plan.                                                                                                                                                                                                                        
                                                         
~~The filter that's being removed was originally added to mitigate a separate, pre-existing problem: the SLO API GET handler returns empty fastburn/slowburn shells even when the PUT did not include them, causing perpetual terraform plan drift for users who omit those blocks. As such, the workaround adopted by most users is `{ fastburn {} slowburn {} }`~~

~~Removing the filter here re-exposes that drift — matching pre-#2527 behavior exactly. The proper fix is on the SLO API side (return exactly what was PUT, no shell injection); that work is [tracked](https://github.com/grafana/slo/issues/4284) separately. Once it lands, the omit-block drift is resolved at the source for new and re-PUT SLOs, and no further provider change will be needed.~~

Fixes #2735 