### PR TITLE
fix(ci): replace native concurrency groups with turnstyle and add /run-cloud-tests slash command

### DIFF
--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -27,14 +27,24 @@ jobs:
       - run: make integration-test
 
   cloudinstance:
-    concurrency: 
-      group: cloud-instance
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+      actions: read
     steps:
+      # Use turnstyle instead of the native `concurrency` group to get a true
+      # FIFO queue. Native concurrency only keeps one pending job per group;
+      # a third arrival cancels the second. Turnstyle polls the API and waits
+      # for earlier runs of the same job to finish, so no run is dropped.
+      - name: Wait for earlier cloudinstance runs
+        uses: softprops/turnstyle@fa86562458e34a9067f0dc1316a76b3975b1c413 # v3.3.1
+        with:
+          job-to-wait-for: cloudinstance
+          poll-interval-seconds: 30
+          abort-after-seconds: 2400 # 40 min safety net
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/acc-tests.yml
+++ b/.github/workflows/acc-tests.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Cancel in-flight runs for the same PR / branch when a new push arrives.
+# Pushes to main each get their own group so they are never cancelled.
+concurrency:
+  group: acc-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # These permissions are needed to assume roles from Github's OIDC.
 permissions:
   contents: read

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -28,12 +28,24 @@ permissions:
 
 jobs:
   cloud:
-    concurrency: cloud-api
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+      actions: read
     steps:
+      # Use turnstyle instead of the native `concurrency` group to get a true
+      # FIFO queue. Native concurrency only keeps one pending job per group;
+      # a third arrival cancels the second. Turnstyle polls the API and waits
+      # for earlier runs of the same job to finish, so no run is dropped.
+      - name: Wait for earlier cloud runs
+        uses: softprops/turnstyle@fa86562458e34a9067f0dc1316a76b3975b1c413 # v3.3.1
+        with:
+          job-to-wait-for: cloud
+          poll-interval-seconds: 30
+          abort-after-seconds: 2400 # 40 min safety net
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           message: |
             In order to lower resource usage and have a faster runtime, PRs will not run Cloud tests automatically.
-            To do so, a Grafana Labs employee must trigger the `cloud acceptance tests` workflow manually.
+            To do so, a Grafana Labs employee must [trigger the `cloud acceptance tests` workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/cloud-acc-tests.yml) manually for the `${{ github.head_ref }}` branch.
           message-id: pr-cloud-tests-info

--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           message: |
             In order to lower resource usage and have a faster runtime, PRs will not run Cloud tests automatically.
-            To do so, a Grafana Labs employee must [trigger the `cloud acceptance tests` workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/cloud-acc-tests.yml) manually for the `${{ github.head_ref }}` branch.
+            A Grafana Labs employee can trigger them by commenting `/run-cloud-tests` on this PR, or via the [Actions UI](${{ github.server_url }}/${{ github.repository }}/actions/workflows/cloud-acc-tests.yml) for the `${{ github.head_ref }}` branch.
           message-id: pr-cloud-tests-info

--- a/.github/workflows/slash-run-cloud-tests.yml
+++ b/.github/workflows/slash-run-cloud-tests.yml
@@ -1,0 +1,77 @@
+name: slash command /run-cloud-tests
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    # Only run on PR comments (not issue comments) that match the slash command.
+    if: >-
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '/run-cloud-tests')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Get PR head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          head_ref=$(gh api "$PR_URL" --jq '.head.ref')
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Add reaction to confirm
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_URL: ${{ github.event.comment.url }}
+        run: |
+          gh api "$COMMENT_URL/reactions" --method POST --field content='rocket'
+
+      - name: Dispatch cloud acceptance tests
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REF: ${{ steps.pr.outputs.head_ref }}
+        run: |
+          # Record timestamp just before dispatch so we can find the run.
+          before=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run cloud-acc-tests.yml --repo "$REPO" --ref "$REF"
+
+          # Poll for the new run (it takes a few seconds to appear).
+          for i in $(seq 1 10); do
+            sleep 3
+            run_url=$(gh api \
+              "repos/${REPO}/actions/workflows/cloud-acc-tests.yml/runs?branch=${REF}&event=workflow_dispatch&created=>=${before}&per_page=1" \
+              --jq '.workflow_runs[0].html_url // empty')
+            if [ -n "$run_url" ]; then
+              echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
+              echo "Found run: $run_url"
+              exit 0
+            fi
+          done
+
+          echo "::warning::Could not find the dispatched workflow run URL."
+          echo "run_url=" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment with run link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          REF: ${{ steps.pr.outputs.head_ref }}
+          RUN_URL: ${{ steps.dispatch.outputs.run_url }}
+        run: |
+          if [ -n "$RUN_URL" ]; then
+            body="Cloud acceptance tests dispatched for \`${REF}\`: [view run](${RUN_URL})"
+          else
+            body="Cloud acceptance tests dispatched for \`${REF}\`, but the run URL could not be determined. Check the [workflow runs](${GITHUB_SERVER_URL}/${REPO}/actions/workflows/cloud-acc-tests.yml) page."
+          fi
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"

--- a/.github/workflows/slash-run-cloud-tests.yml
+++ b/.github/workflows/slash-run-cloud-tests.yml
@@ -9,10 +9,15 @@ permissions:
 
 jobs:
   dispatch:
-    # Only run on PR comments (not issue comments) that match the slash command.
+    # Only run on PR comments from org members/collaborators that match the slash command.
     if: >-
       github.event.issue.pull_request
       && contains(github.event.comment.body, '/run-cloud-tests')
+      && (
+        github.event.comment.author_association == 'MEMBER'
+        || github.event.comment.author_association == 'COLLABORATOR'
+        || github.event.comment.author_association == 'OWNER'
+      )
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,29 @@ gh pr create --draft --base main --head fork-pr-<PR_NUMBER> \
 
 Once CI passes on the draft PR, close it and merge the original fork PR. Clean up the temporary branch with `git push origin --delete fork-pr-<PR_NUMBER>`.
 
+## CI for fork pull requests
+
+Some CI jobs (`cloudinstance`, `cloud`, enterprise tests) require secrets that are not available to fork pull requests. Those jobs will be skipped or fail on your PR — this is expected and not something you need to fix.
+
+**For external contributors:** A maintainer will review your code and trigger the full test suite on your behalf. You don't need to do anything beyond opening the PR and making sure the non-secret jobs (unit tests, linter, OSS acceptance tests) pass.
+
+**For maintainers:** After reviewing the fork PR code for safety, run the secret-requiring tests by pushing the fork's commits to an origin branch:
+
+```sh
+# Fetch the fork PR's commits and create a local branch
+git fetch origin refs/pull/<PR_NUMBER>/head:fork-pr-<PR_NUMBER>
+
+# Push to origin so CI can access secrets
+git push origin fork-pr-<PR_NUMBER>
+
+# Open a draft PR from that branch to trigger full CI
+gh pr create --draft --base main --head fork-pr-<PR_NUMBER> \
+  --title "ci: run full CI for #<PR_NUMBER>" \
+  --body "Draft PR to run secret-requiring CI for #<PR_NUMBER>."
+```
+
+Once CI passes on the draft PR, close it and merge the original fork PR. Clean up the temporary branch with `git push origin --delete fork-pr-<PR_NUMBER>`.
+
 ## PR title format
 
 This repository uses **squash merges**, so all commits in a PR are combined into a single commit when merged. The **PR title becomes the commit message**, so it must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,29 @@ We welcome contributions. Here’s how to get changes merged.
 5. **Update generated docs** if you changed resource/datasource schema or examples: run `go generate ./...` (or `make docs`). CI will fail if `docs/` is out of sync.
 6. **Open a pull request** against `main` — see [PR title format](#pr-title-format) below.
 
+## CI for fork pull requests
+
+Some CI jobs (`cloudinstance`, `cloud`, enterprise tests) require secrets that are not available to fork pull requests. Those jobs will be skipped or fail on your PR — this is expected and not something you need to fix.
+
+**For external contributors:** A maintainer will review your code and trigger the full test suite on your behalf. You don't need to do anything beyond opening the PR and making sure the non-secret jobs (unit tests, linter, OSS acceptance tests) pass.
+
+**For maintainers:** After reviewing the fork PR code for safety, run the secret-requiring tests by pushing the fork's commits to an origin branch:
+
+```sh
+# Fetch the fork PR's commits and create a local branch
+git fetch origin refs/pull/<PR_NUMBER>/head:fork-pr-<PR_NUMBER>
+
+# Push to origin so CI can access secrets
+git push origin fork-pr-<PR_NUMBER>
+
+# Open a draft PR from that branch to trigger full CI
+gh pr create --draft --base main --head fork-pr-<PR_NUMBER> \
+  --title "ci: run full CI for #<PR_NUMBER>" \
+  --body "Draft PR to run secret-requiring CI for #<PR_NUMBER>."
+```
+
+Once CI passes on the draft PR, close it and merge the original fork PR. Clean up the temporary branch with `git push origin --delete fork-pr-<PR_NUMBER>`.
+
 ## PR title format
 
 This repository uses **squash merges**, so all commits in a PR are combined into a single commit when merged. The **PR title becomes the commit message**, so it must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:


### PR DESCRIPTION
## Summary

- Replace native `concurrency` groups on the `cloudinstance` and `cloud` jobs with [`softprops/turnstyle`](https://github.com/softprops/turnstyle) for true FIFO queuing
- Add a `/run-cloud-tests` slash command to trigger cloud acceptance tests from PR comments
- Add workflow-level `cancel-in-progress` to `acc-tests.yml` so new pushes cancel stale runs

## Problem

GitHub Actions concurrency groups only keep **one** pending job per group. When a third run arrives while one is running and one is pending, the pending run is silently cancelled. This causes spurious `cloudinstance` and `cloud` job failures on busy repos.

## Changes

1. **acc-tests.yml**: Remove `concurrency: { group: cloud-instance, cancel-in-progress: false }` from the `cloudinstance` job, add a turnstyle step with `job-to-wait-for: cloudinstance`. Add a workflow-level concurrency group per PR with `cancel-in-progress: true` to cancel stale runs on new pushes.
2. **cloud-acc-tests.yml**: Remove `concurrency: cloud-api` from the `cloud` job, add a turnstyle step with `job-to-wait-for: cloud`.
3. **slash-run-cloud-tests.yml** (new): `issue_comment`-triggered workflow that dispatches cloud acceptance tests when a maintainer comments `/run-cloud-tests` on a PR. Posts back a comment with a link to the triggered run.
4. **comment-on-pr.yml**: Update the info comment to mention the slash command and include a link to the Actions UI.

Both turnstyle steps use a 40-minute `abort-after-seconds` safety net and 30-second poll interval. Since this is a public repo on GitHub-hosted runners, the polling wait has no billing impact.

## Test plan

- [ ] Verify `cloudinstance` job queues correctly when multiple acc-tests runs overlap (turnstyle waits instead of cancelling)
- [ ] Verify `cloud` job queues correctly when multiple cloud-acc-tests runs overlap
- [ ] Verify new pushes to a PR cancel in-flight acc-tests runs
- [ ] Verify `/run-cloud-tests` slash command works after merge (cannot test on this PR — `issue_comment` workflows run from main)
- [ ] Verify PR info comment renders with slash command instructions and Actions UI link