### PR TITLE
chore(codeowners): replace data-sources with data-sources-plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,7 +121,7 @@
 # internal/resources/grafana
 /internal/resources/grafana/data_source_dashboard*                               @grafana/dashboards-squad
 /internal/resources/grafana/data_source_dashboards*                              @grafana/dashboards-squad
-/internal/resources/grafana/data_source_data_source*                             @grafana/data-sources
+/internal/resources/grafana/data_source_data_source*                             @grafana/data-sources-plugins
 /internal/resources/grafana/data_source_folder*                                  @grafana/grafana-search-and-storage
 /internal/resources/grafana/data_source_folders*                                 @grafana/grafana-search-and-storage
 /internal/resources/grafana/data_source_library_panel*                           @grafana/dataviz-squad
@@ -145,9 +145,9 @@
 /internal/resources/grafana/resource_dashboard_permission*                       @grafana/access-squad
 /internal/resources/grafana/resource_dashboard_permission_item*                  @grafana/access-squad
 /internal/resources/grafana/resource_dashboard_public*                           @grafana/grafana-operator-experience-squad
-/internal/resources/grafana/resource_data_source*                                @grafana/data-sources
+/internal/resources/grafana/resource_data_source*                                @grafana/data-sources-plugins
 /internal/resources/grafana/resource_data_source_cache_config*                   @grafana/grafana-operator-experience-squad
-/internal/resources/grafana/resource_data_source_config*                         @grafana/data-sources
+/internal/resources/grafana/resource_data_source_config*                         @grafana/data-sources-plugins
 /internal/resources/grafana/resource_data_source_config_lbac_rules*              @grafana/access-squad
 /internal/resources/grafana/resource_data_source_permission*                     @grafana/access-squad
 /internal/resources/grafana/resource_data_source_permission_item*                @grafana/access-squad
@@ -199,7 +199,7 @@
 /examples/data-sources/grafana_connections_metrics_endpoint_scrape_job/*         @grafana/o11y-apps-backend
 /examples/data-sources/grafana_dashboard/*                                       @grafana/dashboards-squad
 /examples/data-sources/grafana_dashboards/*                                      @grafana/dashboards-squad
-/examples/data-sources/grafana_data_source/*                                     @grafana/data-sources
+/examples/data-sources/grafana_data_source/*                                     @grafana/data-sources-plugins
 /examples/data-sources/grafana_fleet_management_collector/*                      @grafana/fleet-management-backend
 /examples/data-sources/grafana_fleet_management_collectors/*                     @grafana/fleet-management-backend
 /examples/data-sources/grafana_folder/*                                          @grafana/grafana-search-and-storage
@@ -294,9 +294,9 @@
 /examples/resources/grafana_dashboard_permission/*                               @grafana/access-squad
 /examples/resources/grafana_dashboard_permission_item/*                          @grafana/access-squad
 /examples/resources/grafana_dashboard_public/*                                   @grafana/grafana-operator-experience-squad
-/examples/resources/grafana_data_source/*                                        @grafana/data-sources
+/examples/resources/grafana_data_source/*                                        @grafana/data-sources-plugins
 /examples/resources/grafana_data_source_cache_config/*                           @grafana/grafana-operator-experience-squad
-/examples/resources/grafana_data_source_config/*                                 @grafana/data-sources
+/examples/resources/grafana_data_source_config/*                                 @grafana/data-sources-plugins
 /examples/resources/grafana_data_source_config_lbac_rules/*                      @grafana/access-squad
 /examples/resources/grafana_data_source_permission/*                             @grafana/access-squad
 /examples/resources/grafana_data_source_permission_item/*                        @grafana/access-squad
@@ -365,7 +365,7 @@
 /docs/data-sources/connections_metrics_endpoint_scrape_job.md                    @grafana/o11y-apps-backend
 /docs/data-sources/dashboard.md                                                  @grafana/dashboards-squad
 /docs/data-sources/dashboards.md                                                 @grafana/dashboards-squad
-/docs/data-sources/data_source.md                                                @grafana/data-sources
+/docs/data-sources/data_source.md                                                @grafana/data-sources-plugins
 /docs/data-sources/fleet_management_collector.md                                 @grafana/fleet-management-backend
 /docs/data-sources/fleet_management_collectors.md                                @grafana/fleet-management-backend
 /docs/data-sources/folder.md                                                     @grafana/grafana-search-and-storage
@@ -465,9 +465,9 @@
 /docs/resources/dashboard_permission.md                                          @grafana/access-squad
 /docs/resources/dashboard_permission_item.md                                     @grafana/access-squad
 /docs/resources/dashboard_public.md                                              @grafana/grafana-operator-experience-squad
-/docs/resources/data_source.md                                                   @grafana/data-sources
+/docs/resources/data_source.md                                                   @grafana/data-sources-plugins
 /docs/resources/data_source_cache_config.md                                      @grafana/grafana-operator-experience-squad
-/docs/resources/data_source_config.md                                            @grafana/data-sources
+/docs/resources/data_source_config.md                                            @grafana/data-sources-plugins
 /docs/resources/data_source_config_lbac_rules.md                                 @grafana/access-squad
 /docs/resources/data_source_permission.md                                        @grafana/access-squad
 /docs/resources/data_source_permission_item.md                                   @grafana/access-squad

--- a/internal/resources/grafana/catalog-data-source.yaml
+++ b/internal/resources/grafana/catalog-data-source.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-data-source
-  owner: group:default/data-sources
+  owner: group:default/data-sources-plugins
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1

--- a/internal/resources/grafana/catalog-resource.yaml
+++ b/internal/resources/grafana/catalog-resource.yaml
@@ -87,7 +87,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/data-sources
+  owner: group:default/data-sources-plugins
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1
@@ -113,7 +113,7 @@ metadata:
 spec:
   subcomponentOf: component:default/terraform-provider-grafana
   type: terraform-resource
-  owner: group:default/data-sources
+  owner: group:default/data-sources-plugins
   lifecycle: production
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
Swaps the @grafana/data-sources parent team for the @grafana/data-sources-plugins squad in CODEOWNERS, so reviews land with the squad directly.
