### PR TITLE
feat(oncall): expose inbound_email computed attribute on integration resource

### DIFF
--- a/docs/resources/oncall_integration.md
+++ b/docs/resources/oncall_integration.md
@@ -102,6 +102,7 @@ resource "grafana_oncall_integration" "test-acc-integration" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `inbound_email` (String) The inbound email address for the integration. Only available for integration type `inbound_email`.
 - `link` (String) The link for using in an integrated tool.
 
 <a id="nestedblock--default_route"></a>

--- a/internal/resources/oncall/resource_integration.go
+++ b/internal/resources/oncall/resource_integration.go
@@ -164,6 +164,11 @@ func resourceIntegration() *common.Resource {
 				Computed:    true,
 				Description: "The link for using in an integrated tool.",
 			},
+			"inbound_email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The inbound email address for the integration. Only available for integration type `inbound_email`.",
+			},
 			"templates": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -416,6 +421,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, client
 	d.Set("type", integration.Type)
 	d.Set("templates", flattenTemplates(integration.Templates))
 	d.Set("link", integration.Link)
+	d.Set("inbound_email", integration.InboundEmail)
 	d.Set("labels", flattenLabels(integration.Labels))
 	d.Set("dynamic_labels", flattenLabels(integration.DynamicLabels))
 

--- a/internal/resources/oncall/resource_integration_test.go
+++ b/internal/resources/oncall/resource_integration_test.go
@@ -29,6 +29,7 @@ func TestAccOnCallIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "name", rName),
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "type", rType),
 					resource.TestCheckResourceAttrSet("grafana_oncall_integration.test-acc-integration", "link"),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "inbound_email", ""),
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "templates.#", "0"),
 				),
 			},
@@ -88,6 +89,34 @@ func TestAccOnCallIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "labels.#", "1"),
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "labels.0.key", "TestKey"),
 					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "labels.0.value", "TestValue"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOnCallIntegration_inboundEmail(t *testing.T) {
+	testutils.CheckCloudInstanceTestsEnabled(t)
+
+	rName := fmt.Sprintf("test-acc-%s", acctest.RandString(8))
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOnCallIntegrationResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOnCallIntegrationConfig(rName, "inbound_email", ``),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOnCallIntegrationResourceExists("grafana_oncall_integration.test-acc-integration"),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "name", rName),
+					resource.TestCheckResourceAttr("grafana_oncall_integration.test-acc-integration", "type", "inbound_email"),
+					resource.TestCheckResourceAttrSet("grafana_oncall_integration.test-acc-integration", "inbound_email"),
+					resource.TestCheckResourceAttrWith("grafana_oncall_integration.test-acc-integration", "inbound_email", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("expected inbound_email to be non-empty for inbound_email integration type")
+						}
+						return nil
+					}),
 				),
 			},
 		},


### PR DESCRIPTION
## Summary

- Add a read-only `inbound_email` computed attribute to `grafana_oncall_integration` so users can reference the email address assigned to `inbound_email`-type integrations (e.g. `grafana_oncall_integration.my_email.inbound_email`).
- For all other integration types the API returns empty, so the field is just an empty string — no diff noise.
- Add acceptance test `TestAccOnCallIntegration_inboundEmail` that creates an `inbound_email` integration and asserts the attribute is populated, plus a check in the existing basic test confirming it's empty for non-email types.

### Upgrade note

On the first plan/refresh after upgrading, Terraform may note `inbound_email` as "known after apply" for existing `grafana_oncall_integration` resources. This resolves cleanly on the next apply/refresh without modifying the integration.

## Test plan

- [ ] `TestAccOnCallIntegration_basic` — existing test, now also asserts `inbound_email` is empty for `grafana` type integrations
- [ ] `TestAccOnCallIntegration_inboundEmail` — new test, creates an `inbound_email` integration and verifies the attribute is non-empty
- [ ] `go build ./...` passes
- [ ] `go vet ./internal/resources/oncall/...` passes
- [ ] Docs regenerated (`make docs`) — already committed