### PR TITLE
feat: add enabled field to Azure credentials

### DIFF
--- a/docs/data-sources/cloud_provider_azure_credential.md
+++ b/docs/data-sources/cloud_provider_azure_credential.md
@@ -83,6 +83,7 @@ data "grafana_cloud_provider_azure_credential" "test" {
 - `auto_discovery_configuration` (Block List) The list of auto discovery configurations. (see [below for nested schema](#nestedblock--auto_discovery_configuration))
 - `client_id` (String) The client ID of the Azure Credential.
 - `client_secret` (String, Sensitive) The client secret of the Azure Credential.
+- `enabled` (Boolean) Whether the Azure Credential is enabled or not.
 - `id` (String) The Terraform Resource ID. This has the format "{{ stack_id }}:{{ resource_id }}".
 - `name` (String) The name of the Azure Credential.
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))

--- a/docs/resources/cloud_provider_azure_credential.md
+++ b/docs/resources/cloud_provider_azure_credential.md
@@ -79,6 +79,7 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 ### Optional
 
 - `auto_discovery_configuration` (Block List) The list of auto discovery configurations. (see [below for nested schema](#nestedblock--auto_discovery_configuration))
+- `enabled` (Boolean) Whether the Azure Credential is enabled or not. Defaults to `true`.
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
 - `resource_tags_to_add_to_metrics` (Set of String) The list of resource tags to add to metrics.
 

--- a/internal/common/cloudproviderapi/client.go
+++ b/internal/common/cloudproviderapi/client.go
@@ -299,6 +299,9 @@ type AzureCredential struct {
 	// StackID is the unique identifier for the stack in our systems.
 	StackID string `json:"stack_id"`
 
+	// Enabled indicates whether the Azure credential is active.
+	Enabled bool `json:"enabled"`
+
 	// ResourceTagFilters is the list of Azure resource tag filters.
 	ResourceTagFilters []TagFilter `json:"resource_tag_filters"`
 

--- a/internal/resources/cloudprovider/azure_credential_test.go
+++ b/internal/resources/cloudprovider/azure_credential_test.go
@@ -27,6 +27,7 @@ func TestAcc_AzureCredential(t *testing.T) {
     "client_id": "my_client_id",
     "client_secret": "",
     "stack_id": "1",
+    "enabled": true,
     "resource_tag_filters": [
       {
         "key": "key-1",
@@ -85,6 +86,7 @@ func TestAcc_AzureCredential(t *testing.T) {
     "client_id": "my-client-id",
     "client_secret": "",
     "stack_id":"1",
+    "enabled": true,
     "resource_tag_filters": [
       {
         "key": "key-1",
@@ -138,6 +140,7 @@ func TestAcc_AzureCredential(t *testing.T) {
     "client_id": "my-client-id",
     "client_secret": "",
     "stack_id":"1",
+    "enabled": true,
     "resource_tag_filters": [
       {
         "key": "key-1",
@@ -209,6 +212,7 @@ func TestAcc_AzureCredential(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "tenant_id", "my-tenant-id"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "client_id", "my-client-id"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "client_secret", "my-client-secret"),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_discovery_tag_filter.0.key", "key-1"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_discovery_tag_filter.1.key", "key-2"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_discovery_tag_filter.0.value", "value-1"),
@@ -236,6 +240,7 @@ func TestAcc_AzureCredential(t *testing.T) {
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "client_id", "my-client-id"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "client_secret", ""),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_id", resourceID),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_discovery_tag_filter.0.key", "key-1"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_discovery_tag_filter.1.key", "key-2"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_discovery_tag_filter.0.value", "value-1"),

--- a/internal/resources/cloudprovider/data_source_azure_credential.go
+++ b/internal/resources/cloudprovider/data_source_azure_credential.go
@@ -83,6 +83,10 @@ for information on authentication and required access policy scopes.
 				Computed:    true,
 				Sensitive:   true,
 			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the Azure Credential is enabled or not.",
+				Computed:    true,
+			},
 			"resource_tags_to_add_to_metrics": schema.SetAttribute{
 				Description: "The list of resource tags to add to metrics.",
 				Computed:    true,
@@ -168,6 +172,12 @@ func (r *datasourceAzureCredential) Read(ctx context.Context, req datasource.Rea
 	}
 
 	diags = resp.State.SetAttribute(ctx, path.Root("client_secret"), credential.ClientSecret)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("enabled"), credential.Enabled)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,6 +34,7 @@ type resourceAzureCredentialModel struct {
 	StackID                    types.String `tfsdk:"stack_id"`
 	ClientSecret               types.String `tfsdk:"client_secret"`
 	ResourceID                 types.String `tfsdk:"resource_id"`
+	Enabled                    types.Bool   `tfsdk:"enabled"`
 	ResourceTagFilters         types.List   `tfsdk:"resource_discovery_tag_filter"`
 	AutoDiscoveryConfiguration types.List   `tfsdk:"auto_discovery_configuration"`
 	ResourceTagsToAddToMetrics types.Set    `tfsdk:"resource_tags_to_add_to_metrics"`
@@ -180,6 +182,12 @@ for information on authentication and required access policy scopes.
 				Required:    true,
 				Sensitive:   true,
 			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the Azure Credential is enabled or not. Defaults to `true`.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+			},
 			"resource_tags_to_add_to_metrics": schema.SetAttribute{
 				Description: "The list of resource tags to add to metrics.",
 				Optional:    true,
@@ -267,6 +275,7 @@ func (r *resourceAzureCredential) ImportState(ctx context.Context, req resource.
 		StackID:                    types.StringValue(stackID),
 		ResourceID:                 types.StringValue(resourceID),
 		ClientSecret:               types.StringValue(""), // We don't import the client secret
+		Enabled:                    types.BoolValue(credentials.Enabled),
 		ResourceTagFilters:         tagFilters,
 		AutoDiscoveryConfiguration: autoconfiguration,
 		ResourceTagsToAddToMetrics: resourceTagsToAddToMetrics,
@@ -310,6 +319,7 @@ func (r *resourceAzureCredential) Create(ctx context.Context, req resource.Creat
 		TenantID:                   data.TenantID.ValueString(),
 		ClientID:                   data.ClientID.ValueString(),
 		ClientSecret:               data.ClientSecret.ValueString(),
+		Enabled:                    data.Enabled.ValueBool(),
 		ResourceTagFilters:         requestTagFilters,
 		AutoDiscoveryConfiguration: requestAutoDiscoveryConfiguration,
 	}
@@ -338,6 +348,7 @@ func (r *resourceAzureCredential) Create(ctx context.Context, req resource.Creat
 		StackID:                    data.StackID,
 		ClientSecret:               data.ClientSecret,
 		ResourceID:                 types.StringValue(credential.ID),
+		Enabled:                    types.BoolValue(credential.Enabled),
 		ResourceTagFilters:         data.ResourceTagFilters,
 		AutoDiscoveryConfiguration: data.AutoDiscoveryConfiguration,
 		ResourceTagsToAddToMetrics: data.ResourceTagsToAddToMetrics,
@@ -400,6 +411,12 @@ func (r *resourceAzureCredential) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	diags = resp.State.SetAttribute(ctx, path.Root("enabled"), credential.Enabled)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	tagFilters, diags := r.convertTagFilters(ctx, credential.ResourceTagFilters)
 	resp.Diagnostics.Append(diags...)
 	diags = resp.State.SetAttribute(ctx, path.Root("resource_discovery_tag_filter"), tagFilters)
@@ -436,6 +453,7 @@ func (r *resourceAzureCredential) Update(ctx context.Context, req resource.Updat
 	credential.TenantID = planData.TenantID.ValueString()
 	credential.ClientID = planData.ClientID.ValueString()
 	credential.ClientSecret = planData.ClientSecret.ValueString()
+	credential.Enabled = planData.Enabled.ValueBool()
 
 	var tagFilters []TagFilter
 	diags = planData.ResourceTagFilters.ElementsAs(ctx, &tagFilters, false)
@@ -497,6 +515,12 @@ func (r *resourceAzureCredential) Update(ctx context.Context, req resource.Updat
 	}
 
 	diags = resp.State.SetAttribute(ctx, path.Root("client_secret"), planData.ClientSecret)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("enabled"), credentialResponse.Enabled)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
This pull request adds support for managing the enabled/disabled state of Azure credentials in the cloud provider resource. The main changes introduce an `enabled` field to the Azure credential schema, ensure it is handled throughout the resource lifecycle (create, read, update, import), and update the relevant tests to verify this new functionality.
