### PR TITLE
fix(alerting): invalid plan on creating template with whitespace

### DIFF
--- a/examples/resources/grafana_message_template/_acc_template_heredoc.tf
+++ b/examples/resources/grafana_message_template/_acc_template_heredoc.tf
@@ -1,0 +1,8 @@
+resource "grafana_message_template" "heredoc_template" {
+  name     = "Heredoc Notification Template Group"
+  template = <<-EOT
+{{define "custom.message" }}
+ template content
+{{ end }}
+EOT
+}

--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"context"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-openapi/runtime"
@@ -42,11 +41,11 @@ func resourceMessageTemplate() *common.Resource {
 }
 
 type messageTemplateModel struct {
-	ID                types.String `tfsdk:"id"`
-	OrgID             types.String `tfsdk:"org_id"`
-	Name              types.String `tfsdk:"name"`
-	Template          types.String `tfsdk:"template"`
-	DisableProvenance types.Bool   `tfsdk:"disable_provenance"`
+	ID                types.String  `tfsdk:"id"`
+	OrgID             types.String  `tfsdk:"org_id"`
+	Name              types.String  `tfsdk:"name"`
+	Template          templateValue `tfsdk:"template"`
+	DisableProvenance types.Bool    `tfsdk:"disable_provenance"`
 }
 
 type messageTemplateResource struct {
@@ -94,6 +93,7 @@ This resource requires Grafana 9.1.0 or later.
 			"template": schema.StringAttribute{
 				Required:    true,
 				Description: "The content of the notification template group.",
+				CustomType:  templateType{},
 			},
 			"disable_provenance": schema.BoolAttribute{
 				Optional:    true,
@@ -109,23 +109,29 @@ This resource requires Grafana 9.1.0 or later.
 }
 
 func (r *messageTemplateResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Normalize template to trimmed value so plan matches state when only whitespace differs
-	if req.Plan.Raw.IsNull() {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
 		return
 	}
-	var plan messageTemplateModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	var plan, state messageTemplateModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	if plan.Template.IsNull() || plan.Template.IsUnknown() {
 		return
 	}
-	trimmed := strings.TrimSpace(plan.Template.ValueString())
-	if trimmed != plan.Template.ValueString() {
-		plan.Template = types.StringValue(trimmed)
-		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+
+	// If planned value is semantically equal to the current value, do not update the plan. This is to avoid diffs
+	// due to trailing whitespace, for example from heredoc strings.
+	semEqual, diags := state.Template.StringSemanticEquals(ctx, plan.Template)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	if semEqual {
+		plan.Template = state.Template
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 	}
 }
 
@@ -156,7 +162,7 @@ func (r *messageTemplateResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	name := plan.Name.ValueString()
-	content := strings.TrimSpace(plan.Template.ValueString())
+	content := plan.Template.Normalized()
 	disableProvenance := plan.DisableProvenance.ValueBool()
 
 	var putErr error
@@ -229,7 +235,7 @@ func (r *messageTemplateResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 	name := split[0].(string)
-	content := strings.TrimSpace(plan.Template.ValueString())
+	content := plan.Template.Normalized()
 	disableProvenance := plan.DisableProvenance.ValueBool()
 
 	var putErr error
@@ -326,7 +332,7 @@ func (r *messageTemplateResource) read(ctx context.Context, id string) (*message
 		ID:                types.StringValue(MakeOrgResourceID(orgID, tmpl.Name)),
 		OrgID:             types.StringValue(strconv.FormatInt(orgID, 10)),
 		Name:              types.StringValue(tmpl.Name),
-		Template:          types.StringValue(strings.TrimSpace(tmpl.Template)),
+		Template:          templateValue{StringValue: types.StringValue(tmpl.Template)},
 		DisableProvenance: types.BoolValue(false), // API does not return provenance
 	}, diags
 }

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccMessageTemplate_basic(t *testing.T) {
@@ -73,6 +74,81 @@ EOT`,
 					resource.TestCheckResourceAttr("grafana_message_template.my_template", "name", "A Different Template"),
 					resource.TestCheckResourceAttr("grafana_message_template.my_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}"),
 					alertingMessageTemplateCheckExists.destroyed(&models.NotificationTemplate{Name: "My Notification Template Group"}, nil),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMessageTemplate_heredoc(t *testing.T) {
+	// Intended to prevent regression on whitespace trimming for newly created templates using heredoc.
+	testutils.CheckOSSTestsEnabled(t, ">=9.0.0")
+
+	var tmpl models.NotificationTemplate
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		// Implicitly tests deletion.
+		CheckDestroy: alertingMessageTemplateCheckExists.destroyed(&tmpl, nil),
+		Steps: []resource.TestStep{
+			// Test creation.
+			{
+				Config: testutils.TestAccExample(t, "resources/grafana_message_template/_acc_template_heredoc.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					alertingMessageTemplateCheckExists.exists("grafana_message_template.heredoc_template", &tmpl),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "name", "Heredoc Notification Template Group"),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}\n"),
+					testutils.CheckLister("grafana_message_template.heredoc_template"),
+				),
+			},
+			// Test import.
+			{
+				ResourceName: "grafana_message_template.heredoc_template",
+				ImportState:  true,
+				//ImportStateVerify: true,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					expected := "{{define \"custom.message\" }}\n template content\n{{ end }}"
+					if is[0].Attributes["template"] != expected {
+						return fmt.Errorf("expected template to be %q, got %q", expected, is[0].Attributes["template"])
+					}
+					return nil
+				},
+				ImportStateVerifyIgnore: []string{"disable_provenance"},
+			},
+			// Test update without heredoc template doesn't change
+			{
+				Config: `
+resource "grafana_message_template" "heredoc_template" {
+  name     = "Heredoc Notification Template Group"
+  template = "{{define \"custom.message\" }}\n template content\n{{ end }}"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					alertingMessageTemplateCheckExists.exists("grafana_message_template.heredoc_template", &tmpl),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "name", "Heredoc Notification Template Group"),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}\n"),
+				),
+			},
+			// Test update content.
+			{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/_acc_template_heredoc.tf", map[string]string{
+					"template content": "different content",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					alertingMessageTemplateCheckExists.exists("grafana_message_template.heredoc_template", &tmpl),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "name", "Heredoc Notification Template Group"),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "template", "{{define \"custom.message\" }}\n different content\n{{ end }}\n"),
+				),
+			},
+			// Test rename.
+			{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_message_template/_acc_template_heredoc.tf", map[string]string{
+					"Heredoc Notification Template Group": "A Different Template",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					alertingMessageTemplateCheckExists.exists("grafana_message_template.heredoc_template", &tmpl),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "name", "A Different Template"),
+					resource.TestCheckResourceAttr("grafana_message_template.heredoc_template", "template", "{{define \"custom.message\" }}\n template content\n{{ end }}\n"),
+					alertingMessageTemplateCheckExists.destroyed(&models.NotificationTemplate{Name: "Heredoc Notification Template Group"}, nil),
 				),
 			},
 		},

--- a/internal/resources/grafana/resource_alerting_message_template_type.go
+++ b/internal/resources/grafana/resource_alerting_message_template_type.go
@@ -1,0 +1,58 @@
+package grafana
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ basetypes.StringTypable = templateType{}
+
+type templateType struct {
+	basetypes.StringType
+}
+
+func (t templateType) Equal(o attr.Type) bool {
+	other, ok := o.(templateType)
+	if !ok {
+		return false
+	}
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t templateType) String() string {
+	return "templateType"
+}
+
+func (t templateType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return templateValue{
+		StringValue: in,
+	}, nil
+}
+
+func (t templateType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t templateType) ValueType(context.Context) attr.Value {
+	return templateValue{}
+}

--- a/internal/resources/grafana/resource_alerting_message_template_value.go
+++ b/internal/resources/grafana/resource_alerting_message_template_value.go
@@ -1,0 +1,47 @@
+package grafana
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var _ basetypes.StringValuableWithSemanticEquals = templateValue{}
+
+type templateValue struct {
+	basetypes.StringValue
+}
+
+func (v templateValue) Normalized() string {
+	return strings.TrimSpace(v.StringValue.ValueString())
+}
+
+func (v templateValue) Equal(o attr.Value) bool {
+	other, ok := o.(templateValue)
+	if !ok {
+		return false
+	}
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v templateValue) Type(context.Context) attr.Type {
+	return templateType{}
+}
+
+func (v templateValue) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	other, ok := newValuable.(templateValue)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"unexpected value type for template semantic equality",
+		)
+		return false, diags
+	}
+
+	return v.Normalized() == other.Normalized(), diags
+}


### PR DESCRIPTION
Fixes bug introduced in https://github.com/grafana/terraform-provider-grafana/pull/2567 where templates with leading/trailing whitespace (e.g. from heredoc) would work fine assuming an existing state (during `update`), but would cause `Provider produced invalid plan` on initial create.

Ex:

```
resource "grafana_message_template" "heredoc_template" {
  name     = "Heredoc Notification Template Group"
  template = <<-EOT
{{define "custom.message" }}
 template content
{{ end }}
EOT
}
```

This was due to `ModifyPlan` breaking [data consistency](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md#planresourcechange) guarantees when trimming whitespace. Plan values for a configured attribute must be equal to the prior state or the config value.

Since we normalize the templates before sending them to the API, we need to create a custom type to define a semantic equals that ignores leading/trailing whitespace.