### PR TITLE
fix(ci): give git-cliff steps distinct output files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,14 +120,16 @@ jobs:
         passphrase: ${{ env.PASSPHRASE }}
     # git-cliff-action writes under git-cliff/ (untracked). GoReleaser refuses to run when git is dirty.
     - name: Prepare release notes outside repo for GoReleaser
+      env:
+        CHANGELOG_FILE: ${{ steps.changelog.outputs.changelog }}
       run: |
         set -euo pipefail
-        notes="${{ steps.changelog.outputs.changelog }}"
-        if [ ! -s "$notes" ]; then
-          echo "::error::Changelog file missing or empty at $notes"
-          exit 1
+        if [ -s "$CHANGELOG_FILE" ]; then
+          cp "$CHANGELOG_FILE" /tmp/goreleaser-release-notes.md
+        else
+          echo "::warning::Changelog file missing or empty at ${CHANGELOG_FILE}; release notes will be empty"
+          : > /tmp/goreleaser-release-notes.md
         fi
-        cp "$notes" /tmp/goreleaser-release-notes.md
         rm -rf git-cliff/
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,21 @@ jobs:
         persist-credentials: false
     - name: Unshallow
       run: git fetch --prune --unshallow
+    # git-cliff-action defaults its output file to git-cliff/CHANGELOG.md. Give each
+    # git-cliff step an explicit, distinct --output path so the --bumped-version step
+    # below does not clobber the generated changelog used for the release notes.
     - name: Generate changelog
       id: changelog
       uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
       with:
-        args: --latest --strip header
+        args: --latest --strip header --output git-cliff/RELEASE_NOTES.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Compute expected version
       id: expected_version
       uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
       with:
-        args: --bumped-version
+        args: --bumped-version --output git-cliff/bumped-version.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Validate semver bump
@@ -120,8 +123,8 @@ jobs:
       run: |
         set -euo pipefail
         notes="${{ steps.changelog.outputs.changelog }}"
-        if [ ! -f "$notes" ]; then
-          echo "::error::Changelog file not found at $notes"
+        if [ ! -s "$notes" ]; then
+          echo "::error::Changelog file missing or empty at $notes"
           exit 1
         fi
         cp "$notes" /tmp/goreleaser-release-notes.md


### PR DESCRIPTION
## Summary

The `release` workflow runs `orhun/git-cliff-action` twice, and both invocations defaulted to the **same** output file, `git-cliff/CHANGELOG.md`:

1. `Generate changelog` (`--latest --strip header`) writes the rendered changelog to `git-cliff/CHANGELOG.md`.
2. `Compute expected version` (`--bumped-version`) runs the same action with the same default output file, **overwriting** `git-cliff/CHANGELOG.md` with just the version string (e.g. `v4.37.0`).
3. `Prepare release notes` then copies that clobbered file to GoReleaser via `--release-notes`, so the published release body ends up being only the version with no changelog.

This is why `v4.37.0` shipped with an empty body. It is not a GoReleaser or GitHub API issue — GoReleaser faithfully published the file it was handed.

## Changes

- Pass an explicit, distinct `--output` to each git-cliff step:
  - `Generate changelog` → `git-cliff/RELEASE_NOTES.md`
  - `Compute expected version` → `git-cliff/bumped-version.txt`
  
  The action parses `-o/--output` out of `args` and sets `steps.<id>.outputs.changelog` to that path, so `Prepare release notes` (which reads `steps.changelog.outputs.changelog`) now picks up the real changelog and the bump step can no longer clobber it.
- Harden the release-notes guard to fail on an **empty** (not just missing) changelog file (`[ ! -s ]`), so this class of silent-empty-notes failure can't recur unnoticed.

## Test plan

- [ ] Next tagged release produces a draft GitHub Release whose body contains the grouped git-cliff changelog (Features / Bug Fixes / etc.) and the Full Changelog link, instead of just the version string.
- [ ] `Validate semver bump` step still passes (reads `steps.expected_version.outputs.content`, unaffected by the output-path change).