### PR TITLE
chore(cloud): move to new stacks connections endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grafana/fleet-management-api v1.2.0
 	github.com/grafana/grafana-app-sdk v0.56.0
 	github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996
-	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260617152731-7617f086369b
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260622091431-7fe3d665bcc0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae
 	github.com/grafana/grafana/apps/alerting/alertenrichment v0.0.0-20250925121631-89b988ca553e
 	github.com/grafana/grafana/apps/alerting/rules v0.0.0-20260414202405-94b5db3554f5

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grafana/fleet-management-api v1.2.0
 	github.com/grafana/grafana-app-sdk v0.56.0
 	github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996
-	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260408092732-49b2323fa034
+	github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260617152731-7617f086369b
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae
 	github.com/grafana/grafana/apps/alerting/alertenrichment v0.0.0-20250925121631-89b988ca553e
 	github.com/grafana/grafana/apps/alerting/rules v0.0.0-20260414202405-94b5db3554f5

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/grafana/grafana-app-sdk/logging v0.55.0 h1:xgynJ60GT9TrdQWghLAan2Aqqm
 github.com/grafana/grafana-app-sdk/logging v0.55.0/go.mod h1:t0rXNkTz3R6PLpjxk4BIl2erHYkMBX+rd+UHSL0k5nw=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996 h1:AnLo+NlmGY4lJaZvH4Mzb8eng9byn/hbl1WuMthY9QQ=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996/go.mod h1:piOOzeZUPg0tP4sfe1y+MFp5+jGVPri4WOVV4oSJS30=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260617152731-7617f086369b h1:MgAhaGTpz5FPgkeLNbqQam/gAfjijFCRUuEmwzlA7zY=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260617152731-7617f086369b/go.mod h1:1NirfPnyqo/RQKgfSCXw+EPy77sP8lj4Dqsdgnv+2oo=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260622091431-7fe3d665bcc0 h1:zJJOdQOUr2PbMwVSmah94SF5+t6ZJPJ0gcqYVQ7G1Ts=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260622091431-7fe3d665bcc0/go.mod h1:1NirfPnyqo/RQKgfSCXw+EPy77sP8lj4Dqsdgnv+2oo=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae h1:ExiJ4Ha24+MRuKxymlGp5bAJwbUSHe+QXcf6E8pwlo0=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae/go.mod h1:4WkWL9W7QMnRgRA1XrrSbZRg/UIoTx4x5ynx5RjJldU=
 github.com/grafana/grafana-plugin-sdk-go v0.292.0 h1:HaFIbBmPX9K+BVsVemid+poDEbja+HJ8VE+6tVnZKLU=

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/grafana/grafana-app-sdk/logging v0.55.0 h1:xgynJ60GT9TrdQWghLAan2Aqqm
 github.com/grafana/grafana-app-sdk/logging v0.55.0/go.mod h1:t0rXNkTz3R6PLpjxk4BIl2erHYkMBX+rd+UHSL0k5nw=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996 h1:AnLo+NlmGY4lJaZvH4Mzb8eng9byn/hbl1WuMthY9QQ=
 github.com/grafana/grafana-asserts-public-clients/go/gcom v0.0.0-20260203142553-433280da6996/go.mod h1:piOOzeZUPg0tP4sfe1y+MFp5+jGVPri4WOVV4oSJS30=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260408092732-49b2323fa034 h1:ZLtSNSQ4+VvFhF7AVSX/hZfy2NF09aRc+0S+a42R9G8=
-github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260408092732-49b2323fa034/go.mod h1:M4Y79J2TYgmcNwvVKVlHrGM9nWfSmfzJNhUHrwGJe2M=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260617152731-7617f086369b h1:MgAhaGTpz5FPgkeLNbqQam/gAfjijFCRUuEmwzlA7zY=
+github.com/grafana/grafana-com-public-clients/go/gcom v0.0.0-20260617152731-7617f086369b/go.mod h1:1NirfPnyqo/RQKgfSCXw+EPy77sP8lj4Dqsdgnv+2oo=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae h1:ExiJ4Ha24+MRuKxymlGp5bAJwbUSHe+QXcf6E8pwlo0=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20260414120814-5b95bb183fae/go.mod h1:4WkWL9W7QMnRgRA1XrrSbZRg/UIoTx4x5ynx5RjJldU=
 github.com/grafana/grafana-plugin-sdk-go v0.292.0 h1:HaFIbBmPX9K+BVsVemid+poDEbja+HJ8VE+6tVnZKLU=

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -563,7 +563,25 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 		return apiError(err)
 	}
 
-	if err := flattenStack(d, stack, connections); err != nil {
+	var legacyConnections *gcom.FormattedApiInstanceConnections
+	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		resp, httpResp, err := client.InstancesAPI.GetConnections(ctx, id.(string)).Execute()
+		if err != nil {
+			if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		legacyConnections = resp
+		return nil
+	})
+	if err != nil {
+		return apiError(err)
+	}
+
+	ipAllowListCNAMByTenantType := ipAllowListCNAMByTenantType(legacyConnections.GetPrivateConnectivityInfo().Tenants)
+
+	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType); err != nil {
 		return diag.FromErr(err)
 	}
 	// Always set the wait attribute to true after creation
@@ -576,7 +594,12 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	return nil
 }
 
-func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, connections *gcom.StackConnectionsV1) error {
+func flattenStack(
+	d *schema.ResourceData,
+	stack *gcom.FormattedApiInstance,
+	connections *gcom.StackConnectionsV1,
+	ipAllowListCNAMByTenantType map[string]string,
+) error {
 	id := strconv.FormatInt(int64(stack.Id), 10)
 
 	tenants := connections.GetTenants()
@@ -588,9 +611,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	// The GCOM tenant name is "grafana" (singular) but the schema attribute
 	// key is "grafanas_ip_allow_list_cname" (plural). Pass the schema prefix
 	// "grafanas" to addIPAllowListIfPresent so d.Set uses the correct key.
-	runIfTenantFound(tenants, "grafana", func(tenant gcom.StackConnectionTenantV1) {
-		addIPAllowListIfPresent(d, "grafanas", tenant)
-	})
+	addIPAllowListIfPresent(d, "grafanas", "grafana", ipAllowListCNAMByTenantType)
 
 	d.Set("status", stack.Status)
 	d.Set("region_slug", stack.RegionSlug)
@@ -620,8 +641,8 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("prometheus_status", stack.HmInstancePromStatus)
 	runIfTenantFound(tenants, "prometheus", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "prometheus", tenant)
-		addIPAllowListIfPresent(d, "prometheus", tenant)
 	})
+	addIPAllowListIfPresent(d, "prometheus", "prometheus", ipAllowListCNAMByTenantType)
 
 	d.Set("logs_user_id", stack.HlInstanceId)
 	d.Set("logs_url", stack.HlInstanceUrl)
@@ -629,16 +650,14 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("logs_status", stack.HlInstanceStatus)
 	runIfTenantFound(tenants, "logs", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "logs", tenant)
-		addIPAllowListIfPresent(d, "logs", tenant)
 	})
+	addIPAllowListIfPresent(d, "logs", "logs", ipAllowListCNAMByTenantType)
 
 	d.Set("alertmanager_user_id", stack.AmInstanceId)
 	d.Set("alertmanager_name", stack.AmInstanceName)
 	d.Set("alertmanager_url", stack.AmInstanceUrl)
 	d.Set("alertmanager_status", stack.AmInstanceStatus)
-	runIfTenantFound(tenants, "alerts", func(tenant gcom.StackConnectionTenantV1) {
-		addIPAllowListIfPresent(d, "alertmanager", tenant)
-	})
+	addIPAllowListIfPresent(d, "alertmanager", "alerts", ipAllowListCNAMByTenantType)
 
 	d.Set("sm_url", stack.RegionSyntheticMonitoringApiUrl)
 
@@ -657,8 +676,8 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("traces_status", stack.HtInstanceStatus)
 	runIfTenantFound(tenants, "traces", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "traces", tenant)
-		addIPAllowListIfPresent(d, "traces", tenant)
 	})
+	addIPAllowListIfPresent(d, "traces", "traces", ipAllowListCNAMByTenantType)
 
 	d.Set("profiles_user_id", stack.HpInstanceId)
 	d.Set("profiles_name", stack.HpInstanceName)
@@ -666,8 +685,8 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("profiles_status", stack.HpInstanceStatus)
 	runIfTenantFound(tenants, "profiles", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "profiles", tenant)
-		addIPAllowListIfPresent(d, "profiles", tenant)
 	})
+	addIPAllowListIfPresent(d, "profiles", "profiles", ipAllowListCNAMByTenantType)
 
 	d.Set("graphite_user_id", stack.HmInstanceGraphiteId)
 	d.Set("graphite_name", stack.HmInstanceGraphiteName)
@@ -675,8 +694,8 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
 	runIfTenantFound(tenants, "graphite", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "graphite", tenant)
-		addIPAllowListIfPresent(d, "graphite", tenant)
 	})
+	addIPAllowListIfPresent(d, "graphite", "graphite", ipAllowListCNAMByTenantType)
 
 	d.Set("fleet_management_user_id", stack.AgentManagementInstanceId)
 	d.Set("fleet_management_name", stack.AgentManagementInstanceName)
@@ -731,16 +750,30 @@ func runIfTenantFound(
 	}
 }
 
+func ipAllowListCNAMByTenantType(tenants []gcom.TenantsInner) map[string]string {
+	result := make(map[string]string, len(tenants))
+	for _, tenant := range tenants {
+		if cname := tenant.IpAllowListCNAME.Get(); cname != nil {
+			result[tenant.Type] = *cname
+		}
+	}
+	return result
+}
+
+func addIPAllowListIfPresent(
+	d *schema.ResourceData,
+	schemaPrefix, tenantType string,
+	ipAllowListCNAMByTenantType map[string]string,
+) {
+	if cname, ok := ipAllowListCNAMByTenantType[tenantType]; ok {
+		d.Set(fmt.Sprintf("%s_ip_allow_list_cname", schemaPrefix), cname)
+	}
+}
+
 func addPrivateConnectivityInfoIfPresent(d *schema.ResourceData, preffix string, tenant gcom.StackConnectionTenantV1) {
 	addPrivateConnectivityInfo(d, preffix, &gcom.BasicPrivateConnectivityInfo{})
 	if info, ok := tenant.GetPrivateConnectivityInfoOk(); ok {
 		addPrivateConnectivityInfo(d, preffix, info)
-	}
-}
-
-func addIPAllowListIfPresent(d *schema.ResourceData, preffix string, tenant gcom.StackConnectionTenantV1) {
-	if cname, ok := tenant.GetIpAllowListCNAMEOk(); ok {
-		d.Set(fmt.Sprintf("%s_ip_allow_list_cname", preffix), *cname)
 	}
 }
 

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -547,9 +547,9 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 		return common.WarnMissing("stack", d)
 	}
 
-	var connections *gcom.FormattedApiInstanceConnections
+	var connections *gcom.StackConnectionsV1
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-		resp, httpResp, err := client.InstancesAPI.GetConnections(ctx, id.(string)).Execute()
+		resp, httpResp, err := client.StacksAPI.GetStackConnectionsV1(ctx, id.(string)).Execute()
 		if err != nil {
 			if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
 				return retry.RetryableError(err)
@@ -576,12 +576,10 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	return nil
 }
 
-func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, connections *gcom.FormattedApiInstanceConnections) error {
+func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, connections *gcom.StackConnectionsV1) error {
 	id := strconv.FormatInt(int64(stack.Id), 10)
 
-	// getting tenants information for later use
-	privateConnectivityInfo := connections.PrivateConnectivityInfo
-	tenants := privateConnectivityInfo.GetTenants()
+	tenants := connections.GetTenants()
 
 	d.SetId(id)
 	d.Set("name", stack.Name)
@@ -590,7 +588,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	// The GCOM tenant name is "grafana" (singular) but the schema attribute
 	// key is "grafanas_ip_allow_list_cname" (plural). Pass the schema prefix
 	// "grafanas" to addIPAllowListIfPresent so d.Set uses the correct key.
-	runIfTenantFound(tenants, "grafana", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "grafana", func(tenant gcom.StackConnectionTenantV1) {
 		addIPAllowListIfPresent(d, "grafanas", tenant)
 	})
 
@@ -620,7 +618,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	}
 	d.Set("prometheus_remote_write_endpoint", rweURL)
 	d.Set("prometheus_status", stack.HmInstancePromStatus)
-	runIfTenantFound(tenants, "prometheus", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "prometheus", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "prometheus", tenant)
 		addIPAllowListIfPresent(d, "prometheus", tenant)
 	})
@@ -629,7 +627,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("logs_url", stack.HlInstanceUrl)
 	d.Set("logs_name", stack.HlInstanceName)
 	d.Set("logs_status", stack.HlInstanceStatus)
-	runIfTenantFound(tenants, "logs", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "logs", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "logs", tenant)
 		addIPAllowListIfPresent(d, "logs", tenant)
 	})
@@ -638,21 +636,26 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("alertmanager_name", stack.AmInstanceName)
 	d.Set("alertmanager_url", stack.AmInstanceUrl)
 	d.Set("alertmanager_status", stack.AmInstanceStatus)
-	runIfTenantFound(tenants, "alerts", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "alerts", func(tenant gcom.StackConnectionTenantV1) {
 		addIPAllowListIfPresent(d, "alertmanager", tenant)
 	})
 
 	d.Set("sm_url", stack.RegionSyntheticMonitoringApiUrl)
 
-	if oncallURL := connections.OncallApiUrl; oncallURL.IsSet() {
-		d.Set("oncall_api_url", oncallURL.Get())
+	if services, ok := connections.GetServicesOk(); ok {
+		if oncallURL, urlOk := services.GetOncallApiUrlOk(); urlOk {
+			d.Set("oncall_api_url", *oncallURL)
+		}
+		if influxURL, urlOk := services.GetInfluxUrlOk(); urlOk {
+			d.Set("influx_url", *influxURL)
+		}
 	}
 
 	d.Set("traces_user_id", stack.HtInstanceId)
 	d.Set("traces_name", stack.HtInstanceName)
 	d.Set("traces_url", stack.HtInstanceUrl)
 	d.Set("traces_status", stack.HtInstanceStatus)
-	runIfTenantFound(tenants, "traces", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "traces", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "traces", tenant)
 		addIPAllowListIfPresent(d, "traces", tenant)
 	})
@@ -661,7 +664,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("profiles_name", stack.HpInstanceName)
 	d.Set("profiles_url", stack.HpInstanceUrl)
 	d.Set("profiles_status", stack.HpInstanceStatus)
-	runIfTenantFound(tenants, "profiles", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "profiles", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "profiles", tenant)
 		addIPAllowListIfPresent(d, "profiles", tenant)
 	})
@@ -670,7 +673,7 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("graphite_name", stack.HmInstanceGraphiteName)
 	d.Set("graphite_url", stack.HmInstanceGraphiteUrl)
 	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
-	runIfTenantFound(tenants, "graphite", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "graphite", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "graphite", tenant)
 		addIPAllowListIfPresent(d, "graphite", tenant)
 	})
@@ -679,31 +682,24 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 	d.Set("fleet_management_name", stack.AgentManagementInstanceName)
 	d.Set("fleet_management_url", stack.AgentManagementInstanceUrl)
 	d.Set("fleet_management_status", stack.AgentManagementInstanceStatus)
-	runIfTenantFound(tenants, "agent-management", func(tenant gcom.TenantsInner) {
+	runIfTenantFound(tenants, "agent-management", func(tenant gcom.StackConnectionTenantV1) {
 		addPrivateConnectivityInfoIfPresent(d, "fleet_management", tenant)
 	})
 
-	if otlpURL := connections.OtlpHttpUrl; otlpURL.IsSet() {
-		d.Set("otlp_url", otlpURL.Get())
-		addPrivateConnectivityInfo(d, "otlp", &gcom.InfoAnyOf{})
-		if privateConnectivityInfo.Otlp != nil && privateConnectivityInfo.Otlp.InfoAnyOf != nil {
-			addPrivateConnectivityInfo(d, "otlp", privateConnectivityInfo.Otlp.InfoAnyOf)
+	if otlp, ok := connections.GetOtlpOk(); ok {
+		if otlpURL, urlOk := otlp.GetUrlOk(); urlOk {
+			d.Set("otlp_url", *otlpURL)
+		}
+		addPrivateConnectivityInfo(d, "otlp", &gcom.BasicPrivateConnectivityInfo{})
+		if info, infoOk := otlp.GetPrivateConnectivityInfoOk(); infoOk {
+			addPrivateConnectivityInfo(d, "otlp", info)
 		}
 	}
-	addPrivateConnectivityInfo(d, "pdc_api", &gcom.InfoAnyOf{})
-	addPrivateConnectivityInfo(d, "pdc_gateway", &gcom.InfoAnyOf{})
-	if privateConnectivityInfo.Pdc != nil {
-		pdc := privateConnectivityInfo.Pdc
-		if pdc.Api.InfoAnyOf != nil {
-			addPrivateConnectivityInfo(d, "pdc_api", pdc.Api.InfoAnyOf)
-		}
-		if pdc.Gateway.InfoAnyOf != nil {
-			addPrivateConnectivityInfo(d, "pdc_gateway", pdc.Gateway.InfoAnyOf)
-		}
-	}
-
-	if influxURL := connections.InfluxUrl; influxURL.IsSet() {
-		d.Set("influx_url", influxURL.Get())
+	addPrivateConnectivityInfo(d, "pdc_api", &gcom.BasicPrivateConnectivityInfo{})
+	addPrivateConnectivityInfo(d, "pdc_gateway", &gcom.BasicPrivateConnectivityInfo{})
+	if pdc, ok := connections.GetPdcOk(); ok {
+		addPrivateConnectivityInfo(d, "pdc_api", &pdc.Api)
+		addPrivateConnectivityInfo(d, "pdc_gateway", &pdc.Gateway)
 	}
 
 	// Derive the domain suffix from an API-returned URL so that both the old
@@ -723,9 +719,9 @@ func flattenStack(d *schema.ResourceData, stack *gcom.FormattedApiInstance, conn
 }
 
 func runIfTenantFound(
-	tenants []gcom.TenantsInner,
+	tenants []gcom.StackConnectionTenantV1,
 	tenantType string,
-	action func(gcom.TenantsInner),
+	action func(gcom.StackConnectionTenantV1),
 ) {
 	for _, tenant := range tenants {
 		if tenant.Type == tenantType {
@@ -735,25 +731,25 @@ func runIfTenantFound(
 	}
 }
 
-func addPrivateConnectivityInfoIfPresent(d *schema.ResourceData, preffix string, tenant gcom.TenantsInner) {
-	addPrivateConnectivityInfo(d, preffix, &gcom.InfoAnyOf{})
-	if tenant.Info != nil && tenant.Info.InfoAnyOf != nil {
-		addPrivateConnectivityInfo(d, preffix, tenant.Info.InfoAnyOf)
+func addPrivateConnectivityInfoIfPresent(d *schema.ResourceData, preffix string, tenant gcom.StackConnectionTenantV1) {
+	addPrivateConnectivityInfo(d, preffix, &gcom.BasicPrivateConnectivityInfo{})
+	if info, ok := tenant.GetPrivateConnectivityInfoOk(); ok {
+		addPrivateConnectivityInfo(d, preffix, info)
 	}
 }
 
-func addIPAllowListIfPresent(d *schema.ResourceData, preffix string, tenant gcom.TenantsInner) {
-	if tenant.IpAllowListCNAME.Get() != nil {
-		d.Set(fmt.Sprintf("%s_ip_allow_list_cname", preffix), *tenant.IpAllowListCNAME.Get())
+func addIPAllowListIfPresent(d *schema.ResourceData, preffix string, tenant gcom.StackConnectionTenantV1) {
+	if cname, ok := tenant.GetIpAllowListCNAMEOk(); ok {
+		d.Set(fmt.Sprintf("%s_ip_allow_list_cname", preffix), *cname)
 	}
 }
 
-func addPrivateConnectivityInfo(d *schema.ResourceData, preffix string, info *gcom.InfoAnyOf) {
+func addPrivateConnectivityInfo(d *schema.ResourceData, preffix string, info *gcom.BasicPrivateConnectivityInfo) {
 	if info == nil {
 		return
 	}
-	d.Set(fmt.Sprintf("%s_private_connectivity_info_private_dns", preffix), info.PrivateDNS)
-	d.Set(fmt.Sprintf("%s_private_connectivity_info_service_name", preffix), info.ServiceName)
+	d.Set(fmt.Sprintf("%s_private_connectivity_info_private_dns", preffix), info.GetPrivateDNS())
+	d.Set(fmt.Sprintf("%s_private_connectivity_info_service_name", preffix), info.GetServiceName())
 	d.Set(fmt.Sprintf("%s_private_connectivity_info_regions", preffix), info.Regions)
 	d.Set(fmt.Sprintf("%s_private_connectivity_info_availability_zones", preffix), info.AvailabilityZones)
 	d.Set(fmt.Sprintf("%s_private_connectivity_info_availability_zone_ids", preffix), info.AvailabilityZoneIds)

--- a/internal/resources/cloud/resource_cloud_stack_flatten_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_flatten_test.go
@@ -33,7 +33,7 @@ func TestUnitFlattenStack_BasicStackFields(t *testing.T) {
 	connections := gcom.NewStackConnectionsV1([]gcom.StackConnectionTenantV1{})
 
 	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
-	if err := flattenStack(d, stack, connections); err != nil {
+	if err := flattenStack(d, stack, connections, nil); err != nil {
 		t.Fatalf("flattenStack: %v", err)
 	}
 
@@ -71,14 +71,12 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 	connections := &gcom.StackConnectionsV1{
 		Tenants: []gcom.StackConnectionTenantV1{
 			{
-				Id:               1,
-				Type:             "grafana",
-				IpAllowListCNAME: common.Ref("grafanas.example.net"),
+				Id:   1,
+				Type: "grafana",
 			},
 			{
-				Id:               2,
-				Type:             "prometheus",
-				IpAllowListCNAME: common.Ref("prom.example.net"),
+				Id:   2,
+				Type: "prometheus",
 				PrivateConnectivityInfo: &gcom.BasicPrivateConnectivityInfo{
 					PrivateDNS:  common.Ref("prom-private.example.net"),
 					ServiceName: common.Ref("com.amazonaws.vpce.eu-west-1.vpce-svc-prom"),
@@ -86,9 +84,8 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 				},
 			},
 			{
-				Id:               3,
-				Type:             "alerts",
-				IpAllowListCNAME: common.Ref("alerts.example.net"),
+				Id:   3,
+				Type: "alerts",
 			},
 			{
 				Id:   4,
@@ -122,8 +119,14 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 		},
 	}
 
+	ipAllowListCNAMByTenantType := map[string]string{
+		"grafana":    "grafanas.example.net",
+		"prometheus": "prom.example.net",
+		"alerts":     "alerts.example.net",
+	}
+
 	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
-	if err := flattenStack(d, stack, connections); err != nil {
+	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType); err != nil {
 		t.Fatalf("flattenStack: %v", err)
 	}
 
@@ -144,6 +147,39 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 	requireStringAttr(t, d, "pdc_api_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-pdc-api")
 	requireStringAttr(t, d, "pdc_gateway_private_connectivity_info_private_dns", "pdc-gateway-private.example.net")
 	requireStringAttr(t, d, "pdc_gateway_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-pdc-gateway")
+}
+
+func TestUnitIPAllowListCNAMByTenantType(t *testing.T) {
+	t.Parallel()
+
+	tenants := []gcom.TenantsInner{
+		{
+			Type:             "grafana",
+			IpAllowListCNAME: *gcom.NewNullableString(common.Ref("grafanas.example.net")),
+		},
+		{
+			Type:             "prometheus",
+			IpAllowListCNAME: *gcom.NewNullableString(common.Ref("prom.example.net")),
+		},
+		{
+			Type: "logs",
+		},
+	}
+
+	got := ipAllowListCNAMByTenantType(tenants)
+
+	want := map[string]string{
+		"grafana":    "grafanas.example.net",
+		"prometheus": "prom.example.net",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for tenantType, cname := range want {
+		if got[tenantType] != cname {
+			t.Fatalf("%s: got %q, want %q", tenantType, got[tenantType], cname)
+		}
+	}
 }
 
 func requireStringAttr(t *testing.T, d *schema.ResourceData, key, want string) {

--- a/internal/resources/cloud/resource_cloud_stack_flatten_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_flatten_test.go
@@ -1,0 +1,215 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-com-public-clients/go/gcom"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestUnitFlattenStack_BasicStackFields(t *testing.T) {
+	t.Parallel()
+
+	stack := &gcom.FormattedApiInstance{
+		Id:                             12345,
+		Name:                           "my-stack",
+		Slug:                           "my-stack",
+		Url:                            "https://my-stack.grafana.net",
+		Status:                         "active",
+		RegionSlug:                     "eu",
+		ClusterSlug:                    "prod-eu-west-0",
+		ClusterName:                    "EU West 0",
+		Description:                    "test stack",
+		DeleteProtection:               true,
+		HmInstancePromId:               101,
+		HmInstancePromUrl:              "https://prometheus-prod-04.csp-region-1.grafana.net",
+		HmInstancePromName:             "prometheus",
+		HmInstancePromStatus:           "active",
+		RegionSyntheticMonitoringApiUrl: "https://synthetic-monitoring-api-eu-west-0.grafana.net",
+	}
+
+	connections := gcom.NewStackConnectionsV1([]gcom.StackConnectionTenantV1{})
+
+	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
+	if err := flattenStack(d, stack, connections); err != nil {
+		t.Fatalf("flattenStack: %v", err)
+	}
+
+	requireStringAttr(t, d, "id", "12345")
+	requireStringAttr(t, d, "name", "my-stack")
+	requireStringAttr(t, d, "slug", "my-stack")
+	requireStringAttr(t, d, "url", "https://my-stack.grafana.net")
+	requireStringAttr(t, d, "status", "active")
+	requireStringAttr(t, d, "region_slug", "eu")
+	requireStringAttr(t, d, "cluster_slug", "prod-eu-west-0")
+	requireStringAttr(t, d, "cluster_name", "EU West 0")
+	requireStringAttr(t, d, "description", "test stack")
+	requireBoolAttr(t, d, "delete_protection", true)
+	requireIntAttr(t, d, "prometheus_user_id", 101)
+	requireStringAttr(t, d, "prometheus_remote_endpoint", "https://prometheus-prod-04.csp-region-1.grafana.net/api/prom")
+	requireStringAttr(t, d, "prometheus_remote_write_endpoint", "https://prometheus-prod-04.csp-region-1.grafana.net/api/prom/push")
+	requireStringAttr(t, d, "sm_url", "https://synthetic-monitoring-api-eu-west-0.grafana.net")
+	requireStringAttr(t, d, "cloud_provider_url", "https://cloud-provider-api-prod-eu-west-0.csp-region-1.grafana.net")
+	requireStringAttr(t, d, "connections_api_url", "https://connections-api-prod-eu-west-0.csp-region-1.grafana.net")
+}
+
+func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
+	t.Parallel()
+
+	stack := &gcom.FormattedApiInstance{
+		Id:          99,
+		Name:        "conn-stack",
+		Slug:        "conn-stack",
+		Url:         "https://conn-stack.grafana.net",
+		Status:      "active",
+		ClusterSlug: "prod-eu-west-0",
+		HmInstancePromUrl: "https://prometheus-prod-01-eu-west-0.grafana.net",
+	}
+
+	connections := &gcom.StackConnectionsV1{
+		Tenants: []gcom.StackConnectionTenantV1{
+			{
+				Id:               1,
+				Type:             "grafana",
+				IpAllowListCNAME: common.Ref("grafanas.example.net"),
+			},
+			{
+				Id:   2,
+				Type: "prometheus",
+				IpAllowListCNAME: common.Ref("prom.example.net"),
+				PrivateConnectivityInfo: &gcom.BasicPrivateConnectivityInfo{
+					PrivateDNS:  common.Ref("prom-private.example.net"),
+					ServiceName: common.Ref("com.amazonaws.vpce.eu-west-1.vpce-svc-prom"),
+					Regions:     []string{"eu-west-1"},
+				},
+			},
+			{
+				Id:               3,
+				Type:             "alerts",
+				IpAllowListCNAME: common.Ref("alerts.example.net"),
+			},
+			{
+				Id:   4,
+				Type: "agent-management",
+				PrivateConnectivityInfo: &gcom.BasicPrivateConnectivityInfo{
+					PrivateDNS:  common.Ref("fleet-private.example.net"),
+					ServiceName: common.Ref("com.amazonaws.vpce.eu-west-1.vpce-svc-fleet"),
+				},
+			},
+		},
+		Services: &gcom.StackConnectionServicesV1{
+			OncallApiUrl: common.Ref("https://oncall-prod-eu-west-0.grafana.net/oncall"),
+			InfluxUrl:    common.Ref("https://influx-prod-eu-west-0.grafana.net"),
+		},
+		Otlp: &gcom.StackConnectionOtlpV1{
+			Url: common.Ref("https://otlp-prod-eu-west-0.grafana.net/otlp"),
+			PrivateConnectivityInfo: &gcom.BasicPrivateConnectivityInfo{
+				PrivateDNS:  common.Ref("otlp-private.example.net"),
+				ServiceName: common.Ref("com.amazonaws.vpce.eu-west-1.vpce-svc-otlp"),
+			},
+		},
+		Pdc: &gcom.StackConnectionPdcV1{
+			Api: gcom.BasicPrivateConnectivityInfo{
+				PrivateDNS:  common.Ref("pdc-api-private.example.net"),
+				ServiceName: common.Ref("com.amazonaws.vpce.eu-west-1.vpce-svc-pdc-api"),
+			},
+			Gateway: gcom.BasicPrivateConnectivityInfo{
+				PrivateDNS:  common.Ref("pdc-gateway-private.example.net"),
+				ServiceName: common.Ref("com.amazonaws.vpce.eu-west-1.vpce-svc-pdc-gateway"),
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
+	if err := flattenStack(d, stack, connections); err != nil {
+		t.Fatalf("flattenStack: %v", err)
+	}
+
+	requireStringAttr(t, d, "grafanas_ip_allow_list_cname", "grafanas.example.net")
+	requireStringAttr(t, d, "prometheus_ip_allow_list_cname", "prom.example.net")
+	requireStringAttr(t, d, "prometheus_private_connectivity_info_private_dns", "prom-private.example.net")
+	requireStringAttr(t, d, "prometheus_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-prom")
+	requireStringSliceAttr(t, d, "prometheus_private_connectivity_info_regions", []string{"eu-west-1"})
+	requireStringAttr(t, d, "alertmanager_ip_allow_list_cname", "alerts.example.net")
+	requireStringAttr(t, d, "fleet_management_private_connectivity_info_private_dns", "fleet-private.example.net")
+	requireStringAttr(t, d, "fleet_management_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-fleet")
+	requireStringAttr(t, d, "oncall_api_url", "https://oncall-prod-eu-west-0.grafana.net/oncall")
+	requireStringAttr(t, d, "influx_url", "https://influx-prod-eu-west-0.grafana.net")
+	requireStringAttr(t, d, "otlp_url", "https://otlp-prod-eu-west-0.grafana.net/otlp")
+	requireStringAttr(t, d, "otlp_private_connectivity_info_private_dns", "otlp-private.example.net")
+	requireStringAttr(t, d, "otlp_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-otlp")
+	requireStringAttr(t, d, "pdc_api_private_connectivity_info_private_dns", "pdc-api-private.example.net")
+	requireStringAttr(t, d, "pdc_api_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-pdc-api")
+	requireStringAttr(t, d, "pdc_gateway_private_connectivity_info_private_dns", "pdc-gateway-private.example.net")
+	requireStringAttr(t, d, "pdc_gateway_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-pdc-gateway")
+}
+
+func requireStringAttr(t *testing.T, d *schema.ResourceData, key, want string) {
+	t.Helper()
+
+	got, ok := d.GetOk(key)
+	if !ok {
+		t.Fatalf("%s: attribute not set", key)
+	}
+	if got.(string) != want {
+		t.Fatalf("%s: got %q, want %q", key, got, want)
+	}
+}
+
+func requireBoolAttr(t *testing.T, d *schema.ResourceData, key string, want bool) {
+	t.Helper()
+
+	got, ok := d.GetOk(key)
+	if !ok {
+		t.Fatalf("%s: attribute not set", key)
+	}
+	if got.(bool) != want {
+		t.Fatalf("%s: got %v, want %v", key, got, want)
+	}
+}
+
+func requireIntAttr(t *testing.T, d *schema.ResourceData, key string, want int) {
+	t.Helper()
+
+	got, ok := d.GetOk(key)
+	if !ok {
+		t.Fatalf("%s: attribute not set", key)
+	}
+	if got.(int) != want {
+		t.Fatalf("%s: got %v, want %v", key, got, want)
+	}
+}
+
+func requireStringSliceAttr(t *testing.T, d *schema.ResourceData, key string, want []string) {
+	t.Helper()
+
+	got, ok := d.GetOk(key)
+	if !ok {
+		t.Fatalf("%s: attribute not set", key)
+	}
+
+	gotSlice, ok := got.([]string)
+	if !ok {
+		raw, ok := got.([]any)
+		if !ok {
+			t.Fatalf("%s: got %T, want []string", key, got)
+		}
+		gotSlice = make([]string, len(raw))
+		for i, v := range raw {
+			s, ok := v.(string)
+			if !ok {
+				t.Fatalf("%s[%d]: got %T, want string", key, i, v)
+			}
+			gotSlice[i] = s
+		}
+	}
+	if len(gotSlice) != len(want) {
+		t.Fatalf("%s: got %v, want %v", key, gotSlice, want)
+	}
+	for i := range want {
+		if gotSlice[i] != want[i] {
+			t.Fatalf("%s[%d]: got %q, want %q", key, i, gotSlice[i], want[i])
+		}
+	}
+}

--- a/internal/resources/cloud/resource_cloud_stack_flatten_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_flatten_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana-com-public-clients/go/gcom"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -12,20 +13,20 @@ func TestUnitFlattenStack_BasicStackFields(t *testing.T) {
 	t.Parallel()
 
 	stack := &gcom.FormattedApiInstance{
-		Id:                             12345,
-		Name:                           "my-stack",
-		Slug:                           "my-stack",
-		Url:                            "https://my-stack.grafana.net",
-		Status:                         "active",
-		RegionSlug:                     "eu",
-		ClusterSlug:                    "prod-eu-west-0",
-		ClusterName:                    "EU West 0",
-		Description:                    "test stack",
-		DeleteProtection:               true,
-		HmInstancePromId:               101,
-		HmInstancePromUrl:              "https://prometheus-prod-04.csp-region-1.grafana.net",
-		HmInstancePromName:             "prometheus",
-		HmInstancePromStatus:           "active",
+		Id:                              12345,
+		Name:                            "my-stack",
+		Slug:                            "my-stack",
+		Url:                             "https://my-stack.grafana.net",
+		Status:                          "active",
+		RegionSlug:                      "eu",
+		ClusterSlug:                     "prod-eu-west-0",
+		ClusterName:                     "EU West 0",
+		Description:                     "test stack",
+		DeleteProtection:                true,
+		HmInstancePromId:                101,
+		HmInstancePromUrl:               "https://prometheus-prod-04.csp-region-1.grafana.net",
+		HmInstancePromName:              "prometheus",
+		HmInstancePromStatus:            "active",
 		RegionSyntheticMonitoringApiUrl: "https://synthetic-monitoring-api-eu-west-0.grafana.net",
 	}
 
@@ -58,12 +59,12 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 	t.Parallel()
 
 	stack := &gcom.FormattedApiInstance{
-		Id:          99,
-		Name:        "conn-stack",
-		Slug:        "conn-stack",
-		Url:         "https://conn-stack.grafana.net",
-		Status:      "active",
-		ClusterSlug: "prod-eu-west-0",
+		Id:                99,
+		Name:              "conn-stack",
+		Slug:              "conn-stack",
+		Url:               "https://conn-stack.grafana.net",
+		Status:            "active",
+		ClusterSlug:       "prod-eu-west-0",
 		HmInstancePromUrl: "https://prometheus-prod-01-eu-west-0.grafana.net",
 	}
 
@@ -75,8 +76,8 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 				IpAllowListCNAME: common.Ref("grafanas.example.net"),
 			},
 			{
-				Id:   2,
-				Type: "prometheus",
+				Id:               2,
+				Type:             "prometheus",
 				IpAllowListCNAME: common.Ref("prom.example.net"),
 				PrivateConnectivityInfo: &gcom.BasicPrivateConnectivityInfo{
 					PrivateDNS:  common.Ref("prom-private.example.net"),


### PR DESCRIPTION
Changes the endpoint used from GET /instances/:idOrSlug/connections to GET /v1/stacks/:idOrSlug/connections

The only exception is the ipAllowlistCNAME field which will be deprecated and later removed from the infrastructure and substituted with a new field (to be added later to terraform) so in order to avoid adding it to the new endpoint, we will continue to pull it from the connections endpoint.