### PR TITLE
docs(alerting): mark alert enrichment as generally available

### DIFF
--- a/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
+++ b/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
@@ -4,14 +4,14 @@ page_title: "grafana_apps_alertenrichment_alertenrichment_v1beta1 Resource - ter
 subcategory: "Alerting"
 description: |-
   Manages Grafana Cloud Alert Enrichment https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/.
-  Alert enrichment is currently in public preview. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+  Alert enrichment is generally available.
 ---
 
 # grafana_apps_alertenrichment_alertenrichment_v1beta1 (Resource)
 
 Manages [Grafana Cloud Alert Enrichment](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/).
 
-Alert enrichment is currently in public preview. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+Alert enrichment is generally available.
 
 ## Example Usage
 

--- a/internal/resources/appplatform/alertenrichment_resource.go
+++ b/internal/resources/appplatform/alertenrichment_resource.go
@@ -1113,7 +1113,7 @@ func AlertEnrichment() NamedResource {
 				MarkdownDescription: `
 Manages [Grafana Cloud Alert Enrichment](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/alert-enrichment/).
 
-Alert enrichment is currently in public preview. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+Alert enrichment is generally available.
 `,
 				SpecAttributes: func() map[string]schema.Attribute {
 					attrs := map[string]schema.Attribute{


### PR DESCRIPTION
## Summary
- Update the `grafana_apps_alertenrichment_alertenrichment_v1beta1` resource description to state that alert enrichment is generally available, replacing the previous public preview notice.
- Regenerate the corresponding docs page.


## Test plan
- [x] `go generate ./...` regenerates docs cleanly with no other diffs

Made with [Cursor](https://cursor.com)