### PR TITLE
fix(provider): forward http_headers to the app platform client

### DIFF
--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -269,6 +269,16 @@ func createGrafanaAppPlatformClient(client *common.Client, cfg ProviderConfig) e
 		}
 	}
 
+	headers, err := getHTTPHeadersMap(cfg)
+	if err != nil {
+		return err
+	}
+	// The Kubernetes rest client does not forward the provider's http_headers like the REST client does.
+	// Inject them on every request so deployments behind a header-based auth proxy (e.g. Google IAP) work.
+	rcfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &appPlatformHeaderRoundTripper{base: rt, headers: headers}
+	})
+
 	client.GrafanaOrgID = cfg.OrgID.ValueInt64()
 	client.GrafanaStackID = cfg.StackID.ValueInt64()
 	client.GrafanaAppPlatformAPIClientID = appplatform.DefaultManagerIdentity
@@ -749,6 +759,25 @@ func (rt *grafanaHTTPRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		req.SetBasicAuth(rt.userInfo.Username(), password)
 	}
 
+	return rt.base.RoundTrip(req)
+}
+
+// appPlatformHeaderRoundTripper sets the provider's configured http_headers on every App Platform
+// (Kubernetes API) request, which the rest.Config has no other way to forward.
+type appPlatformHeaderRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (rt *appPlatformHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, value := range rt.headers {
+		// Don't overwrite a header the rest.Config already set (e.g. the bearer Authorization),
+		// matching the REST client where configured auth wins over http_headers.
+		if req.Header.Get(key) != "" {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
 	return rt.base.RoundTrip(req)
 }
 

--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -273,6 +273,16 @@ func createGrafanaAppPlatformClient(client *common.Client, cfg ProviderConfig) e
 		}
 	}
 
+	headers, err := getHTTPHeadersMap(cfg)
+	if err != nil {
+		return err
+	}
+	// The Kubernetes rest client does not forward the provider's http_headers like the REST client does.
+	// Inject them on every request so deployments behind a header-based auth proxy (e.g. Google IAP) work.
+	rcfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &appPlatformHeaderRoundTripper{base: rt, headers: headers}
+	})
+
 	client.GrafanaOrgID = cfg.OrgID.ValueInt64()
 	client.GrafanaStackID = cfg.StackID.ValueInt64()
 	client.GrafanaAppPlatformAPIClientID = appplatform.DefaultManagerIdentity
@@ -779,6 +789,25 @@ func (rt *grafanaHTTPRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		req.SetBasicAuth(rt.userInfo.Username(), password)
 	}
 
+	return rt.base.RoundTrip(req)
+}
+
+// appPlatformHeaderRoundTripper sets the provider's configured http_headers on every App Platform
+// (Kubernetes API) request, which the rest.Config has no other way to forward.
+type appPlatformHeaderRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (rt *appPlatformHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, value := range rt.headers {
+		// Don't overwrite a header the rest.Config already set (e.g. the bearer Authorization),
+		// matching the REST client where configured auth wins over http_headers.
+		if req.Header.Get(key) != "" {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
 	return rt.base.RoundTrip(req)
 }
 

--- a/pkg/provider/configure_clients_test.go
+++ b/pkg/provider/configure_clients_test.go
@@ -157,6 +157,38 @@ func TestGrafanaHTTPRoundTripperNoAuthWhenNoneConfigured(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestAppPlatformHeaderRoundTripper(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Configured headers are sent...
+		assert.Equal(t, "Bearer iap-token", r.Header.Get("Proxy-Authorization"))
+		assert.Equal(t, "custom-value", r.Header.Get("X-Custom-Header"))
+		// ...but a header already on the request (e.g. auth set by rest.Config) is not overwritten.
+		assert.Equal(t, "Bearer real-token", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: &appPlatformHeaderRoundTripper{
+			base: http.DefaultTransport,
+			headers: map[string]string{
+				"Proxy-Authorization": "Bearer iap-token",
+				"X-Custom-Header":     "custom-value",
+				"Authorization":       "Bearer should-not-win",
+			},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer real-token")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestCreateClients(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Problem

The App Platform (Kubernetes API) client (`createGrafanaAppPlatformClient`) sets only auth on its `rest.Config` and never injects the provider's `http_headers`, unlike the REST clients (which forward them via `grafanaHTTPRoundTripper`). So behind a header-based auth proxy — e.g. Google IAP, which needs a `Proxy-Authorization` header set via `http_headers` / `GRAFANA_HTTP_HEADERS` — every App Platform resource gets HTTP 401 while REST resources work.

## Fix

Wrap the `rest.Config` transport to set the configured `http_headers` on each request, skipping any header already set so configured auth still wins — matching the REST client.

## Testing

A unit test covering both behaviours (configured headers are sent; an existing `Authorization` is preserved). No schema change; not breaking.