### PR TITLE
fix(k6): handle null project folder uid

### DIFF
--- a/internal/resources/k6/data_source_k6_project.go
+++ b/internal/resources/k6/data_source_k6_project.go
@@ -127,8 +127,9 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 }
 
 func handleGrafanaFolderUID(grafanaFolderUID k6.NullableString) types.String {
-	if !grafanaFolderUID.IsSet() {
+	value := grafanaFolderUID.Get()
+	if !grafanaFolderUID.IsSet() || value == nil {
 		return types.StringNull()
 	}
-	return types.StringValue(*grafanaFolderUID.Get())
+	return types.StringValue(*value)
 }

--- a/internal/resources/k6/project_internal_test.go
+++ b/internal/resources/k6/project_internal_test.go
@@ -1,0 +1,47 @@
+package k6
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/grafana/k6-cloud-openapi-client-go/k6"
+)
+
+func TestUnitHandleGrafanaFolderUID(t *testing.T) {
+	folderUID := "folder-uid"
+	var explicitNull k6.NullableString
+	if err := json.Unmarshal([]byte("null"), &explicitNull); err != nil {
+		t.Fatalf("unmarshal explicit null: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		value    k6.NullableString
+		expected types.String
+	}{
+		{
+			name:     "unset is null",
+			value:    k6.NullableString{},
+			expected: types.StringNull(),
+		},
+		{
+			name:     "explicit null is null",
+			value:    explicitNull,
+			expected: types.StringNull(),
+		},
+		{
+			name:     "value is preserved",
+			value:    *k6.NewNullableString(&folderUID),
+			expected: types.StringValue(folderUID),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := handleGrafanaFolderUID(tc.value)
+			if !got.Equal(tc.expected) {
+				t.Errorf("handleGrafanaFolderUID(%v) = %v, want %v", tc.value, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- treat both unset and explicitly null k6 project `grafana_folder_uid` values as Terraform null
- avoid dereferencing a nil value returned by the generated k6 client
- add unit coverage for unset, explicitly null, and non-null folder UIDs

## Testing

- `go test ./internal/resources/k6 -count=1`
- `go test ./... -run TestUnit -count=1`

Closes #2943
