### PR TITLE
feat(grafana_cloud_stack): add allowlist API endpoint outputs

### DIFF
--- a/docs/data-sources/cloud_stack.md
+++ b/docs/data-sources/cloud_stack.md
@@ -35,6 +35,7 @@ available at “https://<stack_slug>.grafana.net".
 
 ### Read-Only
 
+- `alertmanager_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Alertmanager instances.
 - `alertmanager_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Alertmanager instances (Optional)
 - `alertmanager_name` (String) Name of the Alertmanager instance configured for this stack.
 - `alertmanager_status` (String) Status of the Alertmanager instance configured for this stack.
@@ -46,6 +47,7 @@ available at “https://<stack_slug>.grafana.net".
 - `connections_api_url` (String) Base URL of the Connections API for this stack's cluster. This can be used with the `connections_api_url` provider config option to manage Connections resources for this stack.
 - `delete_protection` (Boolean) Whether to enable delete protection for the stack, preventing accidental deletion.
 - `description` (String) Description of stack.
+- `fleet_management_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Fleet Management instance.
 - `fleet_management_name` (String) Name of the Fleet Management instance configured for this stack.
 - `fleet_management_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Fleet Management when using AWS PrivateLink (only for AWS stacks)
 - `fleet_management_private_connectivity_info_availability_zones` (List of String) Availability Zones for Fleet Management when using AWS PrivateLink (only for AWS stacks)
@@ -55,7 +57,9 @@ available at “https://<stack_slug>.grafana.net".
 - `fleet_management_status` (String) Status of the Fleet Management instance configured for this stack.
 - `fleet_management_url` (String) Base URL of the Fleet Management instance configured for this stack.
 - `fleet_management_user_id` (Number) User ID of the Fleet Management instance configured for this stack.
+- `grafanas_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the grafana instance.
 - `grafanas_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the grafana instance (Optional)
+- `graphite_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Graphite instance.
 - `graphite_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Graphite instance (Optional)
 - `graphite_name` (String)
 - `graphite_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Graphite when using AWS PrivateLink (only for AWS stacks)
@@ -69,6 +73,7 @@ available at “https://<stack_slug>.grafana.net".
 - `id` (String) The stack id assigned to this stack by Grafana.
 - `influx_url` (String) Base URL of the InfluxDB instance configured for this stack. The username is the same as the metrics' (`prometheus_user_id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/push-from-telegraf/ for docs on how to use this.
 - `labels` (Map of String) A map of labels to assign to the stack. Label keys and values must match the following regexp: "^[a-zA-Z0-9/\\-._]+$" and stacks cannot have more than 10 labels.
+- `logs_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Logs instance.
 - `logs_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Logs instance (Optional)
 - `logs_name` (String)
 - `logs_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Logs when using AWS PrivateLink (only for AWS stacks)
@@ -100,6 +105,7 @@ available at “https://<stack_slug>.grafana.net".
 - `pdc_gateway_private_connectivity_info_private_dns` (String) Private DNS for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)
 - `pdc_gateway_private_connectivity_info_regions` (List of String) Regions for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)
 - `pdc_gateway_private_connectivity_info_service_name` (String) Service Name for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)
+- `profiles_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Profiles instance.
 - `profiles_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Profiles instance (Optional)
 - `profiles_name` (String)
 - `profiles_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Profiles when using AWS PrivateLink (only for AWS stacks)
@@ -110,6 +116,7 @@ available at “https://<stack_slug>.grafana.net".
 - `profiles_status` (String)
 - `profiles_url` (String)
 - `profiles_user_id` (Number)
+- `prometheus_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Prometheus instance.
 - `prometheus_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Prometheus instance (Optional)
 - `prometheus_name` (String) Prometheus name for this instance.
 - `prometheus_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Prometheus when using AWS PrivateLink (only for AWS stacks)
@@ -125,6 +132,7 @@ available at “https://<stack_slug>.grafana.net".
 - `region_slug` (String) The region this stack is deployed to.
 - `sm_url` (String) Base URL of the Synthetic Monitoring API for this stack's region. This can be used with the `sm_url` provider config option. Note: Synthetic Monitoring requires activation either via the `grafana_synthetic_monitoring_installation` resource or manually in the Grafana Cloud UI before it can be used.
 - `status` (String) Status of the stack.
+- `traces_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Traces instance.
 - `traces_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Traces instance (Optional)
 - `traces_name` (String)
 - `traces_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Traces when using AWS PrivateLink (only for AWS stacks)

--- a/docs/resources/cloud_stack.md
+++ b/docs/resources/cloud_stack.md
@@ -49,6 +49,7 @@ resource "grafana_cloud_stack" "test" {
 
 ### Read-Only
 
+- `alertmanager_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Alertmanager instances.
 - `alertmanager_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Alertmanager instances (Optional)
 - `alertmanager_name` (String) Name of the Alertmanager instance configured for this stack.
 - `alertmanager_status` (String) Status of the Alertmanager instance configured for this stack.
@@ -58,6 +59,7 @@ resource "grafana_cloud_stack" "test" {
 - `cluster_name` (String) Name of the cluster where this stack resides.
 - `cluster_slug` (String) Slug of the cluster where this stack resides.
 - `connections_api_url` (String) Base URL of the Connections API for this stack's cluster. This can be used with the `connections_api_url` provider config option to manage Connections resources for this stack.
+- `fleet_management_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Fleet Management instance.
 - `fleet_management_name` (String) Name of the Fleet Management instance configured for this stack.
 - `fleet_management_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Fleet Management when using AWS PrivateLink (only for AWS stacks)
 - `fleet_management_private_connectivity_info_availability_zones` (List of String) Availability Zones for Fleet Management when using AWS PrivateLink (only for AWS stacks)
@@ -67,7 +69,9 @@ resource "grafana_cloud_stack" "test" {
 - `fleet_management_status` (String) Status of the Fleet Management instance configured for this stack.
 - `fleet_management_url` (String) Base URL of the Fleet Management instance configured for this stack.
 - `fleet_management_user_id` (Number) User ID of the Fleet Management instance configured for this stack.
+- `grafanas_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the grafana instance.
 - `grafanas_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the grafana instance (Optional)
+- `graphite_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Graphite instance.
 - `graphite_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Graphite instance (Optional)
 - `graphite_name` (String)
 - `graphite_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Graphite when using AWS PrivateLink (only for AWS stacks)
@@ -80,6 +84,7 @@ resource "grafana_cloud_stack" "test" {
 - `graphite_user_id` (Number)
 - `id` (String) The stack id assigned to this stack by Grafana.
 - `influx_url` (String) Base URL of the InfluxDB instance configured for this stack. The username is the same as the metrics' (`prometheus_user_id` attribute of this resource). See https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/push-from-telegraf/ for docs on how to use this.
+- `logs_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Logs instance.
 - `logs_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Logs instance (Optional)
 - `logs_name` (String)
 - `logs_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Logs when using AWS PrivateLink (only for AWS stacks)
@@ -110,6 +115,7 @@ resource "grafana_cloud_stack" "test" {
 - `pdc_gateway_private_connectivity_info_private_dns` (String) Private DNS for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)
 - `pdc_gateway_private_connectivity_info_regions` (List of String) Regions for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)
 - `pdc_gateway_private_connectivity_info_service_name` (String) Service Name for PDC's Gateway when using AWS PrivateLink (only for AWS stacks)
+- `profiles_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Profiles instance.
 - `profiles_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Profiles instance (Optional)
 - `profiles_name` (String)
 - `profiles_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Profiles when using AWS PrivateLink (only for AWS stacks)
@@ -120,6 +126,7 @@ resource "grafana_cloud_stack" "test" {
 - `profiles_status` (String)
 - `profiles_url` (String)
 - `profiles_user_id` (Number)
+- `prometheus_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Prometheus instance.
 - `prometheus_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Prometheus instance (Optional)
 - `prometheus_name` (String) Prometheus name for this instance.
 - `prometheus_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Prometheus when using AWS PrivateLink (only for AWS stacks)
@@ -134,6 +141,7 @@ resource "grafana_cloud_stack" "test" {
 - `prometheus_user_id` (Number) Prometheus user ID. Used for e.g. remote_write.
 - `sm_url` (String) Base URL of the Synthetic Monitoring API for this stack's region. This can be used with the `sm_url` provider config option. Note: Synthetic Monitoring requires activation either via the `grafana_synthetic_monitoring_installation` resource or manually in the Grafana Cloud UI before it can be used.
 - `status` (String) Status of the stack.
+- `traces_allowlist_url` (String) Allowlist API endpoint that returns the source IP addresses to allow for the Traces instance.
 - `traces_ip_allow_list_cname` (String) Comma-separated list of CNAMEs that can be whitelisted to access the Traces instance (Optional)
 - `traces_name` (String)
 - `traces_private_connectivity_info_availability_zone_ids` (List of String) Availability Zone IDs for Traces when using AWS PrivateLink (only for AWS stacks)

--- a/internal/resources/cloud/resource_cloud_stack.go
+++ b/internal/resources/cloud/resource_cloud_stack.go
@@ -56,6 +56,14 @@ func ipAllowListCNAMEDescription(service string) *schema.Schema {
 	)
 }
 
+func allowlistURLDescription(service string) *schema.Schema {
+	return common.ComputedStringWithDescription(
+		fmt.Sprintf(
+			"Allowlist API endpoint that returns the source IP addresses to allow for %s.", service,
+		),
+	)
+}
+
 func resourceStack() *common.Resource {
 	schema := &schema.Resource{
 		Description: `
@@ -176,6 +184,7 @@ Required access policy scopes:
 			},
 
 			"grafanas_ip_allow_list_cname": ipAllowListCNAMEDescription("the grafana instance"),
+			"grafanas_allowlist_url":       allowlistURLDescription("the grafana instance"),
 
 			// Metrics (Mimir/Prometheus)
 			"prometheus_user_id":                                         common.ComputedIntWithDescription("Prometheus user ID. Used for e.g. remote_write."),
@@ -190,6 +199,7 @@ Required access policy scopes:
 			"prometheus_private_connectivity_info_availability_zones":    privateConnectivityArrayDescription("Availability Zones", "Prometheus"),
 			"prometheus_private_connectivity_info_availability_zone_ids": privateConnectivityArrayDescription("Availability Zone IDs", "Prometheus"),
 			"prometheus_ip_allow_list_cname":                             ipAllowListCNAMEDescription("the Prometheus instance"),
+			"prometheus_allowlist_url":                                   allowlistURLDescription("the Prometheus instance"),
 
 			// Alertmanager
 			"alertmanager_user_id":             common.ComputedIntWithDescription("User ID of the Alertmanager instance configured for this stack."),
@@ -197,6 +207,7 @@ Required access policy scopes:
 			"alertmanager_url":                 common.ComputedStringWithDescription("Base URL of the Alertmanager instance configured for this stack."),
 			"alertmanager_status":              common.ComputedStringWithDescription("Status of the Alertmanager instance configured for this stack."),
 			"alertmanager_ip_allow_list_cname": ipAllowListCNAMEDescription("the Alertmanager instances"),
+			"alertmanager_allowlist_url":       allowlistURLDescription("the Alertmanager instances"),
 
 			// Synthetic Monitoring
 			"sm_url": common.ComputedStringWithDescription("Base URL of the Synthetic Monitoring API for this stack's region. This can be used with the `sm_url` provider config option. Note: Synthetic Monitoring requires activation either via the `grafana_synthetic_monitoring_installation` resource or manually in the Grafana Cloud UI before it can be used."),
@@ -215,6 +226,7 @@ Required access policy scopes:
 			"logs_private_connectivity_info_availability_zones":    privateConnectivityArrayDescription("Availability Zones", "Logs"),
 			"logs_private_connectivity_info_availability_zone_ids": privateConnectivityArrayDescription("Availability Zone IDs", "Logs"),
 			"logs_ip_allow_list_cname":                             ipAllowListCNAMEDescription("the Logs instance"),
+			"logs_allowlist_url":                                   allowlistURLDescription("the Logs instance"),
 
 			// Traces (Tempo)
 			"traces_user_id": common.ComputedInt(),
@@ -227,6 +239,7 @@ Required access policy scopes:
 			"traces_private_connectivity_info_availability_zones":    privateConnectivityArrayDescription("Availability Zones", "Traces"),
 			"traces_private_connectivity_info_availability_zone_ids": privateConnectivityArrayDescription("Availability Zone IDs", "Traces"),
 			"traces_ip_allow_list_cname":                             ipAllowListCNAMEDescription("the Traces instance"),
+			"traces_allowlist_url":                                   allowlistURLDescription("the Traces instance"),
 
 			// Profiles (Pyroscope)
 			"profiles_user_id": common.ComputedInt(),
@@ -239,6 +252,7 @@ Required access policy scopes:
 			"profiles_private_connectivity_info_availability_zones":    privateConnectivityArrayDescription("Availability Zones", "Profiles"),
 			"profiles_private_connectivity_info_availability_zone_ids": privateConnectivityArrayDescription("Availability Zone IDs", "Profiles"),
 			"profiles_ip_allow_list_cname":                             ipAllowListCNAMEDescription("the Profiles instance"),
+			"profiles_allowlist_url":                                   allowlistURLDescription("the Profiles instance"),
 
 			// Graphite
 			"graphite_user_id": common.ComputedInt(),
@@ -251,6 +265,7 @@ Required access policy scopes:
 			"graphite_private_connectivity_info_availability_zones":    privateConnectivityArrayDescription("Availability Zones", "Graphite"),
 			"graphite_private_connectivity_info_availability_zone_ids": privateConnectivityArrayDescription("Availability Zone IDs", "Graphite"),
 			"graphite_ip_allow_list_cname":                             ipAllowListCNAMEDescription("the Graphite instance"),
+			"graphite_allowlist_url":                                   allowlistURLDescription("the Graphite instance"),
 
 			// Fleet Management
 			"fleet_management_user_id":                                         common.ComputedIntWithDescription("User ID of the Fleet Management instance configured for this stack."),
@@ -262,6 +277,7 @@ Required access policy scopes:
 			"fleet_management_private_connectivity_info_regions":               privateConnectivityArrayDescription("Regions", "Fleet Management"),
 			"fleet_management_private_connectivity_info_availability_zones":    privateConnectivityArrayDescription("Availability Zones", "Fleet Management"),
 			"fleet_management_private_connectivity_info_availability_zone_ids": privateConnectivityArrayDescription("Availability Zone IDs", "Fleet Management"),
+			"fleet_management_allowlist_url":                                   allowlistURLDescription("the Fleet Management instance"),
 
 			// Cloud Provider
 			"cloud_provider_url": common.ComputedStringWithDescription("Base URL of the Cloud Provider API for this stack's cluster. This can be used with the `cloud_provider_url` provider config option to manage Cloud Provider resources for this stack."),
@@ -580,8 +596,9 @@ func readStack(ctx context.Context, d *schema.ResourceData, client *gcom.APIClie
 	}
 
 	ipAllowListCNAMByTenantType := ipAllowListCNAMByTenantType(legacyConnections.GetPrivateConnectivityInfo().Tenants)
+	allowlistURLByTenantType := allowlistURLByTenantType(legacyConnections.GetPrivateConnectivityInfo().Tenants)
 
-	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType); err != nil {
+	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType, allowlistURLByTenantType); err != nil {
 		return diag.FromErr(err)
 	}
 	// Always set the wait attribute to true after creation
@@ -599,6 +616,7 @@ func flattenStack(
 	stack *gcom.FormattedApiInstance,
 	connections *gcom.StackConnectionsV1,
 	ipAllowListCNAMByTenantType map[string]string,
+	allowlistURLByTenantType map[string]string,
 ) error {
 	id := strconv.FormatInt(int64(stack.Id), 10)
 
@@ -612,6 +630,7 @@ func flattenStack(
 	// key is "grafanas_ip_allow_list_cname" (plural). Pass the schema prefix
 	// "grafanas" to addIPAllowListIfPresent so d.Set uses the correct key.
 	addIPAllowListIfPresent(d, "grafanas", "grafana", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "grafanas", "grafana", allowlistURLByTenantType)
 
 	d.Set("status", stack.Status)
 	d.Set("region_slug", stack.RegionSlug)
@@ -641,6 +660,7 @@ func flattenStack(
 	d.Set("prometheus_status", stack.HmInstancePromStatus)
 	setPrivateConnectivityInfoForTenant(d, "prometheus", "prometheus", tenants)
 	addIPAllowListIfPresent(d, "prometheus", "prometheus", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "prometheus", "prometheus", allowlistURLByTenantType)
 
 	d.Set("logs_user_id", stack.HlInstanceId)
 	d.Set("logs_url", stack.HlInstanceUrl)
@@ -648,12 +668,14 @@ func flattenStack(
 	d.Set("logs_status", stack.HlInstanceStatus)
 	setPrivateConnectivityInfoForTenant(d, "logs", "logs", tenants)
 	addIPAllowListIfPresent(d, "logs", "logs", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "logs", "logs", allowlistURLByTenantType)
 
 	d.Set("alertmanager_user_id", stack.AmInstanceId)
 	d.Set("alertmanager_name", stack.AmInstanceName)
 	d.Set("alertmanager_url", stack.AmInstanceUrl)
 	d.Set("alertmanager_status", stack.AmInstanceStatus)
 	addIPAllowListIfPresent(d, "alertmanager", "alerts", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "alertmanager", "alerts", allowlistURLByTenantType)
 
 	d.Set("sm_url", stack.RegionSyntheticMonitoringApiUrl)
 
@@ -672,6 +694,7 @@ func flattenStack(
 	d.Set("traces_status", stack.HtInstanceStatus)
 	setPrivateConnectivityInfoForTenant(d, "traces", "traces", tenants)
 	addIPAllowListIfPresent(d, "traces", "traces", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "traces", "traces", allowlistURLByTenantType)
 
 	d.Set("profiles_user_id", stack.HpInstanceId)
 	d.Set("profiles_name", stack.HpInstanceName)
@@ -679,6 +702,7 @@ func flattenStack(
 	d.Set("profiles_status", stack.HpInstanceStatus)
 	setPrivateConnectivityInfoForTenant(d, "profiles", "profiles", tenants)
 	addIPAllowListIfPresent(d, "profiles", "profiles", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "profiles", "profiles", allowlistURLByTenantType)
 
 	d.Set("graphite_user_id", stack.HmInstanceGraphiteId)
 	d.Set("graphite_name", stack.HmInstanceGraphiteName)
@@ -686,12 +710,14 @@ func flattenStack(
 	d.Set("graphite_status", stack.HmInstanceGraphiteStatus)
 	setPrivateConnectivityInfoForTenant(d, "graphite", "graphite", tenants)
 	addIPAllowListIfPresent(d, "graphite", "graphite", ipAllowListCNAMByTenantType)
+	addAllowlistURLIfPresent(d, "graphite", "graphite", allowlistURLByTenantType)
 
 	d.Set("fleet_management_user_id", stack.AgentManagementInstanceId)
 	d.Set("fleet_management_name", stack.AgentManagementInstanceName)
 	d.Set("fleet_management_url", stack.AgentManagementInstanceUrl)
 	d.Set("fleet_management_status", stack.AgentManagementInstanceStatus)
 	setPrivateConnectivityInfoForTenant(d, "fleet_management", "agent-management", tenants)
+	addAllowlistURLIfPresent(d, "fleet_management", "agent-management", allowlistURLByTenantType)
 
 	addPrivateConnectivityInfo(d, "otlp", &gcom.BasicPrivateConnectivityInfo{})
 	if otlp, ok := connections.GetOtlpOk(); ok {
@@ -748,6 +774,16 @@ func ipAllowListCNAMByTenantType(tenants []gcom.TenantsInner) map[string]string 
 	return result
 }
 
+func allowlistURLByTenantType(tenants []gcom.TenantsInner) map[string]string {
+	result := make(map[string]string, len(tenants))
+	for _, tenant := range tenants {
+		if url := tenant.AllowlistUrl.Get(); url != nil {
+			result[tenant.Type] = *url
+		}
+	}
+	return result
+}
+
 func addIPAllowListIfPresent(
 	d *schema.ResourceData,
 	schemaPrefix, tenantType string,
@@ -769,6 +805,16 @@ func setPrivateConnectivityInfoForTenant(
 			addPrivateConnectivityInfo(d, prefix, info)
 		}
 	})
+}
+
+func addAllowlistURLIfPresent(
+	d *schema.ResourceData,
+	schemaPrefix, tenantType string,
+	allowlistURLByTenantType map[string]string,
+) {
+	if url, ok := allowlistURLByTenantType[tenantType]; ok {
+		d.Set(fmt.Sprintf("%s_allowlist_url", schemaPrefix), url)
+	}
 }
 
 func addPrivateConnectivityInfo(d *schema.ResourceData, preffix string, info *gcom.BasicPrivateConnectivityInfo) {

--- a/internal/resources/cloud/resource_cloud_stack_flatten_test.go
+++ b/internal/resources/cloud/resource_cloud_stack_flatten_test.go
@@ -52,7 +52,7 @@ func TestUnitFlattenStack_BasicStackFields(t *testing.T) {
 	connections := gcom.NewStackConnectionsV1([]gcom.StackConnectionTenantV1{})
 
 	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
-	if err := flattenStack(d, stack, connections, nil); err != nil {
+	if err := flattenStack(d, stack, connections, nil, nil); err != nil {
 		t.Fatalf("flattenStack: %v", err)
 	}
 
@@ -144,14 +144,22 @@ func TestUnitFlattenStack_StackConnectionsV1(t *testing.T) {
 		"prometheus": "prom.example.net",
 		"alerts":     "alerts.example.net",
 	}
+	allowlistURLByTenantType := map[string]string{
+		"grafana":    "https://allowlists.eu.grafana.net/grafana",
+		"prometheus": "https://allowlists.eu.grafana.net/prometheus",
+		"alerts":     "https://allowlists.eu.grafana.net/alerts",
+	}
 
 	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
-	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType); err != nil {
+	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType, allowlistURLByTenantType); err != nil {
 		t.Fatalf("flattenStack: %v", err)
 	}
 
 	requireStringAttr(t, d, "grafanas_ip_allow_list_cname", "grafanas.example.net")
 	requireStringAttr(t, d, "prometheus_ip_allow_list_cname", "prom.example.net")
+	requireStringAttr(t, d, "grafanas_allowlist_url", "https://allowlists.eu.grafana.net/grafana")
+	requireStringAttr(t, d, "prometheus_allowlist_url", "https://allowlists.eu.grafana.net/prometheus")
+	requireStringAttr(t, d, "alertmanager_allowlist_url", "https://allowlists.eu.grafana.net/alerts")
 	requireStringAttr(t, d, "prometheus_private_connectivity_info_private_dns", "prom-private.example.net")
 	requireStringAttr(t, d, "prometheus_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-prom")
 	requireStringSliceAttr(t, d, "prometheus_private_connectivity_info_regions", []string{"eu-west-1"})
@@ -253,7 +261,7 @@ func TestUnitFlattenStack_PrivateConnectivityLists(t *testing.T) {
 	}
 
 	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
-	if err := flattenStack(d, stack, connections, nil); err != nil {
+	if err := flattenStack(d, stack, connections, nil, nil); err != nil {
 		t.Fatalf("flattenStack: %v", err)
 	}
 
@@ -325,14 +333,22 @@ func TestUnitFlattenStack_StackConnectionsV1_MissingAgentManagement(t *testing.T
 		"prometheus": "prom.example.net",
 		"alerts":     "alerts.example.net",
 	}
+	allowlistURLByTenantType := map[string]string{
+		"grafana":    "https://allowlists.eu.grafana.net/grafana",
+		"prometheus": "https://allowlists.eu.grafana.net/prometheus",
+		"alerts":     "https://allowlists.eu.grafana.net/alerts",
+	}
 
 	d := schema.TestResourceDataRaw(t, resourceStack().Schema.Schema, map[string]any{})
-	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType); err != nil {
+	if err := flattenStack(d, stack, connections, ipAllowListCNAMByTenantType, allowlistURLByTenantType); err != nil {
 		t.Fatalf("flattenStack: %v", err)
 	}
 
 	requireStringAttr(t, d, "grafanas_ip_allow_list_cname", "grafanas.example.net")
 	requireStringAttr(t, d, "prometheus_ip_allow_list_cname", "prom.example.net")
+	requireStringAttr(t, d, "grafanas_allowlist_url", "https://allowlists.eu.grafana.net/grafana")
+	requireStringAttr(t, d, "prometheus_allowlist_url", "https://allowlists.eu.grafana.net/prometheus")
+	requireStringAttr(t, d, "alertmanager_allowlist_url", "https://allowlists.eu.grafana.net/alerts")
 	requireStringAttr(t, d, "prometheus_private_connectivity_info_private_dns", "prom-private.example.net")
 	requireStringAttr(t, d, "prometheus_private_connectivity_info_service_name", "com.amazonaws.vpce.eu-west-1.vpce-svc-prom")
 	requireStringSliceAttr(t, d, "prometheus_private_connectivity_info_regions", []string{"eu-west-1"})


### PR DESCRIPTION
## What

Exposes the new per-service **allowlist API endpoint** on `grafana_cloud_stack` as computed `*_allowlist_url` attributes, alongside the existing `*_ip_allow_list_cname` outputs:

`grafanas_allowlist_url`, `prometheus_allowlist_url`, `alertmanager_allowlist_url`, `logs_allowlist_url`, `traces_allowlist_url`, `profiles_allowlist_url`, `graphite_allowlist_url`, `fleet_management_allowlist_url`.

Each is read from the new `allowlistUrl` field on the connections API tenants (`gcom.TenantsInner`), mirroring how `*_ip_allow_list_cname` is read today. The CNAME outputs are unchanged.


## Relates

- https://github.com/grafana/grafana-com/pull/19065
- https://github.com/grafana/deployment_tools/pull/620120
- https://github.com/grafana/deployment_tools/issues/607927
