### PR TITLE
fix(ci): add permissions block to validate-catalog workflow

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -2,6 +2,9 @@ name: Validate catalog
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   validate-catalog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add explicit `permissions: contents: read` block to the `validate-catalog` workflow to satisfy the [zizmor `excessive-permissions` audit](https://docs.zizmor.sh/audits/#excessive-permissions)
- The workflow only checks out code and runs local validation (jsonnet, Go, terraform), so `contents: read` is the only permission needed

Fixes the zizmor warning reported in https://github.com/grafana/terraform-provider-grafana/pull/2824#issuecomment-4716125020