### PR TITLE
feat: add static labels to Azure credentials

### DIFF
--- a/docs/data-sources/cloud_provider_azure_credential.md
+++ b/docs/data-sources/cloud_provider_azure_credential.md
@@ -30,6 +30,11 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 
   resource_tags_to_add_to_metrics = ["tag1", "tag2"]
 
+  static_labels = {
+    "label1" = "value1"
+    "label2" = "value2"
+  }
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"
@@ -88,6 +93,7 @@ data "grafana_cloud_provider_azure_credential" "test" {
 - `name` (String) The name of the Azure Credential.
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
 - `resource_tags_to_add_to_metrics` (Set of String) The list of resource tags to add to metrics.
+- `static_labels` (Map of String) A set of static labels to add to all metrics exported using this credential.
 - `tenant_id` (String) The tenant ID of the Azure Credential.
 
 <a id="nestedblock--auto_discovery_configuration"></a>

--- a/docs/resources/cloud_provider_azure_credential.md
+++ b/docs/resources/cloud_provider_azure_credential.md
@@ -30,6 +30,11 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 
   resource_tags_to_add_to_metrics = ["tag1", "tag2"]
 
+  static_labels = {
+    "label1" = "value1"
+    "label2" = "value2"
+  }
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"
@@ -82,6 +87,7 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 - `enabled` (Boolean) Whether the Azure Credential is enabled or not. Defaults to `true`.
 - `resource_discovery_tag_filter` (Block List) The list of tag filters to apply to resources. (see [below for nested schema](#nestedblock--resource_discovery_tag_filter))
 - `resource_tags_to_add_to_metrics` (Set of String) The list of resource tags to add to metrics.
+- `static_labels` (Map of String) A set of static labels to add to all metrics exported using this credential.
 
 ### Read-Only
 

--- a/examples/data-sources/grafana_cloud_provider_azure_credential/data-source.tf
+++ b/examples/data-sources/grafana_cloud_provider_azure_credential/data-source.tf
@@ -7,6 +7,11 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 
   resource_tags_to_add_to_metrics = ["tag1", "tag2"]
 
+  static_labels = {
+    "label1" = "value1"
+    "label2" = "value2"
+  }
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"

--- a/examples/resources/grafana_cloud_provider_azure_credential/resource.tf
+++ b/examples/resources/grafana_cloud_provider_azure_credential/resource.tf
@@ -7,6 +7,11 @@ resource "grafana_cloud_provider_azure_credential" "test" {
 
   resource_tags_to_add_to_metrics = ["tag1", "tag2"]
 
+  static_labels = {
+    "label1" = "value1"
+    "label2" = "value2"
+  }
+
   resource_discovery_tag_filter {
     key   = "key-1"
     value = "value-1"

--- a/internal/common/cloudproviderapi/client.go
+++ b/internal/common/cloudproviderapi/client.go
@@ -310,6 +310,9 @@ type AzureCredential struct {
 
 	// ResourceTagsToAddToMetrics is the list of Azure resource tags to add to metrics.
 	ResourceTagsToAddToMetrics []string `json:"resource_tags_to_add_to_metrics"`
+
+	// StaticLabels is a set of static labels to add to all metrics exported using this credential.
+	StaticLabels map[string]string `json:"static_labels"`
 }
 
 type AutoDiscoveryConfiguration struct {

--- a/internal/resources/cloudprovider/azure_credential_test.go
+++ b/internal/resources/cloudprovider/azure_credential_test.go
@@ -39,6 +39,7 @@ func TestAcc_AzureCredential(t *testing.T) {
       }
     ],
 	"resource_tags_to_add_to_metrics" : ["tag1", "tag2"],
+	"static_labels" : { "label1": "value1", "label2": "value2" },
     "auto_discovery_configuration": [
       {
         "subscription_id": "my-subscription_id",
@@ -98,6 +99,7 @@ func TestAcc_AzureCredential(t *testing.T) {
       }
     ],
 	"resource_tags_to_add_to_metrics" : ["tag1", "tag2"],
+	"static_labels" : { "label1": "value1", "label2": "value2" },
 	"auto_discovery_configuration": [
       {
         "subscription_id": "my-subscription_id",
@@ -152,6 +154,7 @@ func TestAcc_AzureCredential(t *testing.T) {
       }
     ],
 	"resource_tags_to_add_to_metrics" : ["tag1", "tag2"],
+	"static_labels" : { "label1": "value1", "label2": "value2" },
 	"auto_discovery_configuration": [
       {
         "subscription_id": "my-subscription_id",
@@ -227,6 +230,8 @@ func TestAcc_AzureCredential(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.aggregations.0", "Average"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.0", "tag1"),
 					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.1", "tag2"),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "static_labels.label1", "value1"),
+					resource.TestCheckResourceAttr("grafana_cloud_provider_azure_credential.test", "static_labels.label2", "value2"),
 				),
 			},
 			{
@@ -255,6 +260,8 @@ func TestAcc_AzureCredential(t *testing.T) {
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "auto_discovery_configuration.0.resource_type_configurations.1.metric_configuration.0.aggregations.0", "Average"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.0", "tag1"),
 					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "resource_tags_to_add_to_metrics.1", "tag2"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "static_labels.label1", "value1"),
+					resource.TestCheckResourceAttr("data.grafana_cloud_provider_azure_credential.test", "static_labels.label2", "value2"),
 				),
 			},
 		},

--- a/internal/resources/cloudprovider/data_source_azure_credential.go
+++ b/internal/resources/cloudprovider/data_source_azure_credential.go
@@ -92,6 +92,11 @@ for information on authentication and required access policy scopes.
 				Computed:    true,
 				ElementType: types.StringType,
 			},
+			"static_labels": schema.MapAttribute{
+				Description: "A set of static labels to add to all metrics exported using this credential.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"resource_discovery_tag_filter": schema.ListNestedBlock{
@@ -205,6 +210,8 @@ func (r *datasourceAzureCredential) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
+	diags = resp.State.SetAttribute(ctx, path.Root("static_labels"), credential.StaticLabels)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resources/cloudprovider/resource_azure_credential.go
+++ b/internal/resources/cloudprovider/resource_azure_credential.go
@@ -38,6 +38,7 @@ type resourceAzureCredentialModel struct {
 	ResourceTagFilters         types.List   `tfsdk:"resource_discovery_tag_filter"`
 	AutoDiscoveryConfiguration types.List   `tfsdk:"auto_discovery_configuration"`
 	ResourceTagsToAddToMetrics types.Set    `tfsdk:"resource_tags_to_add_to_metrics"`
+	StaticLabels               types.Map    `tfsdk:"static_labels"`
 }
 
 type TagFilter struct {
@@ -193,6 +194,11 @@ for information on authentication and required access policy scopes.
 				Optional:    true,
 				ElementType: types.StringType,
 			},
+			"static_labels": schema.MapAttribute{
+				Description: "A set of static labels to add to all metrics exported using this credential.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"resource_discovery_tag_filter": schema.ListNestedBlock{
@@ -267,6 +273,12 @@ func (r *resourceAzureCredential) ImportState(ctx context.Context, req resource.
 		return
 	}
 
+	staticLabels, diags := types.MapValueFrom(ctx, types.StringType, credentials.StaticLabels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.State.Set(ctx, &resourceAzureCredentialModel{
 		ID:                         types.StringValue(req.ID),
 		Name:                       types.StringValue(credentials.Name),
@@ -279,6 +291,7 @@ func (r *resourceAzureCredential) ImportState(ctx context.Context, req resource.
 		ResourceTagFilters:         tagFilters,
 		AutoDiscoveryConfiguration: autoconfiguration,
 		ResourceTagsToAddToMetrics: resourceTagsToAddToMetrics,
+		StaticLabels:               staticLabels,
 	})
 }
 
@@ -330,6 +343,12 @@ func (r *resourceAzureCredential) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	diags = data.StaticLabels.ElementsAs(ctx, &azureCredential.StaticLabels, false)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	credential, err := r.client.CreateAzureCredential(
 		ctx,
 		data.StackID.ValueString(),
@@ -352,6 +371,7 @@ func (r *resourceAzureCredential) Create(ctx context.Context, req resource.Creat
 		ResourceTagFilters:         data.ResourceTagFilters,
 		AutoDiscoveryConfiguration: data.AutoDiscoveryConfiguration,
 		ResourceTagsToAddToMetrics: data.ResourceTagsToAddToMetrics,
+		StaticLabels:               data.StaticLabels,
 	})
 }
 
@@ -438,6 +458,12 @@ func (r *resourceAzureCredential) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("static_labels"), credential.StaticLabels)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 func (r *resourceAzureCredential) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -480,6 +506,12 @@ func (r *resourceAzureCredential) Update(ctx context.Context, req resource.Updat
 	credential.AutoDiscoveryConfiguration = autoDiscoveryConfigurations
 
 	diags = planData.ResourceTagsToAddToMetrics.ElementsAs(ctx, &credential.ResourceTagsToAddToMetrics, false)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = planData.StaticLabels.ElementsAs(ctx, &credential.StaticLabels, false)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -549,6 +581,12 @@ func (r *resourceAzureCredential) Update(ctx context.Context, req resource.Updat
 	}
 
 	diags = resp.State.SetAttribute(ctx, path.Root("resource_tags_to_add_to_metrics"), planData.ResourceTagsToAddToMetrics)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.SetAttribute(ctx, path.Root("static_labels"), planData.StaticLabels)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
This pull request adds support for specifying static labels that will be attached to all metrics exported using an Azure Credential in the Grafana Cloud Provider. The changes update the provider's resource and data source schemas, documentation, and acceptance tests to support the new `static_labels` field.
