### PR TITLE
fix(assistant): keep explicitly-empty optional values out of null

### DIFF
--- a/internal/resources/assistant/converters.go
+++ b/internal/resources/assistant/converters.go
@@ -20,11 +20,54 @@ func listValueToStrings(ctx context.Context, list types.List) ([]string, diag.Di
 	return values, diags
 }
 
-func stringsToListValue(ctx context.Context, values []string) (types.List, diag.Diagnostics) {
-	if len(values) == 0 {
-		return types.ListNull(types.StringType), nil
+// The Assistant API omits empty optional fields from its responses, so "unset"
+// and "set to an empty value" come back identically. Collapsing both to null
+// loses the distinction: when the configuration said `""`, `[]` or `{}`,
+// Terraform fails the apply with "Provider produced inconsistent result after
+// apply ... was cty.StringVal(\"\"), but now null".
+//
+// The reconcile* helpers below take the corresponding plan (or, on refresh,
+// prior state) value and fall back to it whenever the API returned nothing, so
+// an explicitly empty value survives the round trip.
+
+func reconcileList(ctx context.Context, prior types.List, values []string) (types.List, diag.Diagnostics) {
+	if len(values) > 0 {
+		return types.ListValueFrom(ctx, types.StringType, values)
 	}
-	return types.ListValueFrom(ctx, types.StringType, values)
+	if !prior.IsNull() && !prior.IsUnknown() {
+		return prior, nil
+	}
+	return types.ListNull(types.StringType), nil
+}
+
+func reconcileMap(ctx context.Context, prior types.Map, values map[string]string) (types.Map, diag.Diagnostics) {
+	if len(values) > 0 {
+		return types.MapValueFrom(ctx, types.StringType, values)
+	}
+	if !prior.IsNull() && !prior.IsUnknown() {
+		return prior, nil
+	}
+	return types.MapNull(types.StringType), nil
+}
+
+func reconcileString(prior types.String, value string) types.String {
+	if value != "" {
+		return types.StringValue(value)
+	}
+	if !prior.IsNull() && !prior.IsUnknown() {
+		return prior
+	}
+	return types.StringNull()
+}
+
+func reconcileRawJSON(prior types.String, raw json.RawMessage) types.String {
+	if len(raw) > 0 {
+		return types.StringValue(string(raw))
+	}
+	if !prior.IsNull() && !prior.IsUnknown() {
+		return prior
+	}
+	return types.StringNull()
 }
 
 func headersFromMap(headers types.Map) ([]assistantapi.Header, diag.Diagnostics) {
@@ -56,18 +99,4 @@ func rawJSONFromString(ctx context.Context, s types.String) (json.RawMessage, di
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Invalid JSON", "context_items must be valid JSON")}
 	}
 	return json.RawMessage(s.ValueString()), nil
-}
-
-func stringFromRawJSON(raw json.RawMessage) types.String {
-	if len(raw) == 0 {
-		return types.StringNull()
-	}
-	return types.StringValue(string(raw))
-}
-
-func stringValueOrNull(value string) types.String {
-	if value == "" {
-		return types.StringNull()
-	}
-	return types.StringValue(value)
 }

--- a/internal/resources/assistant/resource_empty_values_mock_test.go
+++ b/internal/resources/assistant/resource_empty_values_mock_test.go
@@ -1,0 +1,252 @@
+package assistant_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/grafana/terraform-provider-grafana/v4/internal/testutils"
+)
+
+// The Assistant API omits empty optional fields from its responses, so a field
+// that was configured as `""`, `[]` or `{}` comes back indistinguishable from
+// one that was never set. The provider used to write null into state for those,
+// which makes Terraform abort the apply with "Provider produced inconsistent
+// result after apply ... was cty.StringVal(\"\"), but now null".
+//
+// These tests pin that round trip using a mock Assistant API that echoes back
+// exactly what it was sent — the behaviour of a well-behaved server. Each case
+// also implicitly asserts plan stability: the test harness fails a step whose
+// post-apply plan is non-empty.
+
+// mockAssistantAPI serves the Assistant plugin endpoints for create/read/delete.
+func mockAssistantAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	store := map[string]map[string]any{}
+
+	writeJSON := func(w http.ResponseWriter, data any) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{"status": "ok", "data": data}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}
+
+	decodeBody := func(w http.ResponseWriter, r *http.Request) (map[string]any, bool) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return nil, false
+		}
+		obj := map[string]any{}
+		if err := json.Unmarshal(body, &obj); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return nil, false
+		}
+		return obj, true
+	}
+
+	const base = "/api/plugins/grafana-assistant-app/resources/api/v1"
+	mux := http.NewServeMux()
+	for _, kind := range []string{"rules", "skills", "integrations", "quickstarts"} {
+		id := kind + "-1"
+		mux.HandleFunc(base+"/"+kind, func(w http.ResponseWriter, r *http.Request) {
+			obj, ok := decodeBody(w, r)
+			if !ok {
+				return
+			}
+			obj["id"] = id
+			store[id] = obj
+			writeJSON(w, obj)
+		})
+		mux.HandleFunc(base+"/"+kind+"/"+id, func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodDelete:
+				delete(store, id)
+				writeJSON(w, map[string]any{})
+			case http.MethodPut:
+				patch, ok := decodeBody(w, r)
+				if !ok {
+					return
+				}
+				// A PUT carries only the fields the provider chose to send;
+				// merge so unsent fields keep their stored value.
+				for k, v := range patch {
+					store[id][k] = v
+				}
+				writeJSON(w, store[id])
+			default:
+				writeJSON(w, store[id])
+			}
+		})
+	}
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestUnitAssistantEmptyOptionalValues_Mock(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+		checks []resource.TestCheckFunc
+	}{
+		{
+			name: "mcp server with empty tool maps and empty description",
+			config: `
+resource "grafana_assistant_mcp_server" "test" {
+  name        = "test-mcp"
+  scope       = "tenant"
+  description = ""
+  configuration {
+    url                    = "https://mcp.example.com"
+    tool_preferences       = {}
+    tool_approval_policies = {}
+  }
+  custom_headers = {}
+}`,
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "description", ""),
+				resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "configuration.tool_preferences.%", "0"),
+				resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "configuration.tool_approval_policies.%", "0"),
+				resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "custom_headers.%", "0"),
+			},
+		},
+		{
+			name: "mcp server with empty applications",
+			config: `
+resource "grafana_assistant_mcp_server" "test" {
+  name         = "test-mcp"
+  scope        = "tenant"
+  applications = []
+  configuration {
+    url = "https://mcp.example.com"
+  }
+}`,
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "applications.#", "0"),
+			},
+		},
+		{
+			// `configuration` is an optional block, so omitting it must not fail.
+			name: "mcp server without a configuration block",
+			config: `
+resource "grafana_assistant_mcp_server" "test" {
+  name  = "test-mcp"
+  scope = "tenant"
+}`,
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttrSet("grafana_assistant_mcp_server.test", "id"),
+				resource.TestCheckNoResourceAttr("grafana_assistant_mcp_server.test", "configuration.url"),
+			},
+		},
+		{
+			name: "rule with empty description and applications",
+			config: `
+resource "grafana_assistant_rule" "test" {
+  name         = "test-rule"
+  scope        = "tenant"
+  description  = ""
+  rule_content = "Be concise."
+  applications = []
+}`,
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("grafana_assistant_rule.test", "description", ""),
+				resource.TestCheckResourceAttr("grafana_assistant_rule.test", "applications.#", "0"),
+			},
+		},
+		{
+			name: "skill with empty context items",
+			config: `
+resource "grafana_assistant_skill" "test" {
+  name          = "test-skill"
+  scope         = "tenant"
+  body          = "# skill"
+  context_items = ""
+}`,
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("grafana_assistant_skill.test", "context_items", ""),
+			},
+		},
+		{
+			name: "quickstart with empty context items and title",
+			config: `
+resource "grafana_assistant_quickstart" "test" {
+  scope         = "tenant"
+  title         = ""
+  prompt        = "How do I start?"
+  context_items = ""
+}`,
+			checks: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr("grafana_assistant_quickstart.test", "title", ""),
+				resource.TestCheckResourceAttr("grafana_assistant_quickstart.test", "context_items", ""),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := mockAssistantAPI(t)
+			t.Setenv("GRAFANA_URL", srv.URL)
+			t.Setenv("GRAFANA_AUTH", "mock-token")
+
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+				Steps: []resource.TestStep{{
+					Config: tc.config,
+					Check:  resource.ComposeTestCheckFunc(tc.checks...),
+				}},
+			})
+		})
+	}
+}
+
+// Update takes the plan rather than the prior state as its reconciliation
+// source, so it needs its own coverage: an in-place change must not resurrect
+// the null that Create avoided.
+func TestUnitAssistantEmptyOptionalValuesOnUpdate_Mock(t *testing.T) {
+	srv := mockAssistantAPI(t)
+	t.Setenv("GRAFANA_URL", srv.URL)
+	t.Setenv("GRAFANA_AUTH", "mock-token")
+
+	config := func(name string) string {
+		return `
+resource "grafana_assistant_mcp_server" "test" {
+  name        = "` + name + `"
+  scope       = "tenant"
+  description = ""
+  configuration {
+    url                    = "https://mcp.example.com"
+    tool_approval_policies = {}
+  }
+}`
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config("test-mcp"),
+				Check:  resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "description", ""),
+			},
+			{
+				Config: config("test-mcp-renamed"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "name", "test-mcp-renamed"),
+					resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "description", ""),
+					resource.TestCheckResourceAttr("grafana_assistant_mcp_server.test", "configuration.tool_approval_policies.%", "0"),
+				),
+			},
+			{
+				ResourceName:            "grafana_assistant_mcp_server.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"custom_headers", "description", "configuration.tool_approval_policies"},
+			},
+		},
+	})
+}

--- a/internal/resources/assistant/resource_mcp_server.go
+++ b/internal/resources/assistant/resource_mcp_server.go
@@ -31,14 +31,18 @@ type mcpConfigurationModel struct {
 }
 
 type mcpServerModel struct {
-	ID            types.String          `tfsdk:"id"`
-	Scope         types.String          `tfsdk:"scope"`
-	Name          types.String          `tfsdk:"name"`
-	Description   types.String          `tfsdk:"description"`
-	Enabled       types.Bool            `tfsdk:"enabled"`
-	Applications  types.List            `tfsdk:"applications"`
-	Configuration mcpConfigurationModel `tfsdk:"configuration"`
-	CustomHeaders types.Map             `tfsdk:"custom_headers"`
+	ID    types.String `tfsdk:"id"`
+	Scope types.String `tfsdk:"scope"`
+	Name  types.String `tfsdk:"name"`
+	// Description is documented as optional.
+	Description  types.String `tfsdk:"description"`
+	Enabled      types.Bool   `tfsdk:"enabled"`
+	Applications types.List   `tfsdk:"applications"`
+	// Configuration is a pointer because `configuration` is an optional
+	// SingleNestedBlock: omitting it yields a null object, which cannot be
+	// decoded into a value-typed struct.
+	Configuration *mcpConfigurationModel `tfsdk:"configuration"`
+	CustomHeaders types.Map              `tfsdk:"custom_headers"`
 }
 
 func makeResourceMCPServer() *common.Resource {
@@ -130,7 +134,7 @@ func (r *mcpServerResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	state, stateDiags := mcpToModel(ctx, created, plan.CustomHeaders)
+	state, stateDiags := mcpToModel(ctx, created, plan)
 	resp.Diagnostics.Append(stateDiags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -152,7 +156,7 @@ func (r *mcpServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	model, diags := mcpToModel(ctx, integration, state.CustomHeaders)
+	model, diags := mcpToModel(ctx, integration, state)
 	resp.Diagnostics.Append(diags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -178,11 +182,11 @@ func (r *mcpServerResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// Preserve write-only custom headers from plan when API redacts them.
-	customHeaders := state.CustomHeaders
-	if !plan.CustomHeaders.IsNull() && !plan.CustomHeaders.IsUnknown() {
-		customHeaders = plan.CustomHeaders
+	prior := plan
+	if plan.CustomHeaders.IsNull() || plan.CustomHeaders.IsUnknown() {
+		prior.CustomHeaders = state.CustomHeaders
 	}
-	model, stateDiags := mcpToModel(ctx, updated, customHeaders)
+	model, stateDiags := mcpToModel(ctx, updated, prior)
 	resp.Diagnostics.Append(stateDiags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -205,7 +209,9 @@ func (r *mcpServerResource) ImportState(ctx context.Context, req resource.Import
 		resp.Diagnostics.AddError("Failed to import assistant MCP server", err.Error())
 		return
 	}
-	model, diags := mcpToModel(ctx, integration, types.MapNull(types.StringType))
+	// Import has no prior value to preserve; custom headers are write-only and
+	// never returned, so they stay null.
+	model, diags := mcpToModel(ctx, integration, mcpServerModel{CustomHeaders: types.MapNull(types.StringType)})
 	resp.Diagnostics.Append(diags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -258,8 +264,11 @@ func mcpPlanToUpdate(ctx context.Context, plan mcpServerModel) (assistantapi.Int
 	}, diags
 }
 
-func mcpConfigToJSON(ctx context.Context, cfg mcpConfigurationModel) (json.RawMessage, diag.Diagnostics) {
-	mcpCfg, diags := mcpConfigFromModel(ctx, cfg)
+func mcpConfigToJSON(ctx context.Context, cfg *mcpConfigurationModel) (json.RawMessage, diag.Diagnostics) {
+	if cfg == nil {
+		return nil, nil
+	}
+	mcpCfg, diags := mcpConfigFromModel(ctx, *cfg)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -297,9 +306,13 @@ func mcpConfigFromModel(ctx context.Context, cfg mcpConfigurationModel) (assista
 	return result, diags
 }
 
-func mcpToModel(ctx context.Context, integration assistantapi.Integration, customHeaders types.Map) (mcpServerModel, diag.Diagnostics) {
+// mcpToModel maps an API integration onto Terraform state. prior is the plan (on
+// create/update) or the current state (on read); it supplies the values the API
+// cannot echo back — write-only custom headers, and explicitly-empty optional
+// fields.
+func mcpToModel(ctx context.Context, integration assistantapi.Integration, prior mcpServerModel) (mcpServerModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	applications, appDiags := stringsToListValue(ctx, integration.Applications)
+	applications, appDiags := reconcileList(ctx, prior.Applications, integration.Applications)
 	diags.Append(appDiags...)
 
 	cfg, err := assistantapi.ParseMCPConfig(integration.Configuration)
@@ -307,7 +320,7 @@ func mcpToModel(ctx context.Context, integration assistantapi.Integration, custo
 		diags.AddError("Failed to parse MCP configuration", err.Error())
 		return mcpServerModel{}, diags
 	}
-	configModel, cfgDiags := mcpConfigToModel(ctx, cfg)
+	configModel, cfgDiags := mcpConfigToModel(ctx, cfg, prior.Configuration)
 	diags.Append(cfgDiags...)
 
 	enabled := true
@@ -319,41 +332,34 @@ func mcpToModel(ctx context.Context, integration assistantapi.Integration, custo
 		ID:            types.StringValue(integration.ID),
 		Scope:         types.StringValue(integration.Scope),
 		Name:          types.StringValue(integration.Name),
-		Description:   stringValueOrNull(integration.Description),
+		Description:   reconcileString(prior.Description, integration.Description),
 		Enabled:       types.BoolValue(enabled),
 		Applications:  applications,
 		Configuration: configModel,
-		CustomHeaders: customHeaders,
+		CustomHeaders: prior.CustomHeaders,
 	}, diags
 }
 
-func mcpConfigToModel(ctx context.Context, cfg assistantapi.MCPConfig) (mcpConfigurationModel, diag.Diagnostics) {
+func mcpConfigToModel(ctx context.Context, cfg assistantapi.MCPConfig, prior *mcpConfigurationModel) (*mcpConfigurationModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	toolPrefs, prefsDiags := stringMapToTypesMap(ctx, cfg.ToolPreferences)
+	if prior == nil {
+		// The block was omitted. Keep it absent unless the API reported a
+		// configuration of its own (import).
+		if cfg.URL == "" && cfg.BuiltinID == "" && len(cfg.ToolPreferences) == 0 && len(cfg.ToolApprovalPolicies) == 0 {
+			return nil, diags
+		}
+		prior = &mcpConfigurationModel{}
+	}
+
+	toolPrefs, prefsDiags := reconcileMap(ctx, prior.ToolPreferences, cfg.ToolPreferences)
 	diags.Append(prefsDiags...)
-	toolPolicies, polDiags := stringMapToTypesMap(ctx, cfg.ToolApprovalPolicies)
+	toolPolicies, polDiags := reconcileMap(ctx, prior.ToolApprovalPolicies, cfg.ToolApprovalPolicies)
 	diags.Append(polDiags...)
 
-	url := types.StringNull()
-	if cfg.URL != "" {
-		url = types.StringValue(cfg.URL)
-	}
-	builtinID := types.StringNull()
-	if cfg.BuiltinID != "" {
-		builtinID = types.StringValue(cfg.BuiltinID)
-	}
-
-	return mcpConfigurationModel{
-		URL:                  url,
-		BuiltinID:            builtinID,
+	return &mcpConfigurationModel{
+		URL:                  reconcileString(prior.URL, cfg.URL),
+		BuiltinID:            reconcileString(prior.BuiltinID, cfg.BuiltinID),
 		ToolPreferences:      toolPrefs,
 		ToolApprovalPolicies: toolPolicies,
 	}, diags
-}
-
-func stringMapToTypesMap(ctx context.Context, m map[string]string) (types.Map, diag.Diagnostics) {
-	if len(m) == 0 {
-		return types.MapNull(types.StringType), nil
-	}
-	return types.MapValueFrom(ctx, types.StringType, m)
 }

--- a/internal/resources/assistant/resource_quickstart.go
+++ b/internal/resources/assistant/resource_quickstart.go
@@ -98,7 +98,7 @@ func (r *quickstartResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	state, stateDiags := quickstartToModel(created)
+	state, stateDiags := quickstartToModel(created, plan)
 	resp.Diagnostics.Append(stateDiags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -120,7 +120,7 @@ func (r *quickstartResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	model, diags := quickstartToModel(quickstart)
+	model, diags := quickstartToModel(quickstart, state)
 	resp.Diagnostics.Append(diags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -145,7 +145,7 @@ func (r *quickstartResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	model, stateDiags := quickstartToModel(updated)
+	model, stateDiags := quickstartToModel(updated, plan)
 	resp.Diagnostics.Append(stateDiags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -168,7 +168,8 @@ func (r *quickstartResource) ImportState(ctx context.Context, req resource.Impor
 		resp.Diagnostics.AddError("Failed to import assistant quickstart", err.Error())
 		return
 	}
-	model, diags := quickstartToModel(quickstart)
+	// Import has no prior value to preserve: every field comes from the API.
+	model, diags := quickstartToModel(quickstart, quickstartModel{})
 	resp.Diagnostics.Append(diags...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
@@ -214,7 +215,10 @@ func quickstartPlanToUpdate(ctx context.Context, plan quickstartModel) (assistan
 	}, diags
 }
 
-func quickstartToModel(q assistantapi.Quickstart) (quickstartModel, diag.Diagnostics) {
+// quickstartToModel maps an API quickstart onto Terraform state. prior is the
+// plan (on create/update) or the current state (on read); it supplies the values
+// the API cannot echo back for explicitly-empty optional fields.
+func quickstartToModel(q assistantapi.Quickstart, prior quickstartModel) (quickstartModel, diag.Diagnostics) {
 	enabled := true
 	if q.Enabled != nil {
 		enabled = *q.Enabled
@@ -228,7 +232,7 @@ func quickstartToModel(q assistantapi.Quickstart) (quickstartModel, diag.Diagnos
 		Scope:        types.StringValue(q.Scope),
 		Title:        title,
 		Prompt:       types.StringValue(q.Prompt),
-		ContextItems: stringFromRawJSON(q.ContextItems),
+		ContextItems: reconcileRawJSON(prior.ContextItems, q.ContextItems),
 		Enabled:      types.BoolValue(enabled),
 	}, nil
 }

--- a/internal/resources/assistant/resource_rule.go
+++ b/internal/resources/assistant/resource_rule.go
@@ -105,7 +105,7 @@ func (r *ruleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	state, diags := ruleToModel(ctx, created)
+	state, diags := ruleToModel(ctx, created, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -130,7 +130,7 @@ func (r *ruleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	model, diags := ruleToModel(ctx, rule)
+	model, diags := ruleToModel(ctx, rule, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -168,7 +168,7 @@ func (r *ruleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	model, diags := ruleToModel(ctx, updated)
+	model, diags := ruleToModel(ctx, updated, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -195,7 +195,8 @@ func (r *ruleResource) ImportState(ctx context.Context, req resource.ImportState
 		resp.Diagnostics.AddError("Failed to import assistant rule", err.Error())
 		return
 	}
-	model, diags := ruleToModel(ctx, rule)
+	// Import has no prior value to preserve: every field comes from the API.
+	model, diags := ruleToModel(ctx, rule, ruleModel{})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -203,9 +204,12 @@ func (r *ruleResource) ImportState(ctx context.Context, req resource.ImportState
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
-func ruleToModel(ctx context.Context, rule assistantapi.Rule) (ruleModel, diag.Diagnostics) {
+// ruleToModel maps an API rule onto Terraform state. prior is the plan (on
+// create/update) or the current state (on read); it supplies the values the API
+// cannot echo back for explicitly-empty optional fields.
+func ruleToModel(ctx context.Context, rule assistantapi.Rule, prior ruleModel) (ruleModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	applications, appDiags := stringsToListValue(ctx, rule.Applications)
+	applications, appDiags := reconcileList(ctx, prior.Applications, rule.Applications)
 	diags.Append(appDiags...)
 
 	enabled := true
@@ -217,7 +221,7 @@ func ruleToModel(ctx context.Context, rule assistantapi.Rule) (ruleModel, diag.D
 		ID:           types.StringValue(rule.ID),
 		Scope:        types.StringValue(rule.Scope),
 		Name:         types.StringValue(rule.Name),
-		Description:  stringValueOrNull(rule.Description),
+		Description:  reconcileString(prior.Description, rule.Description),
 		RuleContent:  types.StringValue(rule.RuleContent),
 		Enabled:      types.BoolValue(enabled),
 		Priority:     types.Int64Value(int64(rule.Priority)),

--- a/internal/resources/assistant/resource_skill.go
+++ b/internal/resources/assistant/resource_skill.go
@@ -141,7 +141,7 @@ func (r *skillResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
-	state, stateDiags := skillToModel(ctx, created)
+	state, stateDiags := skillToModel(ctx, created, plan)
 	resp.Diagnostics.Append(stateDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -166,7 +166,7 @@ func (r *skillResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	model, diags := skillToModel(ctx, skill)
+	model, diags := skillToModel(ctx, skill, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -201,7 +201,7 @@ func (r *skillResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
-	model, stateDiags := skillToModel(ctx, updated)
+	model, stateDiags := skillToModel(ctx, updated, plan)
 	resp.Diagnostics.Append(stateDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -227,7 +227,8 @@ func (r *skillResource) ImportState(ctx context.Context, req resource.ImportStat
 		resp.Diagnostics.AddError("Failed to import assistant skill", err.Error())
 		return
 	}
-	model, diags := skillToModel(ctx, skill)
+	// Import has no prior value to preserve: every field comes from the API.
+	model, diags := skillToModel(ctx, skill, skillModel{})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -301,7 +302,10 @@ func allowedToolsFromList(ctx context.Context, list types.List) ([]assistantapi.
 	return result, diags
 }
 
-func skillToModel(ctx context.Context, skill assistantapi.Skill) (skillModel, diag.Diagnostics) {
+// skillToModel maps an API skill onto Terraform state. prior is the plan (on
+// create/update) or the current state (on read); it supplies the values the API
+// cannot echo back for explicitly-empty optional fields.
+func skillToModel(ctx context.Context, skill assistantapi.Skill, prior skillModel) (skillModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	allowedTools, toolsDiags := allowedToolsToList(ctx, skill.AllowedTools)
 	diags.Append(toolsDiags...)
@@ -317,7 +321,7 @@ func skillToModel(ctx context.Context, skill assistantapi.Skill) (skillModel, di
 		Body:                   types.StringValue(skill.Body),
 		CommandName:            commandName,
 		IncludeInKnowledgebase: types.BoolValue(skill.IncludeInKnowledgebase),
-		ContextItems:           stringFromRawJSON(skill.ContextItems),
+		ContextItems:           reconcileRawJSON(prior.ContextItems, skill.ContextItems),
 		AllowedTools:           allowedTools,
 	}, diags
 }

--- a/internal/resources/assistant/resource_skill_unit_test.go
+++ b/internal/resources/assistant/resource_skill_unit_test.go
@@ -17,7 +17,7 @@ func TestUnitSkillToModelCommandState(t *testing.T) {
 	enabled, diags := skillToModel(context.Background(), assistantapi.Skill{
 		CommandName:      &commandName,
 		CommandEnabledAt: &enabledAt,
-	})
+	}, skillModel{})
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}
@@ -27,7 +27,7 @@ func TestUnitSkillToModelCommandState(t *testing.T) {
 
 	disabled, diags := skillToModel(context.Background(), assistantapi.Skill{
 		CommandName: &commandName,
-	})
+	}, skillModel{})
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
 	}


### PR DESCRIPTION
## What

Fixes two bugs in the Assistant resources.

The `*ToModel` functions couldn't tell "unset" from "set to empty", so they wrote null for both. Configuring `description = ""` or `tool_approval_policies = {}` failed apply with `Provider produced inconsistent result after apply`. The fix threads the plan (create/update) or the prior state (read) into each `*ToModel` and falls back to it when the API returns nothing, via new `reconcileString` / `reconcileList` / `reconcileMap` / `reconcileRawJSON` helpers. Import is unchanged: there's no prior value, so everything comes from the API.

Separately, `mcpServerModel.Configuration` is now a pointer, so omitting the optional `configuration` block converts cleanly instead of erroring with `Received null value, however the target type cannot handle null values`.

Affected: `grafana_assistant_mcp_server` (`description`, `applications`, `configuration.tool_preferences`, `configuration.tool_approval_policies`), `grafana_assistant_rule` (`description`, `applications`), `grafana_assistant_skill` and `grafana_assistant_quickstart` (`context_items`).

## Tests

`TestUnitAssistantEmptyOptionalValues_Mock` (table, 6 cases) and `TestUnitAssistantEmptyOptionalValuesOnUpdate_Mock` (covers update and import), both against a mock Assistant API. Verified every case fails without the fix.

`go test ./...` passes, golangci-lint clean. No schema change, so generated docs are unchanged.

Closes #2920
