### PR TITLE
fix(cloud): avoid access policy realm churn on label_policy edits

### DIFF
--- a/docs/resources/cloud_access_policy.md
+++ b/docs/resources/cloud_access_policy.md
@@ -58,7 +58,7 @@ resource "grafana_cloud_access_policy_token" "test" {
 ### Required
 
 - `name` (String) Name of the access policy.
-- `realm` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--realm))
+- `realm` (Block List, Min: 1) (see [below for nested schema](#nestedblock--realm))
 - `region` (String) Region where the API is deployed. Generally where the stack is deployed. Use the region list API to get the list of available regions: https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/cloud-api/#list-regions.
 - `scopes` (Set of String) Scopes of the access policy. See https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/#scopes for possible values.
 

--- a/internal/resources/cloud/resource_cloud_access_policy.go
+++ b/internal/resources/cloud/resource_cloud_access_policy.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -122,9 +123,10 @@ Required access policy scopes:
 				},
 			},
 			"realm": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     cloudAccessPolicyRealmSchema,
+				Type:             schema.TypeList,
+				Required:         true,
+				Elem:             cloudAccessPolicyRealmSchema,
+				DiffSuppressFunc: realmsDiffSuppress,
 			},
 			"conditions": {
 				Type:        schema.TypeSet,
@@ -205,7 +207,7 @@ func createCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client
 			Name:        name,
 			DisplayName: &displayName,
 			Scopes:      common.ListToStringSlice(d.Get("scopes").(*schema.Set).List()),
-			Realms:      expandCloudAccessPolicyRealm(d.Get("realm").(*schema.Set).List()),
+			Realms:      expandCloudAccessPolicyRealm(d.Get("realm").([]any)),
 			Conditions:  expandCloudAccessPolicyConditions(d.Get("conditions").(*schema.Set).List()),
 		})
 
@@ -284,7 +286,7 @@ func updateCloudAccessPolicy(ctx context.Context, d *schema.ResourceData, client
 		PostAccessPolicyRequest(gcom.PostAccessPolicyRequest{
 			DisplayName: &displayName,
 			Scopes:      common.ListToStringSlice(d.Get("scopes").(*schema.Set).List()),
-			Realms:      expandCloudAccessPolicyRealm(d.Get("realm").(*schema.Set).List()),
+			Realms:      expandCloudAccessPolicyRealm(d.Get("realm").([]any)),
 			Conditions:  expandCloudAccessPolicyConditions(d.Get("conditions").(*schema.Set).List()),
 		})
 	cfg := DefaultHTTPRequestRetryConfig()
@@ -375,18 +377,56 @@ func flattenCloudAccessPolicyRealm(realm []gcom.AuthAccessPolicyRealmsInner) []a
 		labelPolicy := []any{}
 		for _, lp := range r.LabelPolicies {
 			labelPolicy = append(labelPolicy, map[string]any{
-				"selector": lp.Selector,
+				"selector": lp.GetSelector(),
 			})
 		}
 
 		result = append(result, map[string]any{
-			"type":         r.Type,
-			"identifier":   r.Identifier,
+			"type":         r.GetType(),
+			"identifier":   r.GetIdentifier(),
 			"label_policy": labelPolicy,
 		})
 	}
 
 	return result
+}
+
+// realmsDiffSuppress suppresses order-only diffs on the realm list: the API may return realms
+// in a different order than the config, but a TypeList compares positionally. The diff still
+// shows when a realm's content (including its label_policy selectors) actually changes.
+func realmsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	oldRaw, newRaw := d.GetChange("realm")
+	return realmsEqualIgnoringOrder(oldRaw.([]any), newRaw.([]any))
+}
+
+func realmsEqualIgnoringOrder(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ka, kb := realmKeys(a), realmKeys(b)
+	slices.Sort(ka)
+	slices.Sort(kb)
+	return slices.Equal(ka, kb)
+}
+
+func realmKeys(realms []any) []string {
+	keys := make([]string, len(realms))
+	for i, r := range realms {
+		keys[i] = realmKey(r)
+	}
+	return keys
+}
+
+func realmKey(v any) string {
+	m := v.(map[string]any)
+	var selectors []string
+	if lp, ok := m["label_policy"].(*schema.Set); ok {
+		for _, s := range lp.List() {
+			selectors = append(selectors, s.(map[string]any)["selector"].(string))
+		}
+	}
+	slices.Sort(selectors)
+	return fmt.Sprintf("%q|%q|%q", m["type"], m["identifier"], selectors)
 }
 
 func flattenCloudAccessPolicyConditions(condition *gcom.AuthAccessPolicyConditions) []any {

--- a/internal/resources/cloud/resource_cloud_access_policy_internal_test.go
+++ b/internal/resources/cloud/resource_cloud_access_policy_internal_test.go
@@ -1,0 +1,59 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestUnitRealmsEqualIgnoringOrder(t *testing.T) {
+	labelPolicy := func(selectors ...string) *schema.Set {
+		items := make([]any, len(selectors))
+		for i, s := range selectors {
+			items[i] = map[string]any{"selector": s}
+		}
+		return schema.NewSet(func(v any) int {
+			return schema.HashString(v.(map[string]any)["selector"])
+		}, items)
+	}
+	realm := func(typ, id string, selectors ...string) map[string]any {
+		return map[string]any{"type": typ, "identifier": id, "label_policy": labelPolicy(selectors...)}
+	}
+
+	for name, tc := range map[string]struct {
+		a, b []any
+		want bool
+	}{
+		"same realms in a different order are equal": {
+			a:    []any{realm("stack", "1"), realm("org", "a")},
+			b:    []any{realm("org", "a"), realm("stack", "1")},
+			want: true,
+		},
+		"reordered label_policy selectors are equal": {
+			a:    []any{realm("stack", "1", "{a=\"1\"}", "{b=\"2\"}")},
+			b:    []any{realm("stack", "1", "{b=\"2\"}", "{a=\"1\"}")},
+			want: true,
+		},
+		"different length is not equal": {
+			a:    []any{realm("org", "a")},
+			b:    []any{realm("org", "a"), realm("stack", "1")},
+			want: false,
+		},
+		"different identifier is not equal": {
+			a:    []any{realm("stack", "1")},
+			b:    []any{realm("stack", "2")},
+			want: false,
+		},
+		"different label_policy selector is not equal": {
+			a:    []any{realm("stack", "1", "{a=\"1\"}")},
+			b:    []any{realm("stack", "1", "{a=\"2\"}")},
+			want: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := realmsEqualIgnoringOrder(tc.a, tc.b); got != tc.want {
+				t.Errorf("realmsEqualIgnoringOrder() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Summary

`grafana_cloud_access_policy`'s `realm` block was a `TypeSet`. SDKv2 identifies set elements by a hash of the entire block, so editing a nested `label_policy` selector changed the hash and Terraform planned the whole realm as a destroy-and-recreate instead of an in-place edit (#2862). This switches `realm` to a `TypeList` and adds a `DiffSuppressFunc` to keep it order-insensitive.

## The problem

A one-line `label_policy` change rendered the entire realm as replaced:

```diff
  ~ resource "grafana_cloud_access_policy" "test" {
      - realm {
          - type       = "stack" -> null
          - identifier = "my-stack" -> null
          - label_policy {
              - selector = "{namespace=\"foo\"}" -> null
            }
        }
      + realm {
          + type       = "stack"
          + identifier = "my-stack"
          + label_policy {
              + selector = "{namespace=\"bar\"}"
            }
        }
    }
```

## The fix

As a list, blocks are keyed by position, so the edit is scoped to what changed:

```diff
  ~ resource "grafana_cloud_access_policy" "test" {
      ~ realm {
          - label_policy {
              - selector = "{namespace=\"foo\"}" -> null
            }
          + label_policy {
              + selector = "{namespace=\"bar\"}"
            }
        }
    }
```

Lists compare positionally, and the Cloud API doesn't guarantee it returns realms in the configured order — a bare list would produce spurious reorder diffs for multi-realm policies. The `DiffSuppressFunc` compares the realm list as an unordered set (type, identifier, and `label_policy` selectors), suppressing order-only differences while still surfacing genuine changes.
