### PR TITLE
chore(deps): bump go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/terraform-provider-grafana/v4
 
-go 1.26.3
+go 1.26.4
 
 require (
 	connectrpc.com/connect v1.18.1


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` from `1.26.3` to `1.26.4`.

CI workflows reference the version via `go-version-file: go.mod`, so they pick this up automatically — no workflow changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)