### PR TITLE
fix(cloud): implement more robust retries on service account and service account tokens in cloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/terraform-provider-grafana/v4
 
-go 1.25.9
+go 1.26.2
 
 require (
 	connectrpc.com/connect v1.18.1
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/fleet-management-api v1.2.0
 	github.com/grafana/grafana-app-sdk v0.53.1
 	github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996
-	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260408092732-49b2323fa034
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512212227-f9f669d0ae9c
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae
 	github.com/grafana/grafana/apps/alerting/alertenrichment v0.0.0-20250925121631-89b988ca553e
 	github.com/grafana/grafana/apps/alerting/rules v0.0.0-20260414202405-94b5db3554f5

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/fleet-management-api v1.2.0
 	github.com/grafana/grafana-app-sdk v0.53.1
 	github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996
-	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512214027-9cad79d70382
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512220510-3e89a34e07c0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae
 	github.com/grafana/grafana/apps/alerting/alertenrichment v0.0.0-20250925121631-89b988ca553e
 	github.com/grafana/grafana/apps/alerting/rules v0.0.0-20260414202405-94b5db3554f5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/terraform-provider-grafana/v4
 
-go 1.26.2
+go 1.25.9
 
 require (
 	connectrpc.com/connect v1.18.1
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/fleet-management-api v1.2.0
 	github.com/grafana/grafana-app-sdk v0.53.1
 	github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996
-	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512212227-f9f669d0ae9c
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512214027-9cad79d70382
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae
 	github.com/grafana/grafana/apps/alerting/alertenrichment v0.0.0-20250925121631-89b988ca553e
 	github.com/grafana/grafana/apps/alerting/rules v0.0.0-20260414202405-94b5db3554f5

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/grafana/grafana-app-sdk/logging v0.53.0 h1:o1ag3oZ6JbQfXUSvOLLUQ4Zzjw
 github.com/grafana/grafana-app-sdk/logging v0.53.0/go.mod h1:nC9fLZHZPZFSbGF135ucVbOkMymBB23grTK6uKiNyJo=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996 h1:AnLo+NlmGY4lJaZvH4Mzb8eng9byn/hbl1WuMthY9QQ=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996/go.mod h1:piOOzeZUPg0tP4sfe1y+MFp5+jGVPri4WOVV4oSJS30=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512212227-f9f669d0ae9c h1:uBJBO/LiGURmwN8FVVHSH6F9tlpNBYaAxb8XHf5h8XM=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512212227-f9f669d0ae9c/go.mod h1:zJerpejlLo96lF3wm20BJpSrbOHQokkmultRPyF5sVM=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512214027-9cad79d70382 h1:x28CFNxM9g5INQqr5vjd8bDM3xB+Sfy6CgNoRntSisU=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512214027-9cad79d70382/go.mod h1:YYeJ0TjGirwpZ92J1Krbogvir9uwfPH9bPFw2qaPnew=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae h1:ExiJ4Ha24+MRuKxymlGp5bAJwbUSHe+QXcf6E8pwlo0=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae/go.mod h1:4WkWL9W7QMnRgRA1XrrSbZRg/UIoTx4x5ynx5RjJldU=
 github.com/grafana/grafana-plugin-sdk-go v0.291.0 h1:VlA6wYdjMxx7xpthEd0qZgbtfqlRWRZJ3CqnMNks0+U=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/grafana/grafana-app-sdk/logging v0.53.0 h1:o1ag3oZ6JbQfXUSvOLLUQ4Zzjw
 github.com/grafana/grafana-app-sdk/logging v0.53.0/go.mod h1:nC9fLZHZPZFSbGF135ucVbOkMymBB23grTK6uKiNyJo=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996 h1:AnLo+NlmGY4lJaZvH4Mzb8eng9byn/hbl1WuMthY9QQ=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996/go.mod h1:piOOzeZUPg0tP4sfe1y+MFp5+jGVPri4WOVV4oSJS30=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512214027-9cad79d70382 h1:x28CFNxM9g5INQqr5vjd8bDM3xB+Sfy6CgNoRntSisU=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512214027-9cad79d70382/go.mod h1:YYeJ0TjGirwpZ92J1Krbogvir9uwfPH9bPFw2qaPnew=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512220510-3e89a34e07c0 h1:W7YowuNGC5oKn+GHnL12TLeuMgvdFxqE3eLXNU1O8zY=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512220510-3e89a34e07c0/go.mod h1:jhmXuuq03N0w+kuoKznC65TwErMhvk6drPUNdnOKl34=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae h1:ExiJ4Ha24+MRuKxymlGp5bAJwbUSHe+QXcf6E8pwlo0=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae/go.mod h1:4WkWL9W7QMnRgRA1XrrSbZRg/UIoTx4x5ynx5RjJldU=
 github.com/grafana/grafana-plugin-sdk-go v0.291.0 h1:VlA6wYdjMxx7xpthEd0qZgbtfqlRWRZJ3CqnMNks0+U=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/grafana/grafana-app-sdk/logging v0.53.0 h1:o1ag3oZ6JbQfXUSvOLLUQ4Zzjw
 github.com/grafana/grafana-app-sdk/logging v0.53.0/go.mod h1:nC9fLZHZPZFSbGF135ucVbOkMymBB23grTK6uKiNyJo=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996 h1:AnLo+NlmGY4lJaZvH4Mzb8eng9byn/hbl1WuMthY9QQ=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996/go.mod h1:piOOzeZUPg0tP4sfe1y+MFp5+jGVPri4WOVV4oSJS30=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260408092732-49b2323fa034 h1:ZLtSNSQ4+VvFhF7AVSX/hZfy2NF09aRc+0S+a42R9G8=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260408092732-49b2323fa034/go.mod h1:M4Y79J2TYgmcNwvVKVlHrGM9nWfSmfzJNhUHrwGJe2M=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512212227-f9f669d0ae9c h1:uBJBO/LiGURmwN8FVVHSH6F9tlpNBYaAxb8XHf5h8XM=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260512212227-f9f669d0ae9c/go.mod h1:zJerpejlLo96lF3wm20BJpSrbOHQokkmultRPyF5sVM=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae h1:ExiJ4Ha24+MRuKxymlGp5bAJwbUSHe+QXcf6E8pwlo0=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae/go.mod h1:4WkWL9W7QMnRgRA1XrrSbZRg/UIoTx4x5ynx5RjJldU=
 github.com/grafana/grafana-plugin-sdk-go v0.291.0 h1:VlA6wYdjMxx7xpthEd0qZgbtfqlRWRZJ3CqnMNks0+U=

--- a/internal/resources/cloud/instance_service_account_search.go
+++ b/internal/resources/cloud/instance_service_account_search.go
@@ -43,7 +43,9 @@ func findStackServiceAccountByExactName(ctx context.Context, cloudClient *gcom.A
 func searchStackInstanceServiceAccountsPage(ctx context.Context, cloudClient *gcom.APIClient, stackSlug, query string, page int64) (*models.SearchOrgServiceAccountsResult, error) {
 	gResp, httpResp, err := cloudClient.InstancesAPI.GetInstanceServiceAccountsSearch(ctx, stackSlug).
 		Query(query).
+		// nolint: gosec
 		Page(int32(page)).
+		// nolint: gosec
 		Perpage(int32(searchServiceAccountsPerPage)).
 		Execute()
 	if err != nil {

--- a/internal/resources/cloud/instance_service_account_search.go
+++ b/internal/resources/cloud/instance_service_account_search.go
@@ -1,0 +1,104 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	"github.com/grafana/grafana-openapi-client-go/models"
+)
+
+const searchServiceAccountsPerPage = int64(200)
+
+// findStackServiceAccountByExactName returns a service account on the stack whose display name equals name.
+// It uses the Grafana instance search API via the Cloud API proxy. Returns (nil, nil) when not found.
+func findStackServiceAccountByExactName(ctx context.Context, cloudClient *gcom.APIClient, stackSlug, name string) (*models.ServiceAccountDTO, error) {
+	var page int64 = 1
+	for {
+		result, err := searchStackInstanceServiceAccountsPage(ctx, cloudClient, stackSlug, name, page)
+		if err != nil {
+			return nil, err
+		}
+		for _, sa := range result.ServiceAccounts {
+			if sa != nil && sa.Name == name {
+				return sa, nil
+			}
+		}
+		perPage := result.PerPage
+		if perPage == 0 {
+			perPage = int64(len(result.ServiceAccounts))
+		}
+		if perPage == 0 {
+			break
+		}
+		if page*perPage >= result.TotalCount || int64(len(result.ServiceAccounts)) == 0 {
+			break
+		}
+		page++
+	}
+	return nil, nil
+}
+
+func searchStackInstanceServiceAccountsPage(ctx context.Context, cloudClient *gcom.APIClient, stackSlug, query string, page int64) (*models.SearchOrgServiceAccountsResult, error) {
+	cfg := cloudClient.GetConfig()
+	basePath, err := cfg.ServerURLWithContext(ctx, "InstancesAPIService.PostInstanceServiceAccounts")
+	if err != nil {
+		return nil, err
+	}
+
+	path, err := url.JoinPath(basePath, "instances", stackSlug, "api", "serviceaccounts", "search")
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	q.Set("query", query)
+	q.Set("page", strconv.FormatInt(page, 10))
+	q.Set("perpage", strconv.FormatInt(searchServiceAccountsPerPage, 10))
+
+	u := &url.URL{
+		Scheme:   cfg.Scheme,
+		Host:     cfg.Host,
+		Path:     path,
+		RawQuery: q.Encode(),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	for k, v := range cfg.DefaultHeader {
+		req.Header.Add(k, v)
+	}
+	if cfg.UserAgent != "" {
+		req.Header.Add("User-Agent", cfg.UserAgent)
+	}
+
+	httpResp, err := cfg.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("searching instance service accounts for stack %q: HTTP %d: %s", stackSlug, httpResp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out models.SearchOrgServiceAccountsResult
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode search service accounts response: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/resources/cloud/instance_service_account_search.go
+++ b/internal/resources/cloud/instance_service_account_search.go
@@ -2,13 +2,8 @@ package cloud
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -46,59 +41,31 @@ func findStackServiceAccountByExactName(ctx context.Context, cloudClient *gcom.A
 }
 
 func searchStackInstanceServiceAccountsPage(ctx context.Context, cloudClient *gcom.APIClient, stackSlug, query string, page int64) (*models.SearchOrgServiceAccountsResult, error) {
-	cfg := cloudClient.GetConfig()
-	basePath, err := cfg.ServerURLWithContext(ctx, "InstancesAPIService.PostInstanceServiceAccounts")
+	gResp, httpResp, err := cloudClient.InstancesAPI.GetInstanceServiceAccountsSearch(ctx, stackSlug).
+		Query(query).
+		Page(int32(page)).
+		Perpage(int32(searchServiceAccountsPerPage)).
+		Execute()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("search instance service accounts for stack %q: %w", stackSlug, err)
+	}
+	if httpResp != nil && httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("searching instance service accounts for stack %q: unexpected HTTP %d", stackSlug, httpResp.StatusCode)
+	}
+	if gResp == nil {
+		return nil, fmt.Errorf("search instance service accounts for stack %q: empty response", stackSlug)
 	}
 
-	path, err := url.JoinPath(basePath, "instances", stackSlug, "api", "serviceaccounts", "search")
-	if err != nil {
-		return nil, err
+	out := &models.SearchOrgServiceAccountsResult{
+		TotalCount: int64(gResp.GetTotalCount()),
+		Page:       int64(gResp.GetPage()),
+		PerPage:    int64(gResp.GetPerPage()),
 	}
-
-	q := url.Values{}
-	q.Set("query", query)
-	q.Set("page", strconv.FormatInt(page, 10))
-	q.Set("perpage", strconv.FormatInt(searchServiceAccountsPerPage, 10))
-
-	u := &url.URL{
-		Scheme:   cfg.Scheme,
-		Host:     cfg.Host,
-		Path:     path,
-		RawQuery: q.Encode(),
+	for _, inner := range gResp.GetServiceAccounts() {
+		out.ServiceAccounts = append(out.ServiceAccounts, &models.ServiceAccountDTO{
+			ID:   int64(inner.GetId()),
+			Name: inner.GetName(),
+		})
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	for k, v := range cfg.DefaultHeader {
-		req.Header.Add(k, v)
-	}
-	if cfg.UserAgent != "" {
-		req.Header.Add("User-Agent", cfg.UserAgent)
-	}
-
-	httpResp, err := cfg.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("searching instance service accounts for stack %q: HTTP %d: %s", stackSlug, httpResp.StatusCode, strings.TrimSpace(string(body)))
-	}
-
-	var out models.SearchOrgServiceAccountsResult
-	if err := json.Unmarshal(body, &out); err != nil {
-		return nil, fmt.Errorf("decode search service accounts response: %w", err)
-	}
-	return &out, nil
+	return out, nil
 }

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -104,6 +104,7 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
 	}
 
 	var resp *gcom.GrafanaServiceAccountDTO
+	var sawPrior5xxOrNetwork bool
 	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		var httpResp *http.Response
 		var callErr error
@@ -114,7 +115,11 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
 		if callErr == nil {
 			return nil
 		}
-		if postInstanceStackServiceAccountWriteShouldRetry(httpResp) {
+		if !shouldRetryServiceAccountOperation(httpResp, callErr) {
+			return retry.NonRetryableError(callErr)
+		}
+
+		if shouldAdoptResource(sawPrior5xxOrNetwork, httpResp) {
 			if adopted, adoptErr := findStackServiceAccountByExactName(ctx, cloudClient, stackSlug, name); adoptErr != nil {
 				return retry.NonRetryableError(adoptErr)
 			} else if adopted != nil {
@@ -125,21 +130,25 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
 					if httpResp != nil {
 						code = httpResp.StatusCode
 					}
-					log.Printf("[WARN] PostInstanceServiceAccounts failed for stack %q (HTTP %d); found existing service account %q (id %d) before retry but read failed: %v",
+					log.Printf("[WARN] PostInstanceServiceAccounts failed for stack %q (HTTP %d); adopt-after-400: read existing service account %q (id %d) failed: %v",
 						stackSlug, code, name, adopted.ID, getErr)
 					return retry.RetryableError(getErr)
 				}
 				return nil
 			}
-			code := 0
-			if httpResp != nil {
-				code = httpResp.StatusCode
-			}
-			log.Printf("[WARN] PostInstanceServiceAccounts failed for stack %q (HTTP %d), retrying: %v", stackSlug, code, callErr)
-			time.Sleep(5 * time.Second)
-			return retry.RetryableError(callErr)
 		}
-		return retry.NonRetryableError(callErr)
+
+		if is5xxOrNetworkError(httpResp, callErr) {
+			sawPrior5xxOrNetwork = true
+		}
+
+		code := 0
+		if httpResp != nil {
+			code = httpResp.StatusCode
+		}
+		log.Printf("[WARN] PostInstanceServiceAccounts failed for stack %q (HTTP %d), retrying: %v", stackSlug, code, callErr)
+		time.Sleep(5 * time.Second)
+		return retry.RetryableError(callErr)
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -3,6 +3,8 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -11,6 +13,7 @@ import (
 	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -87,15 +90,57 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
 	}
 
 	stackSlug := d.Get("stack_slug").(string)
+	name := d.Get("name").(string)
+	if existing, err := findStackServiceAccountByExactName(ctx, cloudClient, stackSlug, name); err != nil {
+		return diag.FromErr(err)
+	} else if existing != nil {
+		return diag.Errorf("a stack service account named %q already exists in stack %q (id %d)", name, stackSlug, existing.ID)
+	}
+
 	req := gcom.PostInstanceServiceAccountsRequest{
-		Name:       d.Get("name").(string),
+		Name:       name,
 		Role:       d.Get("role").(string),
 		IsDisabled: common.Ref(d.Get("is_disabled").(bool)),
 	}
-	resp, _, err := cloudClient.InstancesAPI.PostInstanceServiceAccounts(ctx, stackSlug).
-		PostInstanceServiceAccountsRequest(req).
-		XRequestId(ClientRequestID()).
-		Execute()
+
+	var resp *gcom.GrafanaServiceAccountDTO
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		var httpResp *http.Response
+		var callErr error
+		resp, httpResp, callErr = cloudClient.InstancesAPI.PostInstanceServiceAccounts(ctx, stackSlug).
+			PostInstanceServiceAccountsRequest(req).
+			XRequestId(ClientRequestID()).
+			Execute()
+		if callErr == nil {
+			return nil
+		}
+		if postInstanceStackServiceAccountWriteShouldRetry(httpResp) {
+			if adopted, adoptErr := findStackServiceAccountByExactName(ctx, cloudClient, stackSlug, name); adoptErr != nil {
+				return retry.NonRetryableError(adoptErr)
+			} else if adopted != nil {
+				var getErr error
+				resp, _, getErr = cloudClient.InstancesAPI.GetInstanceServiceAccount(ctx, stackSlug, strconv.FormatInt(adopted.ID, 10)).Execute()
+				if getErr != nil {
+					code := 0
+					if httpResp != nil {
+						code = httpResp.StatusCode
+					}
+					log.Printf("[WARN] PostInstanceServiceAccounts failed for stack %q (HTTP %d); found existing service account %q (id %d) before retry but read failed: %v",
+						stackSlug, code, name, adopted.ID, getErr)
+					return retry.RetryableError(getErr)
+				}
+				return nil
+			}
+			code := 0
+			if httpResp != nil {
+				code = httpResp.StatusCode
+			}
+			log.Printf("[WARN] PostInstanceServiceAccounts failed for stack %q (HTTP %d), retrying: %v", stackSlug, code, callErr)
+			time.Sleep(5 * time.Second)
+			return retry.RetryableError(callErr)
+		}
+		return retry.NonRetryableError(callErr)
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -93,6 +93,7 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 
 	var resp *gcom.GrafanaNewApiKeyResult
 	var adoptedWithoutKey bool
+	var sawPrior5xxOrNetwork bool
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		var httpResp *http.Response
 		var callErr error
@@ -103,7 +104,11 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 		if callErr == nil {
 			return nil
 		}
-		if postInstanceStackServiceAccountWriteShouldRetry(httpResp) {
+		if !shouldRetryServiceAccountOperation(httpResp, callErr) {
+			return retry.NonRetryableError(callErr)
+		}
+
+		if shouldAdoptResource(sawPrior5xxOrNetwork, httpResp) {
 			if adopted, adoptErr := findStackServiceAccountTokenByName(ctx, cloudClient, stackSlug, serviceAccountID, name); adoptErr != nil {
 				return retry.NonRetryableError(adoptErr)
 			} else if adopted != nil {
@@ -113,16 +118,20 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 				resp.SetKey("")
 				return nil
 			}
-			code := 0
-			if httpResp != nil {
-				code = httpResp.StatusCode
-			}
-			log.Printf("[WARN] PostInstanceServiceAccountTokens failed for stack %q service account %d (HTTP %d), retrying: %v", stackSlug, serviceAccountID, code, callErr)
-			// Do not retry too fast; default backoff is aggressive for rate limits and flaky stack APIs.
-			time.Sleep(5 * time.Second)
-			return retry.RetryableError(callErr)
 		}
-		return retry.NonRetryableError(callErr)
+
+		if is5xxOrNetworkError(httpResp, callErr) {
+			sawPrior5xxOrNetwork = true
+		}
+
+		code := 0
+		if httpResp != nil {
+			code = httpResp.StatusCode
+		}
+		log.Printf("[WARN] PostInstanceServiceAccountTokens failed for stack %q service account %d (HTTP %d), retrying: %v", stackSlug, serviceAccountID, code, callErr)
+		// Do not retry too fast; default backoff is aggressive for rate limits and flaky stack APIs.
+		time.Sleep(5 * time.Second)
+		return retry.RetryableError(callErr)
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -80,12 +80,19 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
+	if existing, err := findStackServiceAccountTokenByName(ctx, cloudClient, stackSlug, serviceAccountID, name); err != nil {
+		return diag.FromErr(err)
+	} else if existing != nil {
+		return diag.Errorf("a stack service account token named %q already exists for service account %d in stack %q (id %d)", name, serviceAccountID, stackSlug, existing.GetId())
+	}
+
 	req := gcom.PostInstanceServiceAccountTokensRequest{
 		Name:          name,
 		SecondsToLive: common.Ref(int32(d.Get("seconds_to_live").(int))), //nolint:gosec
 	}
 
 	var resp *gcom.GrafanaNewApiKeyResult
+	var adoptedWithoutKey bool
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		var httpResp *http.Response
 		var callErr error
@@ -96,7 +103,16 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 		if callErr == nil {
 			return nil
 		}
-		if postInstanceServiceAccountTokensShouldRetry(httpResp, serviceAccountID) {
+		if postInstanceStackServiceAccountWriteShouldRetry(httpResp) {
+			if adopted, adoptErr := findStackServiceAccountTokenByName(ctx, cloudClient, stackSlug, serviceAccountID, name); adoptErr != nil {
+				return retry.NonRetryableError(adoptErr)
+			} else if adopted != nil {
+				adoptedWithoutKey = true
+				resp = gcom.NewGrafanaNewApiKeyResult()
+				resp.SetId(adopted.GetId())
+				resp.SetKey("")
+				return nil
+			}
 			code := 0
 			if httpResp != nil {
 				code = httpResp.StatusCode
@@ -112,33 +128,42 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	d.SetId(strconv.FormatInt(*resp.Id, 10))
-	err = d.Set("key", resp.Key)
+	var diags diag.Diagnostics
+	if adoptedWithoutKey {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Could not recover service account token secret after create error",
+			Detail: "The token named \"" + name + "\" was found on the stack (likely created before a failed API response). " +
+				"The secret key is only returned once on create; it is not available from the Cloud API afterward. " +
+				"Use terraform taint or rotate the token if you need a new key in Terraform state.",
+		})
+	}
+
+	d.SetId(strconv.FormatInt(resp.GetId(), 10))
+	err = d.Set("key", resp.GetKey())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	return nil
+	return diags
 }
 
-// postInstanceServiceAccountTokensShouldRetry reports HTTP responses where creating a stack service
-// account token may succeed after a backoff (rate limits, transient server errors, or timing on
-// the instance after the service account was created — the latter surfaces as 400 for non-default SAs).
-func postInstanceServiceAccountTokensShouldRetry(httpResp *http.Response, serviceAccountID int64) bool {
-	if httpResp == nil {
-		return false
+// findStackServiceAccountTokenByName returns a token on the service account whose name equals name, or (nil, nil) if none match.
+func findStackServiceAccountTokenByName(ctx context.Context, cloudClient *gcom.APIClient, stackSlug string, serviceAccountID int64, name string) (*gcom.GrafanaTokenDTO, error) {
+	tokens, _, err := cloudClient.InstancesAPI.GetInstanceServiceAccountTokens(ctx, stackSlug, strconv.FormatInt(serviceAccountID, 10)).Execute()
+	if err != nil {
+		return nil, err
 	}
-	switch code := httpResp.StatusCode; {
-	case code == http.StatusTooManyRequests:
-		return true
-	case code >= http.StatusInternalServerError:
-		return true
-	// 400 are retried because there is a race-condition
-	case code == http.StatusBadRequest && serviceAccountID != 0:
-		return true
-	default:
-		return false
+	for i := range tokens {
+		t := &tokens[i]
+		if !t.HasName() {
+			continue
+		}
+		if t.GetName() == name {
+			return t, nil
+		}
 	}
+	return nil, nil
 }
 
 func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, cloudClient *gcom.APIClient) diag.Diagnostics {

--- a/internal/resources/cloud/stack_instance_service_account_write_retry.go
+++ b/internal/resources/cloud/stack_instance_service_account_write_retry.go
@@ -1,0 +1,22 @@
+package cloud
+
+import "net/http"
+
+// postInstanceStackServiceAccountWriteShouldRetry reports whether a failed Grafana Cloud instance
+// API POST (service account or token creation) should be retried: rate limits, transient server
+// errors, and 400 responses that may clear after stack provisioning or due to races on the instance.
+func postInstanceStackServiceAccountWriteShouldRetry(httpResp *http.Response) bool {
+	if httpResp == nil {
+		return false
+	}
+	switch code := httpResp.StatusCode; {
+	case code == http.StatusTooManyRequests:
+		return true
+	case code >= http.StatusInternalServerError:
+		return true
+	case code == http.StatusBadRequest:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/resources/cloud/stack_instance_service_account_write_retry.go
+++ b/internal/resources/cloud/stack_instance_service_account_write_retry.go
@@ -2,10 +2,13 @@ package cloud
 
 import "net/http"
 
-// postInstanceStackServiceAccountWriteShouldRetry reports whether a failed Grafana Cloud instance
-// API POST (service account or token creation) should be retried: rate limits, transient server
-// errors, and 400 responses that may clear after stack provisioning or due to races on the instance.
-func postInstanceStackServiceAccountWriteShouldRetry(httpResp *http.Response) bool {
+// shouldRetryServiceAccountOperation reports whether a failed Grafana Cloud instance
+// API POST (service account or token creation) should be retried: transport errors, rate limits,
+// transient server errors, and 400 responses that may clear after stack provisioning or races.
+func shouldRetryServiceAccountOperation(httpResp *http.Response, err error) bool {
+	if err != nil && httpResp == nil {
+		return true
+	}
 	if httpResp == nil {
 		return false
 	}
@@ -19,4 +22,23 @@ func postInstanceStackServiceAccountWriteShouldRetry(httpResp *http.Response) bo
 	default:
 		return false
 	}
+}
+
+// is5xxOrNetworkError reports whether a failed POST had no HTTP
+// response with a non-nil error (typically transport) or a 5xx status.
+func is5xxOrNetworkError(httpResp *http.Response, err error) bool {
+	if err != nil && httpResp == nil {
+		return true
+	}
+	if httpResp != nil && httpResp.StatusCode >= http.StatusInternalServerError {
+		return true
+	}
+	return false
+}
+
+// shouldAdoptResource is true when an earlier attempt failed with
+// a 5xx or network error and the current failure is HTTP 400 — a pattern that can mean the create
+// succeeded server-side but the client did not receive the success response.
+func shouldAdoptResource(sawPrior5xxOrNetwork bool, httpResp *http.Response) bool {
+	return sawPrior5xxOrNetwork && httpResp != nil && httpResp.StatusCode == http.StatusBadRequest
 }


### PR DESCRIPTION
This PR enhances the robustness of the cloud stack service account and service account tokens.

## The problem

Currently, we have some spurious errors where a 503 is returned by the API but the token is still created. When this happens, the previous logic gets in a loop that is unable to leave.

## What changes

- Instead of attempting to blindly create the service account / service account token, we will search for it to see if it exists. If it does, we fail fast
- In the happy path nothing different happens, except that we check the existence of the service account / service account token in advance
- When we try to create, if there is a 5xx or an error, we will then find the account token from the stack's if it exists, we will consider that we created it and adopt it.

## Tests performed


### On error or 5xx, if it exists, it is adopted

Besides the acceptance tests, I added:
```
diff --git a/internal/resources/cloud/resource_cloud_stack_service_account.go b/internal/resources/cloud/resource_cloud_stack_service_account.go
index d9ef5117..136130c7 100644
--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -112,6 +112,11 @@ func createStackServiceAccount(ctx context.Context, d *schema.ResourceData, clou
                        PostInstanceServiceAccountsRequest(req).
                        XRequestId(ClientRequestID()).
                        Execute()
+               if !sawPrior5xxOrNetwork && callErr == nil {
+                       callErr = fmt.Errorf("service account creation failed manually forced")
+                       httpResp = nil
+                       resp = nil
+               }
                if callErr == nil {
                        return nil
                }
diff --git a/internal/resources/cloud/resource_cloud_stack_service_account_token.go b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
index cd41328d..99f64844 100644
--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -101,6 +101,11 @@ func stackServiceAccountTokenCreateHelper(ctx context.Context, d *schema.Resourc
                        PostInstanceServiceAccountTokensRequest(req).
                        XRequestId(ClientRequestID()).
                        Execute()
+               if !sawPrior5xxOrNetwork && callErr == nil {
+                       callErr = fmt.Errorf("service account token creation failed manually forced")
+                       httpResp = nil
+                       resp = nil
+               }
                if callErr == nil {
                        return nil
                }
```

to a local build to verify whether this happens if I forced the error. It correctly recognized the service account and continued.

### Does not adopt existing ones

Created a different SA in grafana directly and relaunched this. It fail fast saying it exists already.

### After removing it from grafana, success now to add it

Because it had been now removed from grafana, upon retry, it worked.