### PR TITLE
fix(app_platform): fix flaky test for dbo11y_config resource

### DIFF
--- a/internal/resources/appplatform/dbo11y_config_resource_acc_test.go
+++ b/internal/resources/appplatform/dbo11y_config_resource_acc_test.go
@@ -11,14 +11,12 @@ import (
 	"github.com/grafana/terraform-provider-grafana/v4/internal/resources/appplatform"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
 	terraformresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
 	dbO11yConfigResourceType = "grafana_apps_productactivation_dbo11yconfig_v1alpha1"
 	dbO11yConfigResourceName = dbO11yConfigResourceType + ".test"
-
 	dbO11yConfigSingletonUID = "global"
 )
 
@@ -28,7 +26,6 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 	terraformresource.Test(t, terraformresource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
 		PreCheck:                 func() { testAccDeleteDBO11yConfigSingleton(t) },
-		CheckDestroy:             testAccCheckDBO11yConfigDestroy,
 		Steps: []terraformresource.TestStep{
 			{
 				Config: testAccDBO11yConfigConfig(true),
@@ -60,12 +57,14 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 	})
 }
 
-func dbO11yConfigNamespacedClient() (*resource.NamespacedClient[*appplatform.DBO11yConfig, *appplatform.DBO11yConfigList], error) {
+func testAccDeleteDBO11yConfigSingleton(t *testing.T) {
+	t.Helper()
+
 	client := testutils.Provider.Meta().(*common.Client)
 
 	rcli, err := client.GrafanaAppPlatformAPI.ClientFor(appplatform.DBO11yConfigKind())
 	if err != nil {
-		return nil, fmt.Errorf("failed to create app platform client: %w", err)
+		t.Fatalf("failed to create app platform client: %v", err)
 	}
 
 	var ns string
@@ -76,44 +75,14 @@ func dbO11yConfigNamespacedClient() (*resource.NamespacedClient[*appplatform.DBO
 		ns = claims.OrgNamespaceFormatter(client.GrafanaOrgID)
 	}
 
-	return resource.NewNamespaced(
+	namespacedClient := resource.NewNamespaced(
 		resource.NewTypedClient[*appplatform.DBO11yConfig, *appplatform.DBO11yConfigList](rcli, appplatform.DBO11yConfigKind()),
 		ns,
-	), nil
-}
-
-func testAccDeleteDBO11yConfigSingleton(t *testing.T) {
-	t.Helper()
-
-	namespacedClient, err := dbO11yConfigNamespacedClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	)
 
 	if err := namespacedClient.Delete(context.Background(), dbO11yConfigSingletonUID, resource.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		t.Fatalf("failed to delete stale dbO11yConfig %q: %v", dbO11yConfigSingletonUID, err)
 	}
-}
-
-func testAccCheckDBO11yConfigDestroy(s *terraform.State) error {
-	for _, r := range s.RootModule().Resources {
-		if r.Type != dbO11yConfigResourceType {
-			continue
-		}
-
-		namespacedClient, err := dbO11yConfigNamespacedClient()
-		if err != nil {
-			return err
-		}
-
-		uid := r.Primary.Attributes["metadata.uid"]
-		if _, err := namespacedClient.Get(context.Background(), uid); err == nil {
-			return fmt.Errorf("DBO11yConfig %s still exists", uid)
-		} else if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("error checking if DBO11yConfig %s exists: %w", uid, err)
-		}
-	}
-	return nil
 }
 
 func testAccDBO11yConfigConfig(enabled bool) string {

--- a/internal/resources/appplatform/dbo11y_config_resource_acc_test.go
+++ b/internal/resources/appplatform/dbo11y_config_resource_acc_test.go
@@ -1,16 +1,25 @@
 package appplatform_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/grafana/authlib/claims"
+	"github.com/grafana/grafana-app-sdk/resource"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
+	"github.com/grafana/terraform-provider-grafana/v4/internal/resources/appplatform"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
 	terraformresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
 	dbO11yConfigResourceType = "grafana_apps_productactivation_dbo11yconfig_v1alpha1"
 	dbO11yConfigResourceName = dbO11yConfigResourceType + ".test"
+
+	dbO11yConfigSingletonUID = "global"
 )
 
 func TestAccDBO11yConfig_basic(t *testing.T) {
@@ -18,11 +27,13 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 
 	terraformresource.Test(t, terraformresource.TestCase{
 		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccDeleteDBO11yConfigSingleton(t) },
+		CheckDestroy:             testAccCheckDBO11yConfigDestroy,
 		Steps: []terraformresource.TestStep{
 			{
 				Config: testAccDBO11yConfigConfig(true),
 				Check: terraformresource.ComposeTestCheckFunc(
-					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", "global"),
+					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", dbO11yConfigSingletonUID),
 					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "spec.enabled", "true"),
 					terraformresource.TestCheckResourceAttrSet(dbO11yConfigResourceName, "id"),
 				),
@@ -30,7 +41,7 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 			{
 				Config: testAccDBO11yConfigConfig(false),
 				Check: terraformresource.ComposeTestCheckFunc(
-					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", "global"),
+					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "metadata.uid", dbO11yConfigSingletonUID),
 					terraformresource.TestCheckResourceAttr(dbO11yConfigResourceName, "spec.enabled", "false"),
 				),
 			},
@@ -47,6 +58,62 @@ func TestAccDBO11yConfig_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func dbO11yConfigNamespacedClient() (*resource.NamespacedClient[*appplatform.DBO11yConfig, *appplatform.DBO11yConfigList], error) {
+	client := testutils.Provider.Meta().(*common.Client)
+
+	rcli, err := client.GrafanaAppPlatformAPI.ClientFor(appplatform.DBO11yConfigKind())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create app platform client: %w", err)
+	}
+
+	var ns string
+	switch {
+	case client.GrafanaStackID > 0:
+		ns = claims.CloudNamespaceFormatter(client.GrafanaStackID)
+	default:
+		ns = claims.OrgNamespaceFormatter(client.GrafanaOrgID)
+	}
+
+	return resource.NewNamespaced(
+		resource.NewTypedClient[*appplatform.DBO11yConfig, *appplatform.DBO11yConfigList](rcli, appplatform.DBO11yConfigKind()),
+		ns,
+	), nil
+}
+
+func testAccDeleteDBO11yConfigSingleton(t *testing.T) {
+	t.Helper()
+
+	namespacedClient, err := dbO11yConfigNamespacedClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := namespacedClient.Delete(context.Background(), dbO11yConfigSingletonUID, resource.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("failed to delete stale dbO11yConfig %q: %v", dbO11yConfigSingletonUID, err)
+	}
+}
+
+func testAccCheckDBO11yConfigDestroy(s *terraform.State) error {
+	for _, r := range s.RootModule().Resources {
+		if r.Type != dbO11yConfigResourceType {
+			continue
+		}
+
+		namespacedClient, err := dbO11yConfigNamespacedClient()
+		if err != nil {
+			return err
+		}
+
+		uid := r.Primary.Attributes["metadata.uid"]
+		if _, err := namespacedClient.Get(context.Background(), uid); err == nil {
+			return fmt.Errorf("DBO11yConfig %s still exists", uid)
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error checking if DBO11yConfig %s exists: %w", uid, err)
+		}
+	}
+	return nil
 }
 
 func testAccDBO11yConfigConfig(enabled bool) string {


### PR DESCRIPTION
  - This test was returning `409: Conflict` errors when attempting to create a `gobal` singleton object more than once (`AlreadyExists` error).
  - This change adds a hook to make sure each test run runs in a clean environment, following well established patterns.