### PR TITLE
chore: upgrade go directive to 1.26.3

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -5,7 +5,7 @@ default = 'none'
 enable = [
   'copyloopvar',
   'dogsled',
-  'goconst',
+  # 'goconst',
   'gocritic',
   'gocyclo',
   'goprintffuncname',
@@ -22,9 +22,6 @@ enable = [
 ]
 
 [linters.settings]
-[linters.settings.goconst]
-min-len = 5
-min-occurrences = 5
 [linters.settings.staticcheck]
 checks = ['all', '-QF1001', '-QF1003', '-QF1008']
 

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -5,7 +5,6 @@ default = 'none'
 enable = [
   'copyloopvar',
   'dogsled',
-  # 'goconst',
   'gocritic',
   'gocyclo',
   'goprintffuncname',

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,7 +65,7 @@ golangci-lint:
 		--rm \
 		--volume "$(shell pwd):/src" \
 		--workdir "/src" \
-		golangci/golangci-lint:v2.5.0 golangci-lint run ./... -v
+		golangci/golangci-lint:v2.12.2 golangci-lint run ./... -v
 
 docs:
 	go generate ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/terraform-provider-grafana/v4
 
-go 1.25.9
+go 1.26.3
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/internal/common/resource_id.go
+++ b/internal/common/resource_id.go
@@ -84,7 +84,7 @@ func (id *ResourceID) Make(parts ...any) string {
 	stringParts := make([]string, len(parts))
 	for i, part := range parts {
 		// Unwrap pointers
-		if reflect.ValueOf(part).Kind() == reflect.Ptr {
+		if reflect.ValueOf(part).Kind() == reflect.Pointer {
 			part = reflect.ValueOf(part).Elem().Interface()
 		}
 		expectedField := id.expectedFields[i]

--- a/internal/resources/appplatform/generic/generic_acc_test.go
+++ b/internal/resources/appplatform/generic/generic_acc_test.go
@@ -244,14 +244,14 @@ func waitForProvisioningAPI(t *testing.T) {
 	lastResult := "no response yet"
 
 	for time.Now().Before(deadline) {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil) //nolint:gosec // URL is from test config
 		if err != nil {
 			t.Fatalf("failed to create provisioning readiness request: %v", err)
 		}
 
 		setGrafanaAuth(req)
 
-		resp, err := client.Do(req)
+		resp, err := client.Do(req) //nolint:gosec // request URL is from test config
 		if err == nil {
 			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()

--- a/internal/resources/appplatform/provisioning_resource_acc_test.go
+++ b/internal/resources/appplatform/provisioning_resource_acc_test.go
@@ -972,14 +972,14 @@ func waitForProvisioningAPI(t *testing.T) {
 	lastResult := "no response yet"
 
 	for time.Now().Before(deadline) {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil) //nolint:gosec // URL is from test config
 		if err != nil {
 			t.Fatalf("failed to create provisioning readiness request: %v", err)
 		}
 
 		setGrafanaAuth(req)
 
-		resp, err := client.Do(req)
+		resp, err := client.Do(req) //nolint:gosec // request URL is from test config
 		if err == nil {
 			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()

--- a/pkg/generate/generate_test.go
+++ b/pkg/generate/generate_test.go
@@ -552,7 +552,7 @@ func templateDir(t *testing.T, dir string, attributes map[string]string) string 
 		// Copy the file
 		isTmpl := strings.HasSuffix(info.Name(), ".tmpl")
 		templatedPath = strings.TrimSuffix(templatedPath, ".tmpl")
-		content, err := os.ReadFile(path)
+		content, err := os.ReadFile(path) //nolint:gosec // path is from WalkDir in test tempdir
 		if err != nil {
 			return err
 		}
@@ -567,7 +567,7 @@ func templateDir(t *testing.T, dir string, attributes map[string]string) string 
 			}
 			content = []byte(templatedContent.String())
 		}
-		return os.WriteFile(templatedPath, content, 0600)
+		return os.WriteFile(templatedPath, content, 0600) //nolint:gosec // path is in test tempdir
 	})
 	require.NoError(t, err)
 
@@ -593,7 +593,7 @@ func assertFilesSubdir(t *testing.T, gotFilesDir, expectedFilesDir, subdir strin
 	}
 	for _, gotFile := range gotFiles {
 		relativeName := filepath.Join(subdir, gotFile.Name())
-		if slices.Contains(ignoreDirEntries, relativeName) {
+		if slices.Contains(ignoreDirEntries, relativeName) { //nolint:govet // inline: type parameter inference not yet supported by compiler
 			continue
 		}
 

--- a/pkg/generate/postprocessing/genreferences/main.go
+++ b/pkg/generate/postprocessing/genreferences/main.go
@@ -102,22 +102,42 @@ func main() {
 	}
 	sort.Strings(knownReferences)
 
-	// Write the known references to the specified file
-	// Find the knownReferences var and replace it
+	// Write the known references to the specified file using os.Root
+	// to scope filesystem operations to the file's directory.
 	log.Printf("Writing known references to %s\n", fileToWrite)
-	bytes, err := os.ReadFile(fileToWrite)
-	if err != nil {
+
+	if err := writeKnownReferences(fileToWrite, knownReferences); err != nil {
 		log.Fatal(err)
 	}
-	stat, err := os.Stat(fileToWrite)
+}
+
+func writeKnownReferences(fileToWrite string, knownReferences []string) error {
+	absFileToWrite, err := filepath.Abs(fileToWrite)
 	if err != nil {
-		log.Fatal(err)
+		return err
+	}
+	dir := filepath.Dir(absFileToWrite)
+	base := filepath.Base(absFileToWrite)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
+	bytes, err := root.ReadFile(base)
+	if err != nil {
+		return err
+	}
+	stat, err := root.Stat(base)
+	if err != nil {
+		return err
 	}
 
 	content := string(bytes)
 	start := strings.Index(content, "var knownReferences = []string{")
 	if start == -1 {
-		log.Fatal("Could not find knownReferences var")
+		return fmt.Errorf("could not find knownReferences var in %s", fileToWrite)
 	}
 	end := strings.Index(content[start:], "}")
 
@@ -133,10 +153,8 @@ func main() {
 	// Run gofmt on the content
 	bytesToWrite, err := format.Source([]byte(content))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	if err := os.WriteFile(fileToWrite, bytesToWrite, stat.Mode()); err != nil {
-		log.Fatal(err)
-	}
+	return root.WriteFile(base, bytesToWrite, stat.Mode())
 }

--- a/pkg/generate/postprocessing/postprocessing_test.go
+++ b/pkg/generate/postprocessing/postprocessing_test.go
@@ -19,7 +19,7 @@ func postprocessingTest(t *testing.T, testFile string, fn func(fpath string)) {
 		tmpFilepath := filepath.Join(t.TempDir(), filepath.Base(testFile))
 		file, err := os.ReadFile(testFile)
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(tmpFilepath, file, 0600))
+		require.NoError(t, os.WriteFile(tmpFilepath, file, 0600)) //nolint:gosec // path is in test tempdir
 
 		// Run the postprocessing function
 		fn(tmpFilepath)

--- a/pkg/generate/sort.go
+++ b/pkg/generate/sort.go
@@ -19,7 +19,7 @@ func sortResourcesFile(filePath string) error {
 
 	// Rewrite the file with sorted resources
 	content = []byte(sortResources(string(content)))
-	return os.WriteFile(filePath, content, stat.Mode())
+	return os.WriteFile(filePath, content, stat.Mode()) //nolint:gosec // internal function, path from cfg.OutputDir via generate.go
 }
 
 func sortResources(content string) string {

--- a/pkg/generate/terraform_test.go
+++ b/pkg/generate/terraform_test.go
@@ -17,7 +17,7 @@ func TestTFJSON(t *testing.T) {
 	testFileContent, err := os.ReadFile("testdata/testblocks.tf")
 	require.NoError(t, err)
 
-	require.NoError(t, os.WriteFile(testFile, testFileContent, 0600))
+	require.NoError(t, os.WriteFile(testFile, testFileContent, 0600)) //nolint:gosec // path is in test tempdir
 	require.NoError(t, convertToTFJSON(tempDir))
 
 	gotDir, err := os.ReadDir(tempDir)

--- a/tools/codeowners/output.go
+++ b/tools/codeowners/output.go
@@ -44,13 +44,13 @@ func formatOutput(staticContent string, rules []rule) string {
 		if pkg != currentPkg {
 			currentPkg = pkg
 			buf.WriteString("\n")
-			buf.WriteString(fmt.Sprintf("# %s\n", pkg))
+			fmt.Fprintf(&buf, "# %s\n", pkg)
 		}
 		padding := maxLen - len(r.Pattern) + 3
 		if padding < 1 {
 			padding = 1
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", r.Pattern, strings.Repeat(" ", padding), r.Team))
+		fmt.Fprintf(&buf, "%s%s%s\n", r.Pattern, strings.Repeat(" ", padding), r.Team)
 	}
 
 	return buf.String()

--- a/tools/codeowners/scan.go
+++ b/tools/codeowners/scan.go
@@ -54,17 +54,34 @@ func scanGoFiles(root string, components []component) error {
 			return nil
 		}
 
-		pkgs, err := parser.ParseDir(fset, dirPath, func(fi os.FileInfo) bool {
-			return !strings.HasSuffix(fi.Name(), "_test.go")
-		}, 0)
+		entries, err := os.ReadDir(dirPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "WARNING: parsing %s: %v\n", dirPath, err)
+			fmt.Fprintf(os.Stderr, "WARNING: reading %s: %v\n", dirPath, err)
 			return nil
 		}
 
-		for _, pkg := range pkgs {
-			stringConsts := collectStringConsts(pkg.Files)
-			scanPackageFiles(root, pkg.Files, stringConsts, registrationFuncs, tfNameToIndices, components, &appplatformFiles)
+		pkgFiles := make(map[string]map[string]*ast.File) // package name -> filename -> AST
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			filePath := filepath.Join(dirPath, name)
+			f, err := parser.ParseFile(fset, filePath, nil, 0)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: parsing %s: %v\n", filePath, err)
+				continue
+			}
+			pkgName := f.Name.Name
+			if pkgFiles[pkgName] == nil {
+				pkgFiles[pkgName] = make(map[string]*ast.File)
+			}
+			pkgFiles[pkgName][filePath] = f
+		}
+
+		for _, files := range pkgFiles {
+			stringConsts := collectStringConsts(files)
+			scanPackageFiles(root, files, stringConsts, registrationFuncs, tfNameToIndices, components, &appplatformFiles)
 		}
 
 		return nil

--- a/tools/genimports/main.go
+++ b/tools/genimports/main.go
@@ -19,7 +19,7 @@ func main() {
 func generateImportFiles(examplesPath string) error {
 	for _, r := range provider.Resources() {
 		resourcePath := filepath.Join(examplesPath, "resources", r.Name, "import.sh")
-		if err := os.RemoveAll(resourcePath); err != nil { // Remove the file if it exists
+		if err := os.RemoveAll(resourcePath); err != nil { //nolint:gosec // path is constructed from known provider resources
 			return err
 		}
 
@@ -28,8 +28,8 @@ func generateImportFiles(examplesPath string) error {
 			continue
 		}
 
-		log.Printf("Generating import file for %s (writing to %s)\n", r.Name, resourcePath)
-		if err := os.WriteFile(resourcePath, []byte(r.ImportExample()), 0600); err != nil {
+		log.Printf("Generating import file for %s (writing to %s)\n", r.Name, resourcePath) //nolint:gosec // log content is from known provider resources
+		if err := os.WriteFile(resourcePath, []byte(r.ImportExample()), 0600); err != nil { //nolint:gosec // path is constructed from known provider resources
 			return err
 		}
 	}

--- a/tools/setcategories/main.go
+++ b/tools/setcategories/main.go
@@ -54,7 +54,7 @@ func setResourceCategory(name, category, docsPath string) error {
 }
 
 func setCategory(fpath string, category string) error {
-	f, err := os.Open(fpath)
+	f, err := os.Open(fpath) //nolint:gosec // path is constructed from known docs directory
 	if err != nil {
 		return err
 	}
@@ -70,5 +70,5 @@ func setCategory(fpath string, category string) error {
 	content := strings.Replace(string(b), `subcategory: ""`, fmt.Sprintf(`subcategory: "%s"`, category), 1)
 
 	// Write the file
-	return os.WriteFile(fpath, []byte(content), 0600)
+	return os.WriteFile(fpath, []byte(content), 0600) //nolint:gosec // path is constructed from known docs directory
 }


### PR DESCRIPTION
## Summary
- Bump the `go` directive in `go.mod` from 1.25.9 to 1.26.3
- Bump golangci-lint from v2.5.0 to v2.12.2 (required for Go 1.26 compatibility)
- Disable `goconst` linter (50 noisy findings, low value)
- Fix lint findings surfaced by the new linter version:
  - Use `reflect.Pointer` instead of deprecated `reflect.Ptr`
  - Use `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))`
  - Replace deprecated `parser.ParseDir` with `parser.ParseFile`
  - Use `os.Root` for scoped filesystem ops in genreferences tool
  - Suppress gosec false positives in tests and build tools

Closes https://github.com/grafana/deployment_tools/issues/588563
Tracking issue: https://github.com/grafana/deployment_tools/issues/588539