### PR TITLE
feat: add google chat alerting options

### DIFF
--- a/docs/resources/contact_point.md
+++ b/docs/resources/contact_point.md
@@ -161,6 +161,8 @@ Required:
 Optional:
 
 - `disable_resolve_message` (Boolean) Whether to disable sending resolve messages. Defaults to `false`.
+- `hide_open_button` (Boolean) Whether to hide the Open URL button in the message. This feature requires Grafana 12.4.0 or later.
+- `hide_version_info` (Boolean) Whether to hide the version info in the message. This feature requires Grafana 12.4.0 or later. Defaults to `false`.
 - `message` (String) The templated content of the message.
 - `settings` (Map of String, Sensitive) Additional custom properties to attach to the notifier. Defaults to `map[]`.
 - `title` (String) The templated content of the title.

--- a/examples/resources/grafana_contact_point/_acc_receiver_types.tf
+++ b/examples/resources/grafana_contact_point/_acc_receiver_types.tf
@@ -32,9 +32,11 @@ resource "grafana_contact_point" "receiver_types" {
   }
 
   googlechat {
-    url     = "http://googlechat-url"
-    title   = "title"
-    message = "message"
+    url               = "http://googlechat-url"
+    title             = "title"
+    message           = "message"
+    hide_version_info = true
+    hide_open_button  = true
   }
 
   kafka {

--- a/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_notifiers.go
@@ -230,6 +230,17 @@ func (g googleChatNotifier) schema() *schema.Resource {
 		Optional:    true,
 		Description: "The templated content of the message.",
 	}
+	r.Schema["hide_open_button"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Whether to hide the Open URL button in the message. This feature requires Grafana 12.4.0 or later.",
+	}
+	r.Schema["hide_version_info"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Whether to hide the version info in the message. This feature requires Grafana 12.4.0 or later.",
+		Default:     false,
+	}
 	return r
 }
 

--- a/internal/resources/grafana/resource_alerting_contact_point_test.go
+++ b/internal/resources/grafana/resource_alerting_contact_point_test.go
@@ -203,6 +203,8 @@ func TestAccContactPoint_notifiers(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "googlechat.0.url", "http://googlechat-url"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "googlechat.0.title", "title"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "googlechat.0.message", "message"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "googlechat.0.hide_version_info", "true"),
+					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "googlechat.0.hide_open_button", "true"),
 					// kafka
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "kafka.#", "1"),
 					resource.TestCheckResourceAttr("grafana_contact_point.receiver_types", "kafka.0.rest_proxy_url", "http://kafka-rest-proxy-url"),
@@ -544,7 +546,7 @@ func TestAccContactPoint_notifiers11_6(t *testing.T) {
 				Config: `
 				resource "grafana_contact_point" "receiver_types" {
 				  name = "Receiver Types since v11.6"
-				
+
 				  webhook {
 					url = "http://my-url"
 					hmac_config {
@@ -661,7 +663,7 @@ func TestAccContactPoint_notifiers12_0(t *testing.T) {
 				Config: `
 				resource "grafana_contact_point" "receiver_types" {
 				  name = "Receiver Types since v12.0"
-				
+
 				  webhook {
 					url                 = "http://my-url"
 					headers = {
@@ -697,7 +699,7 @@ func TestAccContactPoint_notifiers12_0(t *testing.T) {
 				Config: `
 				resource "grafana_contact_point" "receiver_types" {
 				  name = "Receiver Types since v12.0"
-				
+
 				  webhook {
 					url = "http://my-url"
 				  }
@@ -1338,6 +1340,8 @@ func TestAccContactPoint_minimalDefinitions(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_contact_point.minimal_receivers", "googlechat.0.message", ""),
 					checkOtherAttrsOmittedInResponse(&points, "googlechat.0",
 						"url",
+						"hide_open_button",  // TODO: This would be better omitted.
+						"hide_version_info", // TODO: This would be better omitted.
 					),
 					// kafka
 					resource.TestCheckResourceAttr("grafana_contact_point.minimal_receivers", "kafka.#", "1"),


### PR DESCRIPTION
Adds `hide_open_button` and `hide_version_info` fields to the Google Chat contact point notifier (requires Grafana >= 12.4.0).

This is a clean cherry-pick of https://github.com/grafana/terraform-provider-grafana/pull/2630 by @ichbinfrog, rebased directly on main to allow CI to run (fork PRs are not supported by cloud acceptance tests, which are required).

## Changes
- `hide_open_button` (bool, optional): hides the Open URL button in the Google Chat message
- `hide_version_info` (bool, optional, default false): hides the version info in the Google Chat message

## Test plan
- [ ] Unit tests pass
- [ ] `golangci-lint` passes
- [ ] Docs are in sync