### PR TITLE
ci(workflows): auto-run cloud acceptance tests for Renovate

### DIFF
--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -11,13 +11,14 @@ on:
         type: string
         description: 'Tests to run (regex passed to -run)'
         default: '.*'
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - renovate/**
 
-# Cancel superseded Renovate runs; manual/workflow_call runs stay independent.
+# Cancel superseded Renovate branch pushes; manual/workflow_call runs stay independent.
 concurrency:
-  group: cloud-acc-${{ github.event.pull_request.number || format('manual-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: cloud-acc-${{ github.event_name == 'push' && github.ref || format('manual-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 # Keep workflow-level permissions minimal; grant elevated scopes at job level.
 permissions:
@@ -25,7 +26,6 @@ permissions:
 
 jobs:
   cloud:
-    if: github.event_name != 'pull_request' || github.event.pull_request.user.login == 'renovate[bot]'
     concurrency: cloud-api
     runs-on: ubuntu-latest
     permissions:
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with: 
@@ -70,7 +70,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           THIS_REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -11,7 +11,13 @@ on:
         type: string
         description: 'Tests to run (regex passed to -run)'
         default: '.*'
-    
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel superseded Renovate runs; manual/workflow_call runs stay independent.
+concurrency:
+  group: cloud-acc-${{ github.event.pull_request.number || format('manual-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Keep workflow-level permissions minimal; grant elevated scopes at job level.
 permissions:
@@ -19,6 +25,7 @@ permissions:
 
 jobs:
   cloud:
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login == 'renovate[bot]'
     concurrency: cloud-api
     runs-on: ubuntu-latest
     permissions:
@@ -27,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with: 
@@ -40,7 +48,7 @@ jobs:
             GRAFANA_CLOUD_ORG=cloud-tests:org
       - run: make testacc-cloud-api
         env:
-          TESTARGS: -run='${{ github.event.inputs.tests }}' -parallel=2
+          TESTARGS: -run='${{ inputs.tests || github.event.inputs.tests || '.*' }}' -parallel=2
           # Freshly-created Grafana Cloud stacks routinely return 503/504 from
           # individual stack-side microservices (teams, service-accounts) for
           # tens of seconds even after `/api/health` returns 200. Use a longer
@@ -52,7 +60,7 @@ jobs:
   refresh-pr-gate-check:
     name: refresh pull_request gate check
     needs: cloud
-    if: always()
+    if: needs.cloud.result == 'success' || needs.cloud.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,7 +70,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           THIS_REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -11,6 +11,8 @@ on:
         type: string
         description: 'Tests to run (regex passed to -run)'
         default: '.*'
+  # Auto-run on Renovate dependency PRs (branches use the default renovate/ prefix).
+  # Other PRs still require a maintainer to trigger this workflow manually.
   push:
     branches:
       - renovate/**
@@ -34,7 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ github.sha }}
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with: 
@@ -48,7 +49,7 @@ jobs:
             GRAFANA_CLOUD_ORG=cloud-tests:org
       - run: make testacc-cloud-api
         env:
-          TESTARGS: -run='${{ inputs.tests || github.event.inputs.tests || '.*' }}' -parallel=2
+          TESTARGS: -run='${{ github.event.inputs.tests || '.*' }}' -parallel=2
           # Freshly-created Grafana Cloud stacks routinely return 503/504 from
           # individual stack-side microservices (teams, service-accounts) for
           # tens of seconds even after `/api/health` returns 200. Use a longer
@@ -60,7 +61,7 @@ jobs:
   refresh-pr-gate-check:
     name: refresh pull_request gate check
     needs: cloud
-    if: needs.cloud.result == 'success' || needs.cloud.result == 'failure'
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Relates to https://github.com/grafana/deployment_tools/issues/575652

Renovate PRs are getting blocked by the gate. Considering the volume of such PRs, it would be easier to trigger cloud acc tests automatically rather than manually.

[Context](https://raintank-corp.slack.com/archives/C09TK4TSNKU/p1780476601019509)