### PR TITLE
feat(equivalence): support filtering equivalence tests by case

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,6 +4,11 @@ DOCKER_COMPOSE_ARGS ?= --pull always --force-recreate --detach --remove-orphans 
 # Equivalence Makefile targets — see equivalence-tests/README.md Prerequisites & Commands.
 EQUIV_CACHE_BIN := $(CURDIR)/.cache/bin
 EQUIV_BIN ?= $(EQUIV_CACHE_BIN)/terraform-equivalence-testing
+# Optional comma-separated test case names under equivalence-tests/tests/ (e.g. grafana_user).
+EQUIV_FILTERS ?=
+ifneq ($(EQUIV_FILTERS),)
+EQUIV_FILTER_ARGS := --filters=$(EQUIV_FILTERS)
+endif
 
 .PHONY: equivalence-test-ensure-bin \
 	equivalence-test-update equivalence-test-diff equivalence-test-diff-local \
@@ -28,7 +33,8 @@ equivalence-test-update-run: equivalence-test-ensure-bin
 		GRAFANA_AUTH="$${GRAFANA_AUTH:-admin:admin}" \
 		$(EQUIV_BIN) update \
 		--goldens="$(CURDIR)/equivalence-tests/goldens" \
-		--tests="$(CURDIR)/equivalence-tests/tests"
+		--tests="$(CURDIR)/equivalence-tests/tests" \
+		$(EQUIV_FILTER_ARGS)
 
 equivalence-test-diff-run: equivalence-test-ensure-bin
 	env -u TF_CLI_CONFIG_FILE \
@@ -36,13 +42,15 @@ equivalence-test-diff-run: equivalence-test-ensure-bin
 		GRAFANA_AUTH="$${GRAFANA_AUTH:-admin:admin}" \
 		$(EQUIV_BIN) diff \
 		--goldens="$(CURDIR)/equivalence-tests/goldens" \
-		--tests="$(CURDIR)/equivalence-tests/tests"
+		--tests="$(CURDIR)/equivalence-tests/tests" \
+		$(EQUIV_FILTER_ARGS)
 
 # Build provider from this checkout and diff JSON vs checked-in goldens (uses dev_overrides;
 # other providers still resolve via direct{}).
 equivalence-test-diff-local-run: equivalence-test-ensure-bin
 	REPO_ROOT="$(CURDIR)" \
 		EQUIV_BIN="$(EQUIV_BIN)" \
+		EQUIV_FILTERS="$(EQUIV_FILTERS)" \
 		GRAFANA_URL="$${GRAFANA_URL:-http://localhost:3000}" \
 		GRAFANA_AUTH="$${GRAFANA_AUTH:-admin:admin}" \
 		bash "$(CURDIR)/equivalence-tests/diff-local.sh"
@@ -52,6 +60,7 @@ define equivalence-test-with-grafana
 	REPO_ROOT="$(CURDIR)" \
 		GRAFANA_VERSION="$(GRAFANA_VERSION)" \
 		DOCKER_COMPOSE_ARGS="$(DOCKER_COMPOSE_ARGS)" \
+		EQUIV_FILTERS="$(EQUIV_FILTERS)" \
 		bash "$(CURDIR)/equivalence-tests/run-with-grafana.sh" $(1)
 endef
 

--- a/equivalence-tests/README.md
+++ b/equivalence-tests/README.md
@@ -18,6 +18,14 @@ make equivalence-test-diff        # same provider source as update
 make equivalence-test-diff-local  # provider built from this repo vs same goldens
 ```
 
+Run a single case (or subset) with `EQUIV_FILTERS` — comma-separated names matching directories under `tests/`:
+
+```sh
+make equivalence-test-diff-local EQUIV_FILTERS=grafana_user
+make equivalence-test-diff EQUIV_FILTERS=grafana_user
+make equivalence-test-update EQUIV_FILTERS=grafana_user,grafana_team
+```
+
 Exit `0` = match, `2` = diff, `1` = failed run.
 
 `equivalence-test-update` / `-diff` use the registry Grafana provider with the version pinned per case in `main.tf` and `TF_CLI_CONFIG_FILE` unset. `equivalence-test-diff-local` builds this repo and sets `TF_CLI_CONFIG_FILE` with `dev_overrides` so Terraform loads the local `grafana/grafana` plugin instead of the registry.

--- a/equivalence-tests/diff-local.sh
+++ b/equivalence-tests/diff-local.sh
@@ -13,8 +13,14 @@ set -euo pipefail
 : "${REPO_ROOT:?REPO_ROOT must be set to the repository root}"
 
 EQUIV_BIN="${EQUIV_BIN:-$REPO_ROOT/.cache/bin/terraform-equivalence-testing}"
+EQUIV_FILTERS="${EQUIV_FILTERS:-}"
 GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
 GRAFANA_AUTH="${GRAFANA_AUTH:-admin:admin}"
+
+FILTER_ARGS=()
+if [[ -n "$EQUIV_FILTERS" ]]; then
+	FILTER_ARGS=(--filters="$EQUIV_FILTERS")
+fi
 
 LOCAL_PLUGIN="$REPO_ROOT/testdata/plugins/local-dev/terraform-provider-grafana"
 TFRC="$REPO_ROOT/equivalence-tests/local-provider.tfrc"
@@ -40,4 +46,5 @@ cat "$TFRC"
 TF_CLI_CONFIG_FILE="$TFRC" GRAFANA_URL="$GRAFANA_URL" GRAFANA_AUTH="$GRAFANA_AUTH" \
 	"$EQUIV_BIN" diff \
 	--goldens="$REPO_ROOT/equivalence-tests/goldens" \
-	--tests="$REPO_ROOT/equivalence-tests/tests"
+	--tests="$REPO_ROOT/equivalence-tests/tests" \
+	"${FILTER_ARGS[@]}"

--- a/equivalence-tests/run-with-grafana.sh
+++ b/equivalence-tests/run-with-grafana.sh
@@ -17,6 +17,7 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 GRAFANA_URL="${GRAFANA_URL:-http://0.0.0.0:3000}"
 GRAFANA_AUTH="${GRAFANA_AUTH:-admin:admin}"
 GRAFANA_VERSION="${GRAFANA_VERSION:-latest}"
+EQUIV_FILTERS="${EQUIV_FILTERS:-}"
 DOCKER_COMPOSE_ARGS="${DOCKER_COMPOSE_ARGS:---pull always --force-recreate --detach --remove-orphans --wait --renew-anon-volumes}"
 
 cleanup() {
@@ -31,5 +32,5 @@ IFS=' ' read -r -a compose_args <<<"$DOCKER_COMPOSE_ARGS"
 docker compose up "${compose_args[@]}"
 
 status=0
-make -C "$REPO_ROOT" "$1" || status=$?
+make -C "$REPO_ROOT" EQUIV_FILTERS="$EQUIV_FILTERS" "$1" || status=$?
 exit "$status"


### PR DESCRIPTION
Fixes https://github.com/grafana/deployment_tools/issues/645925

Adds optional EQUIV_FILTERS support to the equivalence test Makefile targets, forwarding to terraform-equivalence-testing's built-in --filters flag. You can run a single case (e.g. make equivalence-test-diff-local EQUIV_FILTERS=grafana_user) without running every test under equivalence-tests/tests/. The filter is passed through the docker-compose wrapper and the local-provider diff path, and is documented in equivalence-tests/README.md.