### PR TITLE
fix(cloud_stacks): failfast instead of timing out on existing stack error

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -367,6 +367,14 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 				time.Sleep(waitTime)
 				return retry.RetryableError(err)
 			}
+			// Slug is taken by an existing stack — fail outright instead of possibly adopting via GetInstance below.
+			existing, _, getErr := client.InstancesAPI.GetInstance(ctx, stack.Slug).Execute()
+			if getErr == nil && existing != nil && existing.Status != "deleted" {
+				return retry.NonRetryableError(fmt.Errorf(
+					"cannot create Grafana Cloud stack: slug %q is already used by an existing stack (id %v)",
+					stack.Slug, existing.Id,
+				))
+			}
 			return retry.NonRetryableError(err)
 		case err != nil:
 			// If we had an error that isn't a a conflict error (already exists), try to read the stack

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -348,7 +348,7 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 	}
 	if existing != nil && existing.Status != "deleted" {
 		existingStackError := fmt.Errorf(
-			"cannot create Grafana Cloud stack: slug %q is already used by an existing stack",
+			"That URL has already been taken, please try an alternate URL: %s",
 			stack.Slug,
 		)
 		return apiError(existingStackError)

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -342,8 +342,8 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 	}
 
 	req := client.InstancesAPI.GetInstance(ctx, stack.Slug)
-	existing, _, getErr := req.Execute()
-	if getErr != nil {
+	existing, httpResp, getErr := req.Execute()
+	if getErr != nil && httpResp != nil && httpResp.StatusCode != http.StatusNotFound {
 		return apiError(getErr)
 	}
 	if existing != nil && existing.Status != "deleted" {

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -342,6 +342,9 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 
 	req := client.InstancesAPI.GetInstance(ctx, stack.Slug)
 	existing, _, getErr := req.Execute()
+	if getErr != nil {
+		return apiError(getErr)
+	}
 	if getErr == nil && existing != nil && existing.Status != "deleted" {
 		existingStackError := fmt.Errorf(
 			"cannot create Grafana Cloud stack: slug %q is already used by an existing stack",

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -348,7 +348,7 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 	}
 	if existing != nil && existing.Status != "deleted" {
 		existingStackError := fmt.Errorf(
-			"That URL has already been taken, please try an alternate URL: %s",
+			"could not create stack: That URL has already been taken, please try an alternate URL: %s",
 			stack.Slug,
 		)
 		return apiError(existingStackError)

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -374,6 +375,7 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 				gracePeriodRe := regexp.MustCompile(`wait for (\d+)s`)
 				if matches := gracePeriodRe.FindSubmatch(gcomErr.Body()); len(matches) == 2 {
 					if seconds, parseErr := strconv.Atoi(string(matches[1])); parseErr == nil {
+						log.Printf("[WARN] slug %s is temporarily unavailable, retrying after %s", stack.Slug, waitTime)
 						waitTime = time.Duration(seconds+5) * time.Second // +5s margin for clock skew
 					}
 				}

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -340,6 +340,16 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 		DeleteProtection: *gcom.NewNullableBool(common.Ref(d.Get("delete_protection").(bool))),
 	}
 
+	req := client.InstancesAPI.GetInstance(ctx, stack.Slug)
+	existing, _, getErr := req.Execute()
+	if getErr == nil && existing != nil && existing.Status != "deleted" {
+		existingStackError := fmt.Errorf(
+			"cannot create Grafana Cloud stack: slug %q is already used by an existing stack",
+			stack.Slug,
+		)
+		return apiError(existingStackError)
+	}
+
 	var stackCreationResponse *gcom.StackV1
 	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		req := client.StacksAPI.CreateStackV1(ctx).StackCreateRequestV1(stack)

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -345,7 +345,7 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 	if getErr != nil {
 		return apiError(getErr)
 	}
-	if getErr == nil && existing != nil && existing.Status != "deleted" {
+	if existing != nil && existing.Status != "deleted" {
 		existingStackError := fmt.Errorf(
 			"cannot create Grafana Cloud stack: slug %q is already used by an existing stack",
 			stack.Slug,


### PR DESCRIPTION
Currently, if a stack exists and one tries to re-create it, this times out. This fails fast instead of timing out.