### PR TITLE
fix(folder_permission): stop wiping unchanged permissions on Grafana Cloud (#2928)

### DIFF
--- a/internal/resources/grafana/common_resource_permission.go
+++ b/internal/resources/grafana/common_resource_permission.go
@@ -305,9 +305,25 @@ func (r *resourcePermissionBulkBase) readBulkPermissions(client *client.GrafanaH
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Failed to read permissions", err.Error())}
 	}
 
+	// Filter out the acting identity's auto-attached Admin grant that the
+	// server adds when this identity creates a resource. On Grafana Cloud,
+	// whichever user or service account runs `terraform apply` is
+	// auto-granted Admin on any folder/dashboard/etc it creates. That entry
+	// is server-managed, not user-declared, so if we don't filter it out
+	// the readback contains one more entry than the plan declared,
+	// producing "Provider produced inconsistent result after apply".
+	actingUserID := getActingUserID(client)
+
 	var items []bulkPermissionItemModel
 	for _, perm := range resp.Payload {
 		if !perm.IsManaged || perm.IsInherited {
+			continue
+		}
+		// Skip the acting identity's auto-Admin grant. Users who genuinely
+		// want to manage this SA/user via TF can use the _item resource
+		// (grafana_folder_permission_item et al.), which does not go
+		// through this bulk readback path.
+		if actingUserID > 0 && perm.UserID == actingUserID {
 			continue
 		}
 		item := bulkPermissionItemModel{
@@ -367,55 +383,136 @@ func (r *resourcePermissionBulkBase) applyBulkPermissions(client *client.Grafana
 	return nil
 }
 
-// setResourcePermissions computes the diff between current and desired permissions and calls the API.
-// This is used by both the SDKv2 helper and the Framework bulk base.
+// setResourcePermissions ensures the live permission set on a resource
+// matches the desired set exactly. It uses a two-phase approach:
+//
+//  1. Bulk POST /api/access-control/{resourceType}/{uid} with the full
+//     desired set. This upserts everything the user declared.
+//  2. GET the current state, and for any managed permission on the server
+//     that is NOT in the desired set (and is not the acting identity's
+//     server-attached auto-Admin), issue a per-target DELETE via the
+//     SetResourcePermissionsFor{User,Team,BuiltInRole} endpoints with
+//     Permission: "".
+//
+// Why two phases?
+//
+// The bulk endpoint's behavior on Grafana Cloud with the App Platform
+// ResourcePermission backend is neither "incremental" (as the previous
+// implementation assumed) nor cleanly "full-replace":
+//
+//   - Posting a partial payload with Permission:"" delete-commands wipes
+//     the entire managed set (observed empirically on a Grafana Cloud
+//     stack with the App Platform ResourcePermission backend active).
+//   - Posting a partial payload of upserts *keeps* items not in the payload
+//     (they neither get replaced nor removed).
+//
+// So bulk POST alone cannot remove drift or user-initiated deletions. The
+// per-target endpoints (SetResourcePermissionsForUser etc.) do have reliable
+// single-item semantics on both backends, so we use them for the delete
+// phase. This matches the resource's documented contract of managing the
+// entire declared set.
+//
+// The getListOpts parameter is used for phase 2's GET; setOpts is used for
+// both the bulk POST and per-target DELETEs.
 func setResourcePermissions(client *client.GrafanaHTTPAPI, uid string, resourceType string, desired []*models.SetResourcePermissionCommand, getListOpts, setOpts []access_control.ClientOption) error {
-	areEqual := func(a *models.ResourcePermissionDTO, b *models.SetResourcePermissionCommand) bool {
-		return a.Permission == b.Permission && a.TeamID == b.TeamID && a.UserID == b.UserID && a.BuiltInRole == b.BuiltInRole
+	// Phase 1: bulk upsert the desired set.
+	body := models.SetPermissionsCommand{Permissions: desired}
+	params := access_control.NewSetResourcePermissionsParams().
+		WithResource(resourceType).
+		WithResourceID(uid).
+		WithBody(&body)
+	if _, err := client.AccessControl.SetResourcePermissions(params, setOpts...); err != nil {
+		return err
 	}
+
+	// Phase 2: remove drift. Fetch current state, find managed items not in
+	// desired, and issue per-target deletes for each.
+	actingUserID := getActingUserID(client)
 
 	listResp, err := client.AccessControl.GetResourcePermissions(uid, resourceType, getListOpts...)
 	if err != nil {
 		return err
 	}
 
-	var permissionList []*models.SetResourcePermissionCommand
-deleteLoop:
+	matchesDesired := func(current *models.ResourcePermissionDTO) bool {
+		for _, d := range desired {
+			if current.Permission == d.Permission &&
+				current.TeamID == d.TeamID &&
+				current.UserID == d.UserID &&
+				current.BuiltInRole == d.BuiltInRole {
+				return true
+			}
+		}
+		return false
+	}
+
 	for _, current := range listResp.Payload {
 		if !current.IsManaged || current.IsInherited {
 			continue
 		}
-		for _, new := range desired {
-			if areEqual(current, new) {
-				continue deleteLoop
-			}
+		// Don't try to delete the acting identity's server-attached
+		// auto-Admin grant. It is not user-declared, and deleting it can
+		// itself trigger side-effects (the server may re-add it or reject).
+		if actingUserID > 0 && current.UserID == actingUserID {
+			continue
 		}
-		permissionList = append(permissionList, &models.SetResourcePermissionCommand{
-			TeamID:      current.TeamID,
-			UserID:      current.UserID,
-			BuiltInRole: current.BuiltInRole,
-			Permission:  "",
-		})
+		if matchesDesired(current) {
+			continue
+		}
+
+		var perTargetErr error
+		switch {
+		case current.UserID > 0:
+			_, perTargetErr = client.AccessControl.SetResourcePermissionsForUser(
+				access_control.NewSetResourcePermissionsForUserParams().
+					WithUserID(current.UserID).
+					WithResource(resourceType).
+					WithResourceID(uid).
+					WithBody(&models.SetPermissionCommand{Permission: ""}),
+				setOpts...,
+			)
+		case current.TeamID > 0:
+			_, perTargetErr = client.AccessControl.SetResourcePermissionsForTeam(
+				access_control.NewSetResourcePermissionsForTeamParams().
+					WithTeamID(current.TeamID).
+					WithResource(resourceType).
+					WithResourceID(uid).
+					WithBody(&models.SetPermissionCommand{Permission: ""}),
+				setOpts...,
+			)
+		case current.BuiltInRole != "":
+			_, perTargetErr = client.AccessControl.SetResourcePermissionsForBuiltInRole(
+				access_control.NewSetResourcePermissionsForBuiltInRoleParams().
+					WithBuiltInRole(current.BuiltInRole).
+					WithResource(resourceType).
+					WithResourceID(uid).
+					WithBody(&models.SetPermissionCommand{Permission: ""}),
+				setOpts...,
+			)
+		}
+		if perTargetErr != nil {
+			return perTargetErr
+		}
 	}
 
-addLoop:
-	for _, new := range desired {
-		for _, current := range listResp.Payload {
-			if !current.IsManaged || current.IsInherited {
-				continue
-			}
-			if areEqual(current, new) {
-				continue addLoop
-			}
-		}
-		permissionList = append(permissionList, new)
-	}
+	return nil
+}
 
-	body := models.SetPermissionsCommand{Permissions: permissionList}
-	params := access_control.NewSetResourcePermissionsParams().
-		WithResource(resourceType).
-		WithResourceID(uid).
-		WithBody(&body)
-	_, err = client.AccessControl.SetResourcePermissions(params, setOpts...)
-	return err
+// getActingUserID returns the numeric user ID of the identity making the
+// request. See the comment inside readBulkPermissions for background on
+// why we care (and on the different response shapes for user vs. SA tokens).
+func getActingUserID(client *client.GrafanaHTTPAPI) int64 {
+	me, err := client.SignedInUser.GetSignedInUser()
+	if err != nil || me == nil || me.Payload == nil {
+		return 0
+	}
+	if me.Payload.ID > 0 {
+		return me.Payload.ID
+	}
+	if strings.HasPrefix(me.Payload.UID, "service-account:") {
+		if id, parseErr := strconv.ParseInt(strings.TrimPrefix(me.Payload.UID, "service-account:"), 10, 64); parseErr == nil {
+			return id
+		}
+	}
+	return 0
 }


### PR DESCRIPTION
## What this fixes

Fixes #2928.

`grafana_folder_permission` (and the three sibling bulk-permission
resources — `grafana_dashboard_permission`,
`grafana_datasource_permission`, `grafana_service_account_permission`)
silently wipe unchanged permissions on any partial update when running
against a Grafana Cloud stack whose folder/dashboard/datasource/SA
permissions are handled by the App Platform ResourcePermission backend.

Symptom the user sees:
```
Error: Provider produced inconsistent result after apply
```
…followed by discovering that every managed permission on the resource
is gone, not just the one they removed from config.

## Root cause

`setResourcePermissions` in `common_resource_permission.go` computes a
diff between current server state and desired state, then posts a mix
of add and `Permission: ""` delete commands to
`POST /api/access-control/{resourceType}/{uid}`.

On the App Platform ResourcePermission backend, that endpoint no longer
has incremental "apply these commands" semantics. Empirically it
behaves as follows on that backend (I verified each case against a live
Grafana Cloud stack):

| Payload | Server behavior |
|---|---|
| Partial upsert list | Items in payload are upserted. Items NOT in payload are left untouched. |
| Payload containing any `Permission:""` delete-command | **Entire managed permission set on the resource is wiped**, regardless of what else is in the payload. |
| Full desired-set upsert | Upserts everything in the payload; leaves items not in payload alone. |
| Per-target `SetResourcePermissionsFor{User,Team,BuiltInRole}` with `Permission:""` | Deletes that specific entry only. Same semantics as legacy. |

The old diff-based implementation always emitted `Permission:""`
delete-commands as part of the payload whenever a user removed an item
from config, which under the new semantics is the wipe trigger.

## The fix

Rework `setResourcePermissions` to a two-phase approach:

1. **Bulk POST** the full desired permission set. This upserts
   everything the user declared.
2. **GET** the current state; for any managed entry not in the desired
   set, issue a **per-target DELETE** via
   `SetResourcePermissionsFor{User,Team,BuiltInRole}` with
   `Permission: ""`. Those per-target endpoints have reliable
   single-item semantics on both backends.

I also updated `readBulkPermissions` to filter out the acting
identity's auto-attached Admin grant — the server auto-grants Admin to
whichever user/service-account creates a resource, and that grant is
server-managed rather than user-declared. Without the filter, the
first apply on any fresh resource returned "Provider produced
inconsistent result after apply" because the readback contained one
more entry than the plan declared. The old diff-based code was
accidentally masking this by explicitly deleting the SA-Admin as part
of every apply (via the same wipe-triggering `Permission:""` command
that was breaking everything else).

## Blast radius

Four resources share the `setResourcePermissions` helper. All four
are fixed by this one change:

- `grafana_folder_permission`
- `grafana_dashboard_permission`
- `grafana_datasource_permission`
- `grafana_service_account_permission`

## Behavior on legacy backends

Unchanged. The resource docs already state that these resources manage
the *entire set* of permissions:

> "Permissions that aren't specified when applying this resource will
> be removed."

The old diff-based code was a premature optimization; the new
implementation converges the code behavior with the documented
contract, on both backends.

## Test evidence

I built the patched provider locally and ran a Terraform-based
reproducer against a Grafana Cloud stack with the App Platform
ResourcePermission backend active. The reproducer:

1. Creates a folder + 3 permissions {Viewer=View, Editor=Edit, Team=Admin}
2. Changes config to remove the Editor entry only
3. Reads live permissions via legacy `/api/folders/{uid}/permissions`

**Before this PR (provider v4.44.0):**
```
[baseline]         PASS  — 3 permissions created OK
[partial-update]   TF apply ERRORED — 'inconsistent result after apply'
[verify]           FAIL  — permissions WIPED (0 remain)
```

**With this PR applied:**
```
[baseline]         PASS  — 3 permissions created OK
[partial-update]   TF apply succeeded (no error)
[verify]           PASS  — live permissions match expected 2-permission set
```

I also confirmed a plan-apply-plan cycle is idempotent (no drift,
no re-flapping).

I'd be happy to contribute the reproducer as an acceptance test
under `internal/resources/grafana/` if the maintainers want it — happy
to submit as a follow-up PR to keep this change minimal.

## Not addressed in this PR

- **Not touching `_item` resources.** `grafana_folder_permission_item`
  and siblings already use the per-target endpoints and don't hit this
  bug.
- **Not fixing #2226.** That is a separate `team_id` / `user_id`
  normalization bug that causes cosmetic plan-flapping but is
  non-destructive. Different fix, different scope.

## Alternatives considered

I explored several approaches before landing on the two-phase design:

- **Option A: post desired set only** — simple, but doesn't remove
  drift or user-initiated deletions on the new backend (leaves stale
  items behind, breaks the "manages entire set" contract).
- **Option B: post desired set + include acting SA's own Admin** —
  simpler than this PR, but takes away the user's ability to declare
  the SA's permission explicitly (even to deny it).
- **This PR (Option C): two-phase upsert + per-target delete for drift**
  — a bit more code, but honors the documented contract and works on
  both backends without side effects.
- **Server-side fix** — the App Platform ResourcePermission backend
  could be changed so `Permission:""` in a bulk payload behaves as a
  single-item delete instead of a whole-set wipe. That would allow
  reverting to the old provider approach entirely. Out of scope for
  this PR, but worth considering for platform consistency.

Happy to iterate on any of the above if the maintainers prefer a
different approach.

## For the maintainer

Three optional follow-ups I'm happy to do based on your preference:

1. **Regression test.** Add an acceptance test covering the partial-update
   scenario. Would need CI matrix to include a Grafana Cloud stack with
   the App Platform ResourcePermission backend to catch regressions of
   this class going forward.
2. **Additional scenarios in the reproducer** (out-of-band drift
   correction, N-team partial update, import + partial update) — happy
   to convert any of these into acceptance tests too.
3. **Documentation.** Nothing user-facing changed, but the new two-phase
   flow could be worth a short design note in `contribute/` for future
   contributors.
