### PR TITLE
fix(release): set release notes mode to replace

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,4 +74,10 @@ signs:
 release:
   # If you want to manually examine the release before it's live, uncomment this line:
   draft: true
+  # Always overwrite the release body with our --release-notes content.
+  # The default ("keep-existing") preserves any pre-existing release body
+  # (e.g. from a prior failed run or a release object created before the
+  # workflow runs), discarding the git-cliff changelog passed via
+  # --release-notes. See goreleaser/internal/client/release_notes.go.
+  mode: replace
 


### PR DESCRIPTION
## Summary

GoReleaser's default release notes mode is `keep-existing`, which preserves any pre-existing release body and discards the content passed via `--release-notes`. When a release for the tag exists *before* the workflow runs (e.g. from a previous failed run, or any release object that ended up associated with the tag), the git-cliff-generated changelog is silently dropped.

Setting `release.mode: replace` makes GoReleaser always overwrite the body with the `--release-notes` content, ensuring the git-cliff changelog is what ends up on the GitHub release.

## Symptom on v4.34.0

The v4.34.0 release was created as a draft with body `v4.34.0\n\n` (9 bytes) instead of the proper changelog. The workflow's `Generate changelog` step did produce the correct content (verified in the run log), and `--release-notes=/tmp/goreleaser-release-notes.md` was passed to GoReleaser, but the release body ended up empty-but-for-the-tag-name. After publishing v4.34.0, the body had to be patched manually.

## Reproduction

Reproduced in a private test repo:

1. Pre-create a release with `tag_name=v0.0.5` and body `v0.0.5\n\n`.
2. Push the tag to trigger the same workflow (git-cliff-action v4.7.1 → goreleaser-action v6 → GoReleaser v2.15.4 with `--release-notes=...`).
3. Resulting release body: still `v0.0.5\n\n` (10 bytes). The git-cliff changelog was discarded.

After applying `mode: replace`:
- Same setup, body becomes the full git-cliff changelog (211 bytes). ✅

## Upstream reference

[`internal/client/release_notes.go`](https://github.com/goreleaser/goreleaser/blob/main/internal/client/release_notes.go):

```go
func getReleaseNotes(existing, current string, mode config.ReleaseNotesMode) string {
    switch mode {
    case ReleaseNotesModeAppend:   return existing + "\n\n" + current
    case ReleaseNotesModeReplace:  return current
    case ReleaseNotesModePrepend:  return current + "\n\n" + existing
    default: // keep-existing
        if existing != "" { return existing }
        return current
    }
}
```

The default branch returns the existing body whenever it's non-empty, regardless of `--release-notes`.