### PR TITLE
fix(appplatform): exponential backoff for retries via k8s wait.Backoff

### DIFF
--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -50,7 +50,7 @@ var (
 	// stale between plan/apply and the write.
 	// Sources: pkg/registry/apis/provisioning/controller/connection.go,
 	// pkg/storage/unified/{apistore/store.go,sql/backend.go}.
-	conflictBackoff = wait.Backoff{Duration: 200 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: 2 * time.Second, Steps: 5} // ~200ms→1.6s, ≲4s total
+	conflictBackoff = wait.Backoff{Duration: 200 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: 2 * time.Second, Steps: 5} // ~200ms→1.6s, ≲4.5s total
 
 	// deleteBackoff covers the cross-resource referential-integrity race when a connection is
 	// deleted right after the repository that references it (spec.connection.name). Grafana's
@@ -59,16 +59,17 @@ var (
 	// finalizers to complete — what remains is a storage read-after-write window: the validator
 	// decides at admission via a live ListByConnection, and that list can briefly not yet observe
 	// the repository's freshly-written deletionTimestamp, still count it as a live reference, and
-	// return 422. The budget is a balance — the first retry still waits ~2s (long enough to absorb
-	// that window, which may be served from an eventual-consistent index path rather than a quorum
-	// read), then backs off so a genuinely permanent reference (a connection still referenced by a
-	// LIVE repository) surfaces its real error promptly rather than hanging.
-	deleteBackoff = wait.Backoff{Duration: 2 * time.Second, Factor: 2, Jitter: 0.5, Cap: 4 * time.Second, Steps: 4} // ~2s→4s, ≲16s total
+	// return 422. With exponential backoff the first retry fires quickly (~500ms) to catch the
+	// common case where the window has already cleared, then grows to cover a laggier index path,
+	// with the whole budget kept under ~10s so a genuinely permanent reference (a connection still
+	// referenced by a LIVE repository) surfaces its real error promptly rather than hanging.
+	deleteBackoff = wait.Backoff{Duration: 500 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: 2 * time.Second, Steps: 4} // ~500ms→2s, ≲5.5s total
 
 	// readBackoff covers transient server-side failures (5xx/429) so a single backend blip does not
-	// fail an entire plan/refresh. Reads only sleep when a request actually errors, so the delay
-	// costs nothing on the success path but gives a 5xx room to clear mid-reconcile.
-	readBackoff = wait.Backoff{Duration: time.Second, Factor: 2, Jitter: 0.5, Cap: 4 * time.Second, Steps: 3} // ~1s→2s, ≲5s total
+	// fail an entire plan/refresh. Reads only sleep when a request actually errors, so the first
+	// retry fires quickly (~500ms) to recover fast from a momentary blip and then backs off to give
+	// a slower-clearing 5xx room mid-reconcile.
+	readBackoff = wait.Backoff{Duration: 500 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: 2 * time.Second, Steps: 4} // ~500ms→2s, ≲5.5s total
 )
 
 // ResourceModel is a Terraform model for a Grafana resource.

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -25,41 +25,50 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 )
 
 const (
 	errNamespaceMissingIDs = "Expected either Grafana org ID (for local Grafana) or Grafana stack ID (for Grafana Cloud) to be set"
-	conflictRetryAttempts  = 5
-	conflictRetryDelay     = 200 * time.Millisecond
-
-	// Delete retries cover the cross-resource referential-integrity race when a connection is
-	// deleted right after the repository that references it (spec.connection.name). Grafana's
-	// connection delete validator now ignores repositories that are themselves terminating
-	// (grafana/grafana#126822), so this 422 is no longer the seconds-long wait for the repo's
-	// finalizers to complete — what remains is a storage read-after-write window: the validator
-	// decides at admission via a live ListByConnection, and that list can briefly not yet observe
-	// the repository's freshly-written deletionTimestamp, still count it as a live reference, and
-	// return 422. The budget is a balance — long enough to absorb that window (which may be served
-	// from an eventual-consistent index path rather than a quorum read), but bounded so a genuinely
-	// permanent reference (a connection still referenced by a LIVE repository) surfaces its real
-	// error reasonably quickly rather than hanging.
-	deleteRetryAttempts = 4
-	deleteRetryDelay    = 2 * time.Second
-
-	// Read retries cover transient server-side failures (5xx) so a single backend blip
-	// does not fail an entire plan/refresh. Reads only sleep when a request actually
-	// errors, so a longer delay costs nothing on the success path but gives a 5xx room
-	// to clear mid-reconcile.
-	readRetryAttempts = 3
-	readRetryDelay    = time.Second
 
 	// DefaultManagerIdentity is the static identity stamped on App Platform resources
 	// managed by this Terraform provider. It intentionally excludes version numbers
 	// so that upgrading the provider or Terraform does not change the identity
 	// (which would be rejected by Grafana as a manager change).
 	DefaultManagerIdentity = "grafana-terraform-provider"
+)
+
+// Retry policies for the transient failure classes the App Platform API exhibits.
+// Each is a k8s wait.Backoff (exponential: Duration×Factor per step, jittered up to
+// +Jitter×duration to desynchronize parallel retries, capped at Cap, bounded by Steps).
+// Approximate worst-case waits assume the upper jitter bound.
+var (
+	// conflictBackoff smooths optimistic-lock (409) races on update. Grafana reconciles
+	// provisioning resources asynchronously, so the ResourceVersion Terraform holds can go
+	// stale between plan/apply and the write.
+	// Sources: pkg/registry/apis/provisioning/controller/connection.go,
+	// pkg/storage/unified/{apistore/store.go,sql/backend.go}.
+	conflictBackoff = wait.Backoff{Duration: 200 * time.Millisecond, Factor: 2, Jitter: 0.5, Cap: 2 * time.Second, Steps: 5} // ~200ms→1.6s, ≲4s total
+
+	// deleteBackoff covers the cross-resource referential-integrity race when a connection is
+	// deleted right after the repository that references it (spec.connection.name). Grafana's
+	// connection delete validator now ignores repositories that are themselves terminating
+	// (grafana/grafana#126822), so this 422 is no longer the seconds-long wait for the repo's
+	// finalizers to complete — what remains is a storage read-after-write window: the validator
+	// decides at admission via a live ListByConnection, and that list can briefly not yet observe
+	// the repository's freshly-written deletionTimestamp, still count it as a live reference, and
+	// return 422. The budget is a balance — the first retry still waits ~2s (long enough to absorb
+	// that window, which may be served from an eventual-consistent index path rather than a quorum
+	// read), then backs off so a genuinely permanent reference (a connection still referenced by a
+	// LIVE repository) surfaces its real error promptly rather than hanging.
+	deleteBackoff = wait.Backoff{Duration: 2 * time.Second, Factor: 2, Jitter: 0.5, Cap: 4 * time.Second, Steps: 4} // ~2s→4s, ≲16s total
+
+	// readBackoff covers transient server-side failures (5xx/429) so a single backend blip does not
+	// fail an entire plan/refresh. Reads only sleep when a request actually errors, so the delay
+	// costs nothing on the success path but gives a 5xx room to clear mid-reconcile.
+	readBackoff = wait.Backoff{Duration: time.Second, Factor: 2, Jitter: 0.5, Cap: 4 * time.Second, Steps: 3} // ~1s→2s, ≲5s total
 )
 
 // ResourceModel is a Terraform model for a Grafana resource.
@@ -414,7 +423,7 @@ func (r *Resource[T, L]) readModel(ctx context.Context, data ResourceModel, resp
 	}
 
 	var res T
-	err := retryWhile(ctx, readRetryAttempts, readRetryDelay, isRetryableServerError, func(_ int) error {
+	err := retryWhile(ctx, readBackoff, isRetryableServerError, func() error {
 		var gerr error
 		res, gerr = r.client.Get(ctx, obj.GetName())
 		return gerr
@@ -642,7 +651,8 @@ func (r *Resource[T, L]) updateModel(
 	}
 
 	var res T
-	err := retryOnConflict(ctx, conflictRetryAttempts, conflictRetryDelay, func(attempt int) error {
+	attempt := 0
+	err := retryOnConflict(ctx, conflictBackoff, func() error {
 		if attempt > 0 && !opts.Overwrite {
 			current, err := r.client.Get(ctx, obj.GetName())
 			if err != nil {
@@ -652,6 +662,7 @@ func (r *Resource[T, L]) updateModel(
 			obj.SetResourceVersion(current.GetResourceVersion())
 			reqopts.ResourceVersion = current.GetResourceVersion()
 		}
+		attempt++
 
 		var err error
 		res, err = r.client.Update(ctx, obj, reqopts)
@@ -706,7 +717,7 @@ func (r *Resource[T, L]) deleteModel(ctx context.Context, data ResourceModel, re
 		return
 	}
 
-	if err := retryWhile(ctx, deleteRetryAttempts, deleteRetryDelay, isRetryableDeleteError, func(_ int) error {
+	if err := retryWhile(ctx, deleteBackoff, isRetryableDeleteError, func() error {
 		return r.client.Delete(ctx, obj.GetName(), sdkresource.DeleteOptions{})
 	}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -734,7 +745,7 @@ func (r *Resource[T, L]) importStateModel(
 	setState func(updated ResourceModel),
 ) {
 	var res T
-	err := retryWhile(ctx, readRetryAttempts, readRetryDelay, isRetryableServerError, func(_ int) error {
+	err := retryWhile(ctx, readBackoff, isRetryableServerError, func() error {
 		var gerr error
 		res, gerr = r.client.Get(ctx, req.ID)
 		return gerr
@@ -1774,30 +1785,42 @@ func secureVersionChanged(current, previous types.Int64) bool {
 	}
 }
 
-// retryWhile retries run until it succeeds, the returned error is not retryable
-// (per retryable), or the attempt budget is exhausted. It sleeps delay between
-// attempts and aborts early if ctx is cancelled while waiting.
+// retryWhile runs fn with exponential backoff (per backoff) until it succeeds, returns
+// a non-retryable error (per retryable), the context is cancelled, or the backoff's
+// Steps are exhausted. It wraps k8s wait.ExponentialBackoffWithContext, which owns the
+// context-aware sleep between attempts. On Steps exhaustion it surfaces fn's last
+// (retryable) error rather than wait's sentinel ErrWaitTimeout, and on cancellation it
+// surfaces the context error. A non-positive Steps is clamped to a single attempt so a
+// misconfigured budget still runs fn once and surfaces its error (never a silent nil).
 func retryWhile(
 	ctx context.Context,
-	attempts int,
-	delay time.Duration,
+	backoff wait.Backoff,
 	retryable func(error) bool,
-	run func(attempt int) error,
+	fn func() error,
 ) error {
-	if attempts < 1 {
-		attempts = 1
+	if backoff.Steps < 1 {
+		backoff.Steps = 1
 	}
 
-	var err error
-	for attempt := 0; attempt < attempts; attempt++ {
-		err = run(attempt)
-		if err == nil || !retryable(err) || attempt == attempts-1 {
-			return err
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(context.Context) (bool, error) {
+		lastErr = fn()
+		switch {
+		case lastErr == nil:
+			return true, nil
+		case retryable(lastErr):
+			return false, nil // transient — back off and retry
+		default:
+			return false, lastErr // permanent — stop and surface it
 		}
-
-		if err := waitForRetry(ctx, delay); err != nil {
-			return err
+	})
+	if wait.Interrupted(err) {
+		// Steps exhausted or context cancelled. Prefer the context error if the context
+		// is actually done; otherwise surface fn's last error instead of ErrWaitTimeout.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
 		}
+		return lastErr
 	}
 
 	return err
@@ -1813,13 +1836,8 @@ func retryWhile(
 // - pkg/registry/apis/provisioning/controller/connection.go
 // - pkg/storage/unified/apistore/store.go
 // - pkg/storage/unified/sql/backend.go
-func retryOnConflict(
-	ctx context.Context,
-	attempts int,
-	delay time.Duration,
-	run func(attempt int) error,
-) error {
-	return retryWhile(ctx, attempts, delay, apierrors.IsConflict, run)
+func retryOnConflict(ctx context.Context, backoff wait.Backoff, fn func() error) error {
+	return retryWhile(ctx, backoff, apierrors.IsConflict, fn)
 }
 
 // referencedDependencyMarker is the substring Grafana's provisioning admission controller
@@ -1858,22 +1876,6 @@ func isRetryableServerError(err error) bool {
 		apierrors.IsServerTimeout(err) || // reason=ServerTimeout (sent as HTTP 500)
 		apierrors.IsTimeout(err) || // reason=Timeout / HTTP 504 gateway timeout
 		apierrors.IsTooManyRequests(err) // 429 too many requests
-}
-
-func waitForRetry(ctx context.Context, delay time.Duration) error {
-	if delay <= 0 {
-		return nil
-	}
-
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }
 
 func getSecureFromData(ctx context.Context, src resourceData, attrTypes map[string]attr.Type) (types.Object, diag.Diagnostics) {

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -26,6 +26,7 @@ import (
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func makeMockResource(name, uid string) sdkresource.Object {
@@ -1105,11 +1106,21 @@ func TestSecureVersionChanged(t *testing.T) {
 	})
 }
 
+// errBoom is a sentinel non-retryable error used across the retry tests.
+var errBoom = errors.New("boom")
+
+// noSleepBackoff exercises the retry control flow without real waits: Duration 0 (with
+// Steps n) means wait.ExponentialBackoffWithContext never sleeps, so tests stay fast and
+// deterministic regardless of the jitter the production policies use.
+func noSleepBackoff(steps int) wait.Backoff {
+	return wait.Backoff{Steps: steps}
+}
+
 func TestRetryOnConflict(t *testing.T) {
 	t.Run("retries conflict until success", func(t *testing.T) {
 		attempts := 0
 
-		err := retryOnConflict(context.Background(), 3, 0, func(_ int) error {
+		err := retryOnConflict(context.Background(), noSleepBackoff(3), func() error {
 			attempts++
 			if attempts < 3 {
 				return apierrors.NewConflict(k8sschema.GroupResource{Group: "grafana.app", Resource: "tests"}, "test", nil)
@@ -1125,12 +1136,12 @@ func TestRetryOnConflict(t *testing.T) {
 	t.Run("stops on non-conflict", func(t *testing.T) {
 		attempts := 0
 
-		err := retryOnConflict(context.Background(), 3, 0, func(_ int) error {
+		err := retryOnConflict(context.Background(), noSleepBackoff(3), func() error {
 			attempts++
-			return context.Canceled
+			return errBoom
 		})
 
-		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, errBoom)
 		require.Equal(t, 1, attempts)
 	})
 
@@ -1140,7 +1151,9 @@ func TestRetryOnConflict(t *testing.T) {
 
 		errCh := make(chan error, 1)
 		go func() {
-			errCh <- retryOnConflict(ctx, 3, time.Second, func(_ int) error {
+			// A real Duration forces an actual sleep between attempts, which the
+			// cancellation must interrupt.
+			errCh <- retryOnConflict(ctx, wait.Backoff{Duration: time.Second, Steps: 3}, func() error {
 				attempts++
 				return apierrors.NewConflict(k8sschema.GroupResource{Group: "grafana.app", Resource: "tests"}, "test", nil)
 			})
@@ -1156,14 +1169,12 @@ func TestRetryOnConflict(t *testing.T) {
 }
 
 func TestRetryWhile(t *testing.T) {
-	boom := errors.New("boom")
-
 	t.Run("retries while predicate reports retryable", func(t *testing.T) {
 		attempts := 0
-		err := retryWhile(context.Background(), 4, 0, func(error) bool { return true }, func(_ int) error {
+		err := retryWhile(context.Background(), noSleepBackoff(4), func(error) bool { return true }, func() error {
 			attempts++
 			if attempts < 3 {
-				return boom
+				return errBoom
 			}
 			return nil
 		})
@@ -1174,40 +1185,58 @@ func TestRetryWhile(t *testing.T) {
 
 	t.Run("stops immediately when predicate reports non-retryable", func(t *testing.T) {
 		attempts := 0
-		err := retryWhile(context.Background(), 4, 0, func(error) bool { return false }, func(_ int) error {
+		err := retryWhile(context.Background(), noSleepBackoff(4), func(error) bool { return false }, func() error {
 			attempts++
-			return boom
+			return errBoom
 		})
 
-		require.ErrorIs(t, err, boom)
+		require.ErrorIs(t, err, errBoom)
 		require.Equal(t, 1, attempts)
 	})
 
 	t.Run("returns last error after exhausting attempts", func(t *testing.T) {
 		attempts := 0
-		err := retryWhile(context.Background(), 3, 0, func(error) bool { return true }, func(_ int) error {
+		err := retryWhile(context.Background(), noSleepBackoff(3), func(error) bool { return true }, func() error {
 			attempts++
-			return boom
+			return errBoom
 		})
 
-		require.ErrorIs(t, err, boom)
+		require.ErrorIs(t, err, errBoom)
 		require.Equal(t, 3, attempts)
 	})
 
-	// A non-positive attempt budget must still run once and surface run's error, never
-	// return nil without calling run (which would mask a real failure as success).
-	t.Run("treats non-positive attempts as a single attempt", func(t *testing.T) {
+	// A non-positive Steps budget must still run fn once and surface its error, never
+	// return nil (or wait's ErrWaitTimeout) without calling fn at all.
+	t.Run("treats non-positive steps as a single attempt", func(t *testing.T) {
 		for _, n := range []int{0, -3} {
 			attempts := 0
-			err := retryWhile(context.Background(), n, 0, func(error) bool { return true }, func(_ int) error {
+			err := retryWhile(context.Background(), noSleepBackoff(n), func(error) bool { return true }, func() error {
 				attempts++
-				return boom
+				return errBoom
 			})
 
-			require.ErrorIs(t, err, boom, "attempts=%d should surface run's error", n)
-			require.Equal(t, 1, attempts, "attempts=%d should run exactly once", n)
+			require.ErrorIs(t, err, errBoom, "steps=%d should surface fn's error", n)
+			require.Equal(t, 1, attempts, "steps=%d should run exactly once", n)
 		}
 	})
+}
+
+// TestRetryBackoffPolicies guards the production retry policies against typos: each must
+// run at least once and, when it retries, grow an exponential, jittered, capped delay.
+func TestRetryBackoffPolicies(t *testing.T) {
+	for name, b := range map[string]wait.Backoff{
+		"conflict": conflictBackoff,
+		"delete":   deleteBackoff,
+		"read":     readBackoff,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.GreaterOrEqual(t, b.Steps, 1, "must run at least once")
+			require.Greater(t, b.Duration, time.Duration(0), "needs a positive base delay")
+			require.Greater(t, b.Factor, 1.0, "factor must grow the delay")
+			require.Greater(t, b.Jitter, 0.0, "jitter desynchronizes parallel retries")
+			require.GreaterOrEqual(t, b.Cap, b.Duration, "cap must not be below the base delay")
+		})
+	}
 }
 
 func referencedByConnectionError() error {

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -1221,9 +1221,30 @@ func TestRetryWhile(t *testing.T) {
 	})
 }
 
+// backoffWorstCase returns the maximum total time a policy can spend sleeping across all
+// of its retries: every sleep capped at Cap and inflated by the upper jitter bound. There
+// are Steps-1 sleeps (the final attempt is not followed by a wait).
+func backoffWorstCase(b wait.Backoff) time.Duration {
+	var total time.Duration
+	d := b.Duration
+	for i := 0; i < b.Steps-1; i++ {
+		step := d
+		if b.Cap > 0 && step > b.Cap {
+			step = b.Cap
+		}
+		total += step + time.Duration(float64(step)*b.Jitter)
+		d = time.Duration(float64(d) * b.Factor)
+	}
+	return total
+}
+
 // TestRetryBackoffPolicies guards the production retry policies against typos: each must
-// run at least once and, when it retries, grow an exponential, jittered, capped delay.
+// run at least once, grow an exponential/jittered/capped delay when it retries, and keep
+// its worst-case total wait bounded so a transient failure never stalls an operation.
 func TestRetryBackoffPolicies(t *testing.T) {
+	// A transient failure should never make an operation wait longer than this in total.
+	const maxBudget = 10 * time.Second
+
 	for name, b := range map[string]wait.Backoff{
 		"conflict": conflictBackoff,
 		"delete":   deleteBackoff,
@@ -1235,6 +1256,7 @@ func TestRetryBackoffPolicies(t *testing.T) {
 			require.Greater(t, b.Factor, 1.0, "factor must grow the delay")
 			require.Greater(t, b.Jitter, 0.0, "jitter desynchronizes parallel retries")
 			require.GreaterOrEqual(t, b.Cap, b.Duration, "cap must not be below the base delay")
+			require.LessOrEqual(t, backoffWorstCase(b), maxBudget, "worst-case retry budget must stay within %s", maxBudget)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #2838 (now merged). That PR added retry coverage for transient referential-integrity (422) and server (5xx/429) errors in the App Platform resource base, but retried with a **fixed** delay between attempts. This PR makes those retries use **exponential backoff with jitter**, reusing **`k8s.io/apimachinery/pkg/util/wait`** rather than hand-rolling the backoff — it's already a direct dependency and the idiomatic primitive for this K8s-native file (which already uses `apierrors`).

## Changes

- Each retry policy is now a `wait.Backoff` (initial `Duration` × `Factor` per step, additive `Jitter` to desynchronize parallel retries, capped at `Cap`, bounded by `Steps`), shared across the conflict (update), delete, and read/import paths:

  | Policy | Duration | Factor | Cap | Steps | Base sequence | Worst case (jittered) |
  |---|---|---|---|---|---|---|
  | conflict (update) | 200ms | 2 | 2s | 5 | 200ms→400ms→800ms→1.6s | ~4.5s |
  | delete | 500ms | 2 | 2s | 4 | 500ms→1s→2s | ~5.25s |
  | read / import | 500ms | 2 | 2s | 4 | 500ms→1s→2s | ~5.25s |

  Initial delays for **delete** and **read** are small (500ms): with exponential backoff the first retry fires quickly to recover from the common quick-clearing case (e.g. the validator's storage read-after-write window, a momentary 5xx), and the curve grows to cover a slower tail. The whole budget per policy stays **under 10s** so a transient failure never stalls an operation for long.

- `retryWhile` / `retryOnConflict` now wrap **`wait.ExponentialBackoffWithContext`**, which owns the context-aware sleep between attempts. The wrappers preserve the behaviour #2838 relied on:
  - surface `fn`'s **last error** on `Steps` exhaustion (not wait's sentinel `ErrWaitTimeout`),
  - surface the **context error** on cancellation,
  - clamp a non-positive `Steps` to a single attempt so a misconfigured budget still runs `fn` once (never a silent `nil`).
- Removes the hand-written `backoffDelay` / `waitForRetry` helpers and the `math/rand` jitter.

## Why a library instead of hand-rolling

`wait.Backoff` expresses exactly what we'd otherwise write by hand (base, factor, jitter, cap, max attempts), and `wait.ExponentialBackoffWithContext` is the context-aware loop. The file already imports `k8s.io/apimachinery/pkg/api/errors`, so this adds no new dependency and keeps the retry logic idiomatic for the K8s API surface these resources talk to.

## Scope / blast radius

Same generic App Platform `Resource[T, L]` base as #2838, so it applies to all App Platform resources. Behaviour change is timing-only: the same error classes are retried, just with growing, jittered waits bounded by each policy's `Cap`/`Steps`. Non-retryable errors fail exactly as before.

Note on delete coverage: #2838 used a conservative 2s initial delay because the connection delete validator's field-selector list may be served from an eventual-consistent index path; its only cited data point was a ~100ms happy-path window, so 4 attempts spanning ~5.5s should cover it. If a destroy ever surfaces a transient 422 in the wild, bump delete's `Cap` to 4s and `Steps` to 5 (~9s jittered, still under 10s).

Note: #2838 deliberately left the conflict/update path on fixed delay; this PR brings it under the same `wait.Backoff` scheme for consistency (still conflict-only). Happy to revert just that call site if reviewers prefer. The `appplatform/generic` subpackage has its own separate retry helper and is out of scope.

## Testing

- `go test ./internal/resources/appplatform/...` — pass. Existing `TestRetryWhile` / `TestRetryOnConflict` updated for the `wait.Backoff` signature (using a zero-`Duration` backoff so they never sleep); new `TestRetryBackoffPolicies` guards the production policies (`Steps>=1`, `Factor>1`, `Jitter>0`, `Cap>=Duration`) **and asserts each policy's worst-case total wait stays ≤ 10s** so a future retune can't silently blow the budget.
- `go vet ./internal/resources/appplatform/...` — clean
- `gofmt` — clean
- `go build ./...` — clean
- `golangci-lint` not run locally (its Go 1.25 build is older than the repo's 1.26.4 target); CI runs it in Docker.

No schema/example changes, so no docs regeneration required.

## Checklist
- [x] Tests added/updated
- [x] No docs needed (no schema/example changes)
- [x] No breaking changes (timing-only behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)