### PR TITLE
fix(asserts): omit empty match values for null-check operators

### DIFF
--- a/docs/resources/asserts_log_config.md
+++ b/docs/resources/asserts_log_config.md
@@ -136,7 +136,10 @@ Required:
 
 - `op` (String) Operation to use for matching. One of: =, <>, <, >, <=, >=, IS NULL, IS NOT NULL, STARTS WITH, CONTAINS.
 - `property` (String) Entity property to match.
-- `values` (List of String) Values to match against.
+
+Optional:
+
+- `values` (List of String) Values to match against. Required for all operators except "IS NULL" and "IS NOT NULL", which must not have any values.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/asserts_profile_config.md
+++ b/docs/resources/asserts_profile_config.md
@@ -131,7 +131,10 @@ Required:
 
 - `op` (String) Operation to use for matching. One of: =, <>, <, >, <=, >=, IS NULL, IS NOT NULL, STARTS WITH, CONTAINS.
 - `property` (String) Entity property to match.
-- `values` (List of String) Values to match against.
+
+Optional:
+
+- `values` (List of String) Values to match against. Required for all operators except "IS NULL" and "IS NOT NULL", which must not have any values.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/asserts_trace_config.md
+++ b/docs/resources/asserts_trace_config.md
@@ -131,7 +131,10 @@ Required:
 
 - `op` (String) Operation to use for matching. One of: =, <>, <, >, <=, >=, IS NULL, IS NOT NULL, STARTS WITH, CONTAINS.
 - `property` (String) Entity property to match.
-- `values` (List of String) Values to match against.
+
+Optional:
+
+- `values` (List of String) Values to match against. Required for all operators except "IS NULL" and "IS NOT NULL", which must not have any values.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/internal/resources/asserts/common.go
+++ b/internal/resources/asserts/common.go
@@ -142,6 +142,11 @@ func stringSliceToInterface(items []string) []interface{} {
 	return result
 }
 
+var nullCheckMatchOps = map[string]bool{
+	"IS NULL":     true,
+	"IS NOT NULL": true,
+}
+
 // getMatchRulesSchema returns the common schema definition for match rules used across drilldown configs
 func getMatchRulesSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -159,12 +164,49 @@ func getMatchRulesSchema() map[string]*schema.Schema {
 			}, false),
 		},
 		"values": {
-			Type:        schema.TypeList,
-			Required:    true,
-			Description: "Values to match against.",
-			Elem:        &schema.Schema{Type: schema.TypeString},
+			Type:     schema.TypeList,
+			Optional: true,
+			Description: "Values to match against. Required for all operators except " +
+				"\"IS NULL\" and \"IS NOT NULL\", which must not have any values.",
+			Elem: &schema.Schema{Type: schema.TypeString},
 		},
 	}
+}
+
+// validateMatchRulesDiff enforces the conditional requirement on the "values"
+// attribute of match rules: it must be empty for the null-check operators
+// ("IS NULL"/"IS NOT NULL") and non-empty for every other operator.
+func validateMatchRulesDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	matches, ok := d.Get("match").([]interface{})
+	if !ok {
+		return nil
+	}
+	return validateMatchRules(matches)
+}
+
+func validateMatchRules(matches []interface{}) error {
+	for i, item := range matches {
+		matchMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		op, _ := matchMap["op"].(string)
+		values, _ := matchMap["values"].([]interface{})
+
+		if nullCheckMatchOps[op] {
+			if len(values) > 0 {
+				return fmt.Errorf("match.%d: operator %q must not have any values", i, op)
+			}
+			continue
+		}
+
+		if len(values) == 0 {
+			return fmt.Errorf("match.%d: operator %q requires at least one value", i, op)
+		}
+	}
+
+	return nil
 }
 
 // buildMatchRules converts Terraform schema match data to PropertyMatchEntryDto slice
@@ -193,7 +235,10 @@ func buildMatchRules(matchData interface{}) []assertsapi.PropertyMatchEntryDto {
 					values = append(values, s)
 				}
 			}
-			match.SetValues(values)
+			// Only send "values" when there is at least one value.
+			if len(values) > 0 {
+				match.SetValues(values)
+			}
 		}
 		matches = append(matches, *match)
 	}

--- a/internal/resources/asserts/common_internal_test.go
+++ b/internal/resources/asserts/common_internal_test.go
@@ -1,0 +1,97 @@
+package asserts
+
+import "testing"
+
+// matchRule is a small helper to build the map shape that Terraform produces
+// for a single "match" block element.
+func matchRule(op string, values ...string) map[string]interface{} {
+	vals := make([]interface{}, 0, len(values))
+	for _, v := range values {
+		vals = append(vals, v)
+	}
+	return map[string]interface{}{
+		"property": "environment",
+		"op":       op,
+		"values":   vals,
+	}
+}
+
+func TestUnitValidateMatchRules(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		matches   []interface{}
+		wantError bool
+	}{
+		{
+			name:    "nil matches",
+			matches: nil,
+		},
+		{
+			name:    "empty matches",
+			matches: []interface{}{},
+		},
+		{
+			name:    "comparison op with values",
+			matches: []interface{}{matchRule("=", "production")},
+		},
+		{
+			name:    "comparison op with multiple values",
+			matches: []interface{}{matchRule("CONTAINS", "prod", "staging")},
+		},
+		{
+			name:      "comparison op without values",
+			matches:   []interface{}{matchRule("=")},
+			wantError: true,
+		},
+		{
+			name:    "IS NOT NULL without values",
+			matches: []interface{}{matchRule("IS NOT NULL")},
+		},
+		{
+			name:    "IS NULL without values",
+			matches: []interface{}{matchRule("IS NULL")},
+		},
+		{
+			name:      "IS NOT NULL with values",
+			matches:   []interface{}{matchRule("IS NOT NULL", "production")},
+			wantError: true,
+		},
+		{
+			name:      "IS NULL with values",
+			matches:   []interface{}{matchRule("IS NULL", "production")},
+			wantError: true,
+		},
+		{
+			name: "mixed valid rules",
+			matches: []interface{}{
+				matchRule("=", "production"),
+				matchRule("IS NOT NULL"),
+			},
+		},
+		{
+			name: "second rule invalid",
+			matches: []interface{}{
+				matchRule("=", "production"),
+				matchRule(">"),
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateMatchRules(tc.matches)
+			if tc.wantError && err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/resources/asserts/common_internal_test.go
+++ b/internal/resources/asserts/common_internal_test.go
@@ -81,7 +81,6 @@ func TestUnitValidateMatchRules(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/resources/asserts/resource_log_config.go
+++ b/internal/resources/asserts/resource_log_config.go
@@ -23,6 +23,8 @@ func makeResourceLogConfig() *common.Resource {
 		UpdateContext: resourceLogConfigUpdate,
 		DeleteContext: resourceLogConfigDelete,
 
+		CustomizeDiff: validateMatchRulesDiff,
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(2 * time.Minute),

--- a/internal/resources/asserts/resource_profile_config.go
+++ b/internal/resources/asserts/resource_profile_config.go
@@ -23,6 +23,8 @@ func makeResourceProfileConfig() *common.Resource {
 		UpdateContext: resourceProfileConfigUpdate,
 		DeleteContext: resourceProfileConfigDelete,
 
+		CustomizeDiff: validateMatchRulesDiff,
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(2 * time.Minute),
@@ -102,7 +104,7 @@ func resourceProfileConfigCreate(ctx context.Context, d *schema.ResourceData, me
 
 	_, err := request.Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create profile configuration: %w", err))
+		return diag.FromErr(formatAPIError("failed to create profile configuration", err))
 	}
 
 	d.SetId(name)
@@ -210,7 +212,7 @@ func resourceProfileConfigUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	_, err := request.Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update profile configuration: %w", err))
+		return diag.FromErr(formatAPIError("failed to update profile configuration", err))
 	}
 
 	return resourceProfileConfigRead(ctx, d, meta)
@@ -231,7 +233,7 @@ func resourceProfileConfigDelete(ctx context.Context, d *schema.ResourceData, me
 
 	_, err := request.Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to delete profile configuration: %w", err))
+		return diag.FromErr(formatAPIError("failed to delete profile configuration", err))
 	}
 
 	d.SetId("")

--- a/internal/resources/asserts/resource_trace_config.go
+++ b/internal/resources/asserts/resource_trace_config.go
@@ -23,6 +23,8 @@ func makeResourceTraceConfig() *common.Resource {
 		UpdateContext: resourceTraceConfigUpdate,
 		DeleteContext: resourceTraceConfigDelete,
 
+		CustomizeDiff: validateMatchRulesDiff,
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Read:   schema.DefaultTimeout(2 * time.Minute),


### PR DESCRIPTION
## Problem

Knowledge Graph drilldown configs (`grafana_asserts_profile_config`, `_trace_config`, `_log_config`) failed to create whenever a `match` rule used the `IS NOT NULL` / `IS NULL` operator. The apply errored with the misleading message:

```
failed to create profile configuration: data failed to match schemas in oneOf(ApiErrorStatus)
```

This surfaced from `TestAccAssertsProfileConfig_update`.

## Root cause

`buildMatchRules` always called `SetValues` on the DTO, even for an empty list, producing a non-nil empty `[]string`. The generated client serializes via `IsNil` (not `omitempty`), so a non-nil empty slice was emitted as `"values":[]`. The server rejects `values` on null-check operators with a **422**, and that 422 body didn't match the client's `ApiErrorStatus` oneOf — so the real error was masked behind a decode failure.

This could be due to recent changes in the asserts Go client library.

## Changes

- **`buildMatchRules`** only sets `Values` when at least one value is present, so null-check operators no longer send a `values` field.
- The shared match **`values`** attribute is now `Optional`, with a `CustomizeDiff` (`validateMatchRulesDiff`) enforcing the conditional rule at **plan time**: values are required for all operators except `IS NULL` / `IS NOT NULL`, which must have none. Wired into the profile, trace, and log config resources. This follows the provider's idiom for cross-field validation inside list blocks (cf. `resourceCheckCustomizeDiff` in synthetic monitoring) since schema-level `RequiredWith`/`ConflictsWith` don't work inside nested blocks.
- Profile config Create/Update/Delete now use `formatAPIError` (matching trace/log configs) so future API errors surface the raw response body instead of the oneOf decode error.

## Testing

- `go test ./internal/resources/asserts/ -run TestUnitValidateMatchRules` — passes (11 cases).
- `go build ./...` / `go vet` clean.
