### PR TITLE
chore(changelog): skip provider schema update commits in cliff

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,6 +25,7 @@ commit_preprocessors = [
 filter_unconventional = false
 protect_breaking_commits = true
 commit_parsers = [
+    { message = "^chore: update provider schema and issue templates", skip = true },
     { message = "^feat", group = "Features" },
     { message = "^fix", group = "Bug Fixes" },
     { message = "^docs", group = "Documentation" },


### PR DESCRIPTION
## Summary

- Skip "chore: update provider schema and issue templates" commits from the changelog generated by git-cliff, as these are frequent automated commits that add noise.