### PR TITLE
fix(cloud_stacks): transform waiting until stack is ready on a best effort if wait_for_readiness is set to false

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -416,16 +416,22 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 		return diag
 	}
 
+	waitForReadiness := d.Get("wait_for_readiness").(bool)
 	// we wait until all the resources are ready
 	readinessTimeout := defaultReadinessTimeout
 	if timeoutVal := d.Get("wait_for_readiness_timeout").(string); timeoutVal != "" {
 		readinessTimeout, _ = time.ParseDuration(timeoutVal)
 	}
 	if diag := waitUntilReady(ctx, stackCreationResponse, readinessTimeout, client); diag != nil {
-		return diag
+		// if wait for readiness is enabled we return the error
+		// otherwise we persist so the terraform state has the stack
+		if waitForReadiness {
+			return diag
+		}
+		log.Printf("[WARN] stack %s was not ready within %s, continuing since no wait for readiness is configured", stack.Slug, readinessTimeout)
 	}
 
-	if d.Get("wait_for_readiness").(bool) {
+	if waitForReadiness {
 		return waitForStackReadiness(ctx, readinessTimeout, d.Get("url").(string))
 	}
 	return nil

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -428,7 +428,7 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 		if waitForReadiness {
 			return diag
 		}
-		log.Printf("[WARN] stack %s was not ready within %s, continuing since no wait for readiness is configured", stack.Slug, readinessTimeout)
+		log.Printf("[WARN] stack %s was not ready within %s, continuing because wait_for_readiness is disabled", stack.Slug, readinessTimeout)
 	}
 
 	if waitForReadiness {


### PR DESCRIPTION
This addresses the following situation:
- stack is created successfully
- but it never becomes ready (or something else happens, like rate limiting, etc.)

In that scenario the stack does not end up in the state, so it has to be imported manually.