### PR TITLE
docs: document stack_id as required for Grafana Cloud

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,9 @@ provider "grafana" {
   url  = grafana_cloud_stack.stack.url
   auth = grafana_cloud_stack_service_account_token.sa_token.key
 
+  // Required on Grafana Cloud: selects the "stacks-<stack_id>" namespace
+  stack_id = grafana_cloud_stack.stack.id
+
   // Cloud Provider (AWS/Azure)
   cloud_provider_url          = grafana_cloud_stack.stack.cloud_provider_url
   cloud_provider_access_token = grafana_cloud_access_policy_token.all_services.token
@@ -151,6 +154,8 @@ provider "grafana" {
   frontend_o11y_api_access_token = grafana_cloud_access_policy_token.all_services.token
 }
 ```
+
+~> **Always set `stack_id` when targeting Grafana Cloud.** It selects the `stacks-<stack_id>` namespace required by the App Platform API, which resources are progressively migrating to. Already required by `grafana_apps_*`, Asserts, [`grafana_scim_config`](resources/scim_config.md), and k6.
 
 For Synthetic Monitoring and k6 setup, see the [`grafana_synthetic_monitoring_installation`](resources/synthetic_monitoring_installation.md) and [`grafana_k6_installation`](resources/k6_installation.md) resources, which include comprehensive examples.
 
@@ -183,7 +188,7 @@ For Synthetic Monitoring and k6 setup, see the [`grafana_synthetic_monitoring_in
 - `retry_wait` (Number) The amount of time in seconds to wait between retries for Grafana API and Grafana Cloud API calls. May alternatively be set via the `GRAFANA_RETRY_WAIT` environment variable.
 - `sm_access_token` (String, Sensitive) A Synthetic Monitoring access token. May alternatively be set via the `GRAFANA_SM_ACCESS_TOKEN` environment variable.
 - `sm_url` (String) Synthetic monitoring backend address. May alternatively be set via the `GRAFANA_SM_URL` environment variable. The correct value for each service region is cited in the [Synthetic Monitoring documentation](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#probe-api-server-url). Note the `sm_url` value is optional, but it must correspond with the value specified as the `region_slug` in the `grafana_cloud_stack` resource. Also note that when a Terraform configuration contains multiple provider instances managing SM resources associated with the same Grafana stack, specifying an explicit `sm_url` set to the same value for each provider ensures all providers interact with the same SM API.
-- `stack_id` (Number) The Grafana stack ID, if you are using a Grafana Cloud stack. May alternatively be set via the `GRAFANA_STACK_ID` environment variable.
+- `stack_id` (Number) The Grafana stack ID. Always set this when targeting a Grafana Cloud stack: it selects the `stacks-<stack_id>` namespace required by the App Platform API. May alternatively be set via the `GRAFANA_STACK_ID` environment variable.
 - `store_dashboard_sha256` (Boolean) Set to true if you want to save only the sha256sum instead of complete dashboard model JSON in the tfstate.
 - `tls_cert` (String) Client TLS certificate (file path or literal value) to use to authenticate to the Grafana server. May alternatively be set via the `GRAFANA_TLS_CERT` environment variable.
 - `tls_key` (String) Client TLS key (file path or literal value) to use to authenticate to the Grafana server. May alternatively be set via the `GRAFANA_TLS_KEY` environment variable.

--- a/examples/provider/provider-cloud.tf
+++ b/examples/provider/provider-cloud.tf
@@ -84,6 +84,9 @@ provider "grafana" {
   url  = grafana_cloud_stack.stack.url
   auth = grafana_cloud_stack_service_account_token.sa_token.key
 
+  // Required on Grafana Cloud: selects the "stacks-<stack_id>" namespace
+  stack_id = grafana_cloud_stack.stack.id
+
   // Cloud Provider (AWS/Azure)
   cloud_provider_url          = grafana_cloud_stack.stack.cloud_provider_url
   cloud_provider_access_token = grafana_cloud_access_policy_token.all_services.token

--- a/pkg/generate/postprocessing/replace_references.go
+++ b/pkg/generate/postprocessing/replace_references.go
@@ -49,6 +49,7 @@ var knownReferences = []string{
 	"grafana_cloud_access_policy_token.fleet_management_url=grafana_cloud_stack.fleet_management_url",
 	"grafana_cloud_access_policy_token.frontend_o11y_api_access_token=grafana_cloud_access_policy_token.token",
 	"grafana_cloud_access_policy_token.region=grafana_cloud_access_policy.region",
+	"grafana_cloud_access_policy_token.stack_id=grafana_cloud_stack.id",
 	"grafana_cloud_access_policy_token.url=grafana_cloud_stack.url",
 	"grafana_cloud_plugin_installation.stack_slug=grafana_cloud_stack.slug",
 	"grafana_cloud_private_data_source_connect_network_token.pdc_network_id=grafana_cloud_private_data_source_connect_network.pdc_network_id",

--- a/pkg/provider/framework_provider.go
+++ b/pkg/provider/framework_provider.go
@@ -193,7 +193,7 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			},
 			"stack_id": schema.Int64Attribute{
 				Optional:            true,
-				MarkdownDescription: "The Grafana stack ID, if you are using a Grafana Cloud stack. May alternatively be set via the `GRAFANA_STACK_ID` environment variable.",
+				MarkdownDescription: "The Grafana stack ID. Always set this when targeting a Grafana Cloud stack: it selects the `stacks-<stack_id>` namespace required by the App Platform API. May alternatively be set via the `GRAFANA_STACK_ID` environment variable.",
 			},
 			"tls_key": schema.StringAttribute{
 				Optional:            true,

--- a/pkg/provider/legacy_provider.go
+++ b/pkg/provider/legacy_provider.go
@@ -80,7 +80,7 @@ func Provider(version string) *schema.Provider {
 			"stack_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The Grafana stack ID, if you are using a Grafana Cloud stack. May alternatively be set via the `GRAFANA_STACK_ID` environment variable.",
+				Description: "The Grafana stack ID. Always set this when targeting a Grafana Cloud stack: it selects the `stacks-<stack_id>` namespace required by the App Platform API. May alternatively be set via the `GRAFANA_STACK_ID` environment variable.",
 			},
 			"tls_key": {
 				Type:        schema.TypeString,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -24,6 +24,8 @@ Before using the Terraform Provider to manage Grafana Cloud resources, you need 
 
 {{ tffile "examples/provider/provider-cloud.tf" }}
 
+~> **Always set `stack_id` when targeting Grafana Cloud.** It selects the `stacks-<stack_id>` namespace required by the App Platform API, which resources are progressively migrating to. Already required by `grafana_apps_*`, Asserts, [`grafana_scim_config`](resources/scim_config.md), and k6.
+
 For Synthetic Monitoring and k6 setup, see the [`grafana_synthetic_monitoring_installation`](resources/synthetic_monitoring_installation.md) and [`grafana_k6_installation`](resources/k6_installation.md) resources, which include comprehensive examples.
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Summary

`stack_id` selects the `stacks-<stack_id>` namespace used by the Grafana App Platform API. It is already required by `grafana_apps_*`, Asserts, `grafana_scim_config`, and k6, and as more resources migrate to App Platform it becomes required for Grafana Cloud generally — but the docs presented it as an optional extra.

- Add `stack_id = grafana_cloud_stack.stack.id` to the stack-level provider block in `examples/provider/provider-cloud.tf`
- Add a callout in `templates/index.md.tmpl` telling users to always set it on Cloud
- Update the `stack_id` schema description in both the SDKv2 and Plugin Framework providers
- Regenerate `docs/index.md` (and the generator picked up the new reference in `replace_references.go`)

## Test plan

- `go build ./...`
- `go generate ./...` — docs regenerated, no other drift
- `terraform fmt -check -recursive examples/provider/`

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)