### PR TITLE
fix(private_data_source_connect_networks): fixed retrieval of pdc networks

### DIFF
--- a/internal/resources/cloud/data_source_private_data_source_connect_networks.go
+++ b/internal/resources/cloud/data_source_private_data_source_connect_networks.go
@@ -88,6 +88,14 @@ type PDCNetworksDataSourceModel struct {
 	PrivateDataSourceNetworks []PDCNetworksDataSourcePolicyModel `tfsdk:"private_data_source_connect_networks"`
 }
 
+// isPDCSigningPolicy reports whether an access policy belongs to a Private Data
+// source Connect network. A policy qualifies if it has either the newer
+// "set:pdc-signing" scope or the older "pdc-signing:write" scope; old PDC
+// access policies only carry the latter.
+func isPDCSigningPolicy(scopes []string) bool {
+	return slices.Contains(scopes, "pdc-signing:write") || slices.Contains(scopes, "set:pdc-signing")
+}
+
 func (r *PDCNetworksDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	// Read Terraform state data into the model
 	var data PDCNetworksDataSourceModel
@@ -118,8 +126,7 @@ func (r *PDCNetworksDataSource) Read(ctx context.Context, req datasource.ReadReq
 			if data.NameFilter.ValueString() != "" && data.NameFilter.ValueString() != policy.Name {
 				continue
 			}
-			// Include pdc-signing:write to account for old PDC access policies
-			if !slices.Contains(policy.Scopes, "pdc-signing:write") || !slices.Contains(policy.Scopes, "set:pdc-signing") {
+			if !isPDCSigningPolicy(policy.Scopes) {
 				continue
 			}
 			data.PrivateDataSourceNetworks = append(data.PrivateDataSourceNetworks, PDCNetworksDataSourcePolicyModel{

--- a/internal/resources/cloud/data_source_private_data_source_connect_networks_test.go
+++ b/internal/resources/cloud/data_source_private_data_source_connect_networks_test.go
@@ -1,0 +1,51 @@
+package cloud
+
+import "testing"
+
+func TestUnitIsPDCSigningPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		scopes []string
+		want   bool
+	}{
+		{
+			name:   "new PDC scope only",
+			scopes: []string{"set:pdc-signing"},
+			want:   true,
+		},
+		{
+			name:   "old PDC scope only",
+			scopes: []string{"pdc-signing:write"},
+			want:   true,
+		},
+		{
+			name:   "both PDC scopes",
+			scopes: []string{"pdc-signing:write", "set:pdc-signing"},
+			want:   true,
+		},
+		{
+			name:   "PDC scope alongside unrelated scopes",
+			scopes: []string{"metrics:read", "set:pdc-signing", "logs:write"},
+			want:   true,
+		},
+		{
+			name:   "no PDC scopes",
+			scopes: []string{"metrics:read", "logs:write"},
+			want:   false,
+		},
+		{
+			name:   "empty scopes",
+			scopes: nil,
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isPDCSigningPolicy(tc.scopes); got != tc.want {
+				t.Errorf("isPDCSigningPolicy(%v) = %v, want %v", tc.scopes, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The condition that checked if a PDC network existed would only succeed if both the legacy and current access policy scope were set. This change fixes that and adds a test suite to validate.

Fixes #2850