### PR TITLE
feat(assistant): support slash commands for skills

### DIFF
--- a/docs/resources/assistant_skill.md
+++ b/docs/resources/assistant_skill.md
@@ -14,12 +14,13 @@ Manages a Grafana Assistant skill.
 
 ```terraform
 resource "grafana_assistant_skill" "example" {
-  name  = "Deploy readiness check"
-  body  = <<-EOT
+  name         = "Deploy readiness check"
+  command_name = "deploy-readiness"
+  body         = <<-EOT
   1. Check deployment pipeline status.
   2. Verify SLO error budget before promoting.
   EOT
-  scope = "tenant"
+  scope        = "tenant"
 }
 ```
 
@@ -35,6 +36,7 @@ resource "grafana_assistant_skill" "example" {
 ### Optional
 
 - `allowed_tools` (Block List) MCP tools to auto-approve when this skill is invoked. (see [below for nested schema](#nestedblock--allowed_tools))
+- `command_name` (String) The slash command name that invokes the skill. Setting this enables the skill as a command.
 - `context_items` (String) Optional JSON array of context items referenced by the skill.
 - `include_in_knowledgebase` (Boolean) Whether the skill is included in the knowledgebase.
 

--- a/examples/resources/grafana_assistant_skill/_acc_basic.tf
+++ b/examples/resources/grafana_assistant_skill/_acc_basic.tf
@@ -1,5 +1,6 @@
 resource "grafana_assistant_skill" "test" {
   name                     = "tf-acc-test-skill"
+  command_name             = "tf-acc-command"
   body                     = "Terraform acceptance test skill body."
   scope                    = "tenant"
   include_in_knowledgebase = true

--- a/examples/resources/grafana_assistant_skill/resource.tf
+++ b/examples/resources/grafana_assistant_skill/resource.tf
@@ -1,8 +1,9 @@
 resource "grafana_assistant_skill" "example" {
-  name  = "Deploy readiness check"
-  body  = <<-EOT
+  name         = "Deploy readiness check"
+  command_name = "deploy-readiness"
+  body         = <<-EOT
   1. Check deployment pipeline status.
   2. Verify SLO error budget before promoting.
   EOT
-  scope = "tenant"
+  scope        = "tenant"
 }

--- a/internal/common/assistantapi/client.go
+++ b/internal/common/assistantapi/client.go
@@ -194,6 +194,16 @@ func (c *Client) UpdateSkill(ctx context.Context, id, resourceScope string, body
 	return resp.Data, nil
 }
 
+// SetSkillCommand sets, updates, or disables the slash command for a skill.
+func (c *Client) SetSkillCommand(ctx context.Context, id, resourceScope string, commandName *string) (Skill, error) {
+	var resp apiResponseWrapper[Skill]
+	path := "/skills/" + url.PathEscape(id) + "/command"
+	if err := c.doAPIRequest(ctx, http.MethodPut, path, SkillCommandUpdate{CommandName: commandName}, &resp, scopeHeader(resourceScope)); err != nil {
+		return Skill{}, fmt.Errorf("failed to set command for skill %q: %w", id, err)
+	}
+	return resp.Data, nil
+}
+
 // DeleteSkill deletes a skill by ID.
 func (c *Client) DeleteSkill(ctx context.Context, id, resourceScope string) error {
 	if err := c.doAPIRequest(ctx, http.MethodDelete, "/skills/"+url.PathEscape(id), nil, nil, scopeHeader(resourceScope)); err != nil {

--- a/internal/common/assistantapi/client_test.go
+++ b/internal/common/assistantapi/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/terraform-provider-grafana/v4/internal/util"
 )
@@ -111,6 +112,8 @@ func TestClient_SkillCRUD(t *testing.T) {
 	t.Parallel()
 
 	const id = "22222222-2222-2222-2222-222222222222"
+	commandEnabledAt := time.Now()
+	commandRequests := 0
 	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == pathPrefix+"/skills":
@@ -121,7 +124,33 @@ func TestClient_SkillCRUD(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == pathPrefix+"/skills/"+id:
 			writeJSON(t, w, apiResponseWrapper[Skill]{
 				Status: "success",
-				Data:   Skill{ID: id, Name: "deploy", Body: "body", Scope: "tenant"},
+				Data:   Skill{ID: id, Name: "deploy", Body: "body", CommandName: util.Ptr("deploy"), CommandEnabledAt: &commandEnabledAt, Scope: "tenant"},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == pathPrefix+"/skills/"+id+"/command":
+			if r.Header.Get("X-Resource-Scope") != "tenant" {
+				http.Error(w, "missing scope header", http.StatusBadRequest)
+				return
+			}
+			var body map[string]json.RawMessage
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode skill command request: %v", err)
+			}
+			commandRequests++
+			commandName := util.Ptr("deploy")
+			enabledAt := &commandEnabledAt
+			if commandRequests == 1 {
+				if got := string(body["commandName"]); got != `"deploy"` {
+					t.Fatalf("unexpected enable commandName: %s", got)
+				}
+			} else {
+				if got := string(body["commandName"]); got != "null" {
+					t.Fatalf("unexpected disable commandName: %s", got)
+				}
+				enabledAt = nil
+			}
+			writeJSON(t, w, apiResponseWrapper[Skill]{
+				Status: "success",
+				Data:   Skill{ID: id, Name: "deploy", Body: "body", CommandName: commandName, CommandEnabledAt: enabledAt, Scope: "tenant"},
 			})
 		case r.Method == http.MethodPut && r.URL.Path == pathPrefix+"/skills/"+id:
 			if r.Header.Get("X-Resource-Scope") != "tenant" {
@@ -130,7 +159,7 @@ func TestClient_SkillCRUD(t *testing.T) {
 			}
 			writeJSON(t, w, apiResponseWrapper[Skill]{
 				Status: "success",
-				Data:   Skill{ID: id, Name: "deploy v2", Body: "body", Scope: "tenant"},
+				Data:   Skill{ID: id, Name: "deploy v2", Body: "body", CommandName: util.Ptr("deploy"), CommandEnabledAt: &commandEnabledAt, Scope: "tenant"},
 			})
 		case r.Method == http.MethodDelete && r.URL.Path == pathPrefix+"/skills/"+id:
 			if r.Header.Get("X-Resource-Scope") != "tenant" {
@@ -154,6 +183,13 @@ func TestClient_SkillCRUD(t *testing.T) {
 	if created.ID != id {
 		t.Fatalf("unexpected id: %s", created.ID)
 	}
+	enabled, err := client.SetSkillCommand(context.Background(), id, "tenant", util.Ptr("deploy"))
+	if err != nil {
+		t.Fatalf("SetSkillCommand: %v", err)
+	}
+	if enabled.CommandName == nil || *enabled.CommandName != "deploy" || enabled.CommandEnabledAt == nil {
+		t.Fatalf("unexpected enabled command: %+v", enabled)
+	}
 
 	got, err := client.GetSkill(context.Background(), id)
 	if err != nil {
@@ -171,6 +207,14 @@ func TestClient_SkillCRUD(t *testing.T) {
 	}
 	if updated.Name != "deploy v2" {
 		t.Fatalf("unexpected updated name: %s", updated.Name)
+	}
+
+	disabled, err := client.SetSkillCommand(context.Background(), id, "tenant", nil)
+	if err != nil {
+		t.Fatalf("SetSkillCommand disable: %v", err)
+	}
+	if disabled.CommandName == nil || *disabled.CommandName != "deploy" || disabled.CommandEnabledAt != nil {
+		t.Fatalf("unexpected disabled command: %+v", disabled)
 	}
 
 	if err := client.DeleteSkill(context.Background(), id, "tenant"); err != nil {

--- a/internal/common/assistantapi/client_test.go
+++ b/internal/common/assistantapi/client_test.go
@@ -112,8 +112,6 @@ func TestClient_SkillCRUD(t *testing.T) {
 	t.Parallel()
 
 	const id = "22222222-2222-2222-2222-222222222222"
-	commandEnabledAt := time.Now()
-	commandRequests := 0
 	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == pathPrefix+"/skills":
@@ -124,33 +122,7 @@ func TestClient_SkillCRUD(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == pathPrefix+"/skills/"+id:
 			writeJSON(t, w, apiResponseWrapper[Skill]{
 				Status: "success",
-				Data:   Skill{ID: id, Name: "deploy", Body: "body", CommandName: util.Ptr("deploy"), CommandEnabledAt: &commandEnabledAt, Scope: "tenant"},
-			})
-		case r.Method == http.MethodPut && r.URL.Path == pathPrefix+"/skills/"+id+"/command":
-			if r.Header.Get("X-Resource-Scope") != "tenant" {
-				http.Error(w, "missing scope header", http.StatusBadRequest)
-				return
-			}
-			var body map[string]json.RawMessage
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode skill command request: %v", err)
-			}
-			commandRequests++
-			commandName := util.Ptr("deploy")
-			enabledAt := &commandEnabledAt
-			if commandRequests == 1 {
-				if got := string(body["commandName"]); got != `"deploy"` {
-					t.Fatalf("unexpected enable commandName: %s", got)
-				}
-			} else {
-				if got := string(body["commandName"]); got != "null" {
-					t.Fatalf("unexpected disable commandName: %s", got)
-				}
-				enabledAt = nil
-			}
-			writeJSON(t, w, apiResponseWrapper[Skill]{
-				Status: "success",
-				Data:   Skill{ID: id, Name: "deploy", Body: "body", CommandName: commandName, CommandEnabledAt: enabledAt, Scope: "tenant"},
+				Data:   Skill{ID: id, Name: "deploy", Body: "body", Scope: "tenant"},
 			})
 		case r.Method == http.MethodPut && r.URL.Path == pathPrefix+"/skills/"+id:
 			if r.Header.Get("X-Resource-Scope") != "tenant" {
@@ -159,7 +131,7 @@ func TestClient_SkillCRUD(t *testing.T) {
 			}
 			writeJSON(t, w, apiResponseWrapper[Skill]{
 				Status: "success",
-				Data:   Skill{ID: id, Name: "deploy v2", Body: "body", CommandName: util.Ptr("deploy"), CommandEnabledAt: &commandEnabledAt, Scope: "tenant"},
+				Data:   Skill{ID: id, Name: "deploy v2", Body: "body", Scope: "tenant"},
 			})
 		case r.Method == http.MethodDelete && r.URL.Path == pathPrefix+"/skills/"+id:
 			if r.Header.Get("X-Resource-Scope") != "tenant" {
@@ -183,13 +155,6 @@ func TestClient_SkillCRUD(t *testing.T) {
 	if created.ID != id {
 		t.Fatalf("unexpected id: %s", created.ID)
 	}
-	enabled, err := client.SetSkillCommand(context.Background(), id, "tenant", util.Ptr("deploy"))
-	if err != nil {
-		t.Fatalf("SetSkillCommand: %v", err)
-	}
-	if enabled.CommandName == nil || *enabled.CommandName != "deploy" || enabled.CommandEnabledAt == nil {
-		t.Fatalf("unexpected enabled command: %+v", enabled)
-	}
 
 	got, err := client.GetSkill(context.Background(), id)
 	if err != nil {
@@ -209,16 +174,63 @@ func TestClient_SkillCRUD(t *testing.T) {
 		t.Fatalf("unexpected updated name: %s", updated.Name)
 	}
 
+	if err := client.DeleteSkill(context.Background(), id, "tenant"); err != nil {
+		t.Fatalf("DeleteSkill: %v", err)
+	}
+}
+
+func TestClient_SetSkillCommand(t *testing.T) {
+	t.Parallel()
+
+	const id = "22222222-2222-2222-2222-222222222222"
+	commandEnabledAt := time.Now()
+	commandRequests := 0
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != pathPrefix+"/skills/"+id+"/command" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("X-Resource-Scope") != "tenant" {
+			http.Error(w, "missing scope header", http.StatusBadRequest)
+			return
+		}
+
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode skill command request: %v", err)
+		}
+		commandRequests++
+		enabledAt := &commandEnabledAt
+		if commandRequests == 1 {
+			if got := string(body["commandName"]); got != `"deploy"` {
+				t.Fatalf("unexpected enable commandName: %s", got)
+			}
+		} else {
+			if got := string(body["commandName"]); got != "null" {
+				t.Fatalf("unexpected disable commandName: %s", got)
+			}
+			enabledAt = nil
+		}
+		writeJSON(t, w, apiResponseWrapper[Skill]{
+			Status: "success",
+			Data:   Skill{ID: id, CommandName: util.Ptr("deploy"), CommandEnabledAt: enabledAt, Scope: "tenant"},
+		})
+	})
+
+	enabled, err := client.SetSkillCommand(context.Background(), id, "tenant", util.Ptr("deploy"))
+	if err != nil {
+		t.Fatalf("SetSkillCommand: %v", err)
+	}
+	if enabled.CommandName == nil || *enabled.CommandName != "deploy" || enabled.CommandEnabledAt == nil {
+		t.Fatalf("unexpected enabled command: %+v", enabled)
+	}
+
 	disabled, err := client.SetSkillCommand(context.Background(), id, "tenant", nil)
 	if err != nil {
 		t.Fatalf("SetSkillCommand disable: %v", err)
 	}
 	if disabled.CommandName == nil || *disabled.CommandName != "deploy" || disabled.CommandEnabledAt != nil {
 		t.Fatalf("unexpected disabled command: %+v", disabled)
-	}
-
-	if err := client.DeleteSkill(context.Background(), id, "tenant"); err != nil {
-		t.Fatalf("DeleteSkill: %v", err)
 	}
 }
 

--- a/internal/common/assistantapi/models.go
+++ b/internal/common/assistantapi/models.go
@@ -127,6 +127,11 @@ type SkillUpdate struct {
 	AllowedTools           *[]AllowedTool   `json:"allowedTools,omitempty"`
 }
 
+// SkillCommandUpdate is the request body for setting or disabling a skill command.
+type SkillCommandUpdate struct {
+	CommandName *string `json:"commandName"`
+}
+
 // Quickstart represents an assistant quickstart prompt returned by the API.
 type Quickstart struct {
 	ID           string          `json:"id"`

--- a/internal/resources/assistant/resource_skill.go
+++ b/internal/resources/assistant/resource_skill.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
@@ -35,6 +38,7 @@ type skillModel struct {
 	Scope                  types.String `tfsdk:"scope"`
 	Name                   types.String `tfsdk:"name"`
 	Body                   types.String `tfsdk:"body"`
+	CommandName            types.String `tfsdk:"command_name"`
 	IncludeInKnowledgebase types.Bool   `tfsdk:"include_in_knowledgebase"`
 	ContextItems           types.String `tfsdk:"context_items"`
 	AllowedTools           types.List   `tfsdk:"allowed_tools"`
@@ -66,6 +70,14 @@ func (r *skillResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"scope": scopeAttribute(),
 			"name":  schema.StringAttribute{Description: "The skill name.", Required: true},
 			"body":  schema.StringAttribute{Description: "The skill content.", Required: true},
+			"command_name": schema.StringAttribute{
+				Description: "The slash command name that invokes the skill. Setting this enables the skill as a command.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 25),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]*$`), "must start with a letter or number and contain only letters, numbers, hyphens, or underscores"),
+				},
+			},
 			"include_in_knowledgebase": schema.BoolAttribute{
 				Description: "Whether the skill is included in the knowledgebase.",
 				Optional:    true,
@@ -120,6 +132,14 @@ func (r *skillResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.AddError("Failed to create assistant skill", err.Error())
 		return
 	}
+	if !plan.CommandName.IsNull() && !plan.CommandName.IsUnknown() {
+		created, err = r.client.SetSkillCommand(ctx, created.ID, created.Scope, plan.CommandName.ValueStringPointer())
+		if err != nil {
+			_ = r.client.DeleteSkill(ctx, created.ID, created.Scope)
+			resp.Diagnostics.AddError("Failed to set assistant skill command", err.Error())
+			return
+		}
+	}
 
 	state, stateDiags := skillToModel(ctx, created)
 	resp.Diagnostics.Append(stateDiags...)
@@ -172,6 +192,13 @@ func (r *skillResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update assistant skill", err.Error())
 		return
+	}
+	if !plan.CommandName.IsUnknown() && !plan.CommandName.Equal(state.CommandName) {
+		updated, err = r.client.SetSkillCommand(ctx, state.ID.ValueString(), state.Scope.ValueString(), plan.CommandName.ValueStringPointer())
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to set assistant skill command", err.Error())
+			return
+		}
 	}
 
 	model, stateDiags := skillToModel(ctx, updated)
@@ -278,12 +305,17 @@ func skillToModel(ctx context.Context, skill assistantapi.Skill) (skillModel, di
 	var diags diag.Diagnostics
 	allowedTools, toolsDiags := allowedToolsToList(ctx, skill.AllowedTools)
 	diags.Append(toolsDiags...)
+	commandName := types.StringNull()
+	if skill.CommandEnabledAt != nil && skill.CommandName != nil {
+		commandName = types.StringValue(*skill.CommandName)
+	}
 
 	return skillModel{
 		ID:                     types.StringValue(skill.ID),
 		Scope:                  types.StringValue(skill.Scope),
 		Name:                   types.StringValue(skill.Name),
 		Body:                   types.StringValue(skill.Body),
+		CommandName:            commandName,
 		IncludeInKnowledgebase: types.BoolValue(skill.IncludeInKnowledgebase),
 		ContextItems:           stringFromRawJSON(skill.ContextItems),
 		AllowedTools:           allowedTools,

--- a/internal/resources/assistant/resource_skill_test.go
+++ b/internal/resources/assistant/resource_skill_test.go
@@ -19,6 +19,7 @@ func TestAccAssistantSkill_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_assistant_skill.test", "id"),
 					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "name", "tf-acc-test-skill"),
+					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "command_name", "tf-acc-command"),
 					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "scope", "tenant"),
 					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "body", "Terraform acceptance test skill body."),
 					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "include_in_knowledgebase", "true"),
@@ -33,9 +34,11 @@ func TestAccAssistantSkill_basic(t *testing.T) {
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_assistant_skill/_acc_basic.tf", map[string]string{
 					"tf-acc-test-skill": "tf-acc-test-skill-updated",
+					"tf-acc-command":    "tf-acc-command-updated",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "name", "tf-acc-test-skill-updated"),
+					resource.TestCheckResourceAttr("grafana_assistant_skill.test", "command_name", "tf-acc-command-updated"),
 				),
 			},
 		},

--- a/internal/resources/assistant/resource_skill_unit_test.go
+++ b/internal/resources/assistant/resource_skill_unit_test.go
@@ -1,0 +1,37 @@
+package assistant
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common/assistantapi"
+)
+
+func TestUnitSkillToModelCommandState(t *testing.T) {
+	t.Parallel()
+
+	commandName := "deploy"
+	enabledAt := time.Now()
+
+	enabled, diags := skillToModel(context.Background(), assistantapi.Skill{
+		CommandName:      &commandName,
+		CommandEnabledAt: &enabledAt,
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if enabled.CommandName.ValueString() != commandName {
+		t.Fatalf("unexpected enabled command name: %q", enabled.CommandName.ValueString())
+	}
+
+	disabled, diags := skillToModel(context.Background(), assistantapi.Skill{
+		CommandName: &commandName,
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !disabled.CommandName.IsNull() {
+		t.Fatalf("expected disabled command name to be null, got %q", disabled.CommandName.ValueString())
+	}
+}


### PR DESCRIPTION
## Summary
- add an optional `command_name` attribute to `grafana_assistant_skill`
- manage command enablement through the Assistant command API and reflect its enabled state during refresh/import
- document the attribute and cover command create, update, disable, and state mapping

## Test plan
- [x] `go test ./internal/common/assistantapi ./internal/resources/assistant`
- [x] `git diff --check`
- [ ] Assistant acceptance tests