### PR TITLE
fix(user): skip user update if only is_admin or password are being modified

### DIFF
--- a/internal/resources/grafana/resource_user.go
+++ b/internal/resources/grafana/resource_user.go
@@ -164,13 +164,15 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	u := models.UpdateUserCommand{
-		Email: d.Get("email").(string),
-		Name:  d.Get("name").(string),
-		Login: d.Get("login").(string),
-	}
-	if _, err = client.Users.UpdateUser(id, &u); err != nil {
-		return diag.FromErr(err)
+	if d.HasChange("email") || d.HasChange("name") || d.HasChange("login") {
+		u := models.UpdateUserCommand{
+			Email: d.Get("email").(string),
+			Name:  d.Get("name").(string),
+			Login: d.Get("login").(string),
+		}
+		if _, err = client.Users.UpdateUser(id, &u); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if d.HasChange("password") {
 		f := models.AdminUpdateUserPasswordForm{Password: models.Password(d.Get("password").(string))}


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/125915

This allows updating `is_admin` of an externally synced user (e.g. a user that uses SSO) without running the unnecessary `PUT /users/{user_id}` request that will always fail for externally synced users. The fix just checks if any of the `email`, `name` and `username` fields are being modified and, if not, skips the user-update request.