### PR TITLE
fix(grafana_folder,grafana_folders): reliable folder lookup on large stacks

### DIFF
--- a/internal/resources/grafana/data_source_folder.go
+++ b/internal/resources/grafana/data_source_folder.go
@@ -52,10 +52,28 @@ func findFolderWithTitleAndUID(client *goapi.GrafanaHTTPAPI, title string, uid s
 		return "", errors.New(FolderTitleOrUIDMissing)
 	}
 
+	// When only the UID is known, look the folder up directly instead of
+	// paging through /api/search. Search results are sorted by title with no
+	// stable tie-breaker, so with a large number of same-titled folders the
+	// paginated listing is not consistent between requests and can skip a
+	// folder that actually exists. A direct lookup by UID avoids that.
+	if uid != "" && title == "" {
+		if _, err := client.Folders.GetFolderByUID(uid); err != nil {
+			if common.IsNotFoundError(err) {
+				return "", fmt.Errorf(FolderWithUIDNotFound, uid)
+			}
+			return "", err
+		}
+		return uid, nil
+	}
+
 	var page int64 = 1
 
 	for {
-		params := search.NewSearchParams().WithType(common.Ref("dash-folder")).WithPage(&page)
+		// Sort by title so the paginated listing is ordered consistently
+		// across requests. NewSearchParams does not apply the API's default
+		// sort, so we set it explicitly.
+		params := search.NewSearchParams().WithType(common.Ref("dash-folder")).WithSort(common.Ref("alpha-asc")).WithPage(&page)
 		resp, err := client.Search.Search(params)
 		if err != nil {
 			return "", err

--- a/internal/resources/grafana/data_source_folder_internal_test.go
+++ b/internal/resources/grafana/data_source_folder_internal_test.go
@@ -1,0 +1,102 @@
+package grafana
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
+)
+
+// testGrafanaClient builds a Grafana API client pointed at the given test server.
+func testGrafanaClient(t *testing.T, serverURL string) *goapi.GrafanaHTTPAPI {
+	t.Helper()
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	return goapi.NewHTTPClientWithConfig(strfmt.Default, &goapi.TransportConfig{
+		Host:     parsed.Host,
+		BasePath: "/api",
+		Schemes:  []string{parsed.Scheme},
+	})
+}
+
+// When only the UID is known, the folder is resolved with a direct
+// GET /api/folders/:uid lookup and /api/search is never called. This is what
+// makes the data source reliable for stacks with more folders than a single
+// /api/search page returns.
+func TestFindFolderWithTitleAndUID_UIDOnly_UsesDirectLookup(t *testing.T) {
+	var searchCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/search":
+			searchCalled = true
+			http.Error(w, "search should not be called", http.StatusInternalServerError)
+		case r.URL.Path == "/api/folders/existing-folder":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"uid":"existing-folder","title":"Existing"}`)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	uid, err := findFolderWithTitleAndUID(testGrafanaClient(t, server.URL), "", "existing-folder")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uid != "existing-folder" {
+		t.Fatalf("got uid %q, want %q", uid, "existing-folder")
+	}
+	if searchCalled {
+		t.Fatal("/api/search was called; UID-only lookup must not use search")
+	}
+}
+
+// A missing UID still surfaces the FolderWithUIDNotFound error via the direct
+// lookup, matching the behaviour callers and acceptance tests rely on.
+func TestFindFolderWithTitleAndUID_UIDOnly_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"folder not found"}`)
+	}))
+	defer server.Close()
+
+	_, err := findFolderWithTitleAndUID(testGrafanaClient(t, server.URL), "", "missing-folder")
+	want := fmt.Sprintf(FolderWithUIDNotFound, "missing-folder")
+	if err == nil || err.Error() != want {
+		t.Fatalf("got error %v, want %q", err, want)
+	}
+}
+
+// When searching by title the request is sorted so that the paginated listing
+// is ordered consistently across page requests.
+func TestFindFolderWithTitleAndUID_ByTitle_SendsSort(t *testing.T) {
+	var gotSort string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/search" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		gotSort = r.URL.Query().Get("sort")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"uid":"folder-uid","title":"My Folder"}]`)
+	}))
+	defer server.Close()
+
+	uid, err := findFolderWithTitleAndUID(testGrafanaClient(t, server.URL), "My Folder", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uid != "folder-uid" {
+		t.Fatalf("got uid %q, want %q", uid, "folder-uid")
+	}
+	if gotSort != "alpha-asc" {
+		t.Fatalf("got sort %q, want %q", gotSort, "alpha-asc")
+	}
+}

--- a/internal/resources/grafana/data_source_folder_internal_test.go
+++ b/internal/resources/grafana/data_source_folder_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -32,11 +33,11 @@ func testGrafanaClient(t *testing.T, serverURL string) *goapi.GrafanaHTTPAPI {
 func TestFindFolderWithTitleAndUID_UIDOnly_UsesDirectLookup(t *testing.T) {
 	var searchCalled bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/search":
+		switch r.URL.Path {
+		case "/api/search":
 			searchCalled = true
 			http.Error(w, "search should not be called", http.StatusInternalServerError)
-		case r.URL.Path == "/api/folders/existing-folder":
+		case "/api/folders/existing-folder":
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"uid":"existing-folder","title":"Existing"}`)
 		default:
@@ -98,5 +99,46 @@ func TestFindFolderWithTitleAndUID_ByTitle_SendsSort(t *testing.T) {
 	}
 	if gotSort != "alpha-asc" {
 		t.Fatalf("got sort %q, want %q", gotSort, "alpha-asc")
+	}
+}
+
+// listAllFolders pages through every result and sorts the request so the
+// listing is consistent across page requests.
+func TestListAllFolders_PaginatesAndSorts(t *testing.T) {
+	var sorts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/search" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		sorts = append(sorts, r.URL.Query().Get("sort"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			fmt.Fprint(w, `[{"uid":"a","title":"A"},{"uid":"b","title":"B"}]`)
+		case "2":
+			fmt.Fprint(w, `[{"uid":"c","title":"C"}]`)
+		default:
+			fmt.Fprint(w, `[]`)
+		}
+	}))
+	defer server.Close()
+
+	folders, err := listAllFolders(testGrafanaClient(t, server.URL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gotUIDs []string
+	for _, f := range folders {
+		gotUIDs = append(gotUIDs, f.UID)
+	}
+	if want := []string{"a", "b", "c"}; !slices.Equal(gotUIDs, want) {
+		t.Fatalf("got folders %v, want %v", gotUIDs, want)
+	}
+	for i, s := range sorts {
+		if s != "alpha-asc" {
+			t.Fatalf("page %d requested with sort %q, want %q", i+1, s, "alpha-asc")
+		}
 	}
 }

--- a/internal/resources/grafana/data_source_folders.go
+++ b/internal/resources/grafana/data_source_folders.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 
+	goapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/search"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
@@ -58,18 +59,19 @@ func datasourceFolders() *common.DataSource {
 	return common.NewLegacySDKDataSource(common.CategoryGrafanaOSS, "grafana_folders", schema)
 }
 
-func readFolders(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	metaClient := meta.(*common.Client)
-	client, orgID := OAPIClientFromNewOrgResource(meta, d)
-
+// listAllFolders pages through /api/search and returns every folder. Results
+// are sorted by title so the paginated listing is ordered consistently across
+// requests; without a sort the order is not stable and paging can skip or
+// duplicate folders once there is more than one page of them.
+func listAllFolders(client *goapi.GrafanaHTTPAPI) ([]*models.Hit, error) {
 	var folders []*models.Hit
 	var page int64 = 1
 	searchType := "dash-folder"
 	for {
-		params := search.NewSearchParams().WithType(&searchType).WithPage(&page)
+		params := search.NewSearchParams().WithType(&searchType).WithSort(common.Ref("alpha-asc")).WithPage(&page)
 		resp, err := client.Search.Search(params)
 		if err != nil {
-			return diag.FromErr(err)
+			return nil, err
 		}
 		if len(resp.Payload) == 0 {
 			break
@@ -77,6 +79,17 @@ func readFolders(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 		folders = append(folders, resp.Payload...)
 		page++
+	}
+	return folders, nil
+}
+
+func readFolders(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	metaClient := meta.(*common.Client)
+	client, orgID := OAPIClientFromNewOrgResource(meta, d)
+
+	folders, err := listAllFolders(client)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(MakeOrgResourceID(orgID, "folders"))


### PR DESCRIPTION
The grafana_folder and grafana_folders data sources both resolved folders through /api/search, which returns at most 1000 results per page, ordered by title with no stable tie-breaker. When many folders share the same title, the set of folders returned near a page boundary is not consistent between requests. A customer hit this with ~3600 folders where hundreds share the titles "DEV", "QA" and "STAGE".

For grafana_folder this meant an existing folder could intermittently fail to resolve with "folder with uid ... not found", even though the UID was provided. It now looks the folder up directly with GET /api/folders/:uid when the UID is known, which is a single deterministic request that does not depend on search ordering. When only the title is given, search is still used, but the request is now explicitly sorted so paging is consistent.

For grafana_folders (which lists all folders) the same instability could cause folders to be skipped or duplicated. The search request is now sorted so the paginated listing is consistent across requests.

Added unit tests covering the direct UID lookup, the not-found case, the sort on the title path, and the paginated listing.