### PR TITLE
fix(cloud): recovery of deleted service account / service account token in cloud

### DIFF
--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -845,13 +845,30 @@ func waitForStackReadiness(ctx context.Context, timeout time.Duration, stackURL 
 	return nil
 }
 
+func waitForStackReadinessFromURL(ctx context.Context, timeout time.Duration, url string, client *gcom.APIClient) diag.Diagnostics {
+	return waitForStackReadiness(ctx, timeout, url)
+}
+
 func waitForStackReadinessFromSlug(ctx context.Context, timeout time.Duration, slug string, client *gcom.APIClient) diag.Diagnostics {
 	stack, _, err := client.InstancesAPI.GetInstance(ctx, slug).Execute()
 	if err != nil {
 		return apiError(err)
 	}
+	return waitForStackReadinessFromURL(ctx, timeout, stack.Url, client)
+}
 
-	return waitForStackReadiness(ctx, timeout, stack.Url)
+func ensureStackExistenceAndReadiness(ctx context.Context, timeout time.Duration, resource, slug string, client *gcom.APIClient, d *schema.ResourceData) diag.Diagnostics {
+	stack, httpResp, err := client.InstancesAPI.GetInstance(ctx, slug).Execute()
+	if err != nil && ((httpResp != nil && httpResp.StatusCode == http.StatusNotFound) || common.IsNotFoundError(err)) {
+		return common.WarnMissing(resource, d)
+	}
+	if err != nil {
+		return apiError(err)
+	}
+	if err := waitForStackReadinessFromURL(ctx, timeout, stack.Url, client); err != nil {
+		return err
+	}
+	return nil
 }
 
 func defaultStackURL(slug string) string {

--- a/internal/resources/cloud/resource_cloud_stack_ensure_readiness_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_ensure_readiness_test.go
@@ -1,0 +1,129 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestUnitEnsureStackExistenceAndReadiness_Success(t *testing.T) {
+	t.Parallel()
+
+	stackMux := http.NewServeMux()
+	stackMux.HandleFunc("/login", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	stackMux.HandleFunc("/api/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	stackSrv := httptest.NewServer(stackMux)
+	t.Cleanup(stackSrv.Close)
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/api/instances/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(map[string]string{"url": stackSrv.URL}); err != nil {
+			t.Fatalf("encode instance body: %v", err)
+		}
+	}))
+	t.Cleanup(cloudSrv.Close)
+
+	client := newTestGcomAPIClient(t, cloudSrv)
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]any{})
+	const stateID = "org:resource-id"
+	d.SetId(stateID)
+
+	ctx := context.Background()
+	diags := ensureStackExistenceAndReadiness(ctx, time.Second, "stack service account", "my-stack-slug", client, d)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if d.Id() != stateID {
+		t.Fatalf("resource ID: got %q, want unchanged %q", d.Id(), stateID)
+	}
+}
+
+func TestUnitEnsureStackExistenceAndReadiness_InstanceNotFound(t *testing.T) {
+	t.Parallel()
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/instances/") {
+			http.NotFound(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(cloudSrv.Close)
+
+	client := newTestGcomAPIClient(t, cloudSrv)
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]any{})
+	d.SetId("1:existing-state-id")
+
+	ctx := context.Background()
+	diags := ensureStackExistenceAndReadiness(ctx, time.Second, "stack service account", "missing-stack", client, d)
+
+	if len(diags) != 1 || diags[0].Severity != diag.Warning {
+		t.Fatalf("want exactly one warning diagnostic, got %#v", diags)
+	}
+	if d.Id() != "" {
+		t.Fatalf("resource ID should be cleared on missing stack, got %q", d.Id())
+	}
+}
+
+func TestUnitEnsureStackExistenceAndReadiness_InstanceAPIError(t *testing.T) {
+	t.Parallel()
+
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/instances/") {
+			http.Error(w, `{"message":"forbidden"}`, http.StatusForbidden)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(cloudSrv.Close)
+
+	client := newTestGcomAPIClient(t, cloudSrv)
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]any{})
+	d.SetId("1:state-id")
+
+	ctx := context.Background()
+	diags := ensureStackExistenceAndReadiness(ctx, time.Second, "stack service account", "my-stack", client, d)
+
+	if !diags.HasError() || len(diags) != 1 {
+		t.Fatalf("want one error diagnostic, got %#v", diags)
+	}
+	if diags[0].Severity != diag.Error {
+		t.Fatalf("severity: got %v, want Error", diags[0].Severity)
+	}
+	if d.Id() != "1:state-id" {
+		t.Fatalf("resource ID should be unchanged on API error, got %q", d.Id())
+	}
+}
+
+func newTestGcomAPIClient(t *testing.T, cloudSrv *httptest.Server) *gcom.APIClient {
+	t.Helper()
+	cfg := gcom.NewConfiguration()
+	u, err := url.Parse(cloudSrv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	cfg.Scheme = u.Scheme
+	cfg.Host = u.Host
+	cfg.HTTPClient = cloudSrv.Client()
+	return gcom.NewAPIClient(cfg)
+}

--- a/internal/resources/cloud/resource_cloud_stack_service_account.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account.go
@@ -118,7 +118,7 @@ func readStackServiceAccount(ctx context.Context, d *schema.ResourceData, cloudC
 		stackSlug, serviceAccountID = split[0].(string), split[1].(int64)
 	}
 
-	if err := waitForStackReadinessFromSlug(ctx, 10*time.Minute, stackSlug, cloudClient); err != nil {
+	if err := ensureStackExistenceAndReadiness(ctx, 10*time.Minute, "stack service account", stackSlug, cloudClient, d); err != nil {
 		return err
 	}
 

--- a/internal/resources/cloud/resource_cloud_stack_service_account_token.go
+++ b/internal/resources/cloud/resource_cloud_stack_service_account_token.go
@@ -148,7 +148,7 @@ func stackServiceAccountTokenRead(ctx context.Context, d *schema.ResourceData, c
 		return diag.FromErr(err)
 	}
 
-	if err := waitForStackReadinessFromSlug(ctx, 10*time.Minute, stackSlug, cloudClient); err != nil {
+	if err := ensureStackExistenceAndReadiness(ctx, 10*time.Minute, "stack service account token", stackSlug, cloudClient, d); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If you have a tf file with:
- a stack
- a stack service account
- a stack service account token

and delete the stack outside of terraform, the stack detects it as missing, but it fails because stack service account and token do not

## tested