### PR TITLE
fix(k6): remove publisher_token from grafana_k6_installation

### DIFF
--- a/docs/resources/k6_installation.md
+++ b/docs/resources/k6_installation.md
@@ -9,10 +9,8 @@ description: |-
   Note that this resource must be used on a provider configured with Grafana Cloud credentials.
   Official documentation https://grafana.com/docs/grafana-cloud/testing/k6/
   The provider's cloud_access_policy_token needs the following scopes to manage the resources in the example below:
-  stacks:readstacks:writestacks:deletestack-service-accounts:writeaccesspolicies:readaccesspolicies:writeaccesspolicies:delete
-  The publisher token (publisher_token) is a stack-scoped access policy token with the following scopes, used by Grafana Cloud k6 to publish test metrics to the stack and process thresholds:
-  metrics:readmetrics:writerules:readrules:write
-  It is required when creating new installations.
+  stacks:readstacks:writestacks:deletestack-service-accounts:write
+  The token used by Grafana Cloud k6 to publish test metrics to the stack is provisioned and delivered automatically by Grafana Cloud; it cannot be supplied through this resource.
 ---
 
 # grafana_k6_installation (Resource)
@@ -31,24 +29,14 @@ The provider's `cloud_access_policy_token` needs the following scopes to manage 
 * stacks:write
 * stacks:delete
 * stack-service-accounts:write
-* accesspolicies:read
-* accesspolicies:write
-* accesspolicies:delete
 
-The publisher token (`publisher_token`) is a stack-scoped access policy token with the following scopes, used by Grafana Cloud k6 to publish test metrics to the stack and process thresholds:
-
-* metrics:read
-* metrics:write
-* rules:read
-* rules:write
-
-It is required when creating new installations.
+The token used by Grafana Cloud k6 to publish test metrics to the stack is provisioned and delivered automatically by Grafana Cloud; it cannot be supplied through this resource.
 
 ## Example Usage
 
 ```terraform
 variable "cloud_access_policy_token" {
-  description = "Cloud Access Policy token for Grafana Cloud with the following scopes: stacks:read|write|delete, stack-service-accounts:write, accesspolicies:read|write|delete"
+  description = "Cloud Access Policy token for Grafana Cloud with the following scopes: stacks:read|write|delete, stack-service-accounts:write"
 }
 variable "stack_slug" {}
 variable "cloud_region" {
@@ -87,39 +75,16 @@ resource "grafana_cloud_stack_service_account_token" "k6_sa_token" {
   service_account_id = grafana_cloud_stack_service_account.k6_sa.id
 }
 
-// Step 3: Create an access policy and token used by k6 to publish test metrics to the stack
-resource "grafana_cloud_access_policy" "k6_metrics_publisher" {
-  provider = grafana.cloud
-
-  region = var.cloud_region
-  name   = "${var.stack_slug}-k6-metrics-publisher"
-  scopes = ["metrics:read", "metrics:write", "rules:read", "rules:write"]
-
-  realm {
-    type       = "stack"
-    identifier = grafana_cloud_stack.k6_stack.id
-  }
-}
-
-resource "grafana_cloud_access_policy_token" "k6_metrics_publisher" {
-  provider = grafana.cloud
-
-  region           = var.cloud_region
-  access_policy_id = grafana_cloud_access_policy.k6_metrics_publisher.policy_id
-  name             = "${var.stack_slug}-k6-metrics-publisher"
-}
-
-// Step 4: Install the k6 App on the stack
+// Step 3: Install the k6 App on the stack
 resource "grafana_k6_installation" "k6_installation" {
   provider = grafana.cloud
 
-  publisher_token  = grafana_cloud_access_policy_token.k6_metrics_publisher.token
   stack_id         = grafana_cloud_stack.k6_stack.id
   grafana_sa_token = grafana_cloud_stack_service_account_token.k6_sa_token.key
   grafana_user     = "admin"
 }
 
-// Step 5: Interact with the k6 App: create a new project
+// Step 4: Interact with the k6 App: create a new project
 provider "grafana" {
   alias = "k6"
 
@@ -147,7 +112,6 @@ resource "grafana_k6_project" "my_k6_project" {
 
 - `cloud_access_policy_token` (String, Sensitive, Deprecated) Deprecated: The [Grafana Cloud access policy](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) token. It is no longer used to install the k6 App and can be safely removed.
 - `k6_api_url` (String) The Grafana Cloud k6 API url.
-- `publisher_token` (String, Sensitive) A [Grafana Cloud access policy](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) token with `metrics:read`, `metrics:write`, `rules:read` and `rules:write` scopes on the stack, used by Grafana Cloud k6 to publish test metrics to the stack and process thresholds.
 
 ### Read-Only
 

--- a/docs/resources/k6_installation.md
+++ b/docs/resources/k6_installation.md
@@ -10,7 +10,6 @@ description: |-
   Official documentation https://grafana.com/docs/grafana-cloud/testing/k6/
   The provider's cloud_access_policy_token needs the following scopes to manage the resources in the example below:
   stacks:readstacks:writestacks:deletestack-service-accounts:write
-  The token used by Grafana Cloud k6 to publish test metrics to the stack is provisioned and delivered automatically by Grafana Cloud; it cannot be supplied through this resource.
 ---
 
 # grafana_k6_installation (Resource)
@@ -29,8 +28,6 @@ The provider's `cloud_access_policy_token` needs the following scopes to manage 
 * stacks:write
 * stacks:delete
 * stack-service-accounts:write
-
-The token used by Grafana Cloud k6 to publish test metrics to the stack is provisioned and delivered automatically by Grafana Cloud; it cannot be supplied through this resource.
 
 ## Example Usage
 

--- a/examples/resources/grafana_k6_installation/resource.tf
+++ b/examples/resources/grafana_k6_installation/resource.tf
@@ -1,5 +1,5 @@
 variable "cloud_access_policy_token" {
-  description = "Cloud Access Policy token for Grafana Cloud with the following scopes: stacks:read|write|delete, stack-service-accounts:write, accesspolicies:read|write|delete"
+  description = "Cloud Access Policy token for Grafana Cloud with the following scopes: stacks:read|write|delete, stack-service-accounts:write"
 }
 variable "stack_slug" {}
 variable "cloud_region" {
@@ -38,39 +38,16 @@ resource "grafana_cloud_stack_service_account_token" "k6_sa_token" {
   service_account_id = grafana_cloud_stack_service_account.k6_sa.id
 }
 
-// Step 3: Create an access policy and token used by k6 to publish test metrics to the stack
-resource "grafana_cloud_access_policy" "k6_metrics_publisher" {
-  provider = grafana.cloud
-
-  region = var.cloud_region
-  name   = "${var.stack_slug}-k6-metrics-publisher"
-  scopes = ["metrics:read", "metrics:write", "rules:read", "rules:write"]
-
-  realm {
-    type       = "stack"
-    identifier = grafana_cloud_stack.k6_stack.id
-  }
-}
-
-resource "grafana_cloud_access_policy_token" "k6_metrics_publisher" {
-  provider = grafana.cloud
-
-  region           = var.cloud_region
-  access_policy_id = grafana_cloud_access_policy.k6_metrics_publisher.policy_id
-  name             = "${var.stack_slug}-k6-metrics-publisher"
-}
-
-// Step 4: Install the k6 App on the stack
+// Step 3: Install the k6 App on the stack
 resource "grafana_k6_installation" "k6_installation" {
   provider = grafana.cloud
 
-  publisher_token  = grafana_cloud_access_policy_token.k6_metrics_publisher.token
   stack_id         = grafana_cloud_stack.k6_stack.id
   grafana_sa_token = grafana_cloud_stack_service_account_token.k6_sa_token.key
   grafana_user     = "admin"
 }
 
-// Step 5: Interact with the k6 App: create a new project
+// Step 4: Interact with the k6 App: create a new project
 provider "grafana" {
   alias = "k6"
 

--- a/internal/resources/cloud/resource_k6_installation.go
+++ b/internal/resources/cloud/resource_k6_installation.go
@@ -35,42 +35,13 @@ The provider's ` + "`cloud_access_policy_token`" + ` needs the following scopes 
 * stacks:write
 * stacks:delete
 * stack-service-accounts:write
-* accesspolicies:read
-* accesspolicies:write
-* accesspolicies:delete
 
-The publisher token (` + "`publisher_token`" + `) is a stack-scoped access policy token with the following scopes, used by Grafana Cloud k6 to publish test metrics to the stack and process thresholds:
-
-* metrics:read
-* metrics:write
-* rules:read
-* rules:write
-
-It is required when creating new installations.
+The token used by Grafana Cloud k6 to publish test metrics to the stack is provisioned and delivered automatically by Grafana Cloud; it cannot be supplied through this resource.
 `,
 		CreateContext: withClient[schema.CreateContextFunc](resourceK6InstallationCreate),
 		ReadContext:   withClient[schema.ReadContextFunc](resourceK6InstallationRead),
 		UpdateContext: withClient[schema.UpdateContextFunc](resourceK6InstallationUpdate),
 		DeleteContext: resourceK6InstallationDelete,
-
-		// This block allows us to keep publisher_token optional not to break existing installations,
-		// but at the same time validate them as required for new ones.
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
-			// Skip destroy plans
-			if d.GetRawPlan().IsNull() {
-				return nil
-			}
-			// Skip existing installations
-			if d.Id() != "" {
-				return nil
-			}
-			if d.NewValueKnown("publisher_token") {
-				if v, ok := d.Get("publisher_token").(string); !ok || v == "" {
-					return fmt.Errorf("publisher_token is required when creating a new k6 installation: create a stack-scoped access policy token with metrics:read, metrics:write, rules:read and rules:write scopes")
-				}
-			}
-			return nil
-		},
 
 		Schema: map[string]*schema.Schema{
 			"cloud_access_policy_token": {
@@ -97,12 +68,6 @@ It is required when creating new installations.
 				Required:    true,
 				ForceNew:    true,
 				Description: "The user to use for the installation.",
-			},
-			"publisher_token": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "A [Grafana Cloud access policy](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/) token with `metrics:read`, `metrics:write`, `rules:read` and `rules:write` scopes on the stack, used by Grafana Cloud k6 to publish test metrics to the stack and process thresholds.",
 			},
 			"k6_api_url": {
 				Type:        schema.TypeString,
@@ -147,11 +112,6 @@ func resourceK6InstallationCreate(ctx context.Context, d *schema.ResourceData, c
 		return diag.Errorf("the grafana_k6_installation must have a valid stack_id")
 	}
 
-	publisherToken, ok := d.Get("publisher_token").(string)
-	if !ok || len(publisherToken) == 0 {
-		return diag.Errorf("the grafana_k6_installation must have a valid publisher_token: create a stack-scoped access policy token with metrics:read, metrics:write, rules:read and rules:write scopes")
-	}
-
 	grafanaServiceAccountToken, ok := d.Get("grafana_sa_token").(string)
 	if !ok || len(grafanaServiceAccountToken) == 0 {
 		return diag.Errorf("the grafana_k6_installation must have a valid grafana_sa_token")
@@ -163,7 +123,6 @@ func resourceK6InstallationCreate(ctx context.Context, d *schema.ResourceData, c
 	}
 
 	req.Header.Set("X-Stack-Id", stackID)
-	req.Header.Set("X-Publisher-Token", publisherToken)
 	req.Header.Set("X-Grafana-Service-Token", grafanaServiceAccountToken)
 	req.Header.Set("X-Grafana-User", grafanaUser)
 	req.Header.Set("User-Agent", cloudClient.GetConfig().UserAgent)

--- a/internal/resources/cloud/resource_k6_installation.go
+++ b/internal/resources/cloud/resource_k6_installation.go
@@ -35,8 +35,6 @@ The provider's ` + "`cloud_access_policy_token`" + ` needs the following scopes 
 * stacks:write
 * stacks:delete
 * stack-service-accounts:write
-
-The token used by Grafana Cloud k6 to publish test metrics to the stack is provisioned and delivered automatically by Grafana Cloud; it cannot be supplied through this resource.
 `,
 		CreateContext: withClient[schema.CreateContextFunc](resourceK6InstallationCreate),
 		ReadContext:   withClient[schema.ReadContextFunc](resourceK6InstallationRead),

--- a/internal/resources/cloud/resource_k6_installation_test.go
+++ b/internal/resources/cloud/resource_k6_installation_test.go
@@ -2,7 +2,6 @@ package cloud_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -33,17 +32,11 @@ func TestAccK6Installation(t *testing.T) {
 		CheckDestroy:             testAccStackCheckDestroy(&stack),
 		Steps: []resource.TestStep{
 			{
-				// The publisher token is required for new installations.
-				Config:      testAccK6Installation(stackSlug, accessPolicyName, "", "tfk6installtest_sa_token", "admin"),
-				ExpectError: regexp.MustCompile("publisher_token is required when creating a new k6 installation"),
-			},
-			{
-				Config: testAccK6Installation(stackSlug, accessPolicyName, "publisher", "tfk6installtest_sa_token", "admin"),
+				Config: testAccK6Installation(stackSlug, accessPolicyName, "tfk6installtest_sa_token", "admin"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccStackCheckExists("grafana_cloud_stack.test", &stack),
 					resource.TestCheckResourceAttrSet("grafana_k6_installation.test", "k6_access_token"),
 					resource.TestCheckResourceAttrSet("grafana_k6_installation.test", "k6_organization"),
-					resource.TestCheckResourceAttrSet("grafana_k6_installation.test", "publisher_token"),
 					func(s *terraform.State) error {
 						rs, ok := s.RootModule().Resources["grafana_k6_installation.test"]
 						if !ok {
@@ -55,28 +48,9 @@ func TestAccK6Installation(t *testing.T) {
 				),
 			},
 			{
-				// Changing the publisher token is a state-only in-place update,
-				// not a recreation.
-				Config: testAccK6Installation(stackSlug, accessPolicyName, "publisher2", "tfk6installtest_sa_token", "admin"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("grafana_k6_installation.test", "publisher_token"),
-					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources["grafana_k6_installation.test"]
-						if !ok {
-							return fmt.Errorf("grafana_k6_installation.test not found in state")
-						}
-						if rs.Primary.ID != installationID {
-							return fmt.Errorf("installation was recreated on publisher_token change: id %q != %q", rs.Primary.ID, installationID)
-						}
-						return nil
-					},
-				),
-			},
-			{
 				// grafana_sa_token is not ForceNew: changing it is an in-place
-				// update, so the installation is not recreated and the publisher
-				// token is not required again.
-				Config: testAccK6Installation(stackSlug, accessPolicyName, "publisher2", "tfk6installtest_sa_token2", "admin"),
+				// update, so the installation is not recreated.
+				Config: testAccK6Installation(stackSlug, accessPolicyName, "tfk6installtest_sa_token2", "admin"),
 				Check: resource.ComposeTestCheckFunc(
 					func(s *terraform.State) error {
 						rs, ok := s.RootModule().Resources["grafana_k6_installation.test"]
@@ -93,7 +67,7 @@ func TestAccK6Installation(t *testing.T) {
 			{
 				// grafana_user is still ForceNew, so this replaces the installation.
 				// /start returns the existing organization, so the id is unchanged.
-				Config: testAccK6Installation(stackSlug, accessPolicyName, "publisher2", "tfk6installtest_sa_token2", "someone-else"),
+				Config: testAccK6Installation(stackSlug, accessPolicyName, "tfk6installtest_sa_token2", "someone-else"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("grafana_k6_installation.test", "k6_access_token"),
 					resource.TestCheckResourceAttrSet("grafana_k6_installation.test", "k6_organization"),
@@ -105,47 +79,13 @@ func TestAccK6Installation(t *testing.T) {
 
 func testAccK6InstallationBase(stackSlug, accessPolicyName string) string {
 	return testAccStackConfigBasic(stackSlug, stackSlug, "description") +
-		testAccCloudAccessPolicyTokenConfigBasic(accessPolicyName, accessPolicyName, "eu", []string{"stacks:read", "stacks:write", "subscriptions:read", "orgs:read"}, "", false) +
-		testAccK6InstallationPublisherPolicy(accessPolicyName)
+		testAccCloudAccessPolicyTokenConfigBasic(accessPolicyName, accessPolicyName, "eu", []string{"stacks:read", "stacks:write", "subscriptions:read", "orgs:read"}, "", false)
 }
 
-func testAccK6InstallationPublisherPolicy(accessPolicyName string) string {
-	return fmt.Sprintf(`
-	resource "grafana_cloud_access_policy" "publisher" {
-		region = "eu"
-		name   = "%[1]s-publisher"
-		scopes = ["metrics:read", "metrics:write", "rules:read", "rules:write"]
-
-		realm {
-			type       = "stack"
-			identifier = grafana_cloud_stack.test.id
-		}
-	}
-
-	resource "grafana_cloud_access_policy_token" "publisher" {
-		region           = "eu"
-		access_policy_id = grafana_cloud_access_policy.publisher.policy_id
-		name             = "%[1]s-publisher"
-	}
-
-	resource "grafana_cloud_access_policy_token" "publisher2" {
-		region           = "eu"
-		access_policy_id = grafana_cloud_access_policy.publisher.policy_id
-		name             = "%[1]s-publisher2"
-	}
-	`, accessPolicyName)
-}
-
-// testAccK6Installation builds an installation config. publisherTokenResource is
-// the grafana_cloud_access_policy_token to draw publisher_token from, or "" to
-// omit the attribute. saTokenResource selects which service account token feeds
-// grafana_sa_token, so tests can change it and force a replacement.
-func testAccK6Installation(stackSlug, apiKeyName, publisherTokenResource, saTokenResource, grafanaUser string) string {
-	publisherToken := ""
-	if publisherTokenResource != "" {
-		publisherToken = fmt.Sprintf("publisher_token  = grafana_cloud_access_policy_token.%s.token", publisherTokenResource)
-	}
-
+// testAccK6Installation builds an installation config. saTokenResource selects
+// which service account token feeds grafana_sa_token, so tests can change it
+// and force an in-place update.
+func testAccK6Installation(stackSlug, apiKeyName, saTokenResource, grafanaUser string) string {
 	return testAccK6InstallationBase(stackSlug, apiKeyName) +
 		`
 	resource "grafana_cloud_stack_service_account" "tfk6installtest_sa" {
@@ -172,7 +112,6 @@ func testAccK6Installation(stackSlug, apiKeyName, publisherTokenResource, saToke
 		stack_id         = grafana_cloud_stack.test.id
 		grafana_sa_token = grafana_cloud_stack_service_account_token.%s.key
 		grafana_user     = %q
-		%s
 	}
-	`, saTokenResource, grafanaUser, publisherToken)
+	`, saTokenResource, grafanaUser)
 }

--- a/pkg/generate/postprocessing/replace_references.go
+++ b/pkg/generate/postprocessing/replace_references.go
@@ -107,7 +107,6 @@ var knownReferences = []string{
 	"grafana_folder_permission_item.user=grafana_user.id",
 	"grafana_k6_installation.grafana_sa_token=grafana_cloud_stack_service_account_token.key",
 	"grafana_k6_installation.k6_access_token=grafana_k6_installation.k6_access_token",
-	"grafana_k6_installation.publisher_token=grafana_cloud_access_policy_token.token",
 	"grafana_k6_installation.stack_id=grafana_cloud_stack.id",
 	"grafana_k6_load_test.project_id=grafana_k6_project.id",
 	"grafana_k6_project_allowed_load_zones.project_id=grafana_k6_project.id",


### PR DESCRIPTION
## What this PR does

Removes `publisher_token` from `grafana_k6_installation` (added in #2873, released in v4.45.0).

This token will be handled internally by Grafana Cloud services.