### PR TITLE
feat(hackathon): remote sampling config

### DIFF
--- a/docs/resources/frontend_o11y_app.md
+++ b/docs/resources/frontend_o11y_app.md
@@ -45,7 +45,7 @@ resource "grafana_frontend_o11y_app" "test-app" {
 - `allowed_origins` (List of String) A list of allowed origins for CORS.
 - `extra_log_attributes` (Map of String) The extra attributes to append in each signal.
 - `name` (String) The name of Frontend Observability App. Part of the Terraform Resource ID.
-- `settings` (Map of String) The key-value settings of the Frontend Observability app. Available Settings: `{combineLabData=(0|1),geolocation.level=(0|1),geolocation.level=0-4,geolocation.country_denylist=<comma-separated-list-of-country-codes>}`
+- `settings` (Map of String) The key-value settings of the Frontend Observability app. Available Settings: `{combineLabData=(0|1),geolocation.level=(0|1),geolocation.level=0-4,geolocation.country_denylist=<comma-separated-list-of-country-codes>,sdk.sampling_rate=<float-in-[0,1]>}`
 - `stack_id` (Number) The Stack ID of the Grafana Cloud instance. Part of the Terraform Resource ID.
 
 ### Read-Only

--- a/internal/common/frontendo11yapi/client_test.go
+++ b/internal/common/frontendo11yapi/client_test.go
@@ -97,6 +97,49 @@ func TestClient_CreateApp(t *testing.T) {
 		}, acutalApp)
 	})
 
+	// The settings map is passed through verbatim; the provider does not validate
+	// setting values. In particular the value range of sdk.sampling_rate (a float
+	// in [0,1]) is enforced server-side by the Frontend Observability endpoint, so
+	// here we only assert the key round-trips through the client unchanged.
+	t.Run("passes through the sdk.sampling_rate setting", func(t *testing.T) {
+		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestBody, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, `
+			{
+				"name": "Test App",
+				"settings": {
+					"sdk.sampling_rate": "0.5"
+				}
+			}`, string(requestBody))
+
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`
+			{
+				"id": 1,
+				"name": "Test App",
+				"appKey": "foobar",
+				"settings": {
+					"sdk.sampling_rate": "0.5"
+				},
+				"allowedRate": 0
+			}`))
+		}))
+		defer svr.Close()
+
+		c, err := frontendo11yapi.NewClient("", "grafana-dev.com", "some token", svr.Client(), "some-user-agent", defaultHeaders)
+		require.NoError(t, err)
+		actualApp, err := c.CreateApp(context.Background(), svr.URL, 1, frontendo11yapi.App{
+			Name: "Test App",
+			Settings: map[string]string{
+				"sdk.sampling_rate": "0.5",
+			},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]string{"sdk.sampling_rate": "0.5"}, actualApp.Settings)
+	})
+
 	t.Run("sets auth token, content type, user agent", func(t *testing.T) {
 		svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer 1:some token", r.Header.Get("Authorization"))

--- a/internal/resources/frontendo11y/resource_frontend_o11y_app.go
+++ b/internal/resources/frontendo11y/resource_frontend_o11y_app.go
@@ -113,14 +113,19 @@ func (r *resourceFrontendO11yApp) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 			},
 			"settings": schema.MapAttribute{
-				MarkdownDescription: "The key-value settings of the Frontend Observability app. Available Settings: `{combineLabData=(0|1),geolocation.level=(0|1),geolocation.level=0-4,geolocation.country_denylist=<comma-separated-list-of-country-codes>}`",
+				MarkdownDescription: "The key-value settings of the Frontend Observability app. Available Settings: `{combineLabData=(0|1),geolocation.level=(0|1),geolocation.level=0-4,geolocation.country_denylist=<comma-separated-list-of-country-codes>,sdk.sampling_rate=<float-in-[0,1]>}`",
 				Validators: []validator.Map{
 					mapvalidator.KeysAre(
+						// NOTE: the provider only validates the allowed setting keys, not their
+						// values. The value range for sdk.sampling_rate (a float in [0,1]) is
+						// enforced server-side by the Frontend Observability endpoint, so this
+						// allow-list must stay in sync with the endpoint's allowed settings.
 						stringvalidator.OneOf([]string{
 							"combineLabData",
 							"geolocation.enabled",
 							"geolocation.level",
 							"geolocation.country_denylist",
+							"sdk.sampling_rate",
 						}...),
 					),
 				},


### PR DESCRIPTION
## Why

So the per-app Faro **session sampling rate** is manageable as IaC alongside the rest of `grafana_frontend_o11y_app`.

## What

- Allow-list `"sdk.sampling_rate"` in the `settings` `stringvalidator.OneOf` in `resource_frontend_o11y_app.go`. Settings already flow through as a generic `map[string]string`, so no model/CRUD/client changes were needed.
- The provider is key-only: **value-range `[0,1]` validation is enforced server-side by the endpoint**, so the provider and endpoint allow-lists must stay in sync (noted in a code comment).
- Regenerated `docs/resources/frontend_o11y_app.md`; added a client passthrough test for the new key.

## Links

- Endpoint slice: grafana/app-o11y-kwl-endpoint#1612
- Part of the cross-repo "remote sampling config" hackathon (endpoint + SDK + plugin + this terraform-provider).