### PR TITLE
docs: clarify provider config for git sync App Platform resources

### DIFF
--- a/docs/resources/apps_provisioning_connection_v0alpha1.md
+++ b/docs/resources/apps_provisioning_connection_v0alpha1.md
@@ -10,6 +10,23 @@ description: |-
 
 Manages Grafana Git Sync connections used by repositories for provider authentication.
 
+## Provider Configuration
+
+This is an App Platform resource and talks directly to the Grafana stack's API.
+Configure the provider with `url` and `auth` (not `cloud_api_url` /
+`cloud_access_policy_token`), and set `stack_id`:
+
+```terraform
+provider "grafana" {
+  url      = "https://<your-stack-slug>.grafana.net/"
+  auth     = var.grafana_service_account_token # service account token or "username:password"
+  stack_id = var.grafana_stack_id              # selects the "stacks-<stack_id>" namespace
+}
+```
+
+Configuring only the Grafana Cloud arguments fails with
+`Grafana App Platform API client not configured`.
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/apps_provisioning_repository_v0alpha1.md
+++ b/docs/resources/apps_provisioning_repository_v0alpha1.md
@@ -10,6 +10,23 @@ description: |-
 
 Manages Grafana Git Sync repositories for provisioning dashboards and related resources.
 
+## Provider Configuration
+
+This is an App Platform resource and talks directly to the Grafana stack's API.
+Configure the provider with `url` and `auth` (not `cloud_api_url` /
+`cloud_access_policy_token`), and set `stack_id`:
+
+```terraform
+provider "grafana" {
+  url      = "https://<your-stack-slug>.grafana.net/"
+  auth     = var.grafana_service_account_token # service account token or "username:password"
+  stack_id = var.grafana_stack_id              # selects the "stacks-<stack_id>" namespace
+}
+```
+
+Configuring only the Grafana Cloud arguments fails with
+`Grafana App Platform API client not configured`.
+
 ## Example Usage
 
 ### GitHub Repository with Token Authentication

--- a/templates/resources/apps_provisioning_connection_v0alpha1.md.tmpl
+++ b/templates/resources/apps_provisioning_connection_v0alpha1.md.tmpl
@@ -29,28 +29,6 @@ Configuring only the Grafana Cloud arguments fails with
 
 ## Example Usage
 
-### GitHub Repository with Token Authentication
-
-{{ tffile "examples/resources/grafana_apps_provisioning_repository_v0alpha1/resource.tf" }}
-
-### GitHub Repository via GitHub App Connection
-
-{{ tffile "examples/resources/grafana_apps_provisioning_repository_v0alpha1/github-app-folder.tf" }}
-
-### Bitbucket Repository with Token Authentication - Enterprise/Cloud only
-
-{{ tffile "examples/resources/grafana_apps_provisioning_repository_v0alpha1/bitbucket-token-folder.tf" }}
-
-### GitLab Repository with Token Authentication - Enterprise/Cloud only
-
-{{ tffile "examples/resources/grafana_apps_provisioning_repository_v0alpha1/gitlab-token-folder.tf" }}
-
-### Generic Git Repository
-
-{{ tffile "examples/resources/grafana_apps_provisioning_repository_v0alpha1/pure-git-folder.tf" }}
-
-### Local Filesystem Repository
-
-{{ tffile "examples/resources/grafana_apps_provisioning_repository_v0alpha1/local-repo-folder.tf" }}
+{{ tffile "examples/resources/grafana_apps_provisioning_connection_v0alpha1/resource.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Summary

Following the [Git Sync Terraform setup docs](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/git-sync-setup/set-up-terraform/), users configure the provider with `cloud_api_url` / `stack_id` / `cloud_access_policy_token` and then hit:

```
Error: Grafana App Platform API client not configured
The grafana provider must be configured with 'url' and 'auth' to use App Platform resources.
```

**Root cause:** the App Platform (Kubernetes `/apis`) client is only built in the `url`+`auth` code path (`CreateClients` → `createGrafanaURLClients` → `createGrafanaAppPlatformClient` in `pkg/provider/configure_clients.go`). The `cloud_access_policy_token` path builds only the Grafana Cloud management client, so `client.GrafanaAppPlatformAPI` stays `nil` and the resource's `Configure` hook errors out (`internal/resources/appplatform/resource.go:298`). The error guard is correct — the documented config genuinely never configures an App Platform client.

This PR fixes the provider-side documentation so the registry pages for the Git Sync resources show the **correct** provider configuration (`url` + `auth` + `stack_id`) and explicitly warn against the cloud-only config.

> Note: the upstream guide that triggered the original report lives in the `grafana/grafana` repo (issue is labeled `type/docs` / `area/gitsync`); that page should be updated separately.

## Changes

- `examples/resources/grafana_apps_provisioning_connection_v0alpha1/resource.tf` — add a `provider "grafana"` block with `url`/`auth`/`stack_id` and an explanatory comment.
- `examples/resources/grafana_apps_provisioning_repository_v0alpha1/resource.tf` — same.
- `templates/resources/apps_provisioning_repository_v0alpha1.md.tmpl` — add a **Provider Configuration** section.
- `templates/resources/apps_provisioning_connection_v0alpha1.md.tmpl` — new template (the connection resource previously used the default), with the same **Provider Configuration** section.
- `docs/resources/apps_provisioning_connection_v0alpha1.md` / `docs/resources/apps_provisioning_repository_v0alpha1.md` — regenerated via `go generate ./...`.

## Testing

- `go generate ./...` regenerates docs cleanly; subcategory ("Grafana Apps") preserved by `setcategories`.
- Docs-only change — no Go code modified.

## Checklist

- [ ] Tests added/updated — N/A (docs only)
- [x] Documentation updated (regenerated with `go generate ./...`)
- [x] No breaking changes

Relates to grafana/grafana#126305

🤖 Generated with [Claude Code](https://claude.com/claude-code)