### PR TITLE
test(grafana_apps_servicemodel_component_v1alpha1): poll for deletion in the destroy check

### DIFF
--- a/internal/resources/appplatform/servicemodel_component_resource_acc_test.go
+++ b/internal/resources/appplatform/servicemodel_component_resource_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana-app-sdk/resource"
@@ -120,13 +121,47 @@ func testAccCheckServiceModelComponentDestroy(s *terraform.State) error {
 		)
 
 		uid := r.Primary.Attributes["metadata.uid"]
-		if _, err := namespacedClient.Get(context.Background(), uid); err == nil {
-			return fmt.Errorf("service model component %s still exists", uid)
-		} else if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("error checking if service model component %s exists: %w", uid, err)
+		if err := waitForServiceModelComponentDestroy(context.Background(), namespacedClient, uid); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// waitForServiceModelComponentDestroy polls until the component is gone.
+// Components carry a finalizer, so deletion is asynchronous: the object stays
+// readable until the finalizer is removed.
+func waitForServiceModelComponentDestroy(
+	ctx context.Context,
+	client *resource.NamespacedClient[*appplatform.ServiceModelComponent, *appplatform.ServiceModelComponentList],
+	uid string,
+) error {
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		obj, err := client.Get(ctx, uid)
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil
+		case err != nil:
+			lastErr = fmt.Errorf("error checking if service model component %s exists: %w", uid, err)
+		case obj.DeletionTimestamp != nil:
+			// Deletion accepted, waiting for the finalizer to be removed.
+			lastErr = fmt.Errorf("service model component %s still exists, deletion pending since %s",
+				uid, obj.DeletionTimestamp.Time.Format(time.RFC3339))
+		default:
+			lastErr = fmt.Errorf("service model component %s still exists", uid)
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("timed out waiting for service model component %s to be deleted", uid)
+	}
+
+	return lastErr
 }
 
 func testAccServiceModelComponentMinimalConfig(uid string) string {


### PR DESCRIPTION
`TestAccServiceModelComponent_basic` failed on main with:

```
Error running post-test destroy, there may be dangling resources:
service model component tf-test-component-8fo317 still exists
```

The test body (create, update, import) passed and the same commit passed on an earlier run, so this is a flaky check rather than a broken delete.

## Cause

Components carry a finalizer, so deletion is asynchronous: the API server records the deletion and the object stays readable until the finalizer is removed. The destroy check did a single `Get` and treated any success as "still exists", so it failed whenever it ran inside that window.

## Fix

Poll for the object to disappear (30 second deadline, 1 second interval), following `waitForProvisioningDestroy` in this package, which handles asynchronous deletion the same way. The timeout error distinguishes an object still pending deletion from one that was never deleted, so a future failure points at the right cause. In the common case the first poll returns not-found, so the check adds no measurable time.

Single-`Get` destroy checks are correct for the other resources in this package and for the `destroyed` helpers in the `grafana` and `k6` packages, since those APIs delete synchronously.