### PR TITLE
test(dbo11yconfig): clean up singleton before acceptance test [WIP]

### DIFF
--- a/internal/resources/appplatform/dbo11y_config_resource_acc_test.go
+++ b/internal/resources/appplatform/dbo11y_config_resource_acc_test.go
@@ -1,28 +1,36 @@
 package appplatform_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	sdkresource "github.com/grafana/grafana-app-sdk/resource"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/resources/appplatform"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
 	terraformresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
 	dbO11yConfigResourceType = "grafana_apps_productactivation_dbo11yconfig_v1alpha1"
 	dbO11yConfigResourceName = dbO11yConfigResourceType + ".test"
+	dbO11yConfigUID          = "global"
 )
 
 func TestAccDBO11yConfig_basic(t *testing.T) {
 	testutils.CheckCloudInstanceTestsEnabled(t)
 
 	terraformresource.Test(t, terraformresource.TestCase{
+		PreCheck:                 func() { testAccDeleteExistingDBO11yConfig(t) },
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDBO11yConfigDestroy,
 		Steps: []terraformresource.TestStep{
 			{
 				Config: testAccDBO11yConfigConfig(true),
 				Check: terraformresource.ComposeTestCheckFunc(
-					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", "global"),
+					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", dbO11yConfigUID),
 					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "spec.enabled", "true"),
 					terraformresource.TestCheckResourceAttrSet(dbO11yConfigResourceName, "id"),
 				),
@@ -30,7 +38,7 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 			{
 				Config: testAccDBO11yConfigConfig(false),
 				Check: terraformresource.ComposeTestCheckFunc(
-					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", "global"),
+					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", dbO11yConfigUID),
 					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "spec.enabled", "false"),
 				),
 			},
@@ -49,16 +57,76 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 	})
 }
 
+// testAccDeleteExistingDBO11yConfig removes a leftover singleton from a prior run.
+// DbO11yConfig is namespaced-unique with uid "global"; create fails with HTTP 409
+// if a previous cloudinstance job left it behind.
+func testAccDeleteExistingDBO11yConfig(t *testing.T) {
+	t.Helper()
+
+	client, err := testAccDBO11yConfigClient(testutils.Provider.Meta().(*common.Client))
+	if err != nil {
+		t.Fatalf("failed to create dbo11yconfig client: %v", err)
+	}
+
+	err = client.Delete(context.Background(), dbO11yConfigUID, sdkresource.DeleteOptions{})
+	if err := testAccIgnoreNotFound(err); err != nil {
+		t.Fatalf("failed to delete existing dbo11yconfig %q: %v", dbO11yConfigUID, err)
+	}
+}
+
+func testAccCheckDBO11yConfigDestroy(s *terraform.State) error {
+	client, err := testAccDBO11yConfigClient(testutils.Provider.Meta().(*common.Client))
+	if err != nil {
+		return fmt.Errorf("failed to create dbo11yconfig client: %w", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != dbO11yConfigResourceType {
+			continue
+		}
+
+		uid := rs.Primary.Attributes["metadata.uid"]
+		if uid == "" {
+			uid = dbO11yConfigUID
+		}
+
+		if _, err := client.Get(context.Background(), uid); err == nil {
+			return fmt.Errorf("dbo11yconfig %q still exists", uid)
+		} else if !testAccIsNotFound(err) {
+			return fmt.Errorf("error checking if dbo11yconfig %q exists: %w", uid, err)
+		}
+	}
+	return nil
+}
+
+func testAccDBO11yConfigClient(commonClient *common.Client) (*sdkresource.NamespacedClient[*appplatform.DBO11yConfig, *appplatform.DBO11yConfigList], error) {
+	namespace, err := testAccNamespace(commonClient)
+	if err != nil {
+		return nil, err
+	}
+
+	kind := appplatform.DBO11yConfigKind()
+	rcli, err := commonClient.GrafanaAppPlatformAPI.ClientFor(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	return sdkresource.NewNamespaced(
+		sdkresource.NewTypedClient[*appplatform.DBO11yConfig, *appplatform.DBO11yConfigList](rcli, kind),
+		namespace,
+	), nil
+}
+
 func testAccDBO11yConfigConfig(enabled bool) string {
 	return fmt.Sprintf(`
 resource "grafana_apps_productactivation_dbo11yconfig_v1alpha1" "test" {
   metadata {
-    uid = "global"
+    uid = %q
   }
 
   spec {
     enabled = %v
   }
 }
-`, enabled)
+`, dbO11yConfigUID, enabled)
 }


### PR DESCRIPTION
⚠️ This is for demonstration purposes only. The PR needs to be updated and thoroughly reviewed before it can be merged.

`TestAccDBO11yConfig_basic` was flaking on `cloudinstance` with HTTP 409 when a previous run left the namespaced-unique `global` dbo11yconfig behind (see [Slack thread](https://raintank-corp.slack.com/archives/C02S85R5064/p1784719913132799)). This adds a PreCheck that deletes any leftover singleton (ignoring not-found) and a CheckDestroy check so teardown failures do not poison later CI runs.