### PR TITLE
fix(dashboard): don't parse the sha256 sum as JSON for v2 dashboards

### DIFF
--- a/internal/resources/grafana/resource_dashboard.go
+++ b/internal/resources/grafana/resource_dashboard.go
@@ -392,12 +392,12 @@ func normalizeDashboardBodyJSON(dashboardJSON map[string]any) (string, map[strin
 	}
 	delete(normalizedDashJSON, "uid")
 
+	// NormalizeDashboardConfigJSON mutates the map in place, so normalizedDashJSON
+	// is already the normalized map. Recovering it by unmarshalling the returned
+	// string breaks when StoreDashboardSHA256 is set, because the return value is
+	// then a sha256 sum rather than JSON.
 	normalizedJSON := NormalizeDashboardConfigJSON(normalizedDashJSON)
-	normalizedMap, err := UnmarshalDashboardConfigJSON(normalizedJSON)
-	if err != nil {
-		return "", nil, err
-	}
-	return normalizedJSON, normalizedMap, nil
+	return normalizedJSON, normalizedDashJSON, nil
 }
 
 func cloneDashboardJSON(dashboardJSON map[string]any) (map[string]any, error) {

--- a/internal/resources/grafana/resource_dashboard_internal_test.go
+++ b/internal/resources/grafana/resource_dashboard_internal_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 )
 
 func TestIsKubernetesStyleDashboard(t *testing.T) {
@@ -85,6 +87,53 @@ func TestNormalizeDashboardConfigJSONForState(t *testing.T) {
 		}
 		if got != `{"title":"legacy dashboard"}` {
 			t.Fatalf("expected generated uid to be removed, got %s", got)
+		}
+	})
+}
+
+func TestNormalizeDashboardConfigJSONForStateWithSHA256(t *testing.T) {
+	// NormalizeDashboardConfigJSON returns a sha256 sum rather than JSON when
+	// StoreDashboardSHA256 is set. normalizeDashboardBodyJSON must not try to
+	// parse that sum back into a map, which previously failed with errors such
+	// as "invalid character '4' after top-level value" for kubernetes-style
+	// dashboards only.
+	prev := StoreDashboardSHA256
+	StoreDashboardSHA256 = true
+	t.Cleanup(func() { StoreDashboardSHA256 = prev })
+
+	configJSON := `{"apiVersion":"dashboard.grafana.app/v2beta1","kind":"Dashboard","metadata":{"name":"test-dashboard"},"spec":{"title":"test dashboard"}}`
+
+	t.Run("remote spec matches local spec", func(t *testing.T) {
+		remoteDashJSON := map[string]any{
+			"title":   "test dashboard",
+			"id":      7,
+			"uid":     "test-dashboard",
+			"version": 3,
+		}
+
+		got, err := normalizeDashboardConfigJSONForState(configJSON, remoteDashJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != NormalizeDashboardConfigJSON(configJSON) {
+			t.Fatalf("expected kubernetes-shaped config to be preserved, got %s", got)
+		}
+	})
+
+	t.Run("remote spec differs from local spec", func(t *testing.T) {
+		remoteDashJSON := map[string]any{
+			"title":   "changed remotely",
+			"id":      7,
+			"uid":     "test-dashboard",
+			"version": 4,
+		}
+
+		got, err := normalizeDashboardConfigJSONForState(configJSON, remoteDashJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !common.SHA256Regexp.MatchString(got) {
+			t.Fatalf("expected a sha256 sum, got %s", got)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #2911.

`normalizeDashboardBodyJSON` builds its map return value by unmarshalling the
string returned from `NormalizeDashboardConfigJSON`. When `StoreDashboardSHA256`
is set, that string is a 64-character sha256 sum rather than JSON, so the
unmarshal fails and the error surfaces on apply:

```
Error: invalid character '4' after top-level value
```

The dashboard is created in Grafana, but the read-back fails, so the resource
never lands in state and every subsequent apply repeats the error.

This only affects Kubernetes-style (schema v2) dashboards, because
`normalizeDashboardBodyJSON` is reached solely via
`normalizeKubernetesDashboardConfigJSONForState`. Classic dashboards are
unaffected regardless of size.

The reported character varies per dashboard, since it depends on the leading hex
characters of the sum — which makes the same bug look like several unrelated
ones (`f8…` → `invalid character '8' in literal false`, `04…` → `invalid
character '4' after top-level value`, and so on).

### The change

`NormalizeDashboardConfigJSON` takes `map[string]any` by reference and deletes
`id`/`version` in place, so `normalizedDashJSON` is *already* the normalized map
once it returns. Recovering that map by re-parsing the returned string was
redundant even before the sha256 option existed — `cloneDashboardJSON` has
already round-tripped the value through JSON, so the types match.

Returning the map directly leaves the string return untouched. That string is
only used for the `localSpecJSON == remoteSpecJSON` comparison in
`normalizeKubernetesDashboardConfigJSONForState`, and hashing both sides
preserves equality, so sha256 storage keeps working as intended.

### Testing

- Added `TestNormalizeDashboardConfigJSONForStateWithSHA256`, covering both the
  matching and drifting remote-spec branches. It fails without the fix and
  passes with it.
- Existing `TestNormalizeDashboardConfigJSONForState` subtests still pass, so
  behaviour with `store_dashboard_sha256` disabled is unchanged.
- `go test ./...` passes.
- `golangci-lint run ./internal/resources/grafana/...` reports no issues.
- Verified end to end against Grafana 13.1.1 with a schema-v2 dashboard: apply
  fails on an unpatched build with `store_dashboard_sha256 = true`, succeeds on
  a patched build, and still succeeds with the option disabled.

No schema or documentation changes, so `docs/` is unaffected.
