### PR TITLE
ci(update-schema): sign auto-generated commits

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -98,8 +98,10 @@ jobs:
           branch: 'automated/update-schema'
           delete-branch: true
           base: main
-          committer: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
-          author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+          # Sign commits as the GitHub App bot via the GitHub API so they pass
+          # the "require signed commits" branch protection rule. When enabled,
+          # the committer/author inputs are ignored by the action.
+          sign-commits: true
 
       - name: Approve PR
         if: steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
## Problem

The `create-schema-update-pr` workflow is [failing](https://github.com/grafana/terraform-provider-grafana/actions/runs/28499889263/job/84474460727) at the *Create Pull Request with schema updates* step:

```
The process '/usr/bin/git' failed with exit code 1
```

This is because the repository now requires **signed commits**, but `peter-evans/create-pull-request` was creating plain git commits which are rejected on push.

## Fix

Enable `sign-commits: true` on the `peter-evans/create-pull-request` step. With this option the action creates commits via the GitHub API, which signs them as the GitHub App bot (the token already comes from `create-github-app-token`). These commits are marked as verified and satisfy the branch protection rule.

Per the action docs, when `sign-commits` is enabled the `committer` and `author` inputs are ignored, so they were removed.