### PR TITLE
fix(codeowners): correct invalid team handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,13 +20,13 @@
 /internal/common/connectionsapi/**         @grafana/o11y-apps-backend
 /internal/common/fleetmanagementapi/**     @grafana/fleet-management-backend
 /internal/common/frontendo11yapi/**        @grafana/frontend-o11y
-/internal/common/k6providerapi/**          @grafana/k6-cloud-provisioning
+/internal/common/k6providerapi/**          @grafana/k6-backend
 
 # k6bundle function
-/internal/functions/**                     @grafana/k6-cloud-provisioning
-/examples/functions/k6bundle/**            @grafana/k6-cloud-provisioning
-/docs/functions/k6bundle.md               @grafana/k6-cloud-provisioning
-/templates/functions/k6bundle.md.tmpl    @grafana/k6-cloud-provisioning
+/internal/functions/**                     @grafana/k6-backend
+/examples/functions/k6bundle/**            @grafana/k6-backend
+/docs/functions/k6bundle.md               @grafana/k6-backend
+/templates/functions/k6bundle.md.tmpl    @grafana/k6-backend
 
 # generate tooling
 /cmd/generate/**                           @grafana/platform-monitoring
@@ -94,7 +94,7 @@
 /internal/resources/cloud/resource_cloud_stack_service_account*                  @grafana/identity-squad
 /internal/resources/cloud/resource_cloud_stack_service_account_rotating_token*   @grafana/identity-squad
 /internal/resources/cloud/resource_cloud_stack_service_account_token*            @grafana/identity-squad
-/internal/resources/cloud/resource_k6_installation*                              @grafana/k6-cloud-provisioning
+/internal/resources/cloud/resource_k6_installation*                              @grafana/k6-backend
 /internal/resources/cloud/resource_private_data_source_connect_network*          @grafana/grafana-datasources-core-services
 /internal/resources/cloud/resource_private_data_source_connect_network_token*    @grafana/grafana-datasources-core-services
 /internal/resources/cloud/resource_synthetic_monitoring_installation*            @grafana/synthetic-monitoring
@@ -154,7 +154,7 @@
 /internal/resources/grafana/resource_organization*                               @grafana/access-squad
 /internal/resources/grafana/resource_organization_preferences*                   @grafana/access-squad
 /internal/resources/grafana/resource_playlist*                                   @grafana/sharing-squad
-/internal/resources/grafana/resource_report*                                     @grafana/operator-experience-squad
+/internal/resources/grafana/resource_report*                                     @grafana/grafana-operator-experience-squad
 /internal/resources/grafana/resource_role*                                       @grafana/access-squad
 /internal/resources/grafana/resource_role_assignment*                            @grafana/access-squad
 /internal/resources/grafana/resource_role_assignment_item*                       @grafana/access-squad
@@ -170,7 +170,7 @@
 /internal/resources/grafana/resource_user*                                       @grafana/identity-squad
 
 # internal/resources/k6
-/internal/resources/k6/**                                                        @grafana/k6-cloud-provisioning
+/internal/resources/k6/**                                                        @grafana/k6-backend
 
 # internal/resources/machinelearning
 /internal/resources/machinelearning/**                                           @grafana/machine-learning
@@ -201,14 +201,14 @@
 /examples/data-sources/grafana_folder/*                                          @grafana/grafana-search-and-storage
 /examples/data-sources/grafana_folders/*                                         @grafana/grafana-search-and-storage
 /examples/data-sources/grafana_frontend_o11y_app/*                               @grafana/frontend-o11y
-/examples/data-sources/grafana_k6_load_test/*                                    @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_load_tests/*                                   @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_project/*                                      @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_project_allowed_load_zones/*                   @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_project_limits/*                               @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_projects/*                                     @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_schedule/*                                     @grafana/k6-cloud-provisioning
-/examples/data-sources/grafana_k6_schedules/*                                    @grafana/k6-cloud-provisioning
+/examples/data-sources/grafana_k6_load_test/*                                    @grafana/k6-backend
+/examples/data-sources/grafana_k6_load_tests/*                                   @grafana/k6-backend
+/examples/data-sources/grafana_k6_project/*                                      @grafana/k6-backend
+/examples/data-sources/grafana_k6_project_allowed_load_zones/*                   @grafana/k6-backend
+/examples/data-sources/grafana_k6_project_limits/*                               @grafana/k6-backend
+/examples/data-sources/grafana_k6_projects/*                                     @grafana/k6-backend
+/examples/data-sources/grafana_k6_schedule/*                                     @grafana/k6-backend
+/examples/data-sources/grafana_k6_schedules/*                                    @grafana/k6-backend
 /examples/data-sources/grafana_library_panel/*                                   @grafana/dataviz-squad
 /examples/data-sources/grafana_library_panels/*                                  @grafana/dataviz-squad
 /examples/data-sources/grafana_oncall_escalation_chain/*                         @grafana/grafana-irm-backend
@@ -297,12 +297,12 @@
 /examples/resources/grafana_folder_permission/*                                  @grafana/access-squad
 /examples/resources/grafana_folder_permission_item/*                             @grafana/access-squad
 /examples/resources/grafana_frontend_o11y_app/*                                  @grafana/frontend-o11y
-/examples/resources/grafana_k6_installation/*                                    @grafana/k6-cloud-provisioning
-/examples/resources/grafana_k6_load_test/*                                       @grafana/k6-cloud-provisioning
-/examples/resources/grafana_k6_project/*                                         @grafana/k6-cloud-provisioning
-/examples/resources/grafana_k6_project_allowed_load_zones/*                      @grafana/k6-cloud-provisioning
-/examples/resources/grafana_k6_project_limits/*                                  @grafana/k6-cloud-provisioning
-/examples/resources/grafana_k6_schedule/*                                        @grafana/k6-cloud-provisioning
+/examples/resources/grafana_k6_installation/*                                    @grafana/k6-backend
+/examples/resources/grafana_k6_load_test/*                                       @grafana/k6-backend
+/examples/resources/grafana_k6_project/*                                         @grafana/k6-backend
+/examples/resources/grafana_k6_project_allowed_load_zones/*                      @grafana/k6-backend
+/examples/resources/grafana_k6_project_limits/*                                  @grafana/k6-backend
+/examples/resources/grafana_k6_schedule/*                                        @grafana/k6-backend
 /examples/resources/grafana_library_panel/*                                      @grafana/dataviz-squad
 /examples/resources/grafana_machine_learning_alert/*                             @grafana/machine-learning
 /examples/resources/grafana_machine_learning_holiday/*                           @grafana/machine-learning
@@ -322,7 +322,7 @@
 /examples/resources/grafana_organization/*                                       @grafana/access-squad
 /examples/resources/grafana_organization_preferences/*                           @grafana/access-squad
 /examples/resources/grafana_playlist/*                                           @grafana/sharing-squad
-/examples/resources/grafana_report/*                                             @grafana/operator-experience-squad
+/examples/resources/grafana_report/*                                             @grafana/grafana-operator-experience-squad
 /examples/resources/grafana_role/*                                               @grafana/access-squad
 /examples/resources/grafana_role_assignment/*                                    @grafana/access-squad
 /examples/resources/grafana_role_assignment_item/*                               @grafana/access-squad
@@ -362,14 +362,14 @@
 /docs/data-sources/folder.md                                                     @grafana/grafana-search-and-storage
 /docs/data-sources/folders.md                                                    @grafana/grafana-search-and-storage
 /docs/data-sources/frontend_o11y_app.md                                          @grafana/frontend-o11y
-/docs/data-sources/k6_load_test.md                                               @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_load_tests.md                                              @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_project.md                                                 @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_project_allowed_load_zones.md                              @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_project_limits.md                                          @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_projects.md                                                @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_schedule.md                                                @grafana/k6-cloud-provisioning
-/docs/data-sources/k6_schedules.md                                               @grafana/k6-cloud-provisioning
+/docs/data-sources/k6_load_test.md                                               @grafana/k6-backend
+/docs/data-sources/k6_load_tests.md                                              @grafana/k6-backend
+/docs/data-sources/k6_project.md                                                 @grafana/k6-backend
+/docs/data-sources/k6_project_allowed_load_zones.md                              @grafana/k6-backend
+/docs/data-sources/k6_project_limits.md                                          @grafana/k6-backend
+/docs/data-sources/k6_projects.md                                                @grafana/k6-backend
+/docs/data-sources/k6_schedule.md                                                @grafana/k6-backend
+/docs/data-sources/k6_schedules.md                                               @grafana/k6-backend
 /docs/data-sources/library_panel.md                                              @grafana/dataviz-squad
 /docs/data-sources/library_panels.md                                             @grafana/dataviz-squad
 /docs/data-sources/oncall_escalation_chain.md                                    @grafana/grafana-irm-backend
@@ -463,12 +463,12 @@
 /docs/resources/folder_permission.md                                             @grafana/access-squad
 /docs/resources/folder_permission_item.md                                        @grafana/access-squad
 /docs/resources/frontend_o11y_app.md                                             @grafana/frontend-o11y
-/docs/resources/k6_installation.md                                               @grafana/k6-cloud-provisioning
-/docs/resources/k6_load_test.md                                                  @grafana/k6-cloud-provisioning
-/docs/resources/k6_project.md                                                    @grafana/k6-cloud-provisioning
-/docs/resources/k6_project_allowed_load_zones.md                                 @grafana/k6-cloud-provisioning
-/docs/resources/k6_project_limits.md                                             @grafana/k6-cloud-provisioning
-/docs/resources/k6_schedule.md                                                   @grafana/k6-cloud-provisioning
+/docs/resources/k6_installation.md                                               @grafana/k6-backend
+/docs/resources/k6_load_test.md                                                  @grafana/k6-backend
+/docs/resources/k6_project.md                                                    @grafana/k6-backend
+/docs/resources/k6_project_allowed_load_zones.md                                 @grafana/k6-backend
+/docs/resources/k6_project_limits.md                                             @grafana/k6-backend
+/docs/resources/k6_schedule.md                                                   @grafana/k6-backend
 /docs/resources/library_panel.md                                                 @grafana/dataviz-squad
 /docs/resources/machine_learning_alert.md                                        @grafana/machine-learning
 /docs/resources/machine_learning_holiday.md                                      @grafana/machine-learning
@@ -488,7 +488,7 @@
 /docs/resources/organization.md                                                  @grafana/access-squad
 /docs/resources/organization_preferences.md                                      @grafana/access-squad
 /docs/resources/playlist.md                                                      @grafana/sharing-squad
-/docs/resources/report.md                                                        @grafana/operator-experience-squad
+/docs/resources/report.md                                                        @grafana/grafana-operator-experience-squad
 /docs/resources/role.md                                                          @grafana/access-squad
 /docs/resources/role_assignment.md                                               @grafana/access-squad
 /docs/resources/role_assignment_item.md                                          @grafana/access-squad

--- a/.github/CODEOWNERS.in
+++ b/.github/CODEOWNERS.in
@@ -16,13 +16,13 @@
 /internal/common/connectionsapi/**         @grafana/o11y-apps-backend
 /internal/common/fleetmanagementapi/**     @grafana/fleet-management-backend
 /internal/common/frontendo11yapi/**        @grafana/frontend-o11y
-/internal/common/k6providerapi/**          @grafana/k6-cloud-provisioning
+/internal/common/k6providerapi/**          @grafana/k6-backend
 
 # k6bundle function
-/internal/functions/**                     @grafana/k6-cloud-provisioning
-/examples/functions/k6bundle/**            @grafana/k6-cloud-provisioning
-/docs/functions/k6bundle.md               @grafana/k6-cloud-provisioning
-/templates/functions/k6bundle.md.tmpl    @grafana/k6-cloud-provisioning
+/internal/functions/**                     @grafana/k6-backend
+/examples/functions/k6bundle/**            @grafana/k6-backend
+/docs/functions/k6bundle.md               @grafana/k6-backend
+/templates/functions/k6bundle.md.tmpl    @grafana/k6-backend
 
 # generate tooling
 /cmd/generate/**                           @grafana/platform-monitoring

--- a/internal/resources/cloud/catalog-resource.yaml
+++ b/internal/resources/cloud/catalog-resource.yaml
@@ -152,7 +152,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -295,7 +295,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/operator-experience-squad
+  owner: group:default/grafana-operator-experience-squad
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/k6/catalog-data-source.yaml
+++ b/internal/resources/k6/catalog-data-source.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -22,7 +22,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -35,7 +35,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -48,7 +48,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -61,7 +61,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -74,7 +74,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -87,7 +87,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -100,5 +100,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production

--- a/internal/resources/k6/catalog-resource.yaml
+++ b/internal/resources/k6/catalog-resource.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -22,7 +22,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -35,7 +35,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -48,7 +48,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -61,5 +61,5 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/k6-cloud-provisioning
+  owner: group:default/k6-backend
   lifecycle: production


### PR DESCRIPTION
## Problem

GitHub reports several invalid owners in `.github/CODEOWNERS`:

```
Unknown owner ... @grafana/k6-cloud-provisioning
Unknown owner ... @grafana/operator-experience-squad
```

These are simply incorrect team handles:

- `operator-experience-squad` does not exist. The correct handle, used consistently everywhere else in this file, is `grafana-operator-experience-squad`.
- `k6-cloud-provisioning` does not exist on GitHub at all.

## Fix

- `internal/resources/grafana/catalog-resource.yaml`: fixed `grafana_report` owner to `grafana-operator-experience-squad`.
- `internal/resources/k6/catalog-resource.yaml`, `internal/resources/k6/catalog-data-source.yaml`, `internal/resources/cloud/catalog-resource.yaml`: changed owner from `k6-cloud-provisioning` to `k6-backend`.
- `.github/CODEOWNERS.in`: updated the static k6 rules to `@grafana/k6-backend`.
- Regenerated `.github/CODEOWNERS` via `make codeowners`.

## Note

There are two more invalid owners in CODEOWNERS not addressed here — `@grafana/cloud-integrations` and `@grafana/grafana-assistant-loop`. Those teams exist but currently lack write access to this repo, which is a separate fix tracked in a companion deployment_tools PR (grants push access). This PR only fixes the two teams with genuinely wrong handles.

/cc @grafana/k6-backend — please confirm this is the correct team to own the k6 provider resources (`internal/resources/k6/**`, `internal/resources/cloud/resource_k6_installation*`, k6bundle function) previously attributed to the nonexistent `k6-cloud-provisioning` team.