### PR TITLE
fix(appplatform): retry transient referential-integrity and server errors

### DIFF
--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -34,6 +34,20 @@ const (
 	conflictRetryAttempts  = 5
 	conflictRetryDelay     = 200 * time.Millisecond
 
+	// Delete retries cover the cross-resource referential-integrity race (e.g. deleting a
+	// connection right after its repository): the reference takes a short time to be
+	// reconciled away, so we wait longer than the optimistic-lock retry. The budget is a
+	// balance — long enough to absorb the reconcile window, but bounded so a genuinely
+	// permanent reference (a connection that is still referenced and not being destroyed)
+	// surfaces its real error reasonably quickly rather than hanging.
+	deleteRetryAttempts = 6
+	deleteRetryDelay    = time.Second
+
+	// Read retries cover transient server-side failures (5xx) so a single backend blip
+	// does not fail an entire plan/refresh.
+	readRetryAttempts = 5
+	readRetryDelay    = 200 * time.Millisecond
+
 	// DefaultManagerIdentity is the static identity stamped on App Platform resources
 	// managed by this Terraform provider. It intentionally excludes version numbers
 	// so that upgrading the provider or Terraform does not change the identity
@@ -392,7 +406,12 @@ func (r *Resource[T, L]) readModel(ctx context.Context, data ResourceModel, resp
 		return
 	}
 
-	res, err := r.client.Get(ctx, obj.GetName())
+	var res T
+	err := retryWhile(ctx, readRetryAttempts, readRetryDelay, isRetryableServerError, func(_ int) error {
+		var gerr error
+		res, gerr = r.client.Get(ctx, obj.GetName())
+		return gerr
+	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -680,7 +699,7 @@ func (r *Resource[T, L]) deleteModel(ctx context.Context, data ResourceModel, re
 		return
 	}
 
-	if err := retryOnConflict(ctx, conflictRetryAttempts, conflictRetryDelay, func(_ int) error {
+	if err := retryWhile(ctx, deleteRetryAttempts, deleteRetryDelay, isRetryableDeleteError, func(_ int) error {
 		return r.client.Delete(ctx, obj.GetName(), sdkresource.DeleteOptions{})
 	}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -707,7 +726,12 @@ func (r *Resource[T, L]) importStateModel(
 	resp *resource.ImportStateResponse,
 	setState func(updated ResourceModel),
 ) {
-	res, err := r.client.Get(ctx, req.ID)
+	var res T
+	err := retryWhile(ctx, readRetryAttempts, readRetryDelay, isRetryableServerError, func(_ int) error {
+		var gerr error
+		res, gerr = r.client.Get(ctx, req.ID)
+		return gerr
+	})
 	if err != nil {
 		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionRead, req.ID, r.resourceName, err)...)
 		return
@@ -1743,6 +1767,32 @@ func secureVersionChanged(current, previous types.Int64) bool {
 	}
 }
 
+// retryWhile retries run until it succeeds, the returned error is not retryable
+// (per retryable), or the attempt budget is exhausted. It sleeps delay between
+// attempts and aborts early if ctx is cancelled while waiting.
+func retryWhile(
+	ctx context.Context,
+	attempts int,
+	delay time.Duration,
+	retryable func(error) bool,
+	run func(attempt int) error,
+) error {
+	var err error
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		err = run(attempt)
+		if err == nil || !retryable(err) || attempt == attempts-1 {
+			return err
+		}
+
+		if err := waitForRetry(ctx, delay); err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
 // retryOnConflict smooths over optimistic-lock races with Grafana's unified storage.
 // Provisioning resources can be reconciled asynchronously by Grafana controllers, so
 // the ResourceVersion held by Terraform can go stale between plan/apply and the API
@@ -1759,20 +1809,43 @@ func retryOnConflict(
 	delay time.Duration,
 	run func(attempt int) error,
 ) error {
-	var err error
+	return retryWhile(ctx, attempts, delay, apierrors.IsConflict, run)
+}
 
-	for attempt := 0; attempt < attempts; attempt++ {
-		err = run(attempt)
-		if err == nil || !apierrors.IsConflict(err) || attempt == attempts-1 {
-			return err
-		}
+// referencedDependencyMarker is the substring Grafana's provisioning admission controller
+// uses when a resource cannot be deleted because another resource still references it
+// (e.g. deleting a connection while a repository still points at it via spec.connection.name).
+// Source: apps/provisioning/pkg/connection/delete_validator.go
+const referencedDependencyMarker = "referenced by"
 
-		if err := waitForRetry(ctx, delay); err != nil {
-			return err
-		}
-	}
+// isReferencedDependencyError reports whether err is a transient 422 Invalid error caused
+// by a not-yet-reconciled cross-resource reference. On destroy, Terraform deletes the
+// referencing resource (e.g. a repository) first and the API returns 200 before the
+// reference is reconciled away, so the subsequent delete of the referenced resource
+// (e.g. the connection) can briefly still observe the stale reference and fail with 422.
+// Retrying lets the reference clear; a genuinely-still-referenced resource keeps failing
+// until the attempt budget is exhausted, surfacing the real error.
+func isReferencedDependencyError(err error) bool {
+	return apierrors.IsInvalid(err) &&
+		strings.Contains(strings.ToLower(err.Error()), referencedDependencyMarker)
+}
 
-	return err
+// isRetryableDeleteError reports whether a failed delete is worth retrying: either an
+// optimistic-lock conflict (409) or a transient referential-integrity race (422).
+func isRetryableDeleteError(err error) bool {
+	return apierrors.IsConflict(err) || isReferencedDependencyError(err)
+}
+
+// isRetryableServerError reports whether err is a transient server-side failure
+// (HTTP 5xx, timeouts, or throttling) that is worth retrying on read. The provisioning
+// backend intermittently returns 500s on GET while reconciling, which would otherwise
+// fail an entire plan/refresh.
+func isRetryableServerError(err error) bool {
+	return apierrors.IsInternalError(err) || // 500 internal error
+		apierrors.IsServiceUnavailable(err) || // 503 service unavailable
+		apierrors.IsServerTimeout(err) || // reason=ServerTimeout (sent as HTTP 500)
+		apierrors.IsTimeout(err) || // reason=Timeout / HTTP 504 gateway timeout
+		apierrors.IsTooManyRequests(err) // 429 too many requests
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -34,19 +34,26 @@ const (
 	conflictRetryAttempts  = 5
 	conflictRetryDelay     = 200 * time.Millisecond
 
-	// Delete retries cover the cross-resource referential-integrity race (e.g. deleting a
-	// connection right after its repository): the reference takes a short time to be
-	// reconciled away, so we wait longer than the optimistic-lock retry. The budget is a
-	// balance — long enough to absorb the reconcile window, but bounded so a genuinely
-	// permanent reference (a connection that is still referenced and not being destroyed)
-	// surfaces its real error reasonably quickly rather than hanging.
+	// Delete retries cover the cross-resource referential-integrity race when a connection is
+	// deleted right after the repository that references it (spec.connection.name). Grafana's
+	// connection delete validator now ignores repositories that are themselves terminating
+	// (grafana/grafana#126822), so this 422 is no longer the seconds-long wait for the repo's
+	// finalizers to complete — what remains is a storage read-after-write window: the validator
+	// decides at admission via a live ListByConnection, and that list can briefly not yet observe
+	// the repository's freshly-written deletionTimestamp, still count it as a live reference, and
+	// return 422. The budget is a balance — long enough to absorb that window (which may be served
+	// from an eventual-consistent index path rather than a quorum read), but bounded so a genuinely
+	// permanent reference (a connection still referenced by a LIVE repository) surfaces its real
+	// error reasonably quickly rather than hanging.
 	deleteRetryAttempts = 6
-	deleteRetryDelay    = time.Second
+	deleteRetryDelay    = 2 * time.Second
 
 	// Read retries cover transient server-side failures (5xx) so a single backend blip
-	// does not fail an entire plan/refresh.
+	// does not fail an entire plan/refresh. Reads only sleep when a request actually
+	// errors, so a longer delay costs nothing on the success path but gives a 5xx room
+	// to clear mid-reconcile.
 	readRetryAttempts = 5
-	readRetryDelay    = 200 * time.Millisecond
+	readRetryDelay    = time.Second
 
 	// DefaultManagerIdentity is the static identity stamped on App Platform resources
 	// managed by this Terraform provider. It intentionally excludes version numbers
@@ -1821,13 +1828,15 @@ func retryOnConflict(
 // Source: apps/provisioning/pkg/connection/delete_validator.go
 const referencedDependencyMarker = "referenced by"
 
-// isReferencedDependencyError reports whether err is a transient 422 Invalid error caused
-// by a not-yet-reconciled cross-resource reference. On destroy, Terraform deletes the
-// referencing resource (e.g. a repository) first and the API returns 200 before the
-// reference is reconciled away, so the subsequent delete of the referenced resource
-// (e.g. the connection) can briefly still observe the stale reference and fail with 422.
-// Retrying lets the reference clear; a genuinely-still-referenced resource keeps failing
-// until the attempt budget is exhausted, surfacing the real error.
+// isReferencedDependencyError reports whether err is a transient 422 Invalid error caused by
+// a not-yet-observed cross-resource reference during teardown. On destroy, Terraform deletes
+// the referencing resource (e.g. a repository) first; its DELETE returns 200 and stamps a
+// deletionTimestamp, but the object lingers in storage until its finalizers complete. The
+// connection delete validator ignores terminating repositories (grafana/grafana#126822), so
+// this 422 only occurs when the validator's live ListByConnection has not yet observed that
+// freshly-written deletionTimestamp and still counts the repository as a live reference.
+// Retrying lets the read catch up; a connection still referenced by a genuinely LIVE
+// repository keeps failing until the attempt budget is exhausted, surfacing the real error.
 func isReferencedDependencyError(err error) bool {
 	return apierrors.IsInvalid(err) &&
 		strings.Contains(strings.ToLower(err.Error()), referencedDependencyMarker)

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -1777,8 +1777,11 @@ func retryWhile(
 	retryable func(error) bool,
 	run func(attempt int) error,
 ) error {
-	var err error
+	if attempts < 1 {
+		attempts = 1
+	}
 
+	var err error
 	for attempt := 0; attempt < attempts; attempt++ {
 		err = run(attempt)
 		if err == nil || !retryable(err) || attempt == attempts-1 {

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -45,14 +45,14 @@ const (
 	// from an eventual-consistent index path rather than a quorum read), but bounded so a genuinely
 	// permanent reference (a connection still referenced by a LIVE repository) surfaces its real
 	// error reasonably quickly rather than hanging.
-	deleteRetryAttempts = 6
+	deleteRetryAttempts = 4
 	deleteRetryDelay    = 2 * time.Second
 
 	// Read retries cover transient server-side failures (5xx) so a single backend blip
 	// does not fail an entire plan/refresh. Reads only sleep when a request actually
 	// errors, so a longer delay costs nothing on the success path but gives a 5xx room
 	// to clear mid-reconcile.
-	readRetryAttempts = 5
+	readRetryAttempts = 3
 	readRetryDelay    = time.Second
 
 	// DefaultManagerIdentity is the static identity stamped on App Platform resources

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -2,6 +2,7 @@ package appplatform
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sort"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func makeMockResource(name, uid string) sdkresource.Object {
@@ -1151,6 +1153,99 @@ func TestRetryOnConflict(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 		require.Equal(t, 1, attempts)
 	})
+}
+
+func TestRetryWhile(t *testing.T) {
+	boom := errors.New("boom")
+
+	t.Run("retries while predicate reports retryable", func(t *testing.T) {
+		attempts := 0
+		err := retryWhile(context.Background(), 4, 0, func(error) bool { return true }, func(_ int) error {
+			attempts++
+			if attempts < 3 {
+				return boom
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 3, attempts)
+	})
+
+	t.Run("stops immediately when predicate reports non-retryable", func(t *testing.T) {
+		attempts := 0
+		err := retryWhile(context.Background(), 4, 0, func(error) bool { return false }, func(_ int) error {
+			attempts++
+			return boom
+		})
+
+		require.ErrorIs(t, err, boom)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("returns last error after exhausting attempts", func(t *testing.T) {
+		attempts := 0
+		err := retryWhile(context.Background(), 3, 0, func(error) bool { return true }, func(_ int) error {
+			attempts++
+			return boom
+		})
+
+		require.ErrorIs(t, err, boom)
+		require.Equal(t, 3, attempts)
+	})
+}
+
+func referencedByConnectionError() error {
+	return apierrors.NewInvalid(
+		k8sschema.GroupKind{Group: "provisioning.grafana.app", Kind: "Connection"},
+		"my-connection",
+		field.ErrorList{field.Forbidden(
+			field.NewPath("metadata", "name"),
+			"cannot delete connection: referenced by 1 repository(s): [my-repo]",
+		)},
+	)
+}
+
+func TestIsReferencedDependencyError(t *testing.T) {
+	gk := k8sschema.GroupKind{Group: "provisioning.grafana.app", Kind: "Connection"}
+	gr := k8sschema.GroupResource{Group: gk.Group, Resource: "connections"}
+
+	require.True(t, isReferencedDependencyError(referencedByConnectionError()))
+
+	// A different Invalid error (genuine validation failure) must NOT be retried.
+	otherInvalid := apierrors.NewInvalid(gk, "my-connection", field.ErrorList{
+		field.Required(field.NewPath("spec", "title"), "title is required"),
+	})
+	require.False(t, isReferencedDependencyError(otherInvalid))
+
+	require.False(t, isReferencedDependencyError(apierrors.NewConflict(gr, "my-connection", nil)))
+	require.False(t, isReferencedDependencyError(apierrors.NewNotFound(gr, "my-connection")))
+	require.False(t, isReferencedDependencyError(nil))
+	require.False(t, isReferencedDependencyError(context.Canceled))
+}
+
+func TestIsRetryableDeleteError(t *testing.T) {
+	gr := k8sschema.GroupResource{Group: "provisioning.grafana.app", Resource: "connections"}
+
+	require.True(t, isRetryableDeleteError(apierrors.NewConflict(gr, "my-connection", nil)))
+	require.True(t, isRetryableDeleteError(referencedByConnectionError()))
+	require.False(t, isRetryableDeleteError(apierrors.NewNotFound(gr, "my-connection")))
+	require.False(t, isRetryableDeleteError(apierrors.NewBadRequest("nope")))
+	require.False(t, isRetryableDeleteError(nil))
+}
+
+func TestIsRetryableServerError(t *testing.T) {
+	gr := k8sschema.GroupResource{Group: "provisioning.grafana.app", Resource: "repositories"}
+
+	require.True(t, isRetryableServerError(apierrors.NewInternalError(errors.New("boom"))))
+	require.True(t, isRetryableServerError(apierrors.NewServiceUnavailable("down")))
+	require.True(t, isRetryableServerError(apierrors.NewServerTimeout(gr, "get", 1)))
+	require.True(t, isRetryableServerError(apierrors.NewTooManyRequestsError("slow down")))
+
+	require.False(t, isRetryableServerError(apierrors.NewNotFound(gr, "my-repo")))
+	require.False(t, isRetryableServerError(apierrors.NewBadRequest("bad")))
+	require.False(t, isRetryableServerError(referencedByConnectionError()))
+	require.False(t, isRetryableServerError(nil))
 }
 
 func TestConfiguredSecureAPIKeySetSkipsNullAndUnknownValues(t *testing.T) {

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -1193,6 +1193,21 @@ func TestRetryWhile(t *testing.T) {
 		require.ErrorIs(t, err, boom)
 		require.Equal(t, 3, attempts)
 	})
+
+	// A non-positive attempt budget must still run once and surface run's error, never
+	// return nil without calling run (which would mask a real failure as success).
+	t.Run("treats non-positive attempts as a single attempt", func(t *testing.T) {
+		for _, n := range []int{0, -3} {
+			attempts := 0
+			err := retryWhile(context.Background(), n, 0, func(error) bool { return true }, func(_ int) error {
+				attempts++
+				return boom
+			})
+
+			require.ErrorIs(t, err, boom, "attempts=%d should surface run's error", n)
+			require.Equal(t, 1, attempts, "attempts=%d should run exactly once", n)
+		}
+	})
 }
 
 func referencedByConnectionError() error {


### PR DESCRIPTION
## Summary

App Platform resources only retried HTTP 409 conflicts on delete, and did not retry reads at all. Against the provisioning (Git Sync) API this surfaces as two intermittent, eventual-consistency failures:

1. **Destroy 422 — cross-resource referential-integrity race.** When a connection and a repository that references it (`spec.connection.name`) are destroyed together, Terraform deletes the repository first. The repository `DELETE` returns `200` and stamps a `deletionTimestamp`, but the object lingers in storage until its finalizers complete.

   The connection delete validator decides at admission via a live `ListByConnection` (field selector `spec.connection.name`). With grafana/grafana#126822 (merged) the validator now ignores repositories that are themselves terminating (`DeletionTimestamp != nil`), which reduces the previously-*persistent* 422 to a narrow **storage read-after-write window**: if the validator's list has not yet observed the repository's freshly-written `deletionTimestamp` (~100ms; a field-selector list may be served from the eventual-consistent index path rather than a quorum read), it still counts the repository as a live reference and returns:

   ```
   Error: invalid value for field "metadata.name":
     * Forbidden: cannot delete connection: referenced by 1 repository(s): [...]
   ```

   This 422 (a `StatusReasonInvalid`, not a 409) was not retried, so the destroy failed even though the window clears moments later. The backend change and this client retry are complementary halves of the fix.

2. **Plan/refresh 5xx.** A transient `500` (or `503`/timeout/`429`) on a `GET` during plan/refresh failed the whole operation with no retry. No server-side change covers this yet, so it stands on its own.

## Changes

- Extract a generic `retryWhile(ctx, attempts, delay, retryable, run)` helper. `retryOnConflict` is now a thin wrapper over it — **update-path behaviour is unchanged** (still 409-only, 5×200ms). A non-positive attempt budget is clamped to a single attempt, so a misconfigured budget can never return `nil` without running.
- **Delete** now retries on conflict (409) **or** a transient referential-integrity error (422 `Invalid` whose message reports it is still "referenced by" another resource), bounded at 6×2s so a genuinely-permanent reference still surfaces its real error promptly rather than hanging.
- **Read** and **ImportState** now retry transient server errors (500/503/server-timeout/504/429) at 5×1s; `NotFound` is unaffected and still removes the resource from state.
- Predicates (`isReferencedDependencyError`, `isRetryableDeleteError`, `isRetryableServerError`) and `retryWhile` are unit-tested, including negative cases (a genuine validation 422 is **not** retried) and the non-positive-attempts guard.

## Scope / blast radius

The retry logic lives in the generic App Platform `Resource[T, L]` base, so it applies to all App Platform resources, but the new behaviour only changes outcomes for the transient error classes above; non-retryable errors fail exactly as before. The referential-integrity 422 is the documented behaviour of the provisioning connection delete validator (`apps/provisioning/pkg/connection/delete_validator.go`).

## Related backend work

- **grafana/grafana#126822 (merged):** delete validator ignores terminating repositories — turns the *persistent* 422 (entire finalizer-completion window, seconds) into a *transient* one (storage read-after-write lag) that this PR absorbs.
- **grafana/grafana#126819 (closed):** a finalizer-based alternative; explored but closed. It doesn't touch the validator's read path, so it would not have removed the need for this retry.

## Notes / follow-ups

- The "referenced by" classification matches the admission controller's message text (gated behind `IsInvalid`); the marker is centralized in a named constant with a source pointer. The 422 is a generic `Invalid` + `Forbidden` on `metadata.name`, so the message text is the only distinguishing signal available client-side — a stable machine-readable marker would be a backend follow-up.
- The update-path's inner `Get` (on conflict re-fetch) is intentionally left as conflict-only retry — pre-existing behaviour, out of scope for this fix.
- The combined connection+repository destroy path is exercised by the existing `TestAccProvisioningRepository_viaConnection` acceptance test.

## Testing

- `go test ./internal/resources/appplatform/...` — pass
- `go vet ./internal/resources/appplatform/...` — clean
- `golangci-lint run ./internal/resources/appplatform/...` — 0 issues
- `gofmt` — clean

No schema/example changes, so no docs regeneration required.
