### PR TITLE
fix(oncall): guard against nil elements in labelsSetEqual

### DIFF
--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -887,6 +887,7 @@ func labelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 }
 
 // labelsSetEqual compares two label lists as sets of {key, value} pairs, ignoring order and the "id" field.
+// Elements may be nil when the SDK's readListField encounters a non-existent index during diff (field_reader.go).
 func labelsSetEqual(a, b []any) bool {
 	if len(a) != len(b) {
 		return false
@@ -894,14 +895,20 @@ func labelsSetEqual(a, b []any) bool {
 
 	setA := make(map[string]string, len(a))
 	for _, item := range a {
-		m := item.(map[string]any)
+		m, ok := item.(map[string]any)
+		if !ok {
+			return false
+		}
 		key, _ := m["key"].(string)
 		value, _ := m["value"].(string)
 		setA[key] = value
 	}
 
 	for _, item := range b {
-		m := item.(map[string]any)
+		m, ok := item.(map[string]any)
+		if !ok {
+			return false
+		}
 		key, _ := m["key"].(string)
 		value, _ := m["value"].(string)
 		if setA[key] != value {

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -887,7 +887,6 @@ func labelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 }
 
 // labelsSetEqual compares two label lists as sets of {key, value} pairs, ignoring order and the "id" field.
-// Elements may be nil when the SDK's readListField encounters a non-existent index during diff (field_reader.go).
 func labelsSetEqual(a, b []any) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/resources/oncall/resource_integration_labels_test.go
+++ b/internal/resources/oncall/resource_integration_labels_test.go
@@ -117,6 +117,42 @@ func TestLabelsSetEqual_DifferentValues(t *testing.T) {
 	}
 }
 
+func TestLabelsSetEqual_NilElementInFirstList(t *testing.T) {
+	a := []any{
+		nil,
+		map[string]any{"key": "severity", "value": "critical"},
+	}
+	b := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+		map[string]any{"key": "team", "value": "platform"},
+	}
+	if labelsSetEqual(a, b) {
+		t.Error("expected false when first list contains a nil element")
+	}
+}
+
+func TestLabelsSetEqual_NilElementInSecondList(t *testing.T) {
+	a := []any{
+		map[string]any{"key": "severity", "value": "critical"},
+		map[string]any{"key": "team", "value": "platform"},
+	}
+	b := []any{
+		nil,
+		map[string]any{"key": "severity", "value": "critical"},
+	}
+	if labelsSetEqual(a, b) {
+		t.Error("expected false when second list contains a nil element")
+	}
+}
+
+func TestLabelsSetEqual_BothListsAllNil(t *testing.T) {
+	a := []any{nil, nil}
+	b := []any{nil, nil}
+	if labelsSetEqual(a, b) {
+		t.Error("expected false when both lists contain only nil elements")
+	}
+}
+
 func TestLabelsSetEqual_DifferentCount(t *testing.T) {
 	a := []any{
 		map[string]any{"key": "severity", "value": "critical"},


### PR DESCRIPTION
## Summary
- `labelsSetEqual` panics with `interface conversion: interface {} is nil, not map[string]interface {}`
  when a `labels` or `dynamic_labels` list element is nil at plan time
- The SDK's `readListField` can produce nil elements when `ReadField` returns `Exists: false`
  for a list index during diff computation
- Use comma-ok type assertion on both loops (lines 897 and 904) so a nil element returns `false`
  (don't suppress the diff) instead of crashing the plugin
- Bug was introduced in #2536 (v4.29.2) and is present through current main

## Test plan
- [ ] `go test ./internal/resources/oncall/... -run TestLabelsSetEqual -v` passes, including
  three new cases: nil in first list, nil in second list, both lists all-nil
- [ ] `go build ./...` compiles cleanly