### PR TITLE
fix(appplatform): populate folder uid when present in imported state

### DIFF
--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -886,8 +886,8 @@ func GetModelFromMetadata(
 		return diag
 	}
 
-	if !dst.FolderUID.IsNull() && !dst.FolderUID.IsUnknown() {
-		dst.FolderUID = types.StringValue(meta.GetFolder())
+	if folder := meta.GetFolder(); folder != "" {
+		dst.FolderUID = types.StringValue(folder)
 	}
 
 	dst.UUID = types.StringValue(string(src.GetUID()))

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -888,6 +888,8 @@ func GetModelFromMetadata(
 
 	if folder := meta.GetFolder(); folder != "" {
 		dst.FolderUID = types.StringValue(folder)
+	} else {
+		dst.FolderUID = types.StringNull()
 	}
 
 	dst.UUID = types.StringValue(string(src.GetUID()))

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -318,6 +318,61 @@ func TestGetModelFromMetadata(t *testing.T) {
 	}
 }
 
+func TestGetModelFromMetadata_FolderUID(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		srcFolder      string
+		dstFolder      types.String
+		expectNull     bool
+		expectedFolder string
+	}{
+		{
+			name:           "populates folder_uid from live object on import (empty dst)",
+			srcFolder:      "folder-abc",
+			dstFolder:      types.StringNull(),
+			expectNull:     false,
+			expectedFolder: "folder-abc",
+		},
+		{
+			name:       "leaves folder_uid null when object has no folder",
+			srcFolder:  "",
+			dstFolder:  types.StringNull(),
+			expectNull: true,
+		},
+		{
+			name:           "refreshes folder_uid from live object when already set",
+			srcFolder:      "folder-new",
+			dstFolder:      types.StringValue("folder-old"),
+			expectNull:     false,
+			expectedFolder: "folder-new",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := makeMockResource("test-name", "test-uuid")
+			if tt.srcFolder != "" {
+				meta, err := utils.MetaAccessor(src)
+				require.NoError(t, err)
+				meta.SetFolder(tt.srcFolder)
+			}
+
+			dst := &ResourceMetadataModel{FolderUID: tt.dstFolder}
+			diags := GetModelFromMetadata(ctx, src, dst)
+			require.False(t, diags.HasError())
+
+			if tt.expectNull {
+				require.True(t, dst.FolderUID.IsNull(), "expected folder_uid to be null")
+			} else {
+				require.False(t, dst.FolderUID.IsNull(), "expected folder_uid to be set")
+				require.Equal(t, tt.expectedFolder, dst.FolderUID.ValueString())
+			}
+		})
+	}
+}
+
 func TestNamespaceForClient(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -348,6 +348,12 @@ func TestGetModelFromMetadata_FolderUID(t *testing.T) {
 			expectNull:     false,
 			expectedFolder: "folder-new",
 		},
+		{
+			name:       "sets folder_uid to null if not present on the source",
+			srcFolder:  "",
+			dstFolder:  types.StringValue("foo"),
+			expectNull: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes a bug where we would ignore folder uids set on resources if the destination resource doesn't already have a folder UID defined on it. The fix is to set folder UID when it is defined in the source state.