### PR TITLE
fix(agento11y): expose evaluation rule execution fields

### DIFF
--- a/docs/resources/agento11y_evaluation_rule.md
+++ b/docs/resources/agento11y_evaluation_rule.md
@@ -34,11 +34,13 @@ resource "grafana_agento11y_evaluator" "example" {
 }
 
 resource "grafana_agento11y_evaluation_rule" "example" {
-  rule_id       = "score_user_turns"
-  enabled       = true
-  selector      = "user_visible_turn"
-  sample_rate   = 0.1
-  evaluator_ids = [grafana_agento11y_evaluator.example.evaluator_id]
+  rule_id             = "score_user_turns"
+  enabled             = true
+  selector            = "user_visible_turn"
+  sample_rate         = 0.1
+  evaluator_ids       = [grafana_agento11y_evaluator.example.evaluator_id]
+  execution_mode      = "parallel"
+  filterable_tag_keys = ["environment", "team"]
 
   match = jsonencode({
     agent_name = "checkout-*"
@@ -58,6 +60,8 @@ resource "grafana_agento11y_evaluation_rule" "example" {
 
 - `alert_rule_uids` (List of String) Optional Grafana alert rule UIDs associated with this evaluation rule.
 - `enabled` (Boolean) Whether the rule is enabled. Defaults to `true`.
+- `execution_mode` (String) How evaluators execute. `parallel` runs all evaluators independently; `sequential` treats `evaluator_ids` as an ordered gate chain. Defaults to `parallel`.
+- `filterable_tag_keys` (List of String) Generation tag keys to promote to Prometheus labels on evaluation metrics. Supports at most 10 unique, non-empty keys and cannot be set when `selector` is `conversation`.
 - `match` (String) Optional JSON object of match filters (for example `{"agent_name":"checkout-*"}`). Omit to match everything.
 - `min_idle_seconds` (Number) Idle window, in seconds, before a conversation-scope rule runs. Required when `selector` is `conversation`; must be unset otherwise.
 - `sample_rate` (Number) Fraction of matching generations to evaluate, in `[0,1]`. Defaults to `0.01`.

--- a/examples/resources/grafana_agento11y_evaluation_rule/_acc_basic.tf
+++ b/examples/resources/grafana_agento11y_evaluation_rule/_acc_basic.tf
@@ -16,9 +16,11 @@ resource "grafana_agento11y_evaluator" "test" {
 }
 
 resource "grafana_agento11y_evaluation_rule" "test" {
-  rule_id       = "tf_acc_test_rule"
-  enabled       = true
-  selector      = "user_visible_turn"
-  sample_rate   = 0.1
-  evaluator_ids = [grafana_agento11y_evaluator.test.evaluator_id]
+  rule_id             = "tf_acc_test_rule"
+  enabled             = true
+  selector            = "user_visible_turn"
+  sample_rate         = 0.1
+  evaluator_ids       = [grafana_agento11y_evaluator.test.evaluator_id]
+  execution_mode      = "parallel"
+  filterable_tag_keys = ["environment", "team"]
 }

--- a/examples/resources/grafana_agento11y_evaluation_rule/resource.tf
+++ b/examples/resources/grafana_agento11y_evaluation_rule/resource.tf
@@ -16,11 +16,13 @@ resource "grafana_agento11y_evaluator" "example" {
 }
 
 resource "grafana_agento11y_evaluation_rule" "example" {
-  rule_id       = "score_user_turns"
-  enabled       = true
-  selector      = "user_visible_turn"
-  sample_rate   = 0.1
-  evaluator_ids = [grafana_agento11y_evaluator.example.evaluator_id]
+  rule_id             = "score_user_turns"
+  enabled             = true
+  selector            = "user_visible_turn"
+  sample_rate         = 0.1
+  evaluator_ids       = [grafana_agento11y_evaluator.example.evaluator_id]
+  execution_mode      = "parallel"
+  filterable_tag_keys = ["environment", "team"]
 
   match = jsonencode({
     agent_name = "checkout-*"

--- a/internal/common/agento11yapi/client_test.go
+++ b/internal/common/agento11yapi/client_test.go
@@ -95,17 +95,34 @@ func TestClient_RuleCRUD(t *testing.T) {
 	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == pathPrefix+"/rules":
-			writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}})
+			var body RuleWrite
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "bad body", http.StatusBadRequest)
+				return
+			}
+			if body.ExecutionMode != "parallel" || len(body.FilterableTagKeys) != 2 || body.FilterableTagKeys[0] != "environment" || body.FilterableTagKeys[1] != "team" {
+				http.Error(w, fmt.Sprintf("unexpected execution fields: %+v", body), http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: body.ExecutionMode, FilterableTagKeys: body.FilterableTagKeys})
 		case r.Method == http.MethodGet && r.URL.Path == pathPrefix+"/rules/"+id:
-			writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}})
+			writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: "parallel", FilterableTagKeys: []string{"environment", "team"}})
 		case r.Method == http.MethodPatch && r.URL.Path == pathPrefix+"/rules/"+id:
 			var body RulePatch
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				http.Error(w, "bad body", http.StatusBadRequest)
 				return
 			}
+			if body.ExecutionMode == nil || *body.ExecutionMode != "sequential" {
+				http.Error(w, fmt.Sprintf("unexpected execution_mode: %+v", body.ExecutionMode), http.StatusBadRequest)
+				return
+			}
+			if body.FilterableTagKeys == nil || len(body.FilterableTagKeys) != 0 {
+				http.Error(w, fmt.Sprintf("filterable_tag_keys was not explicitly cleared: %#v", body.FilterableTagKeys), http.StatusBadRequest)
+				return
+			}
 			enabled := body.Enabled != nil && *body.Enabled
-			writeJSON(t, w, Rule{RuleID: id, Enabled: enabled, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}})
+			writeJSON(t, w, Rule{RuleID: id, Enabled: enabled, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: *body.ExecutionMode})
 		case r.Method == http.MethodDelete && r.URL.Path == pathPrefix+"/rules/"+id:
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -114,9 +131,11 @@ func TestClient_RuleCRUD(t *testing.T) {
 	})
 
 	created, err := client.CreateRule(context.Background(), RuleWrite{
-		RuleID:       id,
-		SampleRate:   util.Ptr(0.5),
-		EvaluatorIDs: []string{"toxicity"},
+		RuleID:            id,
+		SampleRate:        util.Ptr(0.5),
+		EvaluatorIDs:      []string{"toxicity"},
+		ExecutionMode:     "parallel",
+		FilterableTagKeys: []string{"environment", "team"},
 	})
 	if err != nil {
 		t.Fatalf("CreateRule: %v", err)
@@ -124,17 +143,31 @@ func TestClient_RuleCRUD(t *testing.T) {
 	if created.RuleID != id {
 		t.Fatalf("unexpected id: %s", created.RuleID)
 	}
-
-	if _, err := client.GetRule(context.Background(), id); err != nil {
-		t.Fatalf("GetRule: %v", err)
+	if created.ExecutionMode != "parallel" || len(created.FilterableTagKeys) != 2 {
+		t.Fatalf("unexpected execution fields: %+v", created)
 	}
 
-	updated, err := client.UpdateRule(context.Background(), id, RulePatch{Enabled: util.Ptr(false)})
+	got, err := client.GetRule(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetRule: %v", err)
+	}
+	if got.ExecutionMode != "parallel" || len(got.FilterableTagKeys) != 2 {
+		t.Fatalf("unexpected execution fields from get: %+v", got)
+	}
+
+	updated, err := client.UpdateRule(context.Background(), id, RulePatch{
+		Enabled:           util.Ptr(false),
+		ExecutionMode:     util.Ptr("sequential"),
+		FilterableTagKeys: []string{},
+	})
 	if err != nil {
 		t.Fatalf("UpdateRule: %v", err)
 	}
 	if updated.Enabled {
 		t.Fatalf("expected rule disabled after update")
+	}
+	if updated.ExecutionMode != "sequential" || len(updated.FilterableTagKeys) != 0 {
+		t.Fatalf("unexpected execution fields after update: %+v", updated)
 	}
 
 	if err := client.DeleteRule(context.Background(), id); err != nil {

--- a/internal/common/agento11yapi/client_test.go
+++ b/internal/common/agento11yapi/client_test.go
@@ -88,46 +88,52 @@ func TestClient_EvaluatorCRUD(t *testing.T) {
 	}
 }
 
+func handleRuleCRUDTestRequest(t *testing.T, id string, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == pathPrefix+"/rules":
+		var body RuleWrite
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		if body.ExecutionMode != "parallel" || len(body.FilterableTagKeys) != 2 || body.FilterableTagKeys[0] != "environment" || body.FilterableTagKeys[1] != "team" {
+			http.Error(w, fmt.Sprintf("unexpected execution fields: %+v", body), http.StatusBadRequest)
+			return
+		}
+		writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: body.ExecutionMode, FilterableTagKeys: body.FilterableTagKeys})
+	case r.Method == http.MethodGet && r.URL.Path == pathPrefix+"/rules/"+id:
+		writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: "parallel", FilterableTagKeys: []string{"environment", "team"}})
+	case r.Method == http.MethodPatch && r.URL.Path == pathPrefix+"/rules/"+id:
+		var body RulePatch
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		if body.ExecutionMode == nil || *body.ExecutionMode != "sequential" {
+			http.Error(w, fmt.Sprintf("unexpected execution_mode: %+v", body.ExecutionMode), http.StatusBadRequest)
+			return
+		}
+		if body.FilterableTagKeys == nil || len(body.FilterableTagKeys) != 0 {
+			http.Error(w, fmt.Sprintf("filterable_tag_keys was not explicitly cleared: %#v", body.FilterableTagKeys), http.StatusBadRequest)
+			return
+		}
+		enabled := body.Enabled != nil && *body.Enabled
+		writeJSON(t, w, Rule{RuleID: id, Enabled: enabled, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: *body.ExecutionMode})
+	case r.Method == http.MethodDelete && r.URL.Path == pathPrefix+"/rules/"+id:
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
 func TestClient_RuleCRUD(t *testing.T) {
 	t.Parallel()
 
 	const id = "toxicity-rule"
 	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == pathPrefix+"/rules":
-			var body RuleWrite
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				http.Error(w, "bad body", http.StatusBadRequest)
-				return
-			}
-			if body.ExecutionMode != "parallel" || len(body.FilterableTagKeys) != 2 || body.FilterableTagKeys[0] != "environment" || body.FilterableTagKeys[1] != "team" {
-				http.Error(w, fmt.Sprintf("unexpected execution fields: %+v", body), http.StatusBadRequest)
-				return
-			}
-			writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: body.ExecutionMode, FilterableTagKeys: body.FilterableTagKeys})
-		case r.Method == http.MethodGet && r.URL.Path == pathPrefix+"/rules/"+id:
-			writeJSON(t, w, Rule{RuleID: id, Enabled: true, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: "parallel", FilterableTagKeys: []string{"environment", "team"}})
-		case r.Method == http.MethodPatch && r.URL.Path == pathPrefix+"/rules/"+id:
-			var body RulePatch
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				http.Error(w, "bad body", http.StatusBadRequest)
-				return
-			}
-			if body.ExecutionMode == nil || *body.ExecutionMode != "sequential" {
-				http.Error(w, fmt.Sprintf("unexpected execution_mode: %+v", body.ExecutionMode), http.StatusBadRequest)
-				return
-			}
-			if body.FilterableTagKeys == nil || len(body.FilterableTagKeys) != 0 {
-				http.Error(w, fmt.Sprintf("filterable_tag_keys was not explicitly cleared: %#v", body.FilterableTagKeys), http.StatusBadRequest)
-				return
-			}
-			enabled := body.Enabled != nil && *body.Enabled
-			writeJSON(t, w, Rule{RuleID: id, Enabled: enabled, Selector: "user_visible_turn", SampleRate: 0.5, EvaluatorIDs: []string{"toxicity"}, ExecutionMode: *body.ExecutionMode})
-		case r.Method == http.MethodDelete && r.URL.Path == pathPrefix+"/rules/"+id:
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			http.NotFound(w, r)
-		}
+		handleRuleCRUDTestRequest(t, id, w, r)
 	})
 
 	created, err := client.CreateRule(context.Background(), RuleWrite{

--- a/internal/common/agento11yapi/models.go
+++ b/internal/common/agento11yapi/models.go
@@ -62,42 +62,48 @@ type EvaluatorWrite struct {
 
 // Rule is an asynchronous (online) evaluation rule returned by the API.
 type Rule struct {
-	TenantID       string          `json:"tenant_id"`
-	RuleID         string          `json:"rule_id"`
-	Enabled        bool            `json:"enabled"`
-	Selector       string          `json:"selector"`
-	Match          json.RawMessage `json:"match,omitempty"`
-	SampleRate     float64         `json:"sample_rate"`
-	EvaluatorIDs   []string        `json:"evaluator_ids"`
-	AlertRuleUIDs  []string        `json:"alert_rule_uids,omitempty"`
-	MinIdleSeconds *int            `json:"min_idle_seconds,omitempty"`
-	CreatedBy      string          `json:"created_by,omitempty"`
-	UpdatedBy      string          `json:"updated_by,omitempty"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
+	TenantID          string          `json:"tenant_id"`
+	RuleID            string          `json:"rule_id"`
+	Enabled           bool            `json:"enabled"`
+	Selector          string          `json:"selector"`
+	Match             json.RawMessage `json:"match,omitempty"`
+	SampleRate        float64         `json:"sample_rate"`
+	EvaluatorIDs      []string        `json:"evaluator_ids"`
+	ExecutionMode     string          `json:"execution_mode,omitempty"`
+	AlertRuleUIDs     []string        `json:"alert_rule_uids,omitempty"`
+	FilterableTagKeys []string        `json:"filterable_tag_keys,omitempty"`
+	MinIdleSeconds    *int            `json:"min_idle_seconds,omitempty"`
+	CreatedBy         string          `json:"created_by,omitempty"`
+	UpdatedBy         string          `json:"updated_by,omitempty"`
+	CreatedAt         time.Time       `json:"created_at"`
+	UpdatedAt         time.Time       `json:"updated_at"`
 }
 
 // RuleWrite is the request body to create (or upsert) an evaluation rule.
 type RuleWrite struct {
-	RuleID         string          `json:"rule_id"`
-	Enabled        *bool           `json:"enabled,omitempty"`
-	Selector       string          `json:"selector,omitempty"`
-	Match          json.RawMessage `json:"match,omitempty"`
-	SampleRate     *float64        `json:"sample_rate,omitempty"`
-	EvaluatorIDs   []string        `json:"evaluator_ids"`
-	AlertRuleUIDs  []string        `json:"alert_rule_uids,omitempty"`
-	MinIdleSeconds *int            `json:"min_idle_seconds,omitempty"`
+	RuleID            string          `json:"rule_id"`
+	Enabled           *bool           `json:"enabled,omitempty"`
+	Selector          string          `json:"selector,omitempty"`
+	Match             json.RawMessage `json:"match,omitempty"`
+	SampleRate        *float64        `json:"sample_rate,omitempty"`
+	EvaluatorIDs      []string        `json:"evaluator_ids"`
+	ExecutionMode     string          `json:"execution_mode,omitempty"`
+	AlertRuleUIDs     []string        `json:"alert_rule_uids,omitempty"`
+	FilterableTagKeys []string        `json:"filterable_tag_keys,omitempty"`
+	MinIdleSeconds    *int            `json:"min_idle_seconds,omitempty"`
 }
 
 // RulePatch is the request body to partially update an evaluation rule.
 type RulePatch struct {
-	Enabled        *bool           `json:"enabled,omitempty"`
-	Selector       *string         `json:"selector,omitempty"`
-	Match          json.RawMessage `json:"match,omitempty"`
-	SampleRate     *float64        `json:"sample_rate,omitempty"`
-	EvaluatorIDs   []string        `json:"evaluator_ids,omitempty"`
-	AlertRuleUIDs  []string        `json:"alert_rule_uids,omitempty"`
-	MinIdleSeconds *int            `json:"min_idle_seconds,omitempty"`
+	Enabled           *bool           `json:"enabled,omitempty"`
+	Selector          *string         `json:"selector,omitempty"`
+	Match             json.RawMessage `json:"match,omitempty"`
+	SampleRate        *float64        `json:"sample_rate,omitempty"`
+	EvaluatorIDs      []string        `json:"evaluator_ids,omitempty"`
+	ExecutionMode     *string         `json:"execution_mode,omitempty"`
+	AlertRuleUIDs     []string        `json:"alert_rule_uids,omitempty"`
+	FilterableTagKeys []string        `json:"filterable_tag_keys"`
+	MinIdleSeconds    *int            `json:"min_idle_seconds,omitempty"`
 }
 
 // RuleActionCondition is the trigger expression attached to a rule action.

--- a/internal/resources/agento11y/resource_agento11y_test.go
+++ b/internal/resources/agento11y/resource_agento11y_test.go
@@ -139,15 +139,31 @@ func TestAccAgento11yEvaluationRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "rule_id", "tf_acc_test_rule"),
 					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "selector", "user_visible_turn"),
 					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "sample_rate", "0.1"),
+					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "execution_mode", "parallel"),
+					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "filterable_tag_keys.#", "2"),
+					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "filterable_tag_keys.0", "environment"),
+					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "filterable_tag_keys.1", "team"),
 					testutils.CheckLister("grafana_agento11y_evaluation_rule.test"),
 				),
 			},
 			{
 				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_agento11y_evaluation_rule/_acc_basic.tf", map[string]string{
-					"enabled       = true": "enabled       = false",
+					"enabled             = true":       "enabled             = false",
+					`execution_mode      = "parallel"`: `execution_mode      = "sequential"`,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "enabled", "false"),
+					resource.TestCheckResourceAttr("grafana_agento11y_evaluation_rule.test", "execution_mode", "sequential"),
+				),
+			},
+			{
+				Config: testutils.TestAccExampleWithReplace(t, "resources/grafana_agento11y_evaluation_rule/_acc_basic.tf", map[string]string{
+					"enabled             = true":                             "enabled             = false",
+					`execution_mode      = "parallel"`:                       `execution_mode      = "sequential"`,
+					`  filterable_tag_keys = ["environment", "team"]` + "\n": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("grafana_agento11y_evaluation_rule.test", "filterable_tag_keys"),
 				),
 			},
 			{

--- a/internal/resources/agento11y/resource_evaluation_rule.go
+++ b/internal/resources/agento11y/resource_evaluation_rule.go
@@ -26,7 +26,12 @@ import (
 
 const resourceEvaluationRuleName = "grafana_agento11y_evaluation_rule"
 
-const selectorConversation = "conversation"
+const (
+	selectorConversation        = "conversation"
+	executionModeParallel       = "parallel"
+	executionModeSequential     = "sequential"
+	maxFilterableTagKeysPerRule = 10
+)
 
 var resourceEvaluationRuleID = common.NewResourceID(common.StringIDField("rule_id"))
 
@@ -35,15 +40,17 @@ type evaluationRuleResource struct {
 }
 
 type evaluationRuleModel struct {
-	ID             types.String         `tfsdk:"id"`
-	RuleID         types.String         `tfsdk:"rule_id"`
-	Enabled        types.Bool           `tfsdk:"enabled"`
-	Selector       types.String         `tfsdk:"selector"`
-	Match          jsontypes.Normalized `tfsdk:"match"`
-	SampleRate     types.Float64        `tfsdk:"sample_rate"`
-	EvaluatorIDs   types.List           `tfsdk:"evaluator_ids"`
-	AlertRuleUIDs  types.List           `tfsdk:"alert_rule_uids"`
-	MinIdleSeconds types.Int64          `tfsdk:"min_idle_seconds"`
+	ID                types.String         `tfsdk:"id"`
+	RuleID            types.String         `tfsdk:"rule_id"`
+	Enabled           types.Bool           `tfsdk:"enabled"`
+	Selector          types.String         `tfsdk:"selector"`
+	Match             jsontypes.Normalized `tfsdk:"match"`
+	SampleRate        types.Float64        `tfsdk:"sample_rate"`
+	EvaluatorIDs      types.List           `tfsdk:"evaluator_ids"`
+	ExecutionMode     types.String         `tfsdk:"execution_mode"`
+	AlertRuleUIDs     types.List           `tfsdk:"alert_rule_uids"`
+	FilterableTagKeys types.List           `tfsdk:"filterable_tag_keys"`
+	MinIdleSeconds    types.Int64          `tfsdk:"min_idle_seconds"`
 }
 
 func makeResourceEvaluationRule() *common.Resource {
@@ -114,10 +121,32 @@ func (r *evaluationRuleResource) Schema(_ context.Context, _ resource.SchemaRequ
 					listvalidator.SizeAtLeast(1),
 				},
 			},
+			"execution_mode": schema.StringAttribute{
+				Description: "How evaluators execute. `parallel` runs all evaluators independently; `sequential` treats `evaluator_ids` as an ordered gate chain. Defaults to `parallel`.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(executionModeParallel),
+				Validators: []validator.String{
+					stringvalidator.OneOf(executionModeParallel, executionModeSequential),
+				},
+			},
 			"alert_rule_uids": schema.ListAttribute{
 				Description: "Optional Grafana alert rule UIDs associated with this evaluation rule.",
 				Optional:    true,
 				ElementType: types.StringType,
+			},
+			"filterable_tag_keys": schema.ListAttribute{
+				Description: "Generation tag keys to promote to Prometheus labels on evaluation metrics. Supports at most 10 unique, non-empty keys and cannot be set when `selector` is `conversation`.",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(maxFilterableTagKeysPerRule),
+					listvalidator.UniqueValues(),
+					listvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+						trimmedStringValidator{},
+					),
+				},
 			},
 			"min_idle_seconds": schema.Int64Attribute{
 				Description: "Idle window, in seconds, before a conversation-scope rule runs. Required when `selector` is `conversation`; must be unset otherwise.",
@@ -138,12 +167,15 @@ func (r *evaluationRuleResource) Configure(_ context.Context, req resource.Confi
 	r.client = client
 }
 
-// validateSelectorIdle enforces the conversation/min_idle_seconds invariant.
-func validateSelectorIdle(selector string, minIdle types.Int64) diag.Diagnostics {
+// validateRuleSelection enforces the selector-specific rule invariants.
+func validateRuleSelection(selector string, minIdle types.Int64, filterableTagKeys types.List) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if selector == selectorConversation {
 		if minIdle.IsNull() || minIdle.IsUnknown() {
 			diags.AddError("Invalid evaluation rule", "min_idle_seconds is required when selector is \"conversation\"")
+		}
+		if !filterableTagKeys.IsNull() && !filterableTagKeys.IsUnknown() && len(filterableTagKeys.Elements()) > 0 {
+			diags.AddError("Invalid evaluation rule", "filterable_tag_keys cannot be set when selector is \"conversation\"")
 		}
 		return diags
 	}
@@ -160,7 +192,7 @@ func (r *evaluationRuleResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	resp.Diagnostics.Append(validateSelectorIdle(plan.Selector.ValueString(), plan.MinIdleSeconds)...)
+	resp.Diagnostics.Append(validateRuleSelection(plan.Selector.ValueString(), plan.MinIdleSeconds, plan.FilterableTagKeys)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -169,18 +201,22 @@ func (r *evaluationRuleResource) Create(ctx context.Context, req resource.Create
 	resp.Diagnostics.Append(diags...)
 	alertUIDs, diags := listValueToStrings(ctx, plan.AlertRuleUIDs)
 	resp.Diagnostics.Append(diags...)
+	filterableTagKeys, diags := listValueToStrings(ctx, plan.FilterableTagKeys)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	body := agento11yapi.RuleWrite{
-		RuleID:        plan.RuleID.ValueString(),
-		Enabled:       util.Ptr(plan.Enabled.ValueBool()),
-		Selector:      plan.Selector.ValueString(),
-		Match:         rawJSONFromNormalized(plan.Match),
-		SampleRate:    util.Ptr(plan.SampleRate.ValueFloat64()),
-		EvaluatorIDs:  evaluatorIDs,
-		AlertRuleUIDs: alertUIDs,
+		RuleID:            plan.RuleID.ValueString(),
+		Enabled:           util.Ptr(plan.Enabled.ValueBool()),
+		Selector:          plan.Selector.ValueString(),
+		Match:             rawJSONFromNormalized(plan.Match),
+		SampleRate:        util.Ptr(plan.SampleRate.ValueFloat64()),
+		EvaluatorIDs:      evaluatorIDs,
+		ExecutionMode:     plan.ExecutionMode.ValueString(),
+		AlertRuleUIDs:     alertUIDs,
+		FilterableTagKeys: filterableTagKeys,
 	}
 	if plan.Selector.ValueString() == selectorConversation && !plan.MinIdleSeconds.IsNull() {
 		body.MinIdleSeconds = util.Ptr(int(plan.MinIdleSeconds.ValueInt64()))
@@ -233,7 +269,7 @@ func (r *evaluationRuleResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	resp.Diagnostics.Append(validateSelectorIdle(plan.Selector.ValueString(), plan.MinIdleSeconds)...)
+	resp.Diagnostics.Append(validateRuleSelection(plan.Selector.ValueString(), plan.MinIdleSeconds, plan.FilterableTagKeys)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -242,23 +278,32 @@ func (r *evaluationRuleResource) Update(ctx context.Context, req resource.Update
 	resp.Diagnostics.Append(diags...)
 	alertUIDs, diags := listValueToStrings(ctx, plan.AlertRuleUIDs)
 	resp.Diagnostics.Append(diags...)
+	filterableTagKeys, diags := listValueToStrings(ctx, plan.FilterableTagKeys)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	if filterableTagKeys == nil {
+		// PATCH requires an explicit empty list to clear previously configured keys.
+		filterableTagKeys = []string{}
+	}
 
 	selector := plan.Selector.ValueString()
+	executionMode := plan.ExecutionMode.ValueString()
 	match := rawJSONFromNormalized(plan.Match)
 	if match == nil {
 		// Send an explicit empty object so PATCH clears a previously-set match.
 		match = []byte("{}")
 	}
 	patch := agento11yapi.RulePatch{
-		Enabled:       util.Ptr(plan.Enabled.ValueBool()),
-		Selector:      &selector,
-		Match:         match,
-		SampleRate:    util.Ptr(plan.SampleRate.ValueFloat64()),
-		EvaluatorIDs:  evaluatorIDs,
-		AlertRuleUIDs: alertUIDs,
+		Enabled:           util.Ptr(plan.Enabled.ValueBool()),
+		Selector:          &selector,
+		Match:             match,
+		SampleRate:        util.Ptr(plan.SampleRate.ValueFloat64()),
+		EvaluatorIDs:      evaluatorIDs,
+		ExecutionMode:     &executionMode,
+		AlertRuleUIDs:     alertUIDs,
+		FilterableTagKeys: filterableTagKeys,
 	}
 	if selector == selectorConversation && !plan.MinIdleSeconds.IsNull() {
 		patch.MinIdleSeconds = util.Ptr(int(plan.MinIdleSeconds.ValueInt64()))
@@ -310,16 +355,20 @@ func ruleToModel(ctx context.Context, rule agento11yapi.Rule) (evaluationRuleMod
 	diags.Append(d...)
 	alertUIDs, d := stringsToListValue(ctx, rule.AlertRuleUIDs)
 	diags.Append(d...)
+	filterableTagKeys, d := stringsToListValue(ctx, rule.FilterableTagKeys)
+	diags.Append(d...)
 
 	return evaluationRuleModel{
-		ID:             types.StringValue(rule.RuleID),
-		RuleID:         types.StringValue(rule.RuleID),
-		Enabled:        types.BoolValue(rule.Enabled),
-		Selector:       types.StringValue(rule.Selector),
-		Match:          normalizedMatchOrNull(rule.Match),
-		SampleRate:     types.Float64Value(rule.SampleRate),
-		EvaluatorIDs:   evaluatorIDs,
-		AlertRuleUIDs:  alertUIDs,
-		MinIdleSeconds: int64PtrValue(rule.MinIdleSeconds),
+		ID:                types.StringValue(rule.RuleID),
+		RuleID:            types.StringValue(rule.RuleID),
+		Enabled:           types.BoolValue(rule.Enabled),
+		Selector:          types.StringValue(rule.Selector),
+		Match:             normalizedMatchOrNull(rule.Match),
+		SampleRate:        types.Float64Value(rule.SampleRate),
+		EvaluatorIDs:      evaluatorIDs,
+		ExecutionMode:     types.StringValue(rule.ExecutionMode),
+		AlertRuleUIDs:     alertUIDs,
+		FilterableTagKeys: filterableTagKeys,
+		MinIdleSeconds:    int64PtrValue(rule.MinIdleSeconds),
 	}, diags
 }

--- a/internal/resources/agento11y/resource_evaluation_rule_unit_test.go
+++ b/internal/resources/agento11y/resource_evaluation_rule_unit_test.go
@@ -1,0 +1,76 @@
+package agento11y
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/grafana/terraform-provider-grafana/v4/internal/common/agento11yapi"
+)
+
+func TestUnitEvaluationRuleSchemaIncludesExecutionAndTagFields(t *testing.T) {
+	t.Parallel()
+
+	var resp resource.SchemaResponse
+	(&evaluationRuleResource{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", resp.Diagnostics)
+	}
+
+	executionMode, ok := resp.Schema.Attributes["execution_mode"].(schema.StringAttribute)
+	if !ok {
+		t.Fatal("execution_mode is not a string attribute")
+	}
+	if !executionMode.Optional || !executionMode.Computed {
+		t.Fatal("execution_mode must be optional and computed")
+	}
+
+	filterableTagKeys, ok := resp.Schema.Attributes["filterable_tag_keys"].(schema.ListAttribute)
+	if !ok {
+		t.Fatal("filterable_tag_keys is not a list attribute")
+	}
+	if !filterableTagKeys.Optional || filterableTagKeys.ElementType != types.StringType {
+		t.Fatal("filterable_tag_keys must be an optional list of strings")
+	}
+}
+
+func TestUnitEvaluationRuleToModelIncludesExecutionAndTagFields(t *testing.T) {
+	t.Parallel()
+
+	model, diags := ruleToModel(context.Background(), agento11yapi.Rule{
+		RuleID:            "quality-gate",
+		ExecutionMode:     executionModeSequential,
+		FilterableTagKeys: []string{"environment", "team"},
+	})
+	if diags.HasError() {
+		t.Fatalf("ruleToModel diagnostics: %v", diags)
+	}
+	if model.ExecutionMode != types.StringValue(executionModeSequential) {
+		t.Fatalf("execution_mode = %v, want %q", model.ExecutionMode, executionModeSequential)
+	}
+
+	var gotTagKeys []string
+	diags = model.FilterableTagKeys.ElementsAs(context.Background(), &gotTagKeys, false)
+	if diags.HasError() {
+		t.Fatalf("filterable_tag_keys diagnostics: %v", diags)
+	}
+	if len(gotTagKeys) != 2 || gotTagKeys[0] != "environment" || gotTagKeys[1] != "team" {
+		t.Fatalf("filterable_tag_keys = %v, want [environment team]", gotTagKeys)
+	}
+}
+
+func TestUnitEvaluationRuleRejectsConversationFilterableTags(t *testing.T) {
+	t.Parallel()
+
+	tagKeys, diags := types.ListValueFrom(context.Background(), types.StringType, []string{"team"})
+	if diags.HasError() {
+		t.Fatalf("build filterable_tag_keys: %v", diags)
+	}
+	got := validateRuleSelection(selectorConversation, types.Int64Value(60), tagKeys)
+	if !got.HasError() {
+		t.Fatal("expected conversation rule with filterable_tag_keys to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

- expose `execution_mode` and `filterable_tag_keys` on `grafana_agento11y_evaluation_rule`
- round-trip both fields through create, read, update, import, and API models
- validate supported execution modes and filterable tag constraints, including explicit clearing on update
- update examples, generated docs, unit tests, and acceptance coverage

Closes grafana/sigil#1515.

## Test plan

- [x] `go test ./... -run TestUnit`
- [x] `go test ./internal/common/agento11yapi ./internal/resources/agento11y`
- [x] Run Sigil's cross-repository `TestTerraformProviderContract`; report contains no findings