### PR TITLE
fix(cloud): implement Retry-After honouring on 429s for grafana.com API calls and add retries where needed

### DIFF
--- a/internal/resources/cloud/common_lister.go
+++ b/internal/resources/cloud/common_lister.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -29,7 +30,14 @@ func (d *ListerData) Stacks(ctx context.Context, client *gcom.APIClient) ([]gcom
 	d.stacksInit.Do(func() {
 		stacksReq := client.InstancesAPI.GetInstances(ctx)
 		var stacksResp *gcom.GetInstances200Response
-		stacksResp, _, err = stacksReq.Execute()
+		err = RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			var hr *http.Response
+			stacksResp, hr, err = stacksReq.Execute()
+			return hr, err
+		})
+		if err != nil {
+			return
+		}
 		d.stacks = stacksResp.Items
 	})
 	return d.stacks, err
@@ -45,7 +53,14 @@ func (d *ListerData) OrgID(ctx context.Context, client *gcom.APIClient) (int32, 
 		org := d.OrgSlug()
 		orgReq := client.OrgsAPI.GetOrg(ctx, org)
 		var orgResp *gcom.FormattedApiOrgPublic
-		orgResp, _, err = orgReq.Execute()
+		err = RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			var hr *http.Response
+			orgResp, hr, err = orgReq.Execute()
+			return hr, err
+		})
+		if err != nil {
+			return
+		}
 		d.orgID = int32(orgResp.Id)
 	})
 	return d.orgID, err

--- a/internal/resources/cloud/data_source_cloud_access_policies.go
+++ b/internal/resources/cloud/data_source_cloud_access_policies.go
@@ -2,8 +2,10 @@ package cloud
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -98,8 +100,12 @@ func (r *AccessPoliciesDataSource) Read(ctx context.Context, req datasource.Read
 	if data.RegionFilter.ValueString() != "" {
 		regions = append(regions, data.RegionFilter.ValueString())
 	} else {
-		apiResp, _, err := r.client.StackRegionsAPI.GetStackRegions(ctx).Execute()
-		if err != nil {
+		var apiResp *gcom.GetStackRegions200Response
+		if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			rs, hr, re := r.client.StackRegionsAPI.GetStackRegions(ctx).Execute()
+			apiResp = rs
+			return hr, re
+		}); err != nil {
 			resp.Diagnostics = diag.Diagnostics{diag.NewErrorDiagnostic("Failed to get stack regions", err.Error())}
 			return
 		}
@@ -116,14 +122,19 @@ func (r *AccessPoliciesDataSource) Read(ctx context.Context, req datasource.Read
 
 	nameFilter := data.NameFilter.ValueString()
 	for _, region := range regions {
+		reg := region
 		g.Go(func() error {
-			req := r.client.AccesspoliciesAPI.GetAccessPolicies(gctx).Region(region)
+			policyReq := r.client.AccesspoliciesAPI.GetAccessPolicies(gctx).Region(reg)
 			if nameFilter != "" {
-				req = req.Name(nameFilter)
+				policyReq = policyReq.Name(nameFilter)
 			}
 
-			apiResp, _, err := req.Execute()
-			if err != nil {
+			var apiResp *gcom.GetAccessPolicies200Response
+			if err := RetryGCOM(gctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+				rs, hr, re := policyReq.Execute()
+				apiResp = rs
+				return hr, re
+			}); err != nil {
 				return err
 			}
 
@@ -131,7 +142,7 @@ func (r *AccessPoliciesDataSource) Read(ctx context.Context, req datasource.Read
 			for _, policy := range apiResp.Items {
 				regionPolicies = append(regionPolicies, AccessPoliciesDataSourcePolicyModel{
 					ID:          types.StringValue(*policy.Id),
-					Region:      types.StringValue(region),
+					Region:      types.StringValue(reg),
 					Name:        types.StringValue(policy.Name),
 					DisplayName: types.StringValue(*policy.DisplayName),
 					Status:      types.StringValue(*policy.Status),

--- a/internal/resources/cloud/data_source_cloud_organization.go
+++ b/internal/resources/cloud/data_source_cloud_organization.go
@@ -2,8 +2,10 @@ package cloud
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -96,9 +98,12 @@ func (r *CloudOrganizationDataSource) Read(ctx context.Context, req datasource.R
 		identifier = data.Slug.ValueString()
 	}
 
-	// Fetch organization from API
-	org, _, err := r.client.OrgsAPI.GetOrg(ctx, identifier).Execute()
-	if err != nil {
+	var org *gcom.FormattedApiOrgPublic
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		o, hr, oe := r.client.OrgsAPI.GetOrg(ctx, identifier).Execute()
+		org = o
+		return hr, oe
+	}); err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to get organization",
 			"Could not read organization: "+err.Error(),

--- a/internal/resources/cloud/data_source_private_data_source_connect_networks.go
+++ b/internal/resources/cloud/data_source_private_data_source_connect_networks.go
@@ -2,8 +2,10 @@ package cloud
 
 import (
 	"context"
+	"net/http"
 	"slices"
 
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -97,8 +99,12 @@ func (r *PDCNetworksDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if data.RegionFilter.ValueString() != "" {
 		regions = append(regions, data.RegionFilter.ValueString())
 	} else {
-		apiResp, _, err := r.client.StackRegionsAPI.GetStackRegions(ctx).Execute()
-		if err != nil {
+		var apiResp *gcom.GetStackRegions200Response
+		if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			rs, hr, re := r.client.StackRegionsAPI.GetStackRegions(ctx).Execute()
+			apiResp = rs
+			return hr, re
+		}); err != nil {
 			resp.Diagnostics = diag.Diagnostics{diag.NewErrorDiagnostic("Failed to get stack regions", err.Error())}
 			return
 		}
@@ -109,8 +115,12 @@ func (r *PDCNetworksDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	data.PrivateDataSourceNetworks = []PDCNetworksDataSourcePolicyModel{}
 	for _, region := range regions {
-		apiResp, _, err := r.client.AccesspoliciesAPI.GetAccessPolicies(ctx).Region(region).Execute()
-		if err != nil {
+		var apiResp *gcom.GetAccessPolicies200Response
+		if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			rs, hr, re := r.client.AccesspoliciesAPI.GetAccessPolicies(ctx).Region(region).Execute()
+			apiResp = rs
+			return hr, re
+		}); err != nil {
 			resp.Diagnostics = diag.Diagnostics{diag.NewErrorDiagnostic("Failed to get access policies", err.Error())}
 			return
 		}

--- a/internal/resources/cloud/gcom_retry.go
+++ b/internal/resources/cloud/gcom_retry.go
@@ -89,6 +89,8 @@ func transientGCOMError(cfg GCOMRetryConfig, resp *http.Response, err error) boo
 // DefaultGCOMTransient classifies Grafana Cloud transient HTTP responses and transport errors.
 //
 // Treats typical 429/408/5xx as retryable. Does not treat 409 as retryable — stack creation keeps bespoke conflict handling (see resource_cloud_stack createStack).
+//
+// Errors satisfying [net.Error] (including *[net.OpError]) are retryable unless the chain includes [context.DeadlineExceeded] (explicit client deadline / cancellation).
 func DefaultGCOMTransient(resp *http.Response, err error) bool {
 	if err == nil {
 		return false
@@ -105,21 +107,16 @@ func DefaultGCOMTransient(resp *http.Response, err error) bool {
 		}
 	}
 
-	var netErr net.Error
-	if errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
-		return true
-	}
-
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		return true
-	}
-
 	if errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 
-	var opErr *net.OpError
-	return errors.As(err, &opErr)
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 func gcomDrainResponse(resp *http.Response) {

--- a/internal/resources/cloud/gcom_retry.go
+++ b/internal/resources/cloud/gcom_retry.go
@@ -1,0 +1,182 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+const (
+	// DefaultGCOMRetryTimeout caps the Grafana Cloud OpenAPI retry loop duration.
+	DefaultGCOMRetryTimeout = 2 * time.Minute
+	gcomRetryAfterCap       = 2 * time.Minute
+)
+
+// GCOMRetryConfig configures RetryGCOM.
+type GCOMRetryConfig struct {
+	Timeout time.Duration
+
+	// TreatNotFoundAsSuccess, when true, treats HTTP 404 responses as success (typically for DELETE),
+	// so destroys are idempotent when the resource is already gone.
+	TreatNotFoundAsSuccess bool
+
+	// OnTransient, when non-nil, is consulted after DefaultGCOMTransient returns false.
+	OnTransient func(resp *http.Response, err error) bool
+}
+
+func (c GCOMRetryConfig) timeoutDuration() time.Duration {
+	if c.Timeout > 0 {
+		return c.Timeout
+	}
+	return DefaultGCOMRetryTimeout
+}
+
+// RetryGCOM runs op under retry.RetryContext until success or non-retryable error.
+//
+// Follow-up retries:
+// - For HTTP 429, sleeps according to Retry-After (RFC 9110 delta-seconds or HTTP-date), capped by gcomRetryAfterCap and ctx cancellation (via SleepRetryAfterHeader).
+// - When TreatNotFoundAsSuccess is set, HTTP 404 is treated as immediate success (common for idempotent DELETE).
+// - Failed response bodies are drained for connection reuse (success responses are unchanged).
+func RetryGCOM(ctx context.Context, cfg GCOMRetryConfig, op func() (*http.Response, error)) error {
+	timeout := cfg.timeoutDuration()
+
+	return retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		resp, err := op()
+		if err == nil {
+			return nil
+		}
+
+		if cfg.TreatNotFoundAsSuccess && resp != nil && resp.StatusCode == http.StatusNotFound {
+			gcomDrainResponse(resp)
+			return nil
+		}
+
+		if transientGCOMError(cfg, resp, err) {
+			logGCOMRetryWarning(resp, err)
+			if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+				SleepRetryAfterHeader(ctx, resp.Header.Get("Retry-After"))
+			}
+			gcomDrainResponse(resp)
+			return retry.RetryableError(err)
+		}
+
+		gcomDrainResponse(resp)
+		return retry.NonRetryableError(err)
+	})
+}
+
+func transientGCOMError(cfg GCOMRetryConfig, resp *http.Response, err error) bool {
+	if err == nil {
+		return false
+	}
+	if DefaultGCOMTransient(resp, err) {
+		return true
+	}
+	if cfg.OnTransient != nil && cfg.OnTransient(resp, err) {
+		return true
+	}
+	return false
+}
+
+// DefaultGCOMTransient classifies Grafana Cloud transient HTTP responses and transport errors.
+//
+// Treats typical 429/408/5xx as retryable. Does not treat 409 as retryable — stack creation keeps bespoke conflict handling (see resource_cloud_stack createStack).
+func DefaultGCOMTransient(resp *http.Response, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if resp != nil {
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests, http.StatusRequestTimeout:
+			return true
+		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			return true
+		default:
+			return resp.StatusCode >= 500
+		}
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+		return true
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
+}
+
+func gcomDrainResponse(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// SleepRetryAfterHeader sleeps per the Retry-After header value before the next retry attempt.
+func SleepRetryAfterHeader(ctx context.Context, header string) {
+	d, ok := parseRetryAfter(header, time.Now())
+	if !ok || d <= 0 {
+		return
+	}
+	if d > gcomRetryAfterCap {
+		d = gcomRetryAfterCap
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+	}
+}
+
+// parseRetryAfter returns the wait duration from Retry-After (RFC 9110).
+func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+
+	if secs, err := strconv.Atoi(header); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second, true
+	}
+
+	if t, err := http.ParseTime(header); err == nil {
+		wait := t.Sub(now)
+		if wait < 0 {
+			return 0, true
+		}
+		return wait, true
+	}
+
+	return 0, false
+}
+
+func logGCOMRetryWarning(resp *http.Response, err error) {
+	if err == nil {
+		return
+	}
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	log.Printf("[WARN] Grafana Cloud API: retrying after transient error (HTTP status=%d): %v", status, err)
+}

--- a/internal/resources/cloud/gcom_retry_test.go
+++ b/internal/resources/cloud/gcom_retry_test.go
@@ -1,0 +1,73 @@
+package cloud
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUnitRetryGCOM_TreatNotFoundAsSuccess(t *testing.T) {
+	ctx := context.Background()
+	errTreat := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}, errors.New("not found")
+	})
+	if errTreat != nil {
+		t.Fatalf("expected nil for DELETE-style 404, got %v", errTreat)
+	}
+	errUntreated := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}, errors.New("not found")
+	})
+	if errUntreated == nil {
+		t.Fatal("expected non-nil error when TreatNotFoundAsSuccess is false")
+	}
+}
+
+func TestUnitParseRetryAfter_DeltaSeconds(t *testing.T) {
+	t.Parallel()
+	fixed := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+	d, ok := parseRetryAfter("120", fixed)
+	if !ok || d != 120*time.Second {
+		t.Fatalf("want 120s, ok=true; got %v, ok=%v", d, ok)
+	}
+	d, ok = parseRetryAfter("0", fixed)
+	if !ok || d != 0 {
+		t.Fatalf("want 0, ok=true; got %v, ok=%v", d, ok)
+	}
+}
+
+func TestUnitParseRetryAfter_HTTPDate(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.June, 1, 12, 0, 0, 0, time.UTC)
+	when := now.Add(90 * time.Second)
+	header := when.UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT")
+	d, ok := parseRetryAfter(header, now)
+	if !ok {
+		t.Fatal("want ok=true")
+	}
+	if d < 89*time.Second || d > 91*time.Second {
+		t.Fatalf("want ~90s, got %v", d)
+	}
+	if d2, ok2 := parseRetryAfter(header, now.Add(300*time.Second)); !ok2 || d2 != 0 {
+		t.Fatalf("past date should yield 0 wait: got %v ok=%v", d2, ok2)
+	}
+}
+
+func TestUnitParseRetryAfter_Invalid(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	for _, h := range []string{"", "   ", "-1", "nan", "Thu, bogus"} {
+		if _, ok := parseRetryAfter(h, now); ok {
+			t.Fatalf("header %q should be invalid", h)
+		}
+	}
+}

--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 
@@ -162,9 +163,14 @@ Required access policy scopes:
 
 func listAccessPolicies(ctx context.Context, client *gcom.APIClient, data *ListerData) ([]string, error) {
 	regionsReq := client.StackRegionsAPI.GetStackRegions(ctx)
-	regionsResp, _, err := regionsReq.Execute()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list regions: %w", err)
+	var regionsResp *gcom.GetStackRegions200Response
+	rgErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		rs, hr, re := regionsReq.Execute()
+		regionsResp = rs
+		return hr, re
+	})
+	if rgErr != nil {
+		return nil, fmt.Errorf("failed to list regions: %w", rgErr)
 	}
 
 	orgID, err := data.OrgID(ctx, client)
@@ -176,9 +182,14 @@ func listAccessPolicies(ctx context.Context, client *gcom.APIClient, data *Liste
 	for _, region := range regionsResp.Items {
 		regionSlug := region.FormattedApiStackRegionAnyOf.Slug
 		req := client.AccesspoliciesAPI.GetAccessPolicies(ctx).Region(regionSlug).OrgId(orgID)
-		resp, _, err := req.Execute()
-		if err != nil {
-			return nil, fmt.Errorf("failed to list access policies in region %s: %w", regionSlug, err)
+		var resp *gcom.GetAccessPolicies200Response
+		polErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			r, hr, pe := req.Execute()
+			resp = r
+			return hr, pe
+		})
+		if polErr != nil {
+			return nil, fmt.Errorf("failed to list access policies in region %s: %w", regionSlug, polErr)
 		}
 
 		for _, policy := range resp.Items {
@@ -206,9 +217,14 @@ func createCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client
 			Conditions:  expandCloudAccessPolicyConditions(d.Get("conditions").(*schema.Set).List()),
 		})
 
-	result, _, err := req.Execute()
-	if err != nil {
-		return apiError(err)
+	var result *gcom.AuthAccessPolicy
+	crErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := req.Execute()
+		result = r
+		return hr, ce
+	})
+	if crErr != nil {
+		return apiError(crErr)
 	}
 
 	d.SetId(resourceAccessPolicyID.Make(region, result.Id))
@@ -235,7 +251,10 @@ func updateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client
 			Realms:      expandCloudAccessPolicyRealm(d.Get("realm").(*schema.Set).List()),
 			Conditions:  expandCloudAccessPolicyConditions(d.Get("conditions").(*schema.Set).List()),
 		})
-	if _, _, err = req.Execute(); err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, ue := req.Execute()
+		return hr, ue
+	}); err != nil {
 		return apiError(err)
 	}
 
@@ -249,9 +268,16 @@ func readCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client *
 	}
 	region, id := split[0], split[1]
 
-	result, _, err := client.AccesspoliciesAPI.GetAccessPolicy(ctx, id.(string)).Region(region.(string)).Execute()
-	if err, shouldReturn := common.CheckReadError("access policy", d, err); shouldReturn {
-		return err
+	var result *gcom.AuthAccessPolicy
+	rdErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := client.AccesspoliciesAPI.GetAccessPolicy(ctx, id.(string)).Region(region.(string)).Execute()
+		result = r
+		return hr, re
+	})
+	if rdErr != nil {
+		if errDiag, shouldReturn := common.CheckReadError("access policy", d, rdErr); shouldReturn {
+			return errDiag
+		}
 	}
 
 	d.Set("region", region)
@@ -277,8 +303,12 @@ func deleteCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client
 	}
 	region, id := split[0], split[1]
 
-	_, err = client.AccesspoliciesAPI.DeleteAccessPolicy(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
-	return apiError(err)
+	if err := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		return client.AccesspoliciesAPI.DeleteAccessPolicy(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
+	}); err != nil {
+		return apiError(err)
+	}
+	return nil
 }
 
 func validateCloudAccessPolicyScope(v any, path cty.Path) diag.Diagnostics {

--- a/internal/resources/cloud/resource_cloud_access_policy_token.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_token.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -91,9 +92,14 @@ func createTokenHelper(ctx context.Context, d *schema.ResourceData, client *gcom
 	}
 
 	req := client.TokensAPI.PostTokens(ctx).Region(region).XRequestId(ClientRequestID()).PostTokensRequest(tokenInput)
-	result, _, err := req.Execute()
-	if err != nil {
-		return apiError(err)
+	var result *gcom.AuthTokenWithSecret
+	crErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := req.Execute()
+		result = r
+		return hr, ce
+	})
+	if crErr != nil {
+		return apiError(crErr)
 	}
 
 	d.SetId(tokenResourceID.Make(region, result.Id))
@@ -128,7 +134,10 @@ func updateTokenHelper(ctx context.Context, d *schema.ResourceData, client *gcom
 	req := client.TokensAPI.PostToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).PostTokenRequest(gcom.PostTokenRequest{
 		DisplayName: &displayName,
 	})
-	if _, _, err := req.Execute(); err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, ue := req.Execute()
+		return hr, ue
+	}); err != nil {
 		return apiError(err)
 	}
 
@@ -147,9 +156,16 @@ func readTokenHelper(ctx context.Context, d *schema.ResourceData, client *gcom.A
 	}
 	region, id := split[0], split[1]
 
-	result, _, err := client.TokensAPI.GetToken(ctx, id.(string)).Region(region.(string)).Execute()
-	if err, shouldReturn := common.CheckReadError("policy token", d, err); shouldReturn {
-		return err
+	var result *gcom.AuthToken
+	rdErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := client.TokensAPI.GetToken(ctx, id.(string)).Region(region.(string)).Execute()
+		result = r
+		return hr, re
+	})
+	if rdErr != nil {
+		if errDiag, shouldReturn := common.CheckReadError("policy token", d, rdErr); shouldReturn {
+			return errDiag
+		}
 	}
 
 	d.Set("access_policy_id", result.AccessPolicyId)
@@ -180,8 +196,13 @@ func deleteTokenHelper(ctx context.Context, d *schema.ResourceData, client *gcom
 	}
 	region, id := split[0], split[1]
 
-	_, _, err = client.TokensAPI.DeleteToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
-	return apiError(err)
+	if err := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		_, hr, de := client.TokensAPI.DeleteToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
+		return hr, de
+	}); err != nil {
+		return apiError(err)
+	}
+	return nil
 }
 
 // tokenResourceWithCustomSchema returns a map that has the fields common to all token-related resources, like tokens

--- a/internal/resources/cloud/resource_cloud_org_member.go
+++ b/internal/resources/cloud/resource_cloud_org_member.go
@@ -89,9 +89,14 @@ func (r *orgMemberResource) Schema(ctx context.Context, req resource.SchemaReque
 }
 
 func listOrgMembers(ctx context.Context, client *gcom.APIClient, data *ListerData) ([]string, error) {
-	resp, _, err := client.OrgsAPI.GetOrgMembers(ctx, data.OrgSlug()).Execute()
-	if err != nil {
-		return nil, err
+	var resp *gcom.OrgMemberListResponse
+	lErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := client.OrgsAPI.GetOrgMembers(ctx, data.OrgSlug()).Execute()
+		resp = r
+		return hr, re
+	})
+	if lErr != nil {
+		return nil, lErr
 	}
 
 	var ids []string
@@ -143,8 +148,10 @@ func (r *orgMemberResource) Create(ctx context.Context, req resource.CreateReque
 	postReq := gcom.NewPostOrgMembersRequest(data.User.ValueString())
 	postReq.SetBilling(billing)
 	postReq.SetRole(data.Role.ValueString())
-	_, _, err := r.client.OrgsAPI.PostOrgMembers(ctx, data.Org.ValueString()).PostOrgMembersRequest(*postReq).XRequestId(ClientRequestID()).Execute()
-	if err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, e := r.client.OrgsAPI.PostOrgMembers(ctx, data.Org.ValueString()).PostOrgMembersRequest(*postReq).XRequestId(ClientRequestID()).Execute()
+		return hr, e
+	}); err != nil {
 		resp.Diagnostics.AddError("Unable to Create Resource", err.Error())
 		return
 	}
@@ -204,7 +211,10 @@ func (r *orgMemberResource) Update(ctx context.Context, req resource.UpdateReque
 	postReq := gcom.NewPostOrgMemberRequest()
 	postReq.SetBilling(billing)
 	postReq.SetRole(data.Role.ValueString())
-	if _, _, err := r.client.OrgsAPI.PostOrgMember(ctx, data.Org.ValueString(), data.User.ValueString()).XRequestId(ClientRequestID()).PostOrgMemberRequest(*postReq).Execute(); err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, e := r.client.OrgsAPI.PostOrgMember(ctx, data.Org.ValueString(), data.User.ValueString()).XRequestId(ClientRequestID()).PostOrgMemberRequest(*postReq).Execute()
+		return hr, e
+	}); err != nil {
 		resp.Diagnostics.AddError("Unable to Update Resource", err.Error())
 		return
 	}
@@ -239,8 +249,9 @@ func (r *orgMemberResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 	org, user := split[0].(string), split[1].(string)
 
-	// DELETE
-	if _, err := r.client.OrgsAPI.DeleteOrgMember(ctx, org, user).XRequestId(ClientRequestID()).Execute(); err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		return r.client.OrgsAPI.DeleteOrgMember(ctx, org, user).XRequestId(ClientRequestID()).Execute()
+	}); err != nil {
 		resp.Diagnostics.AddError("Unable to Delete Resource", err.Error())
 	}
 }
@@ -257,13 +268,19 @@ func (r *orgMemberResource) readFromID(ctx context.Context, id string) (*resourc
 	org, user := split[0].(string), split[1].(string)
 
 	// GET
-	memberResp, httpResp, err := r.client.OrgsAPI.GetOrgMember(ctx, org, user).Execute()
-	if httpResp.StatusCode == http.StatusNotFound {
+	var memberResp *gcom.FormattedOrgMembership
+	var lastHTTP *http.Response
+	readErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		m, hr, e := r.client.OrgsAPI.GetOrgMember(ctx, org, user).Execute()
+		memberResp = m
+		lastHTTP = hr
+		return hr, e
+	})
+	if lastHTTP != nil && lastHTTP.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}
-
-	if err != nil {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unable to read resource", err.Error())}
+	if readErr != nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unable to read resource", readErr.Error())}
 	}
 
 	data := &resourceOrgMemberModel{}

--- a/internal/resources/cloud/resource_cloud_plugin_installation.go
+++ b/internal/resources/cloud/resource_cloud_plugin_installation.go
@@ -2,15 +2,23 @@ package cloud
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+var pluginInstallConflictBackoff = func(resp *http.Response, err error) bool {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "conflict") {
+		time.Sleep(10 * time.Second) // Do not retry too fast on in-progress install/delete conflicts
+		return true
+	}
+	return false
+}
 
 var (
 	resourcePluginInstallationID = common.NewResourceID(
@@ -80,9 +88,14 @@ func listStackPlugins(ctx context.Context, client *gcom.APIClient, data *ListerD
 
 	var pluginIDs []string
 	for _, stack := range stacks {
-		plugins, _, err := client.InstancesAPI.GetInstancePlugins(ctx, stack.Slug).Execute()
-		if err != nil {
-			return nil, err
+		var plugins *gcom.GetInstancePlugins200Response
+		plErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			p, hr, pe := client.InstancesAPI.GetInstancePlugins(ctx, stack.Slug).Execute()
+			plugins = p
+			return hr, pe
+		})
+		if plErr != nil {
+			return nil, plErr
 		}
 		for _, plugin := range plugins.Items {
 			pluginIDs = append(pluginIDs, resourcePluginInstallationID.Make(stack.Slug, plugin.PluginSlug))
@@ -102,20 +115,11 @@ func resourcePluginInstallationCreate(ctx context.Context, d *schema.ResourceDat
 		Version: common.Ref(version),
 	}
 
-	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		_, _, err := client.InstancesAPI.PostInstancePlugins(ctx, stackSlug).
+	err := RetryGCOM(ctx, GCOMRetryConfig{OnTransient: pluginInstallConflictBackoff}, func() (*http.Response, error) {
+		_, hr, e := client.InstancesAPI.PostInstancePlugins(ctx, stackSlug).
 			PostInstancePluginsRequest(req).
 			XRequestId(ClientRequestID()).Execute()
-		if err != nil && strings.Contains(strings.ToLower(err.Error()), "conflict") {
-			// If the API returns a conflict error (409), it means that the plugin installation
-			// is in progress or there's a temporary conflict. Retry after a delay.
-			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
-			return retry.RetryableError(err)
-		}
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-		return nil
+		return hr, e
 	})
 	if err != nil {
 		return apiError(err)
@@ -133,16 +137,29 @@ func resourcePluginInstallationRead(ctx context.Context, d *schema.ResourceData,
 	}
 	stackSlug, pluginSlug := split[0], split[1]
 
-	installation, _, err := client.InstancesAPI.GetInstancePlugin(ctx, stackSlug.(string), pluginSlug.(string)).Execute()
-	if err, shouldReturn := common.CheckReadError("plugin", d, err); shouldReturn {
-		return err
+	var installation *gcom.FormattedApiInstancePlugin
+	if ierr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		in, hr, ie := client.InstancesAPI.GetInstancePlugin(ctx, stackSlug.(string), pluginSlug.(string)).Execute()
+		installation = in
+		return hr, ie
+	}); ierr != nil {
+		if errDiag, shouldReturn := common.CheckReadError("plugin", d, ierr); shouldReturn {
+			return errDiag
+		}
 	}
 	desiredVersion := d.Get("version").(string)
 	catalogVersion := ""
 	if desiredVersion == LatestVersion {
-		catalogPlugin, _, err := client.PluginsAPI.GetPlugin(ctx, pluginSlug.(string)).Execute()
-		if err, shouldReturn := common.CheckReadError("plugin", d, err); shouldReturn {
-			return err
+		var catalogPlugin *gcom.FormattedApiPlugin
+		cerr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			cp, hr, ce := client.PluginsAPI.GetPlugin(ctx, pluginSlug.(string)).Execute()
+			catalogPlugin = cp
+			return hr, ce
+		})
+		if cerr != nil {
+			if errDiag, shouldReturn := common.CheckReadError("plugin", d, cerr); shouldReturn {
+				return errDiag
+			}
 		}
 		catalogVersion = catalogPlugin.Version
 	}
@@ -167,21 +184,12 @@ func resourcePluginInstallationDelete(ctx context.Context, d *schema.ResourceDat
 	}
 	stackSlug, pluginSlug := split[0], split[1]
 
-	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		_, _, err := client.InstancesAPI.DeleteInstancePlugin(ctx, stackSlug.(string), pluginSlug.(string)).XRequestId(ClientRequestID()).Execute()
-		if err != nil && strings.Contains(strings.ToLower(err.Error()), "conflict") {
-			// If the API returns a conflict error (409), it means that the plugin deletion
-			// is in progress or there's a temporary conflict. Retry after a delay.
-			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
-			return retry.RetryableError(err)
-		}
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-		return nil
+	delErr := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true, OnTransient: pluginInstallConflictBackoff}, func() (*http.Response, error) {
+		_, hr, e := client.InstancesAPI.DeleteInstancePlugin(ctx, stackSlug.(string), pluginSlug.(string)).XRequestId(ClientRequestID()).Execute()
+		return hr, e
 	})
-	if err != nil {
-		return apiError(err)
+	if delErr != nil {
+		return apiError(delErr)
 	}
 
 	return nil

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -342,8 +342,16 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 	}
 
 	req := client.InstancesAPI.GetInstance(ctx, stack.Slug)
-	existing, httpResp, getErr := req.Execute()
-	if getErr != nil && httpResp != nil && httpResp.StatusCode != http.StatusNotFound {
+	var existing *gcom.FormattedApiInstance
+	var lastHTTP *http.Response
+	getErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		var hr *http.Response
+		var ge error
+		existing, hr, ge = req.Execute()
+		lastHTTP = hr
+		return hr, ge
+	})
+	if getErr != nil && (lastHTTP == nil || lastHTTP.StatusCode != http.StatusNotFound) {
 		return apiError(getErr)
 	}
 	if existing != nil && existing.Status != "deleted" {
@@ -359,6 +367,10 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 		req := client.StacksAPI.CreateStackV1(ctx).StackCreateRequestV1(stack)
 		createdStack, httpResp, err := req.Execute()
 		switch {
+		case err != nil && httpResp != nil && httpResp.StatusCode == http.StatusTooManyRequests:
+			SleepRetryAfterHeader(ctx, httpResp.Header.Get("Retry-After"))
+			gcomDrainResponse(httpResp)
+			return retry.RetryableError(err)
 		case err != nil && httpResp != nil && httpResp.StatusCode == http.StatusConflict:
 			// 409 Conflict — the slug is unavailable. GCOM returns this for several reasons:
 			//   1. A stack with the same slug is still active (real conflict).
@@ -383,21 +395,28 @@ func createStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 				return retry.RetryableError(err)
 			}
 			// Slug is taken by an existing stack — fail outright instead of possibly adopting via GetInstance below.
-			existing, _, getErr := client.InstancesAPI.GetInstance(ctx, stack.Slug).Execute()
-			if getErr == nil && existing != nil && existing.Status != "deleted" {
+			var existingSlug *gcom.FormattedApiInstance
+			if ierr := RetryGCOM(ctx, GCOMRetryConfig{Timeout: 2 * time.Minute}, func() (*http.Response, error) {
+				es, hr, ge := client.InstancesAPI.GetInstance(ctx, stack.Slug).Execute()
+				existingSlug = es
+				return hr, ge
+			}); ierr == nil && existingSlug != nil && existingSlug.Status != "deleted" {
 				return retry.NonRetryableError(fmt.Errorf(
 					"cannot create Grafana Cloud stack: slug %q is already used by an existing stack (id %v)",
-					stack.Slug, existing.Id,
+					stack.Slug, existingSlug.Id,
 				))
 			}
 			return retry.NonRetryableError(err)
 		case err != nil:
 			// If we had an error that isn't a a conflict error (already exists), try to read the stack
 			// Sometimes, the stack is created but the API returns an error (e.g. 504)
-			readReq := client.InstancesAPI.GetInstance(ctx, stack.Slug)
-			readStack, _, readErr := readReq.Execute()
-			if readErr == nil {
-				d.SetId(strconv.FormatInt(int64(readStack.Id), 10))
+			var readOK *gcom.FormattedApiInstance
+			if ierr := RetryGCOM(ctx, GCOMRetryConfig{Timeout: 2 * time.Minute}, func() (*http.Response, error) {
+				rs, hr, re := client.InstancesAPI.GetInstance(ctx, stack.Slug).Execute()
+				readOK = rs
+				return hr, re
+			}); ierr == nil && readOK != nil {
+				d.SetId(strconv.FormatInt(int64(readOK.Id), 10))
 				return nil
 			}
 			time.Sleep(10 * time.Second) // Do not retry too fast, default is 500ms
@@ -442,14 +461,21 @@ func waitUntilReady(ctx context.Context, stack *gcom.StackV1, timeout time.Durat
 	var lastError error
 	for time.Since(start) < timeout {
 		req := client.StacksAPI.CheckStackReadinessV1(ctx, fmt.Sprintf("%d", stack.Id))
-		response, _, err := req.Execute()
-		if err != nil {
-			lastError = err
+		var stackReady bool
+		errPoll := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			rsp, hr, rerr := req.Execute()
+			if rsp != nil {
+				stackReady = rsp.Ready
+			}
+			return hr, rerr
+		})
+		if errPoll != nil {
+			lastError = errPoll
 			time.Sleep(1 * time.Second)
 			continue
 		}
 		lastError = nil
-		if response.Ready {
+		if stackReady {
 			return nil
 		}
 		time.Sleep(1 * time.Second)
@@ -481,9 +507,12 @@ func updateStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 		DeleteProtection: *gcom.NewNullableBool(common.Ref(d.Get("delete_protection").(bool))),
 	}
 	req := client.StacksAPI.UpdateStackV1(ctx, id.(string)).StackUpdateRequestV1(stack)
-	_, _, err = req.Execute()
-	if err != nil {
-		return apiError(err)
+	updErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, e := req.Execute()
+		return hr, e
+	})
+	if updErr != nil {
+		return apiError(updErr)
 	}
 
 	if diag := readStack(ctx, d, client); diag != nil {
@@ -507,20 +536,29 @@ func deleteStack(ctx context.Context, d *schema.ResourceData, client *gcom.APICl
 	}
 
 	req := client.StacksAPI.DeleteStackV1(ctx, id.(string))
-	_, _, err = req.Execute()
-	return apiError(err)
+	delErr := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		_, hr, e := req.Execute()
+		return hr, e
+	})
+	return apiError(delErr)
 }
 
 func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClient) diag.Diagnostics {
-	id, err := resourceStackID.Single(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
+	id, sidErr := resourceStackID.Single(d.Id())
+	if sidErr != nil {
+		return diag.FromErr(sidErr)
 	}
 
-	req := client.InstancesAPI.GetInstance(ctx, id.(string))
-	stack, _, err := req.Execute()
-	if err, shouldReturn := common.CheckReadError("stack", d, err); shouldReturn {
-		return err
+	var stack *gcom.FormattedApiInstance
+	getInstErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		s, hr, ge := client.InstancesAPI.GetInstance(ctx, id.(string)).Execute()
+		stack = s
+		return hr, ge
+	})
+	if getInstErr != nil {
+		if errDiag, shouldReturn := common.CheckReadError("stack", d, getInstErr); shouldReturn {
+			return errDiag
+		}
 	}
 
 	if stack.Status == "deleted" {
@@ -528,19 +566,19 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	}
 
 	var connections *gcom.FormattedApiInstanceConnections
-	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		resp, httpResp, err := client.InstancesAPI.GetConnections(ctx, id.(string)).Execute()
-		if err != nil {
-			if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-				return retry.RetryableError(err)
-			}
-			return retry.NonRetryableError(err)
+	connErr := RetryGCOM(ctx, GCOMRetryConfig{
+		OnTransient: func(resp *http.Response, err error) bool {
+			return resp != nil && resp.StatusCode == http.StatusNotFound
+		},
+	}, func() (*http.Response, error) {
+		resp, hr, ce := client.InstancesAPI.GetConnections(ctx, id.(string)).Execute()
+		if ce == nil {
+			connections = resp
 		}
-		connections = resp
-		return nil
+		return hr, ce
 	})
-	if err != nil {
-		return apiError(err)
+	if connErr != nil {
+		return apiError(connErr)
 	}
 
 	if err := flattenStack(d, stack, connections); err != nil {
@@ -826,9 +864,14 @@ func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL 
 }
 
 func waitForStackReadinessFromSlug(ctx context.Context, timeout time.Duration, slug string, client *gcom.APIClient) diag.Diagnostics {
-	stack, _, err := client.InstancesAPI.GetInstance(ctx, slug).Execute()
-	if err != nil {
-		return apiError(err)
+	var stack *gcom.FormattedApiInstance
+	stErr := RetryGCOM(ctx, GCOMRetryConfig{Timeout: timeout}, func() (*http.Response, error) {
+		s, hr, se := client.InstancesAPI.GetInstance(ctx, slug).Execute()
+		stack = s
+		return hr, se
+	})
+	if stErr != nil {
+		return apiError(stErr)
 	}
 
 	return waitForStackReadiness(ctx, timeout, stack.Url)

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -92,12 +93,17 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
 		Role:       d.Get("role").(string),
 		IsDisabled: common.Ref(d.Get("is_disabled").(bool)),
 	}
-	resp, _, err := cloudClient.InstancesAPI.PostInstanceServiceAccounts(ctx, stackSlug).
-		PostInstanceServiceAccountsRequest(req).
-		XRequestId(ClientRequestID()).
-		Execute()
-	if err != nil {
-		return diag.FromErr(err)
+	var resp *gcom.GrafanaServiceAccountDTO
+	crErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := cloudClient.InstancesAPI.PostInstanceServiceAccounts(ctx, stackSlug).
+			PostInstanceServiceAccountsRequest(req).
+			XRequestId(ClientRequestID()).
+			Execute()
+		resp = r
+		return hr, ce
+	})
+	if crErr != nil {
+		return diag.FromErr(crErr)
 	}
 
 	d.SetId(resourceStackServiceAccountID.Make(stackSlug, resp.Id))
@@ -122,12 +128,19 @@ func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudC
 		return err
 	}
 
-	resp, httpResp, err := cloudClient.InstancesAPI.GetInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
-	if httpResp != nil && httpResp.StatusCode == 404 {
+	var resp *gcom.GrafanaServiceAccountDTO
+	var lastHTTP *http.Response
+	readErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := cloudClient.InstancesAPI.GetInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
+		resp = r
+		lastHTTP = hr
+		return hr, re
+	})
+	if lastHTTP != nil && lastHTTP.StatusCode == 404 {
 		return common.WarnMissing("stack service account", d)
 	}
-	if err != nil {
-		return diag.FromErr(err)
+	if readErr != nil {
+		return diag.FromErr(readErr)
 	}
 
 	d.Set("stack_slug", stackSlug)
@@ -150,18 +163,25 @@ func deleteStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
 	}
 	stackSlug, serviceAccountID := split[0].(string), split[1].(int64)
 
-	httpResp, err := cloudClient.InstancesAPI.DeleteInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).
-		XRequestId(ClientRequestID()).
-		Execute()
-	if httpResp != nil && httpResp.StatusCode == 404 {
-		return nil
+	delErr := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		hr, e := cloudClient.InstancesAPI.DeleteInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).
+			XRequestId(ClientRequestID()).
+			Execute()
+		return hr, e
+	})
+	if delErr != nil {
+		return diag.FromErr(delErr)
 	}
-	return diag.FromErr(err)
+	return nil
 }
 
 func CreateTemporaryStackGrafanaClient(ctx context.Context, cloudClient *gcom.APIClient, stackSlug, tempSaPrefix string) (*goapi.GrafanaHTTPAPI, func() error, error) {
-	stack, _, err := cloudClient.InstancesAPI.GetInstance(ctx, stackSlug).Execute()
-	if err != nil {
+	var stack *gcom.FormattedApiInstance
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		s, hr, se := cloudClient.InstancesAPI.GetInstance(ctx, stackSlug).Execute()
+		stack = s
+		return hr, se
+	}); err != nil {
 		return nil, nil, err
 	}
 
@@ -172,11 +192,15 @@ func CreateTemporaryStackGrafanaClient(ctx context.Context, cloudClient *gcom.AP
 		Role: "Admin",
 	}
 
-	sa, _, err := cloudClient.InstancesAPI.PostInstanceServiceAccounts(ctx, stackSlug).
-		PostInstanceServiceAccountsRequest(req).
-		XRequestId(ClientRequestID()).
-		Execute()
-	if err != nil {
+	var sa *gcom.GrafanaServiceAccountDTO
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := cloudClient.InstancesAPI.PostInstanceServiceAccounts(ctx, stackSlug).
+			PostInstanceServiceAccountsRequest(req).
+			XRequestId(ClientRequestID()).
+			Execute()
+		sa = r
+		return hr, ce
+	}); err != nil {
 		return nil, nil, err
 	}
 
@@ -184,11 +208,15 @@ func CreateTemporaryStackGrafanaClient(ctx context.Context, cloudClient *gcom.AP
 		Name:          name,
 		SecondsToLive: common.Ref(int32(60)),
 	}
-	token, _, err := cloudClient.InstancesAPI.PostInstanceServiceAccountTokens(ctx, stackSlug, fmt.Sprintf("%d", int(*sa.Id))).
-		PostInstanceServiceAccountTokensRequest(tokenRequest).
-		XRequestId(ClientRequestID()).
-		Execute()
-	if err != nil {
+	var token *gcom.GrafanaNewApiKeyResult
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		tk, hr, te := cloudClient.InstancesAPI.PostInstanceServiceAccountTokens(ctx, stackSlug, fmt.Sprintf("%d", int(*sa.Id))).
+			PostInstanceServiceAccountTokensRequest(tokenRequest).
+			XRequestId(ClientRequestID()).
+			Execute()
+		token = tk
+		return hr, te
+	}); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -82,12 +83,17 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 		SecondsToLive: common.Ref(int32(d.Get("seconds_to_live").(int))), //nolint:gosec
 	}
 
-	resp, _, err := cloudClient.InstancesAPI.PostInstanceServiceAccountTokens(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).
-		PostInstanceServiceAccountTokensRequest(req).
-		XRequestId(ClientRequestID()).
-		Execute()
-	if err != nil {
-		return diag.FromErr(err)
+	var resp *gcom.GrafanaNewApiKeyResult
+	crErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := cloudClient.InstancesAPI.PostInstanceServiceAccountTokens(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).
+			PostInstanceServiceAccountTokensRequest(req).
+			XRequestId(ClientRequestID()).
+			Execute()
+		resp = r
+		return hr, ce
+	})
+	if crErr != nil {
+		return diag.FromErr(crErr)
 	}
 
 	d.SetId(strconv.FormatInt(*resp.Id, 10))
@@ -110,9 +116,14 @@ func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, c
 		return err
 	}
 
-	response, _, err := cloudClient.InstancesAPI.GetInstanceServiceAccountTokens(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
-	if err != nil {
-		return diag.FromErr(err)
+	var response []gcom.GrafanaTokenDTO
+	rdErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := cloudClient.InstancesAPI.GetInstanceServiceAccountTokens(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
+		response = r
+		return hr, re
+	})
+	if rdErr != nil {
+		return diag.FromErr(rdErr)
 	}
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
@@ -154,13 +165,16 @@ func stackServiceAccountTokenDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	httpResp, err := cloudClient.InstancesAPI.DeleteInstanceServiceAccountToken(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10), d.Id()).
-		XRequestId(ClientRequestID()).
-		Execute()
-	if httpResp != nil && httpResp.StatusCode == 404 {
-		return nil
+	delErr := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		hr, de := cloudClient.InstancesAPI.DeleteInstanceServiceAccountToken(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10), d.Id()).
+			XRequestId(ClientRequestID()).
+			Execute()
+		return hr, de
+	})
+	if delErr != nil {
+		return diag.FromErr(delErr)
 	}
-	return diag.FromErr(err)
+	return nil
 }
 
 func getStackServiceAccountID(id string) (int64, error) {

--- a/internal/resources/cloud/resource_private_data_source_connect_network.go
+++ b/internal/resources/cloud/resource_private_data_source_connect_network.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"slices"
 	"time"
 
@@ -104,9 +105,14 @@ Required access policy scopes:
 
 func listPDCNetworkIds(ctx context.Context, client *gcom.APIClient, data *ListerData) ([]string, error) {
 	regionsReq := client.StackRegionsAPI.GetStackRegions(ctx)
-	regionsResp, _, err := regionsReq.Execute()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list regions: %w", err)
+	var regionsResp *gcom.GetStackRegions200Response
+	rgErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		rs, hr, re := regionsReq.Execute()
+		regionsResp = rs
+		return hr, re
+	})
+	if rgErr != nil {
+		return nil, fmt.Errorf("failed to list regions: %w", rgErr)
 	}
 
 	orgID, err := data.OrgID(ctx, client)
@@ -118,9 +124,14 @@ func listPDCNetworkIds(ctx context.Context, client *gcom.APIClient, data *Lister
 	for _, region := range regionsResp.Items {
 		regionSlug := region.FormattedApiStackRegionAnyOf.Slug
 		req := client.AccesspoliciesAPI.GetAccessPolicies(ctx).Region(regionSlug).OrgId(orgID)
-		resp, _, err := req.Execute()
-		if err != nil {
-			return nil, fmt.Errorf("failed to list access policies in region %s: %w", regionSlug, err)
+		var resp *gcom.GetAccessPolicies200Response
+		polErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+			r, hr, pe := req.Execute()
+			resp = r
+			return hr, pe
+		})
+		if polErr != nil {
+			return nil, fmt.Errorf("failed to list access policies in region %s: %w", regionSlug, polErr)
 		}
 
 		for _, policy := range resp.Items {
@@ -149,9 +160,14 @@ func createPDCNetwork(ctx context.Context, d *schema.ResourceData, client *gcom.
 			Scopes:      []string{"set:pdc-signing"},
 			Realms:      []gcom.PostAccessPoliciesRequestRealmsInner{{Type: "stack", Identifier: d.Get("stack_identifier").(string)}},
 		})
-	result, _, err := req.Execute()
-	if err != nil {
-		return apiError(err)
+	var result *gcom.AuthAccessPolicy
+	crErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := req.Execute()
+		result = r
+		return hr, ce
+	})
+	if crErr != nil {
+		return apiError(crErr)
 	}
 
 	d.SetId(resourceAccessPolicyID.Make(region, result.Id))
@@ -176,7 +192,10 @@ func updatePDCNetwork(ctx context.Context, d *schema.ResourceData, client *gcom.
 			DisplayName: &displayName,
 			Realms:      []gcom.PostAccessPoliciesRequestRealmsInner{{Type: "stack", Identifier: d.Get("stack_identifier").(string)}},
 		})
-	if _, _, err = req.Execute(); err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, ue := req.Execute()
+		return hr, ue
+	}); err != nil {
 		return apiError(err)
 	}
 
@@ -190,9 +209,16 @@ func readPDCNetwork(ctx context.Context, d *schema.ResourceData, client *gcom.AP
 	}
 	region, id := split[0], split[1]
 
-	result, _, err := client.AccesspoliciesAPI.GetAccessPolicy(ctx, id.(string)).Region(region.(string)).Execute()
-	if err, shouldReturn := common.CheckReadError("access policy", d, err); shouldReturn {
-		return err
+	var result *gcom.AuthAccessPolicy
+	rdErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := client.AccesspoliciesAPI.GetAccessPolicy(ctx, id.(string)).Region(region.(string)).Execute()
+		result = r
+		return hr, re
+	})
+	if rdErr != nil {
+		if errDiag, shouldReturn := common.CheckReadError("access policy", d, rdErr); shouldReturn {
+			return errDiag
+		}
 	}
 
 	d.Set("region", region)
@@ -215,6 +241,10 @@ func deletePDCNetwork(ctx context.Context, d *schema.ResourceData, client *gcom.
 	}
 	region, id := split[0], split[1]
 
-	_, err = client.AccesspoliciesAPI.DeleteAccessPolicy(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
-	return apiError(err)
+	if err := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		return client.AccesspoliciesAPI.DeleteAccessPolicy(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
+	}); err != nil {
+		return apiError(err)
+	}
+	return nil
 }

--- a/internal/resources/cloud/resource_private_data_source_connect_network_token.go
+++ b/internal/resources/cloud/resource_private_data_source_connect_network_token.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -125,9 +126,14 @@ func createPDCNetworkToken(ctx context.Context, d *schema.ResourceData, client *
 	}
 
 	req := client.TokensAPI.PostTokens(ctx).Region(region).XRequestId(ClientRequestID()).PostTokensRequest(tokenInput)
-	result, _, err := req.Execute()
-	if err != nil {
-		return apiError(err)
+	var result *gcom.AuthTokenWithSecret
+	crErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, ce := req.Execute()
+		result = r
+		return hr, ce
+	})
+	if crErr != nil {
+		return apiError(crErr)
 	}
 
 	d.SetId(pdcNetworkTokenID.Make(region, result.Id))
@@ -151,7 +157,10 @@ func updatePDCNetworkToken(ctx context.Context, d *schema.ResourceData, client *
 	req := client.TokensAPI.PostToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).PostTokenRequest(gcom.PostTokenRequest{
 		DisplayName: &displayName,
 	})
-	if _, _, err := req.Execute(); err != nil {
+	if err := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		_, hr, ue := req.Execute()
+		return hr, ue
+	}); err != nil {
 		return apiError(err)
 	}
 
@@ -165,9 +174,16 @@ func readPDCNetworkToken(ctx context.Context, d *schema.ResourceData, client *gc
 	}
 	region, id := split[0], split[1]
 
-	result, _, err := client.TokensAPI.GetToken(ctx, id.(string)).Region(region.(string)).Execute()
-	if err, shouldReturn := common.CheckReadError("policy token", d, err); shouldReturn {
-		return err
+	var result *gcom.AuthToken
+	rdErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := client.TokensAPI.GetToken(ctx, id.(string)).Region(region.(string)).Execute()
+		result = r
+		return hr, re
+	})
+	if rdErr != nil {
+		if errDiag, shouldReturn := common.CheckReadError("policy token", d, rdErr); shouldReturn {
+			return errDiag
+		}
 	}
 
 	d.Set("pdc_network_id", result.AccessPolicyId)
@@ -193,6 +209,11 @@ func deletePDCNetworkToken(ctx context.Context, d *schema.ResourceData, client *
 	}
 	region, id := split[0], split[1]
 
-	_, _, err = client.TokensAPI.DeleteToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
-	return apiError(err)
+	if err := RetryGCOM(ctx, GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+		_, hr, de := client.TokensAPI.DeleteToken(ctx, id.(string)).Region(region.(string)).XRequestId(ClientRequestID()).Execute()
+		return hr, de
+	}); err != nil {
+		return apiError(err)
+	}
+	return nil
 }

--- a/internal/resources/cloud/resource_synthetic_monitoring_installation.go
+++ b/internal/resources/cloud/resource_synthetic_monitoring_installation.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
@@ -87,10 +88,14 @@ Required access policy scopes:
 }
 
 func resourceInstallationCreate(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {
-	req := cloudClient.InstancesAPI.GetInstance(ctx, d.Get("stack_id").(string))
-	stack, _, err := req.Execute()
-	if err != nil {
-		return apiError(err)
+	var stack *gcom.FormattedApiInstance
+	stErr := RetryGCOM(ctx, GCOMRetryConfig{}, func() (*http.Response, error) {
+		s, hr, se := cloudClient.InstancesAPI.GetInstance(ctx, d.Get("stack_id").(string)).Execute()
+		stack = s
+		return hr, se
+	})
+	if stErr != nil {
+		return apiError(stErr)
 	}
 
 	// TODO: Get this URL programatically

--- a/internal/resources/frontendo11y/data_source_frontend_o11y_app.go
+++ b/internal/resources/frontendo11y/data_source_frontend_o11y_app.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
-	grafcloud "github.com/grafana/terraform-provider-grafana/v4/internal/resources/cloud"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common/frontendo11yapi"
+	grafcloud "github.com/grafana/terraform-provider-grafana/v4/internal/resources/cloud"
 )
 
 type datasourceFrontendO11yApp struct {

--- a/internal/resources/frontendo11y/data_source_frontend_o11y_app.go
+++ b/internal/resources/frontendo11y/data_source_frontend_o11y_app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	grafcloud "github.com/grafana/terraform-provider-grafana/v4/internal/resources/cloud"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common/frontendo11yapi"
 )
@@ -88,16 +89,23 @@ func (r *datasourceFrontendO11yApp) Schema(ctx context.Context, req datasource.S
 
 // getStack gets the stack from the stack id
 func (r *datasourceFrontendO11yApp) getStack(ctx context.Context, stackID string) (*gcom.FormattedApiInstance, error) {
-	stack, res, err := r.gcomClient.InstancesAPI.GetInstance(ctx, stackID).Execute()
+	var stack *gcom.FormattedApiInstance
+	var last *http.Response
+	err := grafcloud.RetryGCOM(ctx, grafcloud.GCOMRetryConfig{}, func() (*http.Response, error) {
+		s, hr, e := r.gcomClient.InstancesAPI.GetInstance(ctx, stackID).Execute()
+		stack = s
+		last = hr
+		return hr, e
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	if res.StatusCode >= 500 {
+	if last != nil && last.StatusCode >= http.StatusInternalServerError {
 		return nil, errors.New("server error")
 	}
 
-	if res.StatusCode == http.StatusNotFound {
+	if last != nil && last.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("stack %q not found", stackID)
 	}
 	return stack, nil

--- a/internal/resources/frontendo11y/resource_frontend_o11y_app.go
+++ b/internal/resources/frontendo11y/resource_frontend_o11y_app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	grafcloud "github.com/grafana/terraform-provider-grafana/v4/internal/resources/cloud"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common/frontendo11yapi"
 )
@@ -133,16 +134,23 @@ func (r *resourceFrontendO11yApp) Schema(ctx context.Context, req resource.Schem
 
 // getStack gets the stack information from the stack id
 func (r *resourceFrontendO11yApp) getStack(ctx context.Context, stackID string) (*gcom.FormattedApiInstance, error) {
-	stack, res, err := r.gcomClient.InstancesAPI.GetInstance(ctx, stackID).Execute()
+	var stack *gcom.FormattedApiInstance
+	var last *http.Response
+	err := grafcloud.RetryGCOM(ctx, grafcloud.GCOMRetryConfig{}, func() (*http.Response, error) {
+		s, hr, e := r.gcomClient.InstancesAPI.GetInstance(ctx, stackID).Execute()
+		stack = s
+		last = hr
+		return hr, e
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	if res.StatusCode >= 500 {
+	if last != nil && last.StatusCode >= http.StatusInternalServerError {
 		return nil, errors.New("server error")
 	}
 
-	if res.StatusCode == http.StatusNotFound {
+	if last != nil && last.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("stack %q not found", stackID)
 	}
 	return stack, nil

--- a/internal/resources/frontendo11y/resource_frontend_o11y_app.go
+++ b/internal/resources/frontendo11y/resource_frontend_o11y_app.go
@@ -21,9 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
-	grafcloud "github.com/grafana/terraform-provider-grafana/v4/internal/resources/cloud"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common/frontendo11yapi"
+	grafcloud "github.com/grafana/terraform-provider-grafana/v4/internal/resources/cloud"
 )
 
 var (

--- a/pkg/generate/cloud.go
+++ b/pkg/generate/cloud.go
@@ -56,7 +56,7 @@ func generateCloudResources(ctx context.Context, cfg *Config) ([]stack, Generati
 	}
 	cloudClient := client.GrafanaCloudAPI
 
-	stacks, _, err := cloudClient.InstancesAPI.GetInstances(ctx).Execute()
+	stacks, err := listCloudInstancesWithRetry(ctx, cloudClient)
 	if err != nil {
 		return nil, failure(err)
 	}
@@ -231,15 +231,20 @@ func createManagementStackServiceAccount(ctx context.Context, cloudClient *gcom.
 	}
 
 	// Delete existing SM installation
-	resp, _, err := cloudClient.AccesspoliciesAPI.GetAccessPolicies(ctx).OrgId(int32(stack.OrgId)).Region(stack.RegionSlug).Execute()
-	if err != nil {
+	var resp *gcom.GetAccessPolicies200Response
+	if err := cloud.RetryGCOM(ctx, cloud.GCOMRetryConfig{}, func() (*http.Response, error) {
+		r, hr, re := cloudClient.AccesspoliciesAPI.GetAccessPolicies(ctx).OrgId(int32(stack.OrgId)).Region(stack.RegionSlug).Execute()
+		resp = r
+		return hr, re
+	}); err != nil {
 		return err
 	}
 	for _, policy := range resp.Items {
 		if policy.Name == smAccessPolicyName(stack) {
 			log.Printf("found existing SM installation (%s) in stack %q\n", smAccessPolicyName(stack), stack.Slug)
-			_, err := cloudClient.AccesspoliciesAPI.DeleteAccessPolicy(ctx, *policy.Id).XRequestId("tf-gen").OrgId(int32(stack.OrgId)).Region(stack.RegionSlug).Execute()
-			if err != nil {
+			if err := cloud.RetryGCOM(ctx, cloud.GCOMRetryConfig{TreatNotFoundAsSuccess: true}, func() (*http.Response, error) {
+				return cloudClient.AccesspoliciesAPI.DeleteAccessPolicy(ctx, *policy.Id).XRequestId("tf-gen").OrgId(int32(stack.OrgId)).Region(stack.RegionSlug).Execute()
+			}); err != nil {
 				return fmt.Errorf("failed to delete existing SM installation (%s) in stack %q: %w", smAccessPolicyName(stack), stack.Slug, err)
 			}
 			break
@@ -270,4 +275,14 @@ func waitForSuccessfulGET(url string, timeout time.Duration) error {
 
 func smAccessPolicyName(stack gcom.FormattedApiInstance) string {
 	return stack.Slug + "-sm-metrics-publish"
+}
+
+func listCloudInstancesWithRetry(ctx context.Context, cloudClient *gcom.APIClient) (*gcom.GetInstances200Response, error) {
+	var stacks *gcom.GetInstances200Response
+	err := cloud.RetryGCOM(ctx, cloud.GCOMRetryConfig{}, func() (*http.Response, error) {
+		s, hr, se := cloudClient.InstancesAPI.GetInstances(ctx).Execute()
+		stacks = s
+		return hr, se
+	})
+	return stacks, err
 }


### PR DESCRIPTION
Closes https://github.com/grafana/grafana-com/issues/18305

This PR:
- [ ] adds retry requests to the grafana.com API in case of non successful responses.
- [ ] adds honouring of the Retry-After header on 429 response from grafana.com API.