### PR TITLE
fix: double canonicalize alloy configs for multiline consistency

### DIFF
--- a/internal/resources/fleetmanagement/model_pipeline_test.go
+++ b/internal/resources/fleetmanagement/model_pipeline_test.go
@@ -220,24 +220,58 @@ func TestPipelineModelToMessage_CustomTerraformSourceNamespace(t *testing.T) {
 
 // https://github.com/grafana/terraform-provider-grafana/issues/2632
 func TestPipelineMessageToModel_PrefersPlannedContentsWhenSemanticallyEqual(t *testing.T) {
-	planned := testPipelineAlloyContents
-	apiFormatted := testPipelineAlloyContents + "\n"
+	t.Run("trailing newline", func(t *testing.T) {
+		planned := testPipelineAlloyContents
+		apiFormatted := testPipelineAlloyContents + "\n"
 
-	eq, err := alloyConfigEqual(planned, apiFormatted)
-	require.NoError(t, err)
-	require.True(t, eq)
+		eq, err := alloyConfigEqual(planned, apiFormatted)
+		require.NoError(t, err)
+		require.True(t, eq)
 
-	msg := &pipelinev1.Pipeline{
-		Name:       "p",
-		Contents:   apiFormatted,
-		ConfigType: pipelinev1.ConfigType_CONFIG_TYPE_ALLOY,
-	}
-	prefs := &pipelineModel{Contents: NewPipelineConfigValue(planned)}
+		msg := &pipelinev1.Pipeline{
+			Name:       "p",
+			Contents:   apiFormatted,
+			ConfigType: pipelinev1.ConfigType_CONFIG_TYPE_ALLOY,
+		}
+		prefs := &pipelineModel{Contents: NewPipelineConfigValue(planned)}
 
-	ctx := context.Background()
-	model, diags := pipelineMessageToModel(ctx, msg, prefs)
-	require.False(t, diags.HasError())
-	require.Equal(t, planned, model.Contents.ValueString())
+		ctx := context.Background()
+		model, diags := pipelineMessageToModel(ctx, msg, prefs)
+		require.False(t, diags.HasError())
+		require.Equal(t, planned, model.Contents.ValueString())
+	})
+
+	// Multiline concat in Terraform vs single-line form from the API: the River
+	// printer is not idempotent on the first pass (=-alignment), so equality
+	// must compare fixed-point canonical forms.
+	t.Run("multiline string concatenation", func(t *testing.T) {
+		planned := `prometheus.relabel "nginx_ingress" {
+  rule {
+    source_labels = ["name"]
+    regex = "nginx_ingress_controller_requests|" +
+      "nginx_ingress_controller_request_size_count"
+    action = "keep"
+  }
+  forward_to = argument.metrics_destinations.value
+}`
+		apiFormatted := "prometheus.relabel \"nginx_ingress\" {\n\trule {\n\t\tsource_labels = [\"name\"]\n\t\tregex         = \"nginx_ingress_controller_requests|\" + \"nginx_ingress_controller_request_size_count\"\n\t\taction = \"keep\"\n\t}\n\tforward_to = argument.metrics_destinations.value\n}"
+
+		eq, err := alloyConfigEqual(planned, apiFormatted)
+		require.NoError(t, err)
+		require.True(t, eq)
+
+		msg := &pipelinev1.Pipeline{
+			Name:       "p",
+			Contents:   apiFormatted,
+			ConfigType: pipelinev1.ConfigType_CONFIG_TYPE_ALLOY,
+		}
+		prefs := &pipelineModel{Contents: NewPipelineConfigValue(planned)}
+
+		ctx := context.Background()
+		model, diags := pipelineMessageToModel(ctx, msg, prefs)
+		require.False(t, diags.HasError())
+		require.Equal(t, planned, model.Contents.ValueString())
+	})
 }
 
 func TestPipelineMessageToModel_FillsOmittedEnabledFromPlan(t *testing.T) {

--- a/internal/resources/fleetmanagement/pipeline_config_value.go
+++ b/internal/resources/fleetmanagement/pipeline_config_value.go
@@ -89,6 +89,21 @@ func alloyConfigEqual(contents1 string, contents2 string) (bool, error) {
 }
 
 func parseAlloyConfig(contents string) (string, error) {
+	parsed, err := printAlloyConfig(contents)
+	if err != nil {
+		return "", err
+	}
+	// The River printer's =-alignment is not idempotent when an attribute value
+	// spans multiple physical lines: the first pass collapses the value onto one
+	// line, but adjacent attributes only join the same alignment run on a second
+	// pass. Without re-printing to that fixed point, semantically equal configs
+	// (e.g. multiline concat in Terraform vs single-line from the API) compare
+	// unequal — the reported case in #2632.
+	// See: https://github.com/grafana/terraform-provider-grafana/issues/2632
+	return printAlloyConfig(parsed)
+}
+
+func printAlloyConfig(contents string) (string, error) {
 	file, err := parser.ParseFile("", []byte(contents))
 	if err != nil {
 		return "", err

--- a/internal/resources/fleetmanagement/pipeline_config_value_test.go
+++ b/internal/resources/fleetmanagement/pipeline_config_value_test.go
@@ -82,6 +82,24 @@ func TestAlloyConfigEqual(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, equal)
 	})
+
+	// https://github.com/grafana/terraform-provider-grafana/issues/2632
+	t.Run("equal despite multiline string concat vs single-line API form", func(t *testing.T) {
+		planned := `prometheus.relabel "nginx_ingress" {
+  rule {
+    source_labels = ["name"]
+    regex = "nginx_ingress_controller_requests|" +
+      "nginx_ingress_controller_request_size_count"
+    action = "keep"
+  }
+  forward_to = argument.metrics_destinations.value
+}`
+		api := "prometheus.relabel \"nginx_ingress\" {\n\trule {\n\t\tsource_labels = [\"name\"]\n\t\tregex         = \"nginx_ingress_controller_requests|\" + \"nginx_ingress_controller_request_size_count\"\n\t\taction = \"keep\"\n\t}\n\tforward_to = argument.metrics_destinations.value\n}"
+
+		equal, err := alloyConfigEqual(planned, api)
+		require.NoError(t, err)
+		require.True(t, equal)
+	})
 }
 
 func TestParseAlloyConfig(t *testing.T) {


### PR DESCRIPTION
fixes #2632