### PR TITLE
test(equivalence): run tests against fresh grafana via docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ terraform-provider-grafana-generate
 .vscode
 vendor/
 .cache/
+equivalence-tests/local-provider.tfrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,10 @@ Before writing `main.tf` and tuning `ignore_fields`, orient yourself from the re
 
 3. **Do not commit `tests/<case>/.terraform/`** — The equivalence harness copies the test tree into a temp directory without preserving execute bits on cached provider binaries; keeping a local `.terraform` can cause `fork/exec ... permission denied`. Rely on `main.tf` + `.terraform.lock.hcl` only under `tests/<case>/`.
 
-4. **Goldens** — With Grafana reachable (`GRAFANA_URL`, `GRAFANA_AUTH`), run `make equivalence-test-update` to write `equivalence-tests/goldens/<case>/`. If a resource uses a fixed name and repeats create, fix HTTP 409 by deleting the conflicting remote object before re-running.
+4. **Goldens** — Run `make equivalence-test-update` to write `equivalence-tests/goldens/<case>/` (starts a fresh Grafana via docker compose).
 
 ```sh
-make equivalence-test-update       # refresh goldens/ (needs live Grafana)
+make equivalence-test-update       # refresh goldens/
 make equivalence-test-diff         # compare fresh run to goldens (registry provider)
 make equivalence-test-diff-local   # built provider vs goldens (dev_overrides)
 ```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,9 @@ DOCKER_COMPOSE_ARGS ?= --pull always --force-recreate --detach --remove-orphans 
 EQUIV_CACHE_BIN := $(CURDIR)/.cache/bin
 EQUIV_BIN ?= $(EQUIV_CACHE_BIN)/terraform-equivalence-testing
 
-.PHONY: equivalence-test-ensure-bin equivalence-test-update equivalence-test-diff equivalence-test-diff-local
+.PHONY: equivalence-test-ensure-bin \
+	equivalence-test-update equivalence-test-diff equivalence-test-diff-local \
+	equivalence-test-update-run equivalence-test-diff-run equivalence-test-diff-local-run
 
 # terraform-equivalence-testing is installed lazily
 $(EQUIV_BIN):
@@ -20,7 +22,7 @@ else
 		|| { echo "EQUIV_BIN not found or not executable: $(EQUIV_BIN)"; exit 1; }
 endif
 
-equivalence-test-update: equivalence-test-ensure-bin
+equivalence-test-update-run: equivalence-test-ensure-bin
 	env -u TF_CLI_CONFIG_FILE \
 		GRAFANA_URL="$${GRAFANA_URL:-http://localhost:3000}" \
 		GRAFANA_AUTH="$${GRAFANA_AUTH:-admin:admin}" \
@@ -28,7 +30,7 @@ equivalence-test-update: equivalence-test-ensure-bin
 		--goldens="$(CURDIR)/equivalence-tests/goldens" \
 		--tests="$(CURDIR)/equivalence-tests/tests"
 
-equivalence-test-diff: equivalence-test-ensure-bin
+equivalence-test-diff-run: equivalence-test-ensure-bin
 	env -u TF_CLI_CONFIG_FILE \
 		GRAFANA_URL="$${GRAFANA_URL:-http://localhost:3000}" \
 		GRAFANA_AUTH="$${GRAFANA_AUTH:-admin:admin}" \
@@ -38,12 +40,29 @@ equivalence-test-diff: equivalence-test-ensure-bin
 
 # Build provider from this checkout and diff JSON vs checked-in goldens (uses dev_overrides;
 # other providers still resolve via direct{}).
-equivalence-test-diff-local: equivalence-test-ensure-bin
+equivalence-test-diff-local-run: equivalence-test-ensure-bin
 	REPO_ROOT="$(CURDIR)" \
 		EQUIV_BIN="$(EQUIV_BIN)" \
 		GRAFANA_URL="$${GRAFANA_URL:-http://localhost:3000}" \
 		GRAFANA_AUTH="$${GRAFANA_AUTH:-admin:admin}" \
 		bash "$(CURDIR)/equivalence-tests/diff-local.sh"
+
+# Fresh Grafana via docker compose (same stack as testacc-oss-docker); no manual cleanup.
+define equivalence-test-with-grafana
+	REPO_ROOT="$(CURDIR)" \
+		GRAFANA_VERSION="$(GRAFANA_VERSION)" \
+		DOCKER_COMPOSE_ARGS="$(DOCKER_COMPOSE_ARGS)" \
+		bash "$(CURDIR)/equivalence-tests/run-with-grafana.sh" $(1)
+endef
+
+equivalence-test-update:
+	$(call equivalence-test-with-grafana,equivalence-test-update-run)
+
+equivalence-test-diff:
+	$(call equivalence-test-with-grafana,equivalence-test-diff-run)
+
+equivalence-test-diff-local:
+	$(call equivalence-test-with-grafana,equivalence-test-diff-local-run)
 
 testacc:
 	go build -o testdata/plugins/registry.terraform.io/grafana/grafana/999.999.999/$$(go env GOOS)_$$(go env GOARCH)/terraform-provider-grafana_v999.999.999_$$(go env GOOS)_$$(go env GOARCH) .

--- a/equivalence-tests/README.md
+++ b/equivalence-tests/README.md
@@ -6,9 +6,11 @@ Uses [terraform-equivalence-testing](https://github.com/hashicorp/terraform-equi
 
 - `terraform` on `PATH`. Registry `init` needs network.
 - Go (to build the repo-local `terraform-equivalence-testing` CLI). The Makefile installs it into `.cache/bin/` on first `update`/`diff` run; override with `EQUIV_BIN` if needed.
-- Defaults when unset: `GRAFANA_URL=http://localhost:3000`, `GRAFANA_AUTH=admin:admin`.
+- Docker (starts a fresh Grafana via `docker compose` for each command below).
 
 ## Commands
+
+Each target starts a fresh Grafana (same stack as `make testacc-oss-docker`), runs the test, then tears down compose.
 
 ```sh
 make equivalence-test-update      # refresh goldens/ (registry provider from main.tf)
@@ -21,8 +23,6 @@ Exit `0` = match, `2` = diff, `1` = failed run.
 `equivalence-test-update` / `-diff` use the registry Grafana provider with the version pinned per case in `main.tf` and `TF_CLI_CONFIG_FILE` unset. `equivalence-test-diff-local` builds this repo and sets `TF_CLI_CONFIG_FILE` with `dev_overrides` so Terraform loads the local `grafana/grafana` plugin instead of the registry.
 
 If you change the provider version in `main.tf`, refresh `.terraform.lock.hcl` with `terraform init -upgrade` in the relevant test directory to update the provider build used when running equivalence tests.
-
-Some cases use fixed resource names in Grafana. If a run fails because the object already exists (for example HTTP 409), delete the conflicting remote resource before re-running update or diff.
 
 ## Adding test cases
 

--- a/equivalence-tests/run-with-grafana.sh
+++ b/equivalence-tests/run-with-grafana.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Runs a Makefile equivalence-test-* target against a fresh Grafana from docker compose.
+# Starts compose with --force-recreate and --renew-anon-volumes so each run gets empty
+# MySQL/Grafana state; tears down on exit (including test failure).
+#
+# Usage: run-with-grafana.sh <make-target>
+#
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+	echo "usage: $0 <make-target>" >&2
+	exit 1
+fi
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+GRAFANA_URL="${GRAFANA_URL:-http://0.0.0.0:3000}"
+GRAFANA_AUTH="${GRAFANA_AUTH:-admin:admin}"
+GRAFANA_VERSION="${GRAFANA_VERSION:-latest}"
+DOCKER_COMPOSE_ARGS="${DOCKER_COMPOSE_ARGS:---pull always --force-recreate --detach --remove-orphans --wait --renew-anon-volumes}"
+
+cleanup() {
+	docker compose -f "$REPO_ROOT/docker-compose.yml" down
+}
+trap cleanup EXIT
+
+cd "$REPO_ROOT"
+export GRAFANA_URL GRAFANA_AUTH GRAFANA_VERSION
+
+IFS=' ' read -r -a compose_args <<<"$DOCKER_COMPOSE_ARGS"
+docker compose up "${compose_args[@]}"
+
+status=0
+make -C "$REPO_ROOT" "$1" || status=$?
+exit "$status"

--- a/equivalence-tests/run-with-grafana.sh
+++ b/equivalence-tests/run-with-grafana.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Runs a Makefile equivalence-test-* target against a fresh Grafana from docker compose.
+# Runs a Makefile equivalence-test-*-run target against a fresh Grafana from docker compose.
 # Starts compose with --force-recreate and --renew-anon-volumes so each run gets empty
 # MySQL/Grafana state; tears down on exit (including test failure).
 #

--- a/equivalence-tests/tests/grafana_team/main.tf
+++ b/equivalence-tests/tests/grafana_team/main.tf
@@ -11,9 +11,7 @@ terraform {
 
 provider "grafana" {}
 
-# Fixed name: each equivalence run uses a fresh temp dir, so Terraform always
-# tries to create this team again. Use a clean Grafana org or delete the team
-# before re-running update/diff.
+# Fixed name: safe with `make equivalence-test-*-docker` (fresh Grafana each run).
 resource "grafana_team" "equivalence" {
   name  = "terraform-equivalence-grafana-team"
   email = "terraform-equivalence-grafana-team@example.com"

--- a/equivalence-tests/tests/grafana_team/main.tf
+++ b/equivalence-tests/tests/grafana_team/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 provider "grafana" {}
 
-# Fixed name: safe with `make equivalence-test-*-docker` (fresh Grafana each run).
+# Fixed name: safe with equivalence tests (fresh Grafana each run via docker compose).
 resource "grafana_team" "equivalence" {
   name  = "terraform-equivalence-grafana-team"
   email = "terraform-equivalence-grafana-team@example.com"


### PR DESCRIPTION
Closes https://github.com/grafana/deployment_tools/issues/585771. Addresses the first bullet point.