### PR TITLE
fix(oncall): make route escalation_chain_id optional

### DIFF
--- a/docs/resources/oncall_route.md
+++ b/docs/resources/oncall_route.md
@@ -53,13 +53,13 @@ resource "grafana_oncall_route" "example_route" {
 
 ### Required
 
-- `escalation_chain_id` (String) The ID of the escalation chain.
 - `integration_id` (String) The ID of the integration.
 - `position` (Number) The position of the route (starts from 0).
 - `routing_regex` (String) Python Regex query. Route is chosen for an alert if there is a match inside the alert payload.
 
 ### Optional
 
+- `escalation_chain_id` (String) The ID of the escalation chain. Omit or set to null for a route with no escalation chain.
 - `msteams` (Block List, Max: 1) MS teams-specific settings for a route. (see [below for nested schema](#nestedblock--msteams))
 - `routing_type` (String) The type of route. Can be jinja2, regex Defaults to `regex`.
 - `slack` (Block List, Max: 1) Slack-specific settings for a route. (see [below for nested schema](#nestedblock--slack))

--- a/internal/resources/oncall/resource_route.go
+++ b/internal/resources/oncall/resource_route.go
@@ -43,8 +43,8 @@ func resourceRoute() *common.Resource {
 			},
 			"escalation_chain_id": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The ID of the escalation chain.",
+				Optional:    true,
+				Description: "The ID of the escalation chain. Omit or set to null for a route with no escalation chain.",
 			},
 			"position": {
 				Type:        schema.TypeInt,
@@ -151,9 +151,21 @@ func listRoutes(client *onCallAPI.Client, listOptions onCallAPI.ListOptions) (id
 	return ids, resp.Next, nil
 }
 
+func getRouteEscalationChainID(d *schema.ResourceData) string {
+	v, ok := d.GetOk("escalation_chain_id")
+	if !ok {
+		return ""
+	}
+	id, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return id
+}
+
 func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
 	integrationID := d.Get("integration_id").(string)
-	escalationChainID := d.Get("escalation_chain_id").(string)
+	escalationChainID := getRouteEscalationChainID(d)
 	routingType := d.Get("routing_type").(string)
 	routingRegex := d.Get("routing_regex").(string)
 	position := d.Get("position").(int)
@@ -216,7 +228,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, client *onCa
 }
 
 func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, client *onCallAPI.Client) diag.Diagnostics {
-	escalationChainID := d.Get("escalation_chain_id").(string)
+	escalationChainID := getRouteEscalationChainID(d)
 	routingType := d.Get("routing_type").(string)
 	routingRegex := d.Get("routing_regex").(string)
 	position := d.Get("position").(int)

--- a/internal/resources/oncall/resource_route_escalation_test.go
+++ b/internal/resources/oncall/resource_route_escalation_test.go
@@ -1,0 +1,40 @@
+package oncall
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestGetRouteEscalationChainID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value any
+		set   bool
+		want  string
+	}{
+		{name: "unset", set: false, want: ""},
+		{name: "null", value: nil, set: true, want: ""},
+		{name: "empty", value: "", set: true, want: ""},
+		{name: "id", value: "EC123", set: true, want: "EC123"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+				"escalation_chain_id": {Type: schema.TypeString, Optional: true},
+			}, map[string]any{})
+			if tc.set {
+				if err := d.Set("escalation_chain_id", tc.value); err != nil {
+					t.Fatalf("Set: %v", err)
+				}
+			}
+			if got := getRouteEscalationChainID(d); got != tc.want {
+				t.Fatalf("getRouteEscalationChainID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/resources/oncall/resource_route_test.go
+++ b/internal/resources/oncall/resource_route_test.go
@@ -33,6 +33,27 @@ func TestAccOnCallRoute_basic(t *testing.T) {
 	})
 }
 
+func TestAccOnCallRoute_withoutEscalationChain(t *testing.T) {
+	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	riName := fmt.Sprintf("integration-%s", acctest.RandString(8))
+	rrRegex := fmt.Sprintf("regex-%s", acctest.RandString(8))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallRouteResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnCallRouteConfigWithoutEscalationChain(riName, rrRegex),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallRouteResourceExists("grafana_oncall_route.test-acc-route"),
+					testAccCheckOnCallRouteHasNoEscalationChain("grafana_oncall_route.test-acc-route"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOnCallRoute_routingRegexWhitespace(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
@@ -102,6 +123,54 @@ resource "grafana_oncall_route" "test-acc-route" {
     }
 }
 `, riName, riName, rrRegex)
+}
+
+func testAccOnCallRouteConfigWithoutEscalationChain(riName string, rrRegex string) string {
+	return fmt.Sprintf(`
+resource "grafana_oncall_integration" "test-acc-integration" {
+	name = "%s"
+	type = "grafana"
+	default_route {
+	    slack {
+	        enabled = false
+	    }
+	    telegram {
+	        enabled = false
+	    }
+	}
+}
+
+resource "grafana_oncall_route" "test-acc-route" {
+	integration_id = grafana_oncall_integration.test-acc-integration.id
+	routing_regex  = "%s"
+	position       = 0
+    slack {
+        enabled = false
+    }
+    telegram {
+        enabled = false
+    }
+}
+`, riName, rrRegex)
+}
+
+func testAccCheckOnCallRouteHasNoEscalationChain(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		client := testutils.Provider.Meta().(*common.Client).OnCallClient
+		route, _, err := client.Routes.GetRoute(rs.Primary.ID, &onCallAPI.GetRouteOptions{})
+		if err != nil {
+			return err
+		}
+		if route.EscalationChainId != "" {
+			return fmt.Errorf("expected no escalation chain, got %q", route.EscalationChainId)
+		}
+		return nil
+	}
 }
 
 func testAccCheckOnCallRouteResourceExists(name string) resource.TestCheckFunc {


### PR DESCRIPTION
Allow grafana_oncall_route to omit or null escalation_chain_id so routes without an escalation chain can be managed via Terraform, matching the OnCall API and UI behavior.