### PR TITLE
docs(github): document issue, PR, and release automation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -67,6 +67,8 @@ flowchart TD
     prc --> coc[codeowners-check.yml]
     prc --> ptl[pr-title.yml]
 
+    vc -.->|catalog must be valid<br/>for CODEOWNERS to be generated| coc
+
     vc -->|jsonnet validates<br/>catalog-info.yaml against schema| ok1{✓}
     coc -->|make codeowners-check| ok2{✓}
     ptl -->|Conventional Commits| ok3{✓}
@@ -161,6 +163,11 @@ rules, contact the Platform Monitoring team.
   `.github/CODEOWNERS` drifts from what `tools/codeowners` would generate from
   `.github/CODEOWNERS.in` (static rules) plus the per-resource ownership
   derived from `catalog-info.yaml`.
+- **Depends on `validate-catalog.yml`.** The codeowners generator reads
+  `catalog-info.yaml` to derive per-resource owners. If the catalog is out
+  of sync with the schema (resources missing or stale), the generated
+  `CODEOWNERS` will be wrong even when this check passes — both workflows
+  must succeed for ownership to be trustworthy.
 - **To regenerate after editing ownership:** `make codeowners`. Edit
   `CODEOWNERS.in` (not `CODEOWNERS`) for static rules.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,222 @@
+# `.github/` automation
+
+This directory contains the GitHub-side automation that ties the provider's
+resource schema to issue triage, PR conventions, and releases. The workflows
+are intentionally interconnected: a single source of truth — the generated
+`provider_schema.json` — drives the bug-report template, the GitHub labels
+applied to issues, project-board routing, and (via Conventional Commits) the
+release changelog.
+
+This README explains how the pieces fit together. For day-to-day contribution
+rules see [`CONTRIBUTING.md`](../CONTRIBUTING.md); for releases see
+[`RELEASING.md`](../RELEASING.md).
+
+## Two flows
+
+The automation is best understood as two largely independent pipelines:
+
+1. **Issue & PR pipeline** — keeps the schema, labels, ownership, and bug
+   report template synchronized; routes incoming issues; enforces PR title
+   conventions.
+2. **Release pipeline** — turns a `v*` tag into a signed GoReleaser release
+   with a changelog assembled from Conventional Commits.
+
+## Flow 1 — Issue & PR pipeline
+
+```mermaid
+flowchart TD
+    src["provider source<br/>(internal/**, pkg/**, go.mod, go.sum)"]
+    src -->|push to main| us[update-schema.yml]
+
+    us -->|opens PR<br/>automated/update-schema| pr["PR: chore: update provider<br/>schema and issue templates"]
+    us -.->|regenerates| schema[provider_schema.json]
+    us -.->|regenerates| tmpl[".github/ISSUE_TEMPLATE/<br/>1-bug-report.yml"]
+    pr -->|auto-approve + auto-merge<br/>via GitHub App token| main[(main)]
+
+    main -->|push: provider_schema.json| sl[sync-labels.yml]
+    sl -->|create| labels["GitHub labels<br/>r/&lt;resource&gt;, ds/&lt;datasource&gt;"]
+
+    user([user files bug report]) -->|uses| tmpl
+    user --> issue([new issue])
+    issue --> ilr[issue-label-resources.yml]
+    ilr -->|parses 'Affected Resource(s)'| labels
+    ilr -->|applies labels| issue
+
+    issue -->|labels trigger| webhook["enghub-github-issue-assigner<br/>(external webhook)"]
+    webhook -->|assigns to| project["GH Project grafana/513<br/>(Platform Monitoring)"]
+
+    prc([contributor opens PR]) --> vc[validate-catalog.yml]
+    prc --> coc[codeowners-check.yml]
+    prc --> ptl[pr-title.yml]
+
+    vc -->|jsonnet validates<br/>catalog-info.yaml against schema| ok1{✓}
+    coc -->|make codeowners-check| ok2{✓}
+    ptl -->|Conventional Commits| ok3{✓}
+```
+
+### `update-schema.yml` — keep schema and bug template in sync
+
+- **Trigger:** push to `main` touching `internal/**`, `pkg/**`, `go.mod`, or
+  `go.sum`.
+- **What it does:** runs `scripts/generate_schema.sh` plus
+  `scripts/generate_issue_template.go --update-schema`, then opens a PR
+  (`automated/update-schema`) with the updated `provider_schema.json` and
+  `.github/ISSUE_TEMPLATE/1-bug-report.yml`.
+- **PR is auto-approved and auto-merged** via a GitHub App token issued by
+  `grafana/shared-workflows/actions/create-github-app-token` (app:
+  `terraform-provider-grafana`).
+- **Why a GitHub App token, not `GITHUB_TOKEN`?** Pushes made with the default
+  `GITHUB_TOKEN` are suppressed from triggering downstream workflows
+  (anti-recursion). Using the app token lets the merge push trigger
+  `sync-labels.yml`, which would otherwise never see the new schema.
+
+### `sync-labels.yml` — schema → repo labels
+
+- **Trigger:** push to `main` that modifies `provider_schema.json` (also
+  available via `workflow_dispatch`).
+- **What it does:** reads every resource and data source from
+  `provider_schema.json` and creates any missing labels:
+  - resources → `r/<name>` (color `#0075ca`), `grafana_` prefix stripped
+  - data sources → `ds/<name>` (color `#e4e669`)
+- It only **creates** missing labels; it does not delete or rename existing
+  ones. Renames must be handled manually.
+
+### `issue-label-resources.yml` — bug report → labels
+
+- **Trigger:** issue `opened` or `edited`.
+- **What it does:** parses the **Affected Resource(s)** dropdown from the bug
+  report body, maps each entry like `grafana_dashboard (resource)` to
+  `r/dashboard` (or `ds/...`), and applies them.
+- Stale `r/*`/`ds/*` labels are stripped first, so editing the dropdown is
+  reflected accurately.
+- **Skips issue #2389** (Renovate Dependency Dashboard) by hard-coded number.
+- The catch-all option `Other (please describe in the issue)` is ignored.
+
+### enghub-github-issue-assigner (external webhook)
+
+The Platform Monitoring team operates an external webhook that watches issue
+events and assigns issues to the appropriate **GitHub Project** based on the
+labels applied above. For this repo it pins issues to project
+[`grafana/513`](https://github.com/orgs/grafana/projects/513) (already
+referenced in the issue templates' `projects:` front-matter).
+
+The webhook is **not** configured from this repo. For changes to its routing
+rules, contact the Platform Monitoring team.
+
+### `validate-catalog.yml` — catalog ↔ schema check
+
+- **Trigger:** every pull request.
+- **What it does:** the composite action `.github/actions/validate-catalog`
+  regenerates the schema (`scripts/generate_schema.sh`) and runs
+  `validate.jsonnet` against `catalog-info.yaml` to ensure every resource
+  referenced in the Backstage catalog actually exists in the provider, and
+  vice versa.
+- This guards the same invariant the labelling depends on: the schema and the
+  catalog must agree about which resources exist and who owns them.
+
+### `codeowners-check.yml` — CODEOWNERS is generated, not hand-written
+
+- **Trigger:** pull request and pushes to `main`.
+- **What it does:** runs `make codeowners-check`
+  (`go run ./tools/codeowners --check`). The check fails if
+  `.github/CODEOWNERS` drifts from what `tools/codeowners` would generate from
+  `.github/CODEOWNERS.in` (static rules) plus the per-resource ownership
+  derived from `catalog-info.yaml`.
+- **To regenerate after editing ownership:** `make codeowners`. Edit
+  `CODEOWNERS.in` (not `CODEOWNERS`) for static rules.
+
+### `pr-title.yml` — Conventional Commits enforcement
+
+- **Trigger:** PR `opened`, `reopened`, `edited`, `synchronize`.
+- **What it does:** runs `amannn/action-semantic-pull-request` to validate
+  the title against the Conventional Commits format
+  `<type>(<scope>): <subject>`.
+- **Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+  `test`, `chore`, `ci`, `build`.
+- Subject must not start with an uppercase letter.
+- A sticky comment posts the rules on failure and is automatically deleted
+  once the title is valid.
+- Because the repo uses **squash merges**, the PR title becomes the commit
+  message — which is what the release pipeline parses to assemble the
+  changelog and determine the next version. Title format is therefore not
+  cosmetic; it directly drives Flow 2.
+
+## Flow 2 — Release pipeline
+
+```mermaid
+flowchart TD
+    tag["maintainer pushes tag vX.Y.Z"]
+    tag --> rel[release.yml]
+
+    rel --> cliff1["git-cliff --latest<br/>build CHANGELOG section"]
+    rel --> cliff2["git-cliff --bumped-version<br/>compute min required semver"]
+    cliff2 --> gate{"tag &gt;= min<br/>required?"}
+    gate -- no --> fail[[fail the job]]
+    gate -- yes --> gpg["import GPG key from Vault<br/>(grafana/shared-workflows)"]
+    cliff1 --> notes["/tmp/goreleaser-release-notes.md"]
+    gpg --> gor[goreleaser release --clean]
+    notes --> gor
+    gor --> artifacts["signed binaries<br/>+ GitHub Release"]
+```
+
+### `release.yml` — tag → signed release
+
+- **Trigger:** push of a tag matching `v*`.
+- **Steps:**
+  1. **Generate release notes** with
+     [`git-cliff`](https://git-cliff.org/) (`--latest --strip header`),
+     using [`cliff.toml`](../cliff.toml) at the repo root. Conventional commit
+     types are mapped to changelog sections (Features, Bug Fixes,
+     Documentation, …).
+  2. **Compute the minimum required version** with `git-cliff --bumped-version`.
+     Per `cliff.toml`:
+     - `feat` → minor bump
+     - `refactor` / `perf` → minor bump (`custom_minor_increment_regex`)
+     - any breaking change (`!` in the type/scope) → major bump
+     - everything else → patch
+  3. **Semver gate.** Compare the pushed tag against the computed minimum and
+     fail the job if the tag would under-bump (e.g. tagging `v3.7.1` when a
+     `feat` since the last release would have required `v3.8.0`).
+  4. **Import GPG key** from Vault via
+     `grafana/shared-workflows/actions/get-vault-secrets` and
+     `crazy-max/ghaction-import-gpg`.
+  5. **Run GoReleaser** with `--release-notes=/tmp/goreleaser-release-notes.md`.
+     The notes are copied out of the working tree because GoReleaser refuses
+     to run on a dirty git state and `git-cliff-action` writes into
+     `git-cliff/`.
+- **Cloud acceptance tests as a pre-release gate** are currently commented out
+  in `release.yml` (flakiness, see the inline comment). Re-enable by
+  uncommenting the `run-cloud-tests` job and the `needs:` reference.
+- See [`RELEASING.md`](../RELEASING.md) for the human-side checklist.
+
+## Quick reference
+
+| Workflow | Trigger | Purpose | Side effects |
+|---|---|---|---|
+| [`update-schema.yml`](workflows/update-schema.yml) | push to `main` (`internal/**`, `pkg/**`, `go.{mod,sum}`) | Regenerate `provider_schema.json` and bug-report template | Auto-approved + auto-merged PR on `automated/update-schema` (uses GitHub App token) |
+| [`sync-labels.yml`](workflows/sync-labels.yml) | push to `main` modifying `provider_schema.json`; `workflow_dispatch` | Create missing `r/*` and `ds/*` labels from the schema | Creates labels (does not delete) |
+| [`issue-label-resources.yml`](workflows/issue-label-resources.yml) | issue `opened` / `edited` | Apply `r/*` and `ds/*` labels from bug report's "Affected Resource(s)" | Edits issue labels; skips issue #2389 |
+| [`validate-catalog.yml`](workflows/validate-catalog.yml) | pull request | Validate `catalog-info.yaml` against the regenerated schema (jsonnet) | Fails PR on mismatch |
+| [`codeowners-check.yml`](workflows/codeowners-check.yml) | PR + push to `main` | Verify `.github/CODEOWNERS` matches generator output | Fails PR on drift; regenerate with `make codeowners` |
+| [`pr-title.yml`](workflows/pr-title.yml) | PR `opened` / `reopened` / `edited` / `synchronize` | Enforce Conventional Commits in PR titles | Fails PR + posts sticky comment with format rules |
+| [`release.yml`](workflows/release.yml) | push of tag `v*` | git-cliff changelog → semver gate → GPG-signed GoReleaser release | Publishes GitHub Release and signed artifacts |
+| enghub-github-issue-assigner *(external)* | label changes on issues | Route issues to GH Project [`grafana/513`](https://github.com/orgs/grafana/projects/513) | Project assignment; managed by the Platform Monitoring team |
+
+## Related files
+
+- [`../provider_schema.json`](../provider_schema.json) — the source of truth
+  consumed by `sync-labels.yml`, `issue-label-resources.yml` (indirectly via
+  the bug template), and `validate-catalog.yml`.
+- [`../scripts/generate_schema.sh`](../scripts/generate_schema.sh) and
+  [`../scripts/generate_issue_template.go`](../scripts/generate_issue_template.go)
+  — generate the schema JSON and bug-report template.
+- [`CODEOWNERS`](CODEOWNERS), [`CODEOWNERS.in`](CODEOWNERS.in), and
+  [`../tools/codeowners/`](../tools/codeowners) — generator inputs/outputs.
+- [`ISSUE_TEMPLATE/`](ISSUE_TEMPLATE) — issue forms; `1-bug-report.yml` is
+  generated, others are hand-edited.
+- [`actions/validate-catalog/`](actions/validate-catalog) — composite action
+  used by `validate-catalog.yml`.
+- [`../cliff.toml`](../cliff.toml) — git-cliff config: commit-type → changelog
+  group mapping and bump rules used by `release.yml`.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — PR title format reference.
+- [`../RELEASING.md`](../RELEASING.md) — human-side release checklist.

--- a/.github/README.md
+++ b/.github/README.md
@@ -11,17 +11,18 @@ This README explains how the pieces fit together. For day-to-day contribution
 rules see [`CONTRIBUTING.md`](../CONTRIBUTING.md); for releases see
 [`RELEASING.md`](../RELEASING.md).
 
-## Two flows
+## Three flows
 
-The automation is best understood as two largely independent pipelines:
+The automation is best understood as three largely independent pipelines:
 
-1. **Issue & PR pipeline** — keeps the schema, labels, ownership, and bug
-   report template synchronized; routes incoming issues; enforces PR title
-   conventions.
-2. **Release pipeline** — turns a `v*` tag into a signed GoReleaser release
+1. **Schema & issue pipeline** — keeps the schema, labels, and bug report
+   template synchronized; routes incoming issues to the right project.
+2. **Pull request pipeline** — guards every contributor PR against catalog
+   drift, ownership drift, and non-conventional commit titles.
+3. **Release pipeline** — turns a `v*` tag into a signed GoReleaser release
    with a changelog assembled from Conventional Commits.
 
-## Flow 1 — Issue & PR pipeline
+## Flow 1 — Schema & issue pipeline
 
 ```mermaid
 flowchart TD
@@ -45,6 +46,19 @@ flowchart TD
     issue -->|labels trigger| webhook["enghub-github-issue-assigner<br/>(external webhook)"]
     webhook -->|assigns to| project["GH Project grafana/513<br/>(Platform Monitoring)"]
 
+    classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
+    classDef external fill:#fef3c7,stroke:#b45309,color:#78350f;
+    class us,sl,ilr workflow;
+    class webhook external;
+```
+
+## Flow 2 — Pull request pipeline
+
+Every contributor PR triggers three independent guards. They all run in
+parallel and any single failure blocks the merge.
+
+```mermaid
+flowchart TD
     prc([contributor opens PR]) --> vc[validate-catalog.yml]
     prc --> coc[codeowners-check.yml]
     prc --> ptl[pr-title.yml]
@@ -52,6 +66,9 @@ flowchart TD
     vc -->|jsonnet validates<br/>catalog-info.yaml against schema| ok1{✓}
     coc -->|make codeowners-check| ok2{✓}
     ptl -->|Conventional Commits| ok3{✓}
+
+    classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
+    class vc,coc,ptl workflow;
 ```
 
 ### `update-schema.yml` — keep schema and bug template in sync
@@ -139,9 +156,9 @@ rules, contact the Platform Monitoring team.
 - Because the repo uses **squash merges**, the PR title becomes the commit
   message — which is what the release pipeline parses to assemble the
   changelog and determine the next version. Title format is therefore not
-  cosmetic; it directly drives Flow 2.
+  cosmetic; it directly drives Flow 3.
 
-## Flow 2 — Release pipeline
+## Flow 3 — Release pipeline
 
 ```mermaid
 flowchart TD
@@ -157,6 +174,9 @@ flowchart TD
     gpg --> gor[goreleaser release --clean]
     notes --> gor
     gor --> artifacts["signed binaries<br/>+ GitHub Release"]
+
+    classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
+    class rel workflow;
 ```
 
 ### `release.yml` — tag → signed release

--- a/.github/README.md
+++ b/.github/README.md
@@ -26,18 +26,22 @@ of the dependencies shown below.
    in turn enables semantic-versioned releases and an auto-generated
    changelog.
 
+Edge labels in the diagrams below name the workflow that performs each
+transition. Edges without a workflow name are human or external-system
+actions.
+
 ## Issue pipeline
 
 ```mermaid
 flowchart TD
     src["change in resource<br/>(internal/**, pkg/**)"]
-    src -->|generates| schema[provider_schema.json]
-    schema -->|generates| tmpl[bug report template]
-    schema -->|updates| labels["issue labels<br/>r/&lt;resource&gt;, ds/&lt;datasource&gt;"]
+    src -->|update-schema.yml<br/>generates| schema[provider_schema.json]
+    schema -->|update-schema.yml<br/>generates| tmpl[bug report template]
+    schema -->|sync-labels.yml<br/>creates| labels["issue labels<br/>r/&lt;resource&gt;, ds/&lt;datasource&gt;"]
 
     issue([new issue])
     tmpl -->|used by| issue
-    issue -->|Affected Resources<br/>field is read| label_apply[issue label assigned]
+    issue -->|issue-label-resources.yml<br/>reads Affected Resources| label_apply[issue label assigned]
     labels -.->|drawn from| label_apply
     label_apply -->|webhook| eng[enghub-github-issue-assigner]
     eng -->|assigns| board["GH Project board<br/>grafana/513"]
@@ -54,14 +58,14 @@ flowchart TD
 flowchart TD
     pr([PR created])
 
-    pr -->|fresh schema generated| schema_pr[provider schema]
-    schema_pr -->|validates| catalog[catalog-info.yaml]
-    catalog -->|generates| codeowners[.github/CODEOWNERS]
+    pr -->|validate-catalog.yml<br/>regenerates schema| schema_pr[provider schema]
+    schema_pr -->|validate-catalog.yml<br/>jsonnet check| catalog[catalog-info.yaml]
+    catalog -->|codeowners-check.yml<br/>make codeowners-check| codeowners[.github/CODEOWNERS]
 
-    pr -->|enforces| cc[Conventional Commit title]
+    pr -->|pr-title.yml<br/>enforces| cc[Conventional Commit title]
     cc -->|squash-merged onto main| history[(commit history)]
-    history -->|enables| sem[semantic-versioned release]
-    history -->|enables| changelog[auto-generated changelog]
+    history -->|release.yml<br/>git-cliff bump| sem[semantic-versioned release]
+    history -->|release.yml<br/>git-cliff --latest| changelog[auto-generated changelog]
 
     classDef artifact fill:#e0f2fe,stroke:#0369a1,color:#0c4a6e;
     class schema_pr,catalog,codeowners,cc,history,sem,changelog artifact;

--- a/.github/README.md
+++ b/.github/README.md
@@ -39,7 +39,7 @@ flowchart TD
     user([user files bug report]) -->|uses| tmpl
     user --> issue([new issue])
     issue --> ilr[issue-label-resources.yml]
-    ilr -->|parses 'Affected Resource(s)'| labels
+    ilr -->|parses Affected Resources field| labels
     ilr -->|applies labels| issue
 
     issue -->|labels trigger| webhook["enghub-github-issue-assigner<br/>(external webhook)"]

--- a/.github/README.md
+++ b/.github/README.md
@@ -11,16 +11,16 @@ This README explains how the pieces fit together. For day-to-day contribution
 rules see [`CONTRIBUTING.md`](../CONTRIBUTING.md); for releases see
 [`RELEASING.md`](../RELEASING.md).
 
-## Three flows
+## Two flows
 
-The automation is best understood as three largely independent pipelines:
+The automation is best understood as two largely independent pipelines:
 
 1. **Schema & issue pipeline** — keeps the schema, labels, and bug report
    template synchronized; routes incoming issues to the right project.
-2. **Pull request pipeline** — guards every contributor PR against catalog
-   drift, ownership drift, and non-conventional commit titles.
-3. **Release pipeline** — turns a `v*` tag into a signed GoReleaser release
-   with a changelog assembled from Conventional Commits.
+2. **Contribution & release pipeline** — guards every contributor PR
+   (catalog, ownership, conventional-commit titles), then later turns a
+   `v*` tag into a signed GoReleaser release whose changelog and version
+   bump are computed from those merged commit messages.
 
 ## Flow 1 — Schema & issue pipeline
 
@@ -52,10 +52,14 @@ flowchart TD
     class webhook external;
 ```
 
-## Flow 2 — Pull request pipeline
+## Flow 2 — Contribution & release pipeline
 
 Every contributor PR triggers three independent guards. They all run in
-parallel and any single failure blocks the merge.
+parallel and any single failure blocks the merge. After merge, the
+Conventional Commits enforced by `pr-title.yml` accumulate on `main` and
+drive the release pipeline whenever a maintainer pushes a `v*` tag — the
+commit history is the **only** input git-cliff uses to build the changelog
+and compute the next version bump.
 
 ```mermaid
 flowchart TD
@@ -67,8 +71,26 @@ flowchart TD
     coc -->|make codeowners-check| ok2{✓}
     ptl -->|Conventional Commits| ok3{✓}
 
+    ok1 --> merge([squash merge to main])
+    ok2 --> merge
+    ok3 --> merge
+    merge -->|PR title becomes<br/>commit message| history[(commit history on main)]
+
+    tag["maintainer pushes tag vX.Y.Z"] --> rel[release.yml]
+    history -.->|read by git-cliff| rel
+
+    rel --> cliff1["git-cliff --latest<br/>build CHANGELOG section"]
+    rel --> cliff2["git-cliff --bumped-version<br/>compute min required semver"]
+    cliff2 --> gate{"tag &gt;= min<br/>required?"}
+    gate -- no --> fail[[fail the job]]
+    gate -- yes --> gpg["import GPG key from Vault<br/>(grafana/shared-workflows)"]
+    cliff1 --> notes["/tmp/goreleaser-release-notes.md"]
+    gpg --> gor[goreleaser release --clean]
+    notes --> gor
+    gor --> artifacts["signed binaries<br/>+ GitHub Release"]
+
     classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
-    class vc,coc,ptl workflow;
+    class vc,coc,ptl,rel workflow;
 ```
 
 ### `update-schema.yml` — keep schema and bug template in sync
@@ -154,30 +176,10 @@ rules, contact the Platform Monitoring team.
 - A sticky comment posts the rules on failure and is automatically deleted
   once the title is valid.
 - Because the repo uses **squash merges**, the PR title becomes the commit
-  message — which is what the release pipeline parses to assemble the
-  changelog and determine the next version. Title format is therefore not
-  cosmetic; it directly drives Flow 3.
-
-## Flow 3 — Release pipeline
-
-```mermaid
-flowchart TD
-    tag["maintainer pushes tag vX.Y.Z"]
-    tag --> rel[release.yml]
-
-    rel --> cliff1["git-cliff --latest<br/>build CHANGELOG section"]
-    rel --> cliff2["git-cliff --bumped-version<br/>compute min required semver"]
-    cliff2 --> gate{"tag &gt;= min<br/>required?"}
-    gate -- no --> fail[[fail the job]]
-    gate -- yes --> gpg["import GPG key from Vault<br/>(grafana/shared-workflows)"]
-    cliff1 --> notes["/tmp/goreleaser-release-notes.md"]
-    gpg --> gor[goreleaser release --clean]
-    notes --> gor
-    gor --> artifacts["signed binaries<br/>+ GitHub Release"]
-
-    classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
-    class rel workflow;
-```
+  message — which is what `release.yml` later parses (via `git-cliff`) to
+  assemble the changelog and determine the next version bump. Title format
+  is therefore not cosmetic; it is a **hard prerequisite** for the release
+  pipeline below.
 
 ### `release.yml` — tag → signed release
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,11 +1,11 @@
 # `.github/` automation
 
 This directory contains the GitHub-side automation that ties the provider's
-resource schema to issue triage, PR conventions, and releases. The workflows
-are intentionally interconnected: a single source of truth — the generated
-`provider_schema.json` — drives the bug-report template, the GitHub labels
-applied to issues, project-board routing, and (via Conventional Commits) the
-release changelog.
+resource schema to issue triage, PR conventions, and releases. The
+workflows are intentionally interconnected: the generated provider schema
+drives the bug-report template, the GitHub issue labels, and (via the
+Backstage catalog) per-resource CODEOWNERS; Conventional Commit titles in
+turn drive the release changelog and version bumps.
 
 This README explains how the pieces fit together. For day-to-day contribution
 rules see [`CONTRIBUTING.md`](../CONTRIBUTING.md); for releases see
@@ -13,86 +13,58 @@ rules see [`CONTRIBUTING.md`](../CONTRIBUTING.md); for releases see
 
 ## Two flows
 
-The automation is best understood as two largely independent pipelines:
+The automation is best understood as two largely independent pipelines,
+each described in terms of the artifacts it produces and the dependencies
+between them. The GitHub Actions workflows are listed in the
+[Quick reference](#quick-reference) at the bottom — they are *implementations*
+of the dependencies shown below.
 
-1. **Schema & issue pipeline** — keeps the schema, labels, and bug report
-   template synchronized; routes incoming issues to the right project.
-2. **Contribution & release pipeline** — guards every contributor PR
-   (catalog, ownership, conventional-commit titles), then later turns a
-   `v*` tag into a signed GoReleaser release whose changelog and version
-   bump are computed from those merged commit messages.
+1. **Issue pipeline** — propagates resource changes into the bug report
+   template and issue labels, then routes new issues to the right project.
+2. **Contribution & release pipeline** — every PR validates the schema,
+   catalog, and CODEOWNERS chain, and enforces Conventional Commits, which
+   in turn enables semantic-versioned releases and an auto-generated
+   changelog.
 
-## Flow 1 — Schema & issue pipeline
+## Issue pipeline
 
 ```mermaid
 flowchart TD
-    src["provider source<br/>(internal/**, pkg/**, go.mod, go.sum)"]
-    src -->|push to main| us[update-schema.yml]
+    src["change in resource<br/>(internal/**, pkg/**)"]
+    src -->|generates| schema[provider_schema.json]
+    schema -->|generates| tmpl[bug report template]
+    schema -->|updates| labels["issue labels<br/>r/&lt;resource&gt;, ds/&lt;datasource&gt;"]
 
-    us -->|opens PR<br/>automated/update-schema| pr["PR: chore: update provider<br/>schema and issue templates"]
-    us -.->|regenerates| schema[provider_schema.json]
-    us -.->|regenerates| tmpl[".github/ISSUE_TEMPLATE/<br/>1-bug-report.yml"]
-    pr -->|auto-approve + auto-merge<br/>via GitHub App token| main[(main)]
+    issue([new issue])
+    tmpl -->|used by| issue
+    issue -->|Affected Resources<br/>field is read| label_apply[issue label assigned]
+    labels -.->|drawn from| label_apply
+    label_apply -->|webhook| eng[enghub-github-issue-assigner]
+    eng -->|assigns| board["GH Project board<br/>grafana/513"]
 
-    main -->|push: provider_schema.json| sl[sync-labels.yml]
-    sl -->|create| labels["GitHub labels<br/>r/&lt;resource&gt;, ds/&lt;datasource&gt;"]
-
-    user([user files bug report]) -->|uses| tmpl
-    user --> issue([new issue])
-    issue --> ilr[issue-label-resources.yml]
-    ilr -->|parses Affected Resources field| labels
-    ilr -->|applies labels| issue
-
-    issue -->|labels trigger| webhook["enghub-github-issue-assigner<br/>(external webhook)"]
-    webhook -->|assigns to| project["GH Project grafana/513<br/>(Platform Monitoring)"]
-
-    classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
+    classDef artifact fill:#e0f2fe,stroke:#0369a1,color:#0c4a6e;
     classDef external fill:#fef3c7,stroke:#b45309,color:#78350f;
-    class us,sl,ilr workflow;
-    class webhook external;
+    class schema,tmpl,labels artifact;
+    class eng,board external;
 ```
 
-## Flow 2 — Contribution & release pipeline
-
-Every contributor PR triggers three independent guards. They all run in
-parallel and any single failure blocks the merge. After merge, the
-Conventional Commits enforced by `pr-title.yml` accumulate on `main` and
-drive the release pipeline whenever a maintainer pushes a `v*` tag — the
-commit history is the **only** input git-cliff uses to build the changelog
-and compute the next version bump.
+## Contribution & release pipeline
 
 ```mermaid
 flowchart TD
-    prc([contributor opens PR]) --> vc[validate-catalog.yml]
-    prc --> coc[codeowners-check.yml]
-    prc --> ptl[pr-title.yml]
+    pr([PR created])
 
-    vc -.->|catalog must be valid<br/>for CODEOWNERS to be generated| coc
+    pr -->|fresh schema generated| schema_pr[provider schema]
+    schema_pr -->|validates| catalog[catalog-info.yaml]
+    catalog -->|generates| codeowners[.github/CODEOWNERS]
 
-    vc -->|jsonnet validates<br/>catalog-info.yaml against schema| ok1{✓}
-    coc -->|make codeowners-check| ok2{✓}
-    ptl -->|Conventional Commits| ok3{✓}
+    pr -->|enforces| cc[Conventional Commit title]
+    cc -->|squash-merged onto main| history[(commit history)]
+    history -->|enables| sem[semantic-versioned release]
+    history -->|enables| changelog[auto-generated changelog]
 
-    ok1 --> merge([squash merge to main])
-    ok2 --> merge
-    ok3 --> merge
-    merge -->|PR title becomes<br/>commit message| history[(commit history on main)]
-
-    tag["maintainer pushes tag vX.Y.Z"] --> rel[release.yml]
-    history -.->|read by git-cliff| rel
-
-    rel --> cliff1["git-cliff --latest<br/>build CHANGELOG section"]
-    rel --> cliff2["git-cliff --bumped-version<br/>compute min required semver"]
-    cliff2 --> gate{"tag &gt;= min<br/>required?"}
-    gate -- no --> fail[[fail the job]]
-    gate -- yes --> gpg["import GPG key from Vault<br/>(grafana/shared-workflows)"]
-    cliff1 --> notes["/tmp/goreleaser-release-notes.md"]
-    gpg --> gor[goreleaser release --clean]
-    notes --> gor
-    gor --> artifacts["signed binaries<br/>+ GitHub Release"]
-
-    classDef workflow fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a;
-    class vc,coc,ptl,rel workflow;
+    classDef artifact fill:#e0f2fe,stroke:#0369a1,color:#0c4a6e;
+    class schema_pr,catalog,codeowners,cc,history,sem,changelog artifact;
 ```
 
 ### `update-schema.yml` — keep schema and bug template in sync
@@ -148,26 +120,29 @@ rules, contact the Platform Monitoring team.
 
 - **Trigger:** every pull request.
 - **What it does:** the composite action `.github/actions/validate-catalog`
-  regenerates the schema (`scripts/generate_schema.sh`) and runs
-  `validate.jsonnet` against `catalog-info.yaml` to ensure every resource
-  referenced in the Backstage catalog actually exists in the provider, and
-  vice versa.
-- This guards the same invariant the labelling depends on: the schema and the
-  catalog must agree about which resources exist and who owns them.
+  **regenerates the provider schema fresh from the PR's source**
+  (`scripts/generate_schema.sh`) — it does **not** read the committed
+  `provider_schema.json`. Then `validate.jsonnet` checks that every
+  resource and data source in `catalog-info.yaml` exists in that
+  freshly-built schema, and vice versa.
+- Because the schema is regenerated in CI, contributors do **not** need to
+  commit `provider_schema.json` updates in the same PR that adds a new
+  resource. That file is reconciled separately by `update-schema.yml`
+  (see below) once the change is on `main`.
 
 ### `codeowners-check.yml` — CODEOWNERS is generated, not hand-written
 
 - **Trigger:** pull request and pushes to `main`.
 - **What it does:** runs `make codeowners-check`
   (`go run ./tools/codeowners --check`). The check fails if
-  `.github/CODEOWNERS` drifts from what `tools/codeowners` would generate from
-  `.github/CODEOWNERS.in` (static rules) plus the per-resource ownership
-  derived from `catalog-info.yaml`.
-- **Depends on `validate-catalog.yml`.** The codeowners generator reads
-  `catalog-info.yaml` to derive per-resource owners. If the catalog is out
-  of sync with the schema (resources missing or stale), the generated
-  `CODEOWNERS` will be wrong even when this check passes — both workflows
-  must succeed for ownership to be trustworthy.
+  `.github/CODEOWNERS` drifts from what `tools/codeowners` would generate
+  from `.github/CODEOWNERS.in` (static rules) plus the per-resource
+  ownership derived from `catalog-info.yaml` and Go AST scanning of the
+  resource registrations. It does **not** read the schema JSON.
+- **Pairs with `validate-catalog.yml`.** Validate-catalog confirms that the
+  catalog matches the actual provider source; codeowners-check confirms
+  that CODEOWNERS matches the catalog. Together they prevent merging a new
+  resource with missing or stale ownership.
 - **To regenerate after editing ownership:** `make codeowners`. Edit
   `CODEOWNERS.in` (not `CODEOWNERS`) for static rules.
 


### PR DESCRIPTION
## Summary

Adds `.github/README.md` documenting how the workflows in `.github/workflows/` fit together. The automation in this repo is a tightly-coupled chain of schema → labels → triage → release, but that wiring isn't obvious from reading the individual YAML files.

The README documents two flows:

- **Issue & PR pipeline** — `update-schema.yml` → `sync-labels.yml` → `issue-label-resources.yml` → external enghub webhook, plus the PR-time guards (`validate-catalog.yml`, `codeowners-check.yml`, `pr-title.yml`).
- **Release pipeline** — `release.yml`: `git-cliff` changelog + semver gate + GoReleaser.

Each flow has a Mermaid diagram. A quick-reference table at the bottom lists every workflow with its trigger, purpose, and side effects.

Notable details captured (and easy to lose otherwise):

- Why `update-schema.yml` uses a GitHub App token instead of `GITHUB_TOKEN` (anti-recursion: needed so the auto-merge push triggers `sync-labels.yml`).
- Label color codes and the `grafana_` prefix-stripping convention.
- That `issue-label-resources.yml` skips issue #2389 (Renovate Dependency Dashboard).
- The `cliff.toml` bump rules used by the release pipeline (`feat`/`refactor`/`perf` → minor, `!` → major).
- Pointer to the external enghub-github-issue-assigner webhook and `grafana/513` project.

No workflow or template changes — documentation only.