### PR TITLE
[docs(grafana_data_source_permission_item)]: make the expected team id data type clear

### DIFF
--- a/docs/resources/data_source_permission_item.md
+++ b/docs/resources/data_source_permission_item.md
@@ -82,7 +82,7 @@ resource "grafana_data_source_permission_item" "service_account" {
 - `datasource_type` (String) The plugin type of the datasource (e.g. "prometheus"). If set, skips the lookup of the datasource type from the API.
 - `org_id` (String) The Organization ID. If not set, the default organization is used for basic authentication, or the one that owns your service account for token authentication.
 - `role` (String) the role onto which the permission is to be assigned
-- `team` (String) the team onto which the permission is to be assigned
+- `team` (String) the team onto which the permission is to be assigned. This has to be the integer ID.
 - `user` (String) the user or service account onto which the permission is to be assigned
 
 ### Read-Only


### PR DESCRIPTION
When the docs eventually end up in the [crossplane provider](https://marketplace.upbound.io/providers/grafana/provider-grafana/v2.9.1/resources/enterprise.grafana.m.crossplane.io/DataSourcePermissionItem/v1alpha1) it becomes unclear what exact value is expected ( uid or id ). This hopefully makes it clear.

If user and role work the same way I can extend the MR. Just let me know.