### PR TITLE
fix(alerting): retry 409 responses on legacy provisioning resources

### DIFF
--- a/internal/resources/grafana/resource_alerting_contact_point.go
+++ b/internal/resources/grafana/resource_alerting_contact_point.go
@@ -110,6 +110,14 @@ This resource requires Grafana 9.1.0 or later.
 	).WithLister(listerFunctionOrgResource(listContactPoints))
 }
 
+// isProvisioningConflict reports whether err is an HTTP 409 from the alerting provisioning
+// API, which happens when a concurrent request (another apply, the UI, ...) modifies the
+// same underlying alertmanager config between our read and write.
+func isProvisioningConflict(err error) bool {
+	status, ok := err.(runtime.ClientResponseStatus)
+	return ok && status.IsCode(409)
+}
+
 func listContactPoints(ctx context.Context, client *goapi.GrafanaHTTPAPI, orgID int64) ([]string, error) {
 	idMap := map[string]bool{}
 	// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
@@ -181,17 +189,28 @@ func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta any
 		var uid string
 		if uid = p.tfState["uid"].(string); uid != "" {
 			// If the contact point already has a UID, update it.
-			params := provisioning.NewPutContactpointParams().WithUID(uid).WithBody(p.gfState)
-			if data.Get("disable_provenance").(bool) {
-				params.SetXDisableProvenance(&provenanceDisabled)
-			}
-			if _, err := client.Provisioning.PutContactpoint(params); err != nil {
+			// Retry on 409: a concurrent request may have modified the alertmanager config.
+			err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+				params := provisioning.NewPutContactpointParams().WithUID(uid).WithBody(p.gfState)
+				if data.Get("disable_provenance").(bool) {
+					params.SetXDisableProvenance(&provenanceDisabled)
+				}
+				if _, err := client.Provisioning.PutContactpoint(params); err != nil {
+					if isProvisioningConflict(err) {
+						return retry.RetryableError(err)
+					}
+					return retry.NonRetryableError(err)
+				}
+				return nil
+			})
+			if err != nil {
 				return diag.FromErr(err)
 			}
 		} else {
 			// If the contact point does not have a UID, create it.
 			// Retry if the API returns 500 because it may be that the alertmanager is not ready in the org yet.
-			// The alertmanager is provisioned asynchronously when the org is created.
+			// The alertmanager is provisioned asynchronously when the org is created. Also retry on 409, since a
+			// concurrent request may have modified the alertmanager config.
 			err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 				params := provisioning.NewPostContactpointsParams().WithBody(p.gfState)
 				if data.Get("disable_provenance").(bool) {
@@ -199,7 +218,7 @@ func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta any
 				}
 				resp, err := client.Provisioning.PostContactpoints(params)
 				if err != nil {
-					if err.(runtime.ClientResponseStatus).IsCode(500) {
+					if err.(runtime.ClientResponseStatus).IsCode(500) || isProvisioningConflict(err) {
 						return retry.RetryableError(err)
 					}
 					return retry.NonRetryableError(err)
@@ -223,8 +242,18 @@ func updateContactPoint(ctx context.Context, data *schema.ResourceData, meta any
 			continue
 		}
 		uid := p.tfState["uid"].(string)
-		// If the contact point is not in the proposed state, delete it.
-		if _, err := client.Provisioning.DeleteContactpoints(uid); err != nil {
+		// If the contact point is not in the proposed state, delete it. Retry on 409, since a
+		// concurrent request may have modified the alertmanager config.
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			if _, err := client.Provisioning.DeleteContactpoints(uid); err != nil {
+				if isProvisioningConflict(err) {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
 			return diag.Errorf("failed to remove contact point notifier with UID %s from contact point %s: %v", uid, data.Id(), err)
 		}
 		continue
@@ -243,7 +272,17 @@ func deleteContactPoint(ctx context.Context, data *schema.ResourceData, meta any
 	}
 
 	for _, cp := range resp.Payload {
-		if _, err := client.Provisioning.DeleteContactpoints(cp.UID); err != nil {
+		// Retry on 409, since a concurrent request may have modified the alertmanager config.
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			if _, err := client.Provisioning.DeleteContactpoints(cp.UID); err != nil {
+				if isProvisioningConflict(err) {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/internal/resources/grafana/resource_alerting_mute_timing.go
+++ b/internal/resources/grafana/resource_alerting_mute_timing.go
@@ -195,7 +195,7 @@ func createMuteTiming(ctx context.Context, data *schema.ResourceData, meta any) 
 		var postErr error
 		resp, postErr = client.Provisioning.PostMuteTiming(params)
 		if postErr != nil {
-			if postErr.(runtime.ClientResponseStatus).IsCode(500) || postErr.(runtime.ClientResponseStatus).IsCode(403) {
+			if postErr.(runtime.ClientResponseStatus).IsCode(500) || postErr.(runtime.ClientResponseStatus).IsCode(403) || isProvisioningConflict(postErr) {
 				return retry.RetryableError(postErr)
 			}
 			return retry.NonRetryableError(postErr)
@@ -225,7 +225,16 @@ func updateMuteTiming(ctx context.Context, data *schema.ResourceData, meta any) 
 		params.SetXDisableProvenance(&provenanceDisabled)
 	}
 
-	_, err := client.Provisioning.PutMuteTiming(params)
+	// Retry on 409, since a concurrent request may have modified the alertmanager config.
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		if _, err := client.Provisioning.PutMuteTiming(params); err != nil {
+			if isProvisioningConflict(err) {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -244,7 +253,16 @@ func deleteMuteTiming(ctx context.Context, data *schema.ResourceData, meta any) 
 	modified := false
 	policy, modified = removeMuteTimingFromRoute(name, policy)
 	if modified {
-		_, err = client.Provisioning.PutPolicyTree(provisioning.NewPutPolicyTreeParams().WithBody(policy))
+		// Retry on 409, since a concurrent request may have modified the alertmanager config.
+		err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+			if _, err := client.Provisioning.PutPolicyTree(provisioning.NewPutPolicyTreeParams().WithBody(policy)); err != nil {
+				if isProvisioningConflict(err) {
+					return retry.RetryableError(err)
+				}
+				return retry.NonRetryableError(err)
+			}
+			return nil
+		})
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -277,9 +295,18 @@ func deleteMuteTiming(ctx context.Context, data *schema.ResourceData, meta any) 
 		}
 	}
 
-	// Delete the mute timing
+	// Delete the mute timing. Retry on 409, since a concurrent request may have modified the
+	// alertmanager config.
 	params := provisioning.NewDeleteMuteTimingParams().WithName(name)
-	_, err = client.Provisioning.DeleteMuteTiming(params)
+	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		if _, err := client.Provisioning.DeleteMuteTiming(params); err != nil {
+			if isProvisioningConflict(err) {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 	diag, _ := common.CheckReadError("mute timing", data, err)
 	return diag
 }

--- a/internal/resources/grafana/resource_alerting_notification_policy.go
+++ b/internal/resources/grafana/resource_alerting_notification_policy.go
@@ -252,7 +252,7 @@ func putNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta 
 	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
 		_, err := client.Provisioning.PutPolicyTree(putParams)
 		if err != nil {
-			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(404) {
+			if err.(runtime.ClientResponseStatus).IsCode(500) || err.(runtime.ClientResponseStatus).IsCode(404) || isProvisioningConflict(err) {
 				return retry.RetryableError(err)
 			}
 			return retry.NonRetryableError(err)
@@ -271,7 +271,17 @@ func putNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta 
 func deleteNotificationPolicy(ctx context.Context, data *schema.ResourceData, meta any) diag.Diagnostics {
 	client, _, _ := OAPIClientFromExistingOrgResource(meta, data.Id())
 
-	if _, err := client.Provisioning.ResetPolicyTree(); err != nil {
+	// Retry on 409, since a concurrent request may have modified the alertmanager config.
+	err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+		if _, err := client.Provisioning.ResetPolicyTree(); err != nil {
+			if isProvisioningConflict(err) {
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
## Summary
- `grafana_contact_point`, `grafana_notification_policy`, and `grafana_mute_timing` call the alerting provisioning API directly (legacy SDKv2 resources) and had no handling for HTTP 409, which the API returns when a concurrent request (another apply, the UI, ...) modifies the same underlying alertmanager config between our read and write.
- Adds `isProvisioningConflict` and retries 409 on every mutating call (create/update/delete) for these three resources, alongside the paths that already retried 500/403/404.
- GET calls are left untouched, since they cannot return 409.
- The alert rule update inside `grafana_mute_timing`'s delete path is also left untouched, since alert rules are not a notification resource.

Retries blindly resend the same request on 409, matching the existing pattern already used in this file for 500/403/404 — they do not re-fetch and reapply on top of the latest config first.

## Test plan
- [x] `go build ./internal/resources/grafana/...`
- [x] `go vet ./internal/resources/grafana/...`
- [x] `golangci-lint run ./internal/resources/grafana/...` (0 issues)
- [x] `go test ./internal/resources/grafana/... -run TestUnit`
- [ ] Acceptance tests (`TF_ACC_OSS=true`) not run — no live Grafana instance in this environment