### PR TITLE
feat: add k6 channel support

### DIFF
--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -430,7 +430,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 
 - `alert_sensitivity` (String) Can be set to `none`, `low`, `medium`, or `high` to correspond to the check [alert levels](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/). Defaults to `none`.
 - `basic_metrics_only` (Boolean) Metrics are reduced by default. Set this to `false` if you'd like to publish all metrics. We maintain a [full list of metrics](https://github.com/grafana/synthetic-monitoring-agent/tree/main/internal/scraper/testdata) collected for each. Defaults to `true`.
-- `channels` (Block List, Max: 1) Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default k6 channel. (see [below for nested schema](#nestedblock--channels))
+- `channels` (Block List, Max: 1) Channels to assign the check to. See [Manage k6 versions](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/manage-k6-versions/) for details. If not specified for scripted/browser checks, the API assigns a default k6 channel. (see [below for nested schema](#nestedblock--channels))
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
 - `folder_uid` (String) The UID of the Grafana folder to associate the check with.
 - `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -430,6 +430,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 
 - `alert_sensitivity` (String) Can be set to `none`, `low`, `medium`, or `high` to correspond to the check [alert levels](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/). Defaults to `none`.
 - `basic_metrics_only` (Boolean) Metrics are reduced by default. Set this to `false` if you'd like to publish all metrics. We maintain a [full list of metrics](https://github.com/grafana/synthetic-monitoring-agent/tree/main/internal/scraper/testdata) collected for each. Defaults to `true`.
+- `channels` (Block List, Max: 1) Channels to assign the check to. (see [below for nested schema](#nestedblock--channels))
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
 - `folder_uid` (String) The UID of the Grafana folder to associate the check with.
 - `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.
@@ -759,6 +760,22 @@ Optional:
 - `max_hops` (Number) Maximum TTL for the trace Defaults to `64`.
 - `max_unknown_hops` (Number) Maximum number of hosts to travers that give no response Defaults to `15`.
 - `ptr_lookup` (Boolean) Reverse lookup hostnames from IP addresses Defaults to `true`.
+
+
+
+<a id="nestedblock--channels"></a>
+### Nested Schema for `channels`
+
+Optional:
+
+- `k6` (Block List, Max: 1) K6 channel configuration. (see [below for nested schema](#nestedblock--channels--k6))
+
+<a id="nestedblock--channels--k6"></a>
+### Nested Schema for `channels.k6`
+
+Required:
+
+- `id` (String) The ID of the k6 channel.
 
 ### MultiHTTP Basic
 

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -430,7 +430,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 
 - `alert_sensitivity` (String) Can be set to `none`, `low`, `medium`, or `high` to correspond to the check [alert levels](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/). Defaults to `none`.
 - `basic_metrics_only` (Boolean) Metrics are reduced by default. Set this to `false` if you'd like to publish all metrics. We maintain a [full list of metrics](https://github.com/grafana/synthetic-monitoring-agent/tree/main/internal/scraper/testdata) collected for each. Defaults to `true`.
-- `channels` (Block List, Max: 1) Channels to assign the check to. (see [below for nested schema](#nestedblock--channels))
+- `channels` (Block List, Max: 1) Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default channel. (see [below for nested schema](#nestedblock--channels))
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
 - `folder_uid` (String) The UID of the Grafana folder to associate the check with.
 - `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.
@@ -773,7 +773,7 @@ Optional:
 <a id="nestedblock--channels--k6"></a>
 ### Nested Schema for `channels.k6`
 
-Required:
+Optional:
 
 - `id` (String) The ID of the k6 channel.
 

--- a/docs/resources/synthetic_monitoring_check.md
+++ b/docs/resources/synthetic_monitoring_check.md
@@ -430,7 +430,7 @@ resource "grafana_synthetic_monitoring_check" "traceroute" {
 
 - `alert_sensitivity` (String) Can be set to `none`, `low`, `medium`, or `high` to correspond to the check [alert levels](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/). Defaults to `none`.
 - `basic_metrics_only` (Boolean) Metrics are reduced by default. Set this to `false` if you'd like to publish all metrics. We maintain a [full list of metrics](https://github.com/grafana/synthetic-monitoring-agent/tree/main/internal/scraper/testdata) collected for each. Defaults to `true`.
-- `channels` (Block List, Max: 1) Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default channel. (see [below for nested schema](#nestedblock--channels))
+- `channels` (Block List, Max: 1) Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default k6 channel. (see [below for nested schema](#nestedblock--channels))
 - `enabled` (Boolean) Whether to enable the check. Defaults to `true`.
 - `folder_uid` (String) The UID of the Grafana folder to associate the check with.
 - `frequency` (Number) How often the check runs in milliseconds (the value is not truly a "frequency" but a "period"). The minimum acceptable value is 1 second (1000 ms), and the maximum is 1 hour (3600000 ms). Defaults to `60000`.

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -790,9 +790,10 @@ multiple checks for a single endpoint to check different capabilities.
 				Optional:    true,
 			},
 			"channels": {
-				Description: "Channels to assign the check to.",
+				Description: "Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default channel.",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -800,13 +801,15 @@ multiple checks for a single endpoint to check different capabilities.
 							Description: "K6 channel configuration.",
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"id": {
 										Description: "The ID of the k6 channel.",
 										Type:        schema.TypeString,
-										Required:    true,
+										Optional:    true,
+										Computed:    true,
 									},
 								},
 							},

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -789,6 +789,31 @@ multiple checks for a single endpoint to check different capabilities.
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"channels": {
+				Description: "Channels to assign the check to.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"k6": {
+							Description: "K6 channel configuration.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Description: "The ID of the k6 channel.",
+										Type:        schema.TypeString,
+										Required:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"probes": {
 				Description: "List of probe location IDs where this target will be checked from.",
 				Type:        schema.TypeSet,
@@ -883,6 +908,17 @@ func resourceCheckRead(ctx context.Context, d *schema.ResourceData, c *smapi.Cli
 	d.Set("alert_sensitivity", chk.AlertSensitivity)
 	d.Set("basic_metrics_only", chk.BasicMetricsOnly)
 	d.Set("folder_uid", chk.FolderUid)
+	if chk.Channels != nil && chk.Channels.K6 != nil {
+		d.Set("channels", []map[string]any{
+			{
+				"k6": []map[string]any{
+					{
+						"id": chk.Channels.K6.Id,
+					},
+				},
+			},
+		})
+	}
 	d.Set("probes", chk.Probes)
 
 	if len(chk.Labels) > 0 {
@@ -1255,6 +1291,22 @@ func makeCheck(d *schema.ResourceData) (*model.Check, error) {
 		timeout = checkMultiHTTPDefaultTimeout
 	}
 
+	var channels *sm.Channels
+	if v, ok := d.GetOk("channels"); ok {
+		channelsList := v.([]any)
+		if len(channelsList) > 0 {
+			ch := channelsList[0].(map[string]any)
+			if k6List, ok := ch["k6"].([]any); ok && len(k6List) > 0 {
+				k6 := k6List[0].(map[string]any)
+				channels = &sm.Channels{
+					K6: &sm.K6Channel{
+						Id: k6["id"].(string),
+					},
+				}
+			}
+		}
+	}
+
 	return &model.Check{
 		Check: sm.Check{
 			Id:               id,
@@ -1269,6 +1321,7 @@ func makeCheck(d *schema.ResourceData) (*model.Check, error) {
 			Probes:           probes,
 			Labels:           labels,
 			Settings:         settings,
+			Channels:         channels,
 		},
 		FolderUid: d.Get("folder_uid").(string),
 	}, nil

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -793,10 +793,10 @@ multiple checks for a single endpoint to check different capabilities.
 				Description: "Channels to assign the check to. " +
 					"See [Manage k6 versions](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/manage-k6-versions/) for details. " +
 					"If not specified for scripted/browser checks, the API assigns a default k6 channel.",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Computed:    true,
-				MaxItems:    1,
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"k6": {

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -790,7 +790,7 @@ multiple checks for a single endpoint to check different capabilities.
 				Optional:    true,
 			},
 			"channels": {
-				Description: "Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default channel.",
+				Description: "Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default k6 channel.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,

--- a/internal/resources/syntheticmonitoring/resource_check.go
+++ b/internal/resources/syntheticmonitoring/resource_check.go
@@ -790,7 +790,9 @@ multiple checks for a single endpoint to check different capabilities.
 				Optional:    true,
 			},
 			"channels": {
-				Description: "Channels to assign the check to. If not specified for scripted/browser checks, the API assigns a default k6 channel.",
+				Description: "Channels to assign the check to. " +
+					"See [Manage k6 versions](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/manage-k6-versions/) for details. " +
+					"If not specified for scripted/browser checks, the API assigns a default k6 channel.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -2,6 +2,7 @@ package syntheticmonitoring_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -603,6 +604,69 @@ func TestAccResourceCheck_multiple(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceCheck_channels(t *testing.T) {
+	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	jobName := acctest.RandomWithPrefix("channels")
+	jobNameUpdated := acctest.RandomWithPrefix("channels")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceCheck_withChannels(jobName, "test-channel-1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.channels", "id"),
+					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.channels", "tenant_id"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "job", jobName),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "target", "grafana.com"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "channels.0.k6.0.id", "test-channel-1"),
+					testutils.CheckLister("grafana_synthetic_monitoring_check.channels"),
+				),
+			},
+			{
+				Config: testAccResourceCheck_withChannels(jobNameUpdated, "test-channel-2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.channels", "id"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "job", jobNameUpdated),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "channels.0.k6.0.id", "test-channel-2"),
+				),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "grafana_synthetic_monitoring_check.channels",
+			},
+		},
+	})
+}
+
+func testAccResourceCheck_withChannels(jobName, channelID string) string {
+	return fmt.Sprintf(`
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+resource "grafana_synthetic_monitoring_check" "channels" {
+  job     = %[1]q
+  target  = "grafana.com"
+  enabled = false
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
+  ]
+  labels = {
+    foo = "bar"
+  }
+  channels {
+    k6 {
+      id = %[2]q
+    }
+  }
+  settings {
+    ping {}
+  }
+}
+`, jobName, channelID)
 }
 
 const testAccResourceCheck_noSettings = `

--- a/internal/resources/syntheticmonitoring/resource_check_test.go
+++ b/internal/resources/syntheticmonitoring/resource_check_test.go
@@ -616,22 +616,22 @@ func TestAccResourceCheck_channels(t *testing.T) {
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceCheck_withChannels(jobName, "test-channel-1"),
+				Config: testAccResourceCheck_withChannels(jobName, "v1"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.channels", "id"),
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.channels", "tenant_id"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "job", jobName),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "target", "grafana.com"),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "channels.0.k6.0.id", "test-channel-1"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "target", "https://grafana.com/"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "channels.0.k6.0.id", "v1"),
 					testutils.CheckLister("grafana_synthetic_monitoring_check.channels"),
 				),
 			},
 			{
-				Config: testAccResourceCheck_withChannels(jobNameUpdated, "test-channel-2"),
+				Config: testAccResourceCheck_withChannels(jobNameUpdated, "v1"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_synthetic_monitoring_check.channels", "id"),
 					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "job", jobNameUpdated),
-					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "channels.0.k6.0.id", "test-channel-2"),
+					resource.TestCheckResourceAttr("grafana_synthetic_monitoring_check.channels", "channels.0.k6.0.id", "v1"),
 				),
 			},
 			{
@@ -649,7 +649,7 @@ data "grafana_synthetic_monitoring_probes" "main" {}
 
 resource "grafana_synthetic_monitoring_check" "channels" {
   job     = %[1]q
-  target  = "grafana.com"
+  target  = "https://grafana.com/"
   enabled = false
   probes = [
     data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
@@ -663,7 +663,9 @@ resource "grafana_synthetic_monitoring_check" "channels" {
     }
   }
   settings {
-    ping {}
+    scripted {
+      script = "export default function() {};"
+    }
   }
 }
 `, jobName, channelID)


### PR DESCRIPTION
## Summary

- **Bump `synthetic-monitoring-api-go-client` to v0.20.0** 
- **Add `channels` attribute** to `grafana_synthetic_monitoring_check`, allowing users to assign a k6 channel (version) to scripted/browser checks via `channels { k6 { id = "..." } }`
- **Mark `channels` as Optional+Computed** so the API-assigned default channel is preserved when not explicitly set, avoiding drift on scripted/browser checks
- Add acceptance test for the new `channels` attribute