### PR TITLE
ci(workflows): rerun cloud acceptance gate after cloud tests

### DIFF
--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -1,28 +1,13 @@
 # Fails until "cloud acceptance tests" has a completed successful run for the PR head commit.
 # Fork PRs skip this requirement (cloud workflow secrets are not available on forks).
-#
-# Triggered by pull_request (unchanged) and by workflow_call from cloud-acc-tests.yml after
-# each cloud acceptance run so the gate re-checks without a new push (GITHUB_TOKEN cannot
-# dispatch another workflow, but a reusable workflow run shares the caller's commit SHA).
 name: cloud acceptance tests gate
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  workflow_call:
-    inputs:
-      cloud_job_result:
-        description: Result of cloud job from caller workflow (success/failure/cancelled/skipped)
-        required: true
-        type: string
 
 concurrency:
-  group: >-
-    ${{
-      github.event_name == 'pull_request'
-      && format('cloud-acc-tests-gate-pr-{0}', github.event.pull_request.number)
-      || format('cloud-acc-tests-gate-sha-{0}', github.sha)
-    }}
+  group: cloud-acc-tests-gate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -37,52 +22,37 @@ jobs:
       - name: Verify cloud acceptance tests for PR head commit
         env:
           GH_TOKEN: ${{ github.token }}
-          CLOUD_JOB_RESULT: ${{ inputs.cloud_job_result }}
-          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          HEAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           THIS_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          conclusion="success"
-          html_url="https://github.com/${THIS_REPO}/actions/runs/${GITHUB_RUN_ID}"
+          if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+            echo "Skipping: pull request is from a fork ($HEAD_REPO). Cloud acceptance tests are not required for this gate."
+            exit 0
+          fi
 
-          if [ -n "${CLOUD_JOB_RESULT}" ]; then
-            echo "workflow_call mode: checking caller cloud job result (${CLOUD_JOB_RESULT})"
-            conclusion="${CLOUD_JOB_RESULT}"
-          else
-            if [ "${IS_PULL_REQUEST}" != "true" ]; then
-              echo "::error::Missing required input cloud_job_result for non-pull_request run."
-              exit 1
-            fi
+          echo "Checking runs of cloud-acc-tests.yml for head_sha=${HEAD_SHA}"
 
-            if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
-              echo "Skipping: pull request is from a fork ($HEAD_REPO). Cloud acceptance tests are not required for this gate."
-              exit 0
-            fi
+          json=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests.yml/runs?head_sha=${HEAD_SHA}&per_page=5")
 
-            echo "Checking runs of cloud-acc-tests.yml for head_sha=${HEAD_SHA}"
+          count=$(echo "$json" | jq '.total_count')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No run of \"cloud acceptance tests\" found for commit ${HEAD_SHA:0:7}. Ask a Grafana Labs maintainer to run Actions → cloud acceptance tests → Run workflow for this branch."
+            exit 1
+          fi
 
-            json=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests.yml/runs?head_sha=${HEAD_SHA}&per_page=5")
+          status=$(echo "$json" | jq -r '.workflow_runs[0].status')
+          conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
+          html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
 
-            count=$(echo "$json" | jq '.total_count')
-            if [ "$count" -eq 0 ]; then
-              echo "::error::No run of \"cloud acceptance tests\" found for commit ${HEAD_SHA:0:7}. Ask a Grafana Labs maintainer to run Actions → cloud acceptance tests → Run workflow for this branch."
-              exit 1
-            fi
+          echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
 
-            status=$(echo "$json" | jq -r '.workflow_runs[0].status')
-            conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
-            html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
-
-            echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
-
-            if [ "$status" != "completed" ]; then
-              echo "::error::Cloud acceptance tests have not finished for this commit (status=${status}). Wait for the run to complete: ${html_url}"
-              exit 1
-            fi
+          if [ "$status" != "completed" ]; then
+            echo "::error::Cloud acceptance tests have not finished for this commit (status=${status}). Wait for the run to complete: ${html_url}"
+            exit 1
           fi
 
           if [ "$conclusion" != "success" ]; then

--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -9,7 +9,12 @@ name: cloud acceptance tests gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      cloud_job_result:
+        description: Result of cloud job from caller workflow (success/failure/cancelled/skipped)
+        required: false
+        type: string
 
 concurrency:
   group: >-
@@ -32,37 +37,47 @@ jobs:
       - name: Verify cloud acceptance tests for PR head commit
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          CLOUD_JOB_RESULT: ${{ inputs.cloud_job_result }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           HEAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           THIS_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
-            echo "Skipping: pull request is from a fork ($HEAD_REPO). Cloud acceptance tests are not required for this gate."
-            exit 0
-          fi
+          conclusion="success"
+          html_url="https://github.com/${THIS_REPO}/actions/runs/${GITHUB_RUN_ID}"
 
-          echo "Checking runs of cloud-acc-tests.yml for head_sha=${HEAD_SHA}"
+          if [ "$EVENT_NAME" = "workflow_call" ] && [ -n "${CLOUD_JOB_RESULT}" ]; then
+            echo "workflow_call mode: checking caller cloud job result (${CLOUD_JOB_RESULT})"
+            conclusion="${CLOUD_JOB_RESULT}"
+          else
+            if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+              echo "Skipping: pull request is from a fork ($HEAD_REPO). Cloud acceptance tests are not required for this gate."
+              exit 0
+            fi
 
-          json=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests.yml/runs?head_sha=${HEAD_SHA}&per_page=5")
+            echo "Checking runs of cloud-acc-tests.yml for head_sha=${HEAD_SHA}"
 
-          count=$(echo "$json" | jq '.total_count')
-          if [ "$count" -eq 0 ]; then
-            echo "::error::No run of \"cloud acceptance tests\" found for commit ${HEAD_SHA:0:7}. Ask a Grafana Labs maintainer to run Actions → cloud acceptance tests → Run workflow for this branch."
-            exit 1
-          fi
+            json=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests.yml/runs?head_sha=${HEAD_SHA}&per_page=5")
 
-          status=$(echo "$json" | jq -r '.workflow_runs[0].status')
-          conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
-          html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
+            count=$(echo "$json" | jq '.total_count')
+            if [ "$count" -eq 0 ]; then
+              echo "::error::No run of \"cloud acceptance tests\" found for commit ${HEAD_SHA:0:7}. Ask a Grafana Labs maintainer to run Actions → cloud acceptance tests → Run workflow for this branch."
+              exit 1
+            fi
 
-          echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
+            status=$(echo "$json" | jq -r '.workflow_runs[0].status')
+            conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
+            html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
 
-          if [ "$status" != "completed" ]; then
-            echo "::error::Cloud acceptance tests have not finished for this commit (status=${status}). Wait for the run to complete: ${html_url}"
-            exit 1
+            echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
+
+            if [ "$status" != "completed" ]; then
+              echo "::error::Cloud acceptance tests have not finished for this commit (status=${status}). Wait for the run to complete: ${html_url}"
+              exit 1
+            fi
           fi
 
           if [ "$conclusion" != "success" ]; then

--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -13,7 +13,7 @@ on:
     inputs:
       cloud_job_result:
         description: Result of cloud job from caller workflow (success/failure/cancelled/skipped)
-        required: false
+        required: true
         type: string
 
 concurrency:
@@ -37,8 +37,8 @@ jobs:
       - name: Verify cloud acceptance tests for PR head commit
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
           CLOUD_JOB_RESULT: ${{ inputs.cloud_job_result }}
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           HEAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           THIS_REPO: ${{ github.repository }}
@@ -47,10 +47,15 @@ jobs:
           conclusion="success"
           html_url="https://github.com/${THIS_REPO}/actions/runs/${GITHUB_RUN_ID}"
 
-          if [ "$EVENT_NAME" = "workflow_call" ] && [ -n "${CLOUD_JOB_RESULT}" ]; then
+          if [ -n "${CLOUD_JOB_RESULT}" ]; then
             echo "workflow_call mode: checking caller cloud job result (${CLOUD_JOB_RESULT})"
             conclusion="${CLOUD_JOB_RESULT}"
           else
+            if [ "${IS_PULL_REQUEST}" != "true" ]; then
+              echo "::error::Missing required input cloud_job_result for non-pull_request run."
+              exit 1
+            fi
+
             if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
               echo "Skipping: pull request is from a fork ($HEAD_REPO). Cloud acceptance tests are not required for this gate."
               exit 0

--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -1,13 +1,23 @@
 # Fails until "cloud acceptance tests" has a completed successful run for the PR head commit.
 # Fork PRs skip this requirement (cloud workflow secrets are not available on forks).
+#
+# Triggered by pull_request (unchanged) and by workflow_call from cloud-acc-tests.yml after
+# each cloud acceptance run so the gate re-checks without a new push (GITHUB_TOKEN cannot
+# dispatch another workflow, but a reusable workflow run shares the caller's commit SHA).
 name: cloud acceptance tests gate
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call: {}
 
 concurrency:
-  group: cloud-acc-tests-gate-${{ github.event.pull_request.number }}
+  group: >-
+    ${{
+      github.event_name == 'pull_request'
+      && format('cloud-acc-tests-gate-pr-{0}', github.event.pull_request.number)
+      || format('cloud-acc-tests-gate-sha-{0}', github.sha)
+    }}
   cancel-in-progress: true
 
 permissions:
@@ -22,8 +32,8 @@ jobs:
       - name: Verify cloud acceptance tests for PR head commit
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          HEAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           THIS_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -49,17 +49,37 @@ jobs:
           GRAFANA_RETRIES: 10
           GRAFANA_RETRY_WAIT: 5
 
-  # Re-run the PR gate on the same commit as this workflow (workflow_dispatch / workflow_call)
-  # without needing a new pull_request event. See cloud-acc-tests-gate.yml.
-  # Called workflows cannot exceed the caller job's token scope; actions:read is only needed here.
-  gate:
+  refresh-pr-gate-check:
+    name: refresh pull_request gate check
     needs: cloud
     if: always()
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read
-    with:
-      cloud_job_result: ${{ needs.cloud.result }}
-    uses: ./.github/workflows/cloud-acc-tests-gate.yml
+      actions: write
+    steps:
+      - name: Re-run pull_request gate workflow for this commit (if present)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          THIS_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          run_id=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests-gate.yml/runs?event=pull_request&head_sha=${HEAD_SHA}&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+
+          if [ -z "${run_id}" ]; then
+            echo "No pull_request gate run found for this commit; nothing to re-run."
+            exit 0
+          fi
+
+          echo "Re-running pull_request gate workflow run id=${run_id}"
+          gh api \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${THIS_REPO}/actions/runs/${run_id}/rerun"
 
 

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -58,6 +58,8 @@ jobs:
     permissions:
       contents: read
       actions: read
+    with:
+      cloud_job_result: ${{ needs.cloud.result }}
     uses: ./.github/workflows/cloud-acc-tests-gate.yml
 
 

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -47,4 +47,15 @@ jobs:
           GRAFANA_RETRIES: 10
           GRAFANA_RETRY_WAIT: 5
 
+  # Re-run the PR gate on the same commit as this workflow (workflow_dispatch / workflow_call)
+  # without needing a new pull_request event. See cloud-acc-tests-gate.yml.
+  # Called workflows cannot exceed the caller job's token scope; actions:read is only needed here.
+  gate:
+    needs: cloud
+    if: always()
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/cloud-acc-tests-gate.yml
+
 

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -13,15 +13,17 @@ on:
         default: '.*'
     
 
-# These permissions are needed to assume roles from Github's OIDC.
+# Keep workflow-level permissions minimal; grant elevated scopes at job level.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   cloud:
     concurrency: cloud-api
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
Related to https://github.com/grafana/deployment_tools/issues/575652

In addition to the gate workflow being triggered by PR changes, it will also be triggered by the end of a cloud acceptance tests run. This should make it easier to work with the provider. Users won't have to trigger the cloud acc tests and then the gate. They will only need to do the first step.