### PR TITLE
ci(workflows): poll cloud acceptance gate until tests finish

### DIFF
--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -1,5 +1,5 @@
-# Waits until "cloud acceptance tests" has a completed successful run for the PR head commit.
-# While cloud tests are still running, this job stays in progress instead of failing early.
+# Merge gate for pull requests: poll cloud acceptance tests on the head commit until they finish.
+# Passes only when the cloud test job succeeded.
 # Fork PRs skip this requirement (cloud workflow secrets are not available on forks).
 name: cloud acceptance tests gate
 
@@ -71,8 +71,7 @@ jobs:
             sleep "$POLL_INTERVAL_SECONDS"
           done
 
-          # Judge the cloud test job, not the whole workflow run. The workflow can
-          # fail when refresh-pr-gate-check cannot re-run an already-polling gate.
+          # Judge the cloud test job, not the whole workflow run; helper jobs can fail independently of the tests.
           cloud_conclusion=$(gh api \
             -H "Accept: application/vnd.github+json" \
             "repos/${THIS_REPO}/actions/runs/${run_id}/jobs" \

--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -1,4 +1,5 @@
-# Fails until "cloud acceptance tests" has a completed successful run for the PR head commit.
+# Waits until "cloud acceptance tests" has a completed successful run for the PR head commit.
+# While cloud tests are still running, this job stays in progress instead of failing early.
 # Fork PRs skip this requirement (cloud workflow secrets are not available on forks).
 name: cloud acceptance tests gate
 
@@ -25,6 +26,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           THIS_REPO: ${{ github.repository }}
+          POLL_INTERVAL_SECONDS: 30
+          ABORT_AFTER_SECONDS: 2400 # match cloud-acc-tests turnstyle safety net
         run: |
           set -euo pipefail
           if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
@@ -34,26 +37,38 @@ jobs:
 
           echo "Checking runs of cloud-acc-tests.yml for head_sha=${HEAD_SHA}"
 
-          json=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests.yml/runs?head_sha=${HEAD_SHA}&per_page=5")
+          started_at=$(date +%s)
 
-          count=$(echo "$json" | jq '.total_count')
-          if [ "$count" -eq 0 ]; then
-            echo "::error::No run of \"cloud acceptance tests\" found for commit ${HEAD_SHA:0:7}. Ask a Grafana Labs maintainer to run Actions → cloud acceptance tests → Run workflow for this branch."
-            exit 1
-          fi
+          while true; do
+            json=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${THIS_REPO}/actions/workflows/cloud-acc-tests.yml/runs?head_sha=${HEAD_SHA}&per_page=5")
 
-          status=$(echo "$json" | jq -r '.workflow_runs[0].status')
-          conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
-          html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
+            count=$(echo "$json" | jq '.total_count')
+            if [ "$count" -eq 0 ]; then
+              echo "::error::No run of \"cloud acceptance tests\" found for commit ${HEAD_SHA:0:7}. Ask a Grafana Labs maintainer to run Actions → cloud acceptance tests → Run workflow for this branch."
+              exit 1
+            fi
 
-          echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
+            status=$(echo "$json" | jq -r '.workflow_runs[0].status')
+            conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
+            html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
 
-          if [ "$status" != "completed" ]; then
-            echo "::error::Cloud acceptance tests have not finished for this commit (status=${status}). Wait for the run to complete: ${html_url}"
-            exit 1
-          fi
+            echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
+
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+
+            elapsed=$(( $(date +%s) - started_at ))
+            if [ "$elapsed" -ge "$ABORT_AFTER_SECONDS" ]; then
+              echo "::error::Timed out after ${ABORT_AFTER_SECONDS}s waiting for cloud acceptance tests to finish (status=${status}): ${html_url}"
+              exit 1
+            fi
+
+            echo "Cloud acceptance tests still ${status}; checking again in ${POLL_INTERVAL_SECONDS}s..."
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
 
           if [ "$conclusion" != "success" ]; then
             echo "::error::Cloud acceptance tests did not succeed (conclusion=${conclusion}). Fix failures or re-run: ${html_url}. If failures look unrelated to your PR, retry the workflow and raise the issue in #terraform-provider on Slack. We want flaky tests surfaced and fixed."

--- a/.github/workflows/cloud-acc-tests-gate.yml
+++ b/.github/workflows/cloud-acc-tests-gate.yml
@@ -38,6 +38,7 @@ jobs:
           echo "Checking runs of cloud-acc-tests.yml for head_sha=${HEAD_SHA}"
 
           started_at=$(date +%s)
+          run_id=""
 
           while true; do
             json=$(gh api \
@@ -50,11 +51,11 @@ jobs:
               exit 1
             fi
 
+            run_id=$(echo "$json" | jq -r '.workflow_runs[0].id')
             status=$(echo "$json" | jq -r '.workflow_runs[0].status')
-            conclusion=$(echo "$json" | jq -r '.workflow_runs[0].conclusion')
             html_url=$(echo "$json" | jq -r '.workflow_runs[0].html_url')
 
-            echo "Latest cloud acceptance run: status=${status} conclusion=${conclusion} url=${html_url}"
+            echo "Latest cloud acceptance run: status=${status} url=${html_url}"
 
             if [ "$status" = "completed" ]; then
               break
@@ -70,8 +71,22 @@ jobs:
             sleep "$POLL_INTERVAL_SECONDS"
           done
 
-          if [ "$conclusion" != "success" ]; then
-            echo "::error::Cloud acceptance tests did not succeed (conclusion=${conclusion}). Fix failures or re-run: ${html_url}. If failures look unrelated to your PR, retry the workflow and raise the issue in #terraform-provider on Slack. We want flaky tests surfaced and fixed."
+          # Judge the cloud test job, not the whole workflow run. The workflow can
+          # fail when refresh-pr-gate-check cannot re-run an already-polling gate.
+          cloud_conclusion=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${THIS_REPO}/actions/runs/${run_id}/jobs" \
+            --jq '.jobs[] | select(.name == "cloud") | .conclusion')
+
+          echo "Cloud acceptance test job conclusion=${cloud_conclusion} url=${html_url}"
+
+          if [ -z "$cloud_conclusion" ] || [ "$cloud_conclusion" = "null" ]; then
+            echo "::error::Could not find the cloud test job for run ${run_id}: ${html_url}"
+            exit 1
+          fi
+
+          if [ "$cloud_conclusion" != "success" ]; then
+            echo "::error::Cloud acceptance tests did not succeed (conclusion=${cloud_conclusion}). Fix failures or re-run: ${html_url}. If failures look unrelated to your PR, retry the workflow and raise the issue in #terraform-provider on Slack. We want flaky tests surfaced and fixed."
             exit 1
           fi
 

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -70,10 +70,9 @@ jobs:
           GRAFANA_RETRIES: 10
           GRAFANA_RETRY_WAIT: 5
 
+  # Re-run the PR gate when cloud tests start so it polls until they finish (see cloud-acc-tests-gate.yml).
   refresh-pr-gate-check:
     name: refresh pull_request gate check
-    needs: cloud
-    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -97,6 +97,8 @@ jobs:
           fi
 
           echo "Re-running pull_request gate workflow run id=${run_id}"
+          # Treat "already running" as success since a polling gate needs no re-run. 
+          # Otherwise, a 403 "already running" from GitHub fails the job when the gate is already polling.
           set +e
           rerun_out=$(gh api \
             -X POST \

--- a/.github/workflows/cloud-acc-tests.yml
+++ b/.github/workflows/cloud-acc-tests.yml
@@ -98,9 +98,21 @@ jobs:
           fi
 
           echo "Re-running pull_request gate workflow run id=${run_id}"
-          gh api \
+          set +e
+          rerun_out=$(gh api \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            "repos/${THIS_REPO}/actions/runs/${run_id}/rerun"
+            "repos/${THIS_REPO}/actions/runs/${run_id}/rerun" 2>&1)
+          rerun_status=$?
+          set -e
+
+          if [ "$rerun_status" -ne 0 ]; then
+            if echo "$rerun_out" | grep -q "already running"; then
+              echo "Gate workflow is already running; no re-run needed."
+              exit 0
+            fi
+            echo "$rerun_out"
+            exit 1
+          fi
 
 


### PR DESCRIPTION
Keep the gate check in progress while cloud acceptance tests run, instead of failing early with a non-actionable error. Also refresh the gate as soon as cloud acc tests are triggered.

Relates to https://github.com/grafana/deployment_tools/issues/575652