### PR TITLE
fix: propagate error message in job client

### DIFF
--- a/internal/common/connectionsapi/client.go
+++ b/internal/common/connectionsapi/client.go
@@ -54,6 +54,12 @@ type apiResponseWrapper[T any] struct {
 	Data T `json:"data"`
 }
 
+type errorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
 type MetricsEndpointScrapeJob struct {
 	Enabled                     bool   `json:"enabled"`
 	AuthenticationMethod        string `json:"authentication_method"`
@@ -141,12 +147,16 @@ func (c *Client) doAPIRequest(ctx context.Context, method string, path string, b
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrUnauthorized
+	}
 	if !(resp.StatusCode >= 200 && resp.StatusCode <= 299) {
-		if resp.StatusCode == 404 {
-			return ErrNotFound
-		}
-		if resp.StatusCode == 401 {
-			return ErrUnauthorized
+		errorData := errorResponse{}
+		if err := json.Unmarshal(bodyContents, &errorData); err == nil && errorData.Error.Message != "" {
+			return fmt.Errorf("message: %s", errorData.Error.Message)
 		}
 		return fmt.Errorf("status: %d", resp.StatusCode)
 	}

--- a/internal/common/connectionsapi/client_test.go
+++ b/internal/common/connectionsapi/client_test.go
@@ -145,6 +145,27 @@ func TestClient_CreateMetricsEndpointScrapeJob(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, `failed to create metrics endpoint scrape job "job-name": failed to do request: Post "some%20random%20url/api/v1/stacks/some-stack-id/metrics-endpoint/jobs/job-name": unsupported protocol scheme ""`, err.Error())
 	})
+
+	t.Run("propagates upstream error message", func(t *testing.T) {
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`
+			{
+        "error": {
+          "code": "job_limit_exceeded",
+          "message": "job_limit_exceeded"
+        }
+			}`))
+		}))
+		defer svr.Close()
+
+		c, err := connectionsapi.NewClient("some token", svr.URL, svr.Client(), "some-user-agent", defaultHeaders)
+		require.NoError(t, err)
+		_, err = c.CreateMetricsEndpointScrapeJob(context.Background(), "some-stack-id", "job-name", connectionsapi.MetricsEndpointScrapeJob{})
+
+		assert.Error(t, err)
+		assert.Equal(t, `failed to create metrics endpoint scrape job "job-name": message: job_limit_exceeded`, err.Error())
+	})
 }
 
 func TestClient_GetMetricsEndpointScrapeJob(t *testing.T) {


### PR DESCRIPTION
By default, stacks are limited to 100 scrape jobs. If this number is exceeded, the terraform provider failed with a generic `status: 400` error.

This PR adds the returned message to the error if present to surface this to users