### PR TITLE
feat(appplatform): add per-resource org_id override for multi-org management

### DIFF
--- a/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
+++ b/docs/resources/apps_alertenrichment_alertenrichment_v1beta1.md
@@ -192,6 +192,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_dashboard_dashboard_v1beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v1beta1.md
@@ -57,6 +57,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_dashboard_dashboard_v2.md
+++ b/docs/resources/apps_dashboard_dashboard_v2.md
@@ -66,6 +66,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_dashboard_dashboard_v2beta1.md
+++ b/docs/resources/apps_dashboard_dashboard_v2beta1.md
@@ -66,6 +66,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_notifications_inhibitionrule_v1beta1.md
+++ b/docs/resources/apps_notifications_inhibitionrule_v1beta1.md
@@ -66,6 +66,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_notifications_routingtree_v1beta1.md
+++ b/docs/resources/apps_notifications_routingtree_v1beta1.md
@@ -168,7 +168,7 @@ blocks are the ones that map to `spec.routes`.
 | `policy.continue`             | `routes.continue` (optional, defaults to false)  |
 | `policy.policy` (deeper nesting) | `routes.routes`                               |
 | `disable_provenance`          | `spec.disable_provenance`                        |
-| `org_id`                      | not a field; the org/stack determines the namespace |
+| `org_id`                      | `metadata.org_id` (optional; self-hosted only — overrides the provider org for this resource) |
 
 -> **Provenance and UI editing:** `disable_provenance` behaves like the legacy
 attribute — `true` leaves the tree editable from other sources (e.g. the Grafana
@@ -199,6 +199,10 @@ attribute, not a top-level resource attribute.
 Required:
 
 - `uid` (String) The unique identifier (Kubernetes name) of the routing tree. The default routing tree is named `default`.
+
+Optional:
+
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_playlist_playlist_v0alpha1.md
+++ b/docs/resources/apps_playlist_playlist_v0alpha1.md
@@ -59,6 +59,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_playlist_playlist_v1.md
+++ b/docs/resources/apps_playlist_playlist_v1.md
@@ -59,6 +59,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_productactivation_appo11yconfig_v1alpha1.md
+++ b/docs/resources/apps_productactivation_appo11yconfig_v1alpha1.md
@@ -53,6 +53,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_productactivation_dbo11yconfig_v1alpha1.md
+++ b/docs/resources/apps_productactivation_dbo11yconfig_v1alpha1.md
@@ -53,6 +53,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_productactivation_k8so11yconfig_v1alpha1.md
+++ b/docs/resources/apps_productactivation_k8so11yconfig_v1alpha1.md
@@ -53,6 +53,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_provisioning_connection_v0alpha1.md
+++ b/docs/resources/apps_provisioning_connection_v0alpha1.md
@@ -83,6 +83,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_provisioning_repository_v0alpha1.md
+++ b/docs/resources/apps_provisioning_repository_v0alpha1.md
@@ -299,6 +299,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_queries_query_v1.md
+++ b/docs/resources/apps_queries_query_v1.md
@@ -67,6 +67,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_rules_alertrule_v0alpha1.md
+++ b/docs/resources/apps_rules_alertrule_v0alpha1.md
@@ -137,6 +137,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_rules_recordingrule_v0alpha1.md
+++ b/docs/resources/apps_rules_recordingrule_v0alpha1.md
@@ -83,6 +83,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_rules_rulesequence_v0alpha1.md
+++ b/docs/resources/apps_rules_rulesequence_v0alpha1.md
@@ -144,6 +144,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_secret_keeper_activation_v1beta1.md
+++ b/docs/resources/apps_secret_keeper_activation_v1beta1.md
@@ -33,6 +33,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_secret_keeper_v1beta1.md
+++ b/docs/resources/apps_secret_keeper_v1beta1.md
@@ -35,6 +35,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_secret_securevalue_v1beta1.md
+++ b/docs/resources/apps_secret_securevalue_v1beta1.md
@@ -37,6 +37,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/docs/resources/apps_servicemodel_component_v1alpha1.md
+++ b/docs/resources/apps_servicemodel_component_v1alpha1.md
@@ -116,6 +116,7 @@ Required:
 Optional:
 
 - `folder_uid` (String) The UID of the folder to save the resource in. For example, it's supported for dashboards and folders. To know if it's supported for the specific resource you're using check the documentation.
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -40,6 +40,10 @@ type Client struct {
 	GrafanaAppPlatformAPIClientID string
 	GrafanaOrgID                  int64
 	GrafanaStackID                int64
+	// GrafanaAppPlatformUsesAPIKey reports whether the App Platform client authenticates with
+	// an API key / service account token (as opposed to basic auth). API keys are already
+	// org-scoped, so per-resource org_id overrides are unsupported in that mode.
+	GrafanaAppPlatformUsesAPIKey bool
 
 	GrafanaCloudAPI            *gcom.APIClient
 	SMAPI                      *SMAPI.Client

--- a/internal/resources/appplatform/provisioning_resource_acc_test.go
+++ b/internal/resources/appplatform/provisioning_resource_acc_test.go
@@ -553,6 +553,51 @@ func TestAccProvisioningRepository_local(t *testing.T) {
 	})
 }
 
+// A user manages GitSync repositories across multiple organizations from a single
+// provider configuration by setting metadata.org_id per resource. This exercises the
+// full lifecycle in a non-default org: create/read in the org's namespace, org_id
+// round-tripping through state, and scoped "<orgID>:<uid>" import.
+func TestAccProvisioningRepository_multiOrg(t *testing.T) {
+	testutils.CheckOSSTestsEnabled(t, ">=13.0.0")
+	waitForProvisioningAPI(t)
+
+	orgName := "gitsync-multiorg-" + strings.ToLower(acctest.RandString(8))
+	uid := "git-sync-repo-org-" + strings.ToLower(acctest.RandString(8))
+
+	terraformresource.Test(t, terraformresource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProvisioningRepositoryOrgScopedDestroy,
+		Steps: []terraformresource.TestStep{
+			{
+				Config: testAccProvisioningRepositoryMultiOrgConfig(orgName, uid),
+				Check: terraformresource.ComposeTestCheckFunc(
+					terraformresource.TestCheckResourceAttr(provisioningRepositoryResourceName, "metadata.uid", uid),
+					// org_id is resolved from the created organization and preserved in state.
+					terraformresource.TestCheckResourceAttrPair(
+						provisioningRepositoryResourceName, "metadata.org_id",
+						"grafana_organization.test", "org_id",
+					),
+					terraformresource.TestCheckResourceAttr(provisioningRepositoryResourceName, "spec.type", "local"),
+					// The repository must actually live in the target org's namespace, not org 1.
+					testAccCheckProvisioningRepositoryInConfiguredOrg(provisioningRepositoryResourceName),
+				),
+			},
+			{
+				ResourceName:      provisioningRepositoryResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"metadata.version",
+					"options.%",
+					"options.overwrite",
+				},
+				// Import using the "<orgID>:<uid>" form so the resource is read from the right org.
+				ImportStateIdFunc: importStateOrgScopedUIDFunc(provisioningRepositoryResourceName),
+			},
+		},
+	})
+}
+
 // A user tries to set secure values on a repository but forgets to set
 // secure_version. The provider should reject that configuration up front with a
 // clear validation error instead of silently ignoring the secure block.
@@ -734,6 +779,135 @@ resource "grafana_apps_provisioning_repository_v0alpha1" "test" {
   }
 }
 `, uid, provisioningLocalRepositoryPath)
+}
+
+func testAccProvisioningRepositoryMultiOrgConfig(orgName, uid string) string {
+	return fmt.Sprintf(`
+resource "grafana_organization" "test" {
+  name = "%s"
+}
+
+resource "grafana_apps_provisioning_repository_v0alpha1" "test" {
+  metadata {
+    uid    = "%s"
+    org_id = grafana_organization.test.org_id
+  }
+
+  spec {
+    title       = "Multi-org local repository"
+    description = "Local repository provisioned in a non-default organization"
+    type        = "local"
+    workflows   = ["write"]
+
+    sync {
+      enabled          = false
+      target           = "instance"
+      interval_seconds = 300
+    }
+
+    local {
+      path = "%s"
+    }
+  }
+}
+`, orgName, uid, provisioningLocalRepositoryPath)
+}
+
+// orgScopedStateID reads metadata.org_id and metadata.uid for a resource from state.
+func orgScopedStateID(s *terraform.State, resourceName string) (int64, string, error) {
+	uid, err := stateResourceAttribute(s, resourceName, "metadata.uid")
+	if err != nil {
+		return 0, "", err
+	}
+	orgIDStr, err := stateResourceAttribute(s, resourceName, "metadata.org_id")
+	if err != nil {
+		return 0, "", err
+	}
+	orgID, err := strconv.ParseInt(orgIDStr, 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("invalid metadata.org_id %q for %s: %w", orgIDStr, resourceName, err)
+	}
+	return orgID, uid, nil
+}
+
+// importStateOrgScopedUIDFunc builds an "<orgID>:<uid>" import ID from state.
+func importStateOrgScopedUIDFunc(resourceName string) terraformresource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		orgID, uid, err := orgScopedStateID(s, resourceName)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%d:%s", orgID, uid), nil
+	}
+}
+
+// testAccCheckProvisioningRepositoryInConfiguredOrg verifies the repository exists in the
+// organization named by its metadata.org_id, confirming the override actually changed the
+// target namespace (rather than writing to the provider-default org).
+func testAccCheckProvisioningRepositoryInConfiguredOrg(resourceName string) terraformresource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		orgID, uid, err := orgScopedStateID(s, resourceName)
+		if err != nil {
+			return err
+		}
+		client := testutils.Provider.Meta().(*common.Client)
+		if _, err := getProvisioningRepositoryInOrg(context.Background(), client, orgID, uid); err != nil {
+			return fmt.Errorf("expected repository %q to exist in org %d: %w", uid, orgID, err)
+		}
+		return nil
+	}
+}
+
+// testAccCheckProvisioningRepositoryOrgScopedDestroy confirms the repository is gone from its
+// org's namespace after destroy. The organization is torn down alongside the repository, so an
+// unreachable namespace (org already deleted) is treated as destroyed.
+func testAccCheckProvisioningRepositoryOrgScopedDestroy(s *terraform.State) error {
+	client := testutils.Provider.Meta().(*common.Client)
+
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "grafana_apps_provisioning_repository_v0alpha1" {
+			continue
+		}
+
+		uid := r.Primary.Attributes["metadata.uid"]
+		if uid == "" {
+			continue
+		}
+
+		orgID, err := strconv.ParseInt(r.Primary.Attributes["metadata.org_id"], 10, 64)
+		if err != nil || orgID <= 0 {
+			continue
+		}
+
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			if _, err := getProvisioningRepositoryInOrg(context.Background(), client, orgID, uid); err != nil {
+				// NotFound, or the org (namespace) no longer exists — either way it is gone.
+				break
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("provisioning repository %s still exists in org %d", uid, orgID)
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	return nil
+}
+
+// getProvisioningRepositoryInOrg reads a repository from a specific organization's namespace.
+func getProvisioningRepositoryInOrg(ctx context.Context, client *common.Client, orgID int64, uid string) (*appplatform.ProvisioningRepository, error) {
+	rcli, err := client.GrafanaAppPlatformAPI.ClientFor(appplatform.RepositoryKind())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create provisioning client: %w", err)
+	}
+
+	namespacedClient := sdkresource.NewNamespaced(
+		sdkresource.NewTypedClient[*appplatform.ProvisioningRepository, *appplatform.ProvisioningRepositoryList](rcli, appplatform.RepositoryKind()),
+		claims.OrgNamespaceFormatter(orgID),
+	)
+
+	return namespacedClient.Get(ctx, uid)
 }
 
 func testAccProvisioningRepositoryMissingSecureVersionConfig(uid string) string {

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -162,8 +162,11 @@ type Resource[T sdkresource.Object, L sdkresource.ListObject] struct {
 	// providerStackID is the provider-level Grafana Cloud stack ID (0 for self-hosted). When
 	// set, per-resource org_id overrides are rejected because they only apply to self-hosted orgs.
 	providerStackID int64
-	clientID        string
-	resourceName    string
+	// providerUsesAPIKey reports whether the provider authenticates with an API key. API keys
+	// are already org-scoped, so per-resource org_id overrides are rejected in that mode.
+	providerUsesAPIKey bool
+	clientID           string
+	resourceName       string
 }
 
 // NamedResource is a Resource with a name and category.
@@ -388,6 +391,7 @@ func (r *Resource[T, L]) Configure(ctx context.Context, req resource.ConfigureRe
 	r.typedClient = sdkresource.NewTypedClient[T, L](rcli, r.config.Kind)
 	r.defaultClient = sdkresource.NewNamespaced(r.typedClient, ns)
 	r.providerStackID = client.GrafanaStackID
+	r.providerUsesAPIKey = client.GrafanaAppPlatformUsesAPIKey
 	r.clientID = client.GrafanaAppPlatformAPIClientID
 }
 
@@ -421,16 +425,36 @@ func (r *Resource[T, L]) clientForOrg(orgID int64) (*sdkresource.NamespacedClien
 	if orgID <= 0 {
 		return r.defaultClient, diags
 	}
-	if r.providerStackID > 0 {
+	if diags.Append(validateOrgOverride(r.providerStackID, r.providerUsesAPIKey)...); diags.HasError() {
+		return nil, diags
+	}
+	return sdkresource.NewNamespaced(r.typedClient, claims.OrgNamespaceFormatter(orgID)), diags
+}
+
+// validateOrgOverride reports why a per-resource metadata.org_id override is not allowed for
+// the current provider auth/target: overrides only apply to self-hosted Grafana reached with
+// basic auth. Grafana Cloud stacks are addressed by stack_id, and API keys are org-scoped by
+// construction, so in both cases an explicit org_id would silently reach (or fail to reach) an
+// unintended namespace. Mirrors the SDKv2 team resource (internal/resources/grafana/resource_team.go).
+func validateOrgOverride(providerStackID int64, usesAPIKey bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+	switch {
+	case usesAPIKey:
+		diags.AddAttributeError(
+			path.Root("metadata").AtName("org_id"),
+			"Invalid metadata.org_id",
+			"metadata.org_id is only supported with basic auth. API keys are already org-scoped. "+
+				"Remove metadata.org_id, or authenticate the provider with basic auth.",
+		)
+	case providerStackID > 0:
 		diags.AddAttributeError(
 			path.Root("metadata").AtName("org_id"),
 			"Invalid metadata.org_id",
 			"metadata.org_id targets a self-hosted Grafana organization, but the provider is configured for a "+
 				"Grafana Cloud stack (stack_id). Remove metadata.org_id, or configure the provider for a self-hosted instance.",
 		)
-		return nil, diags
 	}
-	return sdkresource.NewNamespaced(r.typedClient, claims.OrgNamespaceFormatter(orgID)), diags
+	return diags
 }
 
 // orgIDFromMetadata extracts the optional org_id override from a resource's metadata

--- a/internal/resources/appplatform/resource.go
+++ b/internal/resources/appplatform/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -84,10 +86,25 @@ type ResourceModel struct {
 type ResourceMetadataModel struct {
 	UUID        types.String `tfsdk:"uuid"`
 	UID         types.String `tfsdk:"uid"`
+	OrgID       types.Int64  `tfsdk:"org_id"`
 	FolderUID   types.String `tfsdk:"folder_uid"`
 	Version     types.String `tfsdk:"version"`
 	URL         types.String `tfsdk:"url"`
 	Annotations types.Map    `tfsdk:"annotations"`
+}
+
+// metadataAttrTypes is the attribute-type map for the metadata object. It must stay in
+// sync with both the metadata block in Schema and the fields of ResourceMetadataModel;
+// the Terraform framework requires the struct fields and object attributes to match
+// exactly when converting between them.
+var metadataAttrTypes = map[string]attr.Type{
+	"uuid":        types.StringType,
+	"uid":         types.StringType,
+	"org_id":      types.Int64Type,
+	"folder_uid":  types.StringType,
+	"version":     types.StringType,
+	"url":         types.StringType,
+	"annotations": types.MapType{ElemType: types.StringType},
 }
 
 // ResourceConfig is a configuration for a Grafana resource.
@@ -136,10 +153,17 @@ type ResourceUpdateDecider func(ctx context.Context, req resource.UpdateRequest,
 
 // Resource is a generic Terraform resource for a Grafana resource.
 type Resource[T sdkresource.Object, L sdkresource.ListObject] struct {
-	config       ResourceConfig[T]
-	client       *sdkresource.NamespacedClient[T, L]
-	clientID     string
-	resourceName string
+	config ResourceConfig[T]
+	// typedClient is the namespace-agnostic client; namespaced clients are derived from it
+	// per operation so that a resource can override the target org via metadata.org_id.
+	typedClient *sdkresource.TypedClient[T, L]
+	// defaultClient targets the provider-level namespace (from the provider's org_id/stack_id).
+	defaultClient *sdkresource.NamespacedClient[T, L]
+	// providerStackID is the provider-level Grafana Cloud stack ID (0 for self-hosted). When
+	// set, per-resource org_id overrides are rejected because they only apply to self-hosted orgs.
+	providerStackID int64
+	clientID        string
+	resourceName    string
 }
 
 // NamedResource is a Resource with a name and category.
@@ -197,6 +221,16 @@ func (r *Resource[T, L]) Schema(ctx context.Context, req resource.SchemaRequest,
 					Description: "The unique identifier of the resource.",
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				"org_id": schema.Int64Attribute{
+					Optional: true,
+					Description: "The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. " +
+						"When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration " +
+						"can manage App Platform resources across multiple organizations. Not supported on Grafana Cloud (configure a " +
+						"stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.",
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.RequiresReplace(),
 					},
 				},
 				"folder_uid": schema.StringAttribute{
@@ -310,7 +344,7 @@ func (r *Resource[T, L]) Configure(ctx context.Context, req resource.ConfigureRe
 	}
 
 	// Skip if already configured.
-	if r.client != nil {
+	if r.defaultClient != nil {
 		return
 	}
 
@@ -351,7 +385,9 @@ func (r *Resource[T, L]) Configure(ctx context.Context, req resource.ConfigureRe
 		return
 	}
 
-	r.client = sdkresource.NewNamespaced(sdkresource.NewTypedClient[T, L](rcli, r.config.Kind), ns)
+	r.typedClient = sdkresource.NewTypedClient[T, L](rcli, r.config.Kind)
+	r.defaultClient = sdkresource.NewNamespaced(r.typedClient, ns)
+	r.providerStackID = client.GrafanaStackID
 	r.clientID = client.GrafanaAppPlatformAPIClientID
 }
 
@@ -367,6 +403,88 @@ func namespaceForClient(orgID, stackID int64) (string, string) {
 	default:
 		return "", errNamespaceMissingIDs
 	}
+}
+
+// clientForModel returns the namespaced client to use for the given resource model.
+// When metadata.org_id is set it targets that organization's namespace (self-hosted
+// Grafana only); otherwise the provider-level default namespace is used.
+func (r *Resource[T, L]) clientForModel(data ResourceModel) (*sdkresource.NamespacedClient[T, L], diag.Diagnostics) {
+	return r.clientForOrg(orgIDFromMetadata(data.Metadata))
+}
+
+// clientForOrg resolves the namespaced client for an explicit per-resource org ID
+// override. orgID <= 0 selects the provider-level default client. A non-zero override
+// is only valid for self-hosted Grafana (org-<id> namespaces); when the provider is
+// configured for a Grafana Cloud stack it is rejected rather than silently ignored.
+func (r *Resource[T, L]) clientForOrg(orgID int64) (*sdkresource.NamespacedClient[T, L], diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if orgID <= 0 {
+		return r.defaultClient, diags
+	}
+	if r.providerStackID > 0 {
+		diags.AddAttributeError(
+			path.Root("metadata").AtName("org_id"),
+			"Invalid metadata.org_id",
+			"metadata.org_id targets a self-hosted Grafana organization, but the provider is configured for a "+
+				"Grafana Cloud stack (stack_id). Remove metadata.org_id, or configure the provider for a self-hosted instance.",
+		)
+		return nil, diags
+	}
+	return sdkresource.NewNamespaced(r.typedClient, claims.OrgNamespaceFormatter(orgID)), diags
+}
+
+// orgIDFromMetadata extracts the optional org_id override from a resource's metadata
+// object. It returns 0 when metadata or org_id is absent, null, or unknown.
+func orgIDFromMetadata(metadata types.Object) int64 {
+	if metadata.IsNull() || metadata.IsUnknown() {
+		return 0
+	}
+	v, ok := metadata.Attributes()["org_id"]
+	if !ok {
+		return 0
+	}
+	orgID, ok := v.(types.Int64)
+	if !ok || orgID.IsNull() || orgID.IsUnknown() {
+		return 0
+	}
+	return orgID.ValueInt64()
+}
+
+// splitImportID parses an App Platform import ID. It accepts either "<uid>" (targeting the
+// provider-default org) or "<orgID>:<uid>" (targeting a specific self-hosted organization).
+// A non-numeric or non-positive prefix is treated as part of the uid so that uids that
+// happen to contain a colon are not misparsed.
+func splitImportID(id string) (int64, string) {
+	prefix, rest, found := strings.Cut(id, ":")
+	if !found {
+		return 0, id
+	}
+	orgID, err := strconv.ParseInt(prefix, 10, 64)
+	if err != nil || orgID <= 0 {
+		return 0, id
+	}
+	return orgID, rest
+}
+
+// setMetadataOrgID sets metadata.org_id on the model, rebuilding the metadata object so its
+// attribute set continues to match metadataAttrTypes.
+func setMetadataOrgID(ctx context.Context, data *ResourceModel, orgID int64) diag.Diagnostics {
+	var meta ResourceMetadataModel
+	if diag := data.Metadata.As(ctx, &meta, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	}); diag.HasError() {
+		return diag
+	}
+
+	meta.OrgID = types.Int64Value(orgID)
+
+	obj, diag := types.ObjectValueFrom(ctx, metadataAttrTypes, meta)
+	if diag.HasError() {
+		return diag
+	}
+	data.Metadata = obj
+	return nil
 }
 
 // Read reads the Grafana resource.
@@ -423,10 +541,16 @@ func (r *Resource[T, L]) readModel(ctx context.Context, data ResourceModel, resp
 		return
 	}
 
+	cli, diags := r.clientForModel(data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var res T
 	err := retryWhile(ctx, readBackoff, isRetryableServerError, func() error {
 		var gerr error
-		res, gerr = r.client.Get(ctx, obj.GetName())
+		res, gerr = cli.Get(ctx, obj.GetName())
 		return gerr
 	})
 	if err != nil {
@@ -524,7 +648,13 @@ func (r *Resource[T, L]) createModel(
 		return
 	}
 
-	res, err := r.client.Create(ctx, obj, sdkresource.CreateOptions{})
+	cli, diags := r.clientForModel(data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	res, err := cli.Create(ctx, obj, sdkresource.CreateOptions{})
 	if err != nil {
 		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionCreate, obj.GetName(), r.resourceName, err)...)
 		return
@@ -643,6 +773,12 @@ func (r *Resource[T, L]) updateModel(
 		}
 	}
 
+	cli, diags := r.clientForModel(data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	reqopts := sdkresource.UpdateOptions{
 		ResourceVersion: obj.GetResourceVersion(),
 	}
@@ -655,7 +791,7 @@ func (r *Resource[T, L]) updateModel(
 	attempt := 0
 	err := retryOnConflict(ctx, conflictBackoff, func() error {
 		if attempt > 0 && !opts.Overwrite {
-			current, err := r.client.Get(ctx, obj.GetName())
+			current, err := cli.Get(ctx, obj.GetName())
 			if err != nil {
 				return err
 			}
@@ -666,7 +802,7 @@ func (r *Resource[T, L]) updateModel(
 		attempt++
 
 		var err error
-		res, err = r.client.Update(ctx, obj, reqopts)
+		res, err = cli.Update(ctx, obj, reqopts)
 		return err
 	})
 	if err != nil {
@@ -718,8 +854,14 @@ func (r *Resource[T, L]) deleteModel(ctx context.Context, data ResourceModel, re
 		return
 	}
 
+	cli, diags := r.clientForModel(data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if err := retryWhile(ctx, deleteBackoff, isRetryableDeleteError, func() error {
-		return r.client.Delete(ctx, obj.GetName(), sdkresource.DeleteOptions{})
+		return cli.Delete(ctx, obj.GetName(), sdkresource.DeleteOptions{})
 	}); err != nil {
 		if apierrors.IsNotFound(err) {
 			return
@@ -745,14 +887,24 @@ func (r *Resource[T, L]) importStateModel(
 	resp *resource.ImportStateResponse,
 	setState func(updated ResourceModel),
 ) {
+	// Import IDs may be either "<uid>" (provider-default org) or "<orgID>:<uid>" to import a
+	// resource that lives in a specific self-hosted organization.
+	orgID, name := splitImportID(req.ID)
+
+	cli, diags := r.clientForOrg(orgID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var res T
 	err := retryWhile(ctx, readBackoff, isRetryableServerError, func() error {
 		var gerr error
-		res, gerr = r.client.Get(ctx, req.ID)
+		res, gerr = cli.Get(ctx, name)
 		return gerr
 	})
 	if err != nil {
-		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionRead, req.ID, r.resourceName, err)...)
+		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionRead, name, r.resourceName, err)...)
 		return
 	}
 
@@ -760,6 +912,14 @@ func (r *Resource[T, L]) importStateModel(
 	if diag := SaveResourceToModel(ctx, res, &data); diag.HasError() {
 		resp.Diagnostics.Append(diag...)
 		return
+	}
+
+	// Reflect the imported org into state so subsequent plans target the same namespace.
+	if orgID > 0 {
+		if diag := setMetadataOrgID(ctx, &data, orgID); diag.HasError() {
+			resp.Diagnostics.Append(diag...)
+			return
+		}
 	}
 
 	if diag := r.config.SpecSaver(ctx, res, &data); diag.HasError() {
@@ -850,19 +1010,7 @@ func SaveResourceToModel[T sdkresource.Object](
 	if diag := GetModelFromMetadata(ctx, src, &meta); diag.HasError() {
 		return diag
 	} else {
-		dst.Metadata, diag = types.ObjectValueFrom(
-			ctx,
-			// TODO: re-use these from the schema.
-			map[string]attr.Type{
-				"uuid":        types.StringType,
-				"uid":         types.StringType,
-				"folder_uid":  types.StringType,
-				"version":     types.StringType,
-				"url":         types.StringType,
-				"annotations": types.MapType{ElemType: types.StringType},
-			},
-			meta,
-		)
+		dst.Metadata, diag = types.ObjectValueFrom(ctx, metadataAttrTypes, meta)
 
 		if diag.HasError() {
 			return diag

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -177,17 +177,11 @@ func TestSaveResourceToModel(t *testing.T) {
 
 			dst := &ResourceModel{
 				Metadata: types.ObjectValueMust(
-					map[string]attr.Type{
-						"uuid":        types.StringType,
-						"uid":         types.StringType,
-						"folder_uid":  types.StringType,
-						"version":     types.StringType,
-						"url":         types.StringType,
-						"annotations": types.MapType{ElemType: types.StringType},
-					},
+					metadataAttrTypes,
 					map[string]attr.Value{
 						"uuid":        types.StringNull(),
 						"uid":         types.StringNull(),
+						"org_id":      types.Int64Null(),
 						"folder_uid":  types.StringNull(),
 						"version":     types.StringNull(),
 						"url":         types.StringNull(),
@@ -416,6 +410,75 @@ func TestNamespaceForClient(t *testing.T) {
 			require.Equal(t, tt.expectErr, errMsg)
 		})
 	}
+}
+
+func TestSplitImportID(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		expectOrg int64
+		expectUID string
+	}{
+		{name: "plain uid", id: "my-repo", expectOrg: 0, expectUID: "my-repo"},
+		{name: "org-scoped uid", id: "2:my-repo", expectOrg: 2, expectUID: "my-repo"},
+		{name: "zero org falls back to full id", id: "0:my-repo", expectOrg: 0, expectUID: "0:my-repo"},
+		{name: "negative org falls back to full id", id: "-1:my-repo", expectOrg: 0, expectUID: "-1:my-repo"},
+		{name: "non-numeric prefix is part of uid", id: "team:my-repo", expectOrg: 0, expectUID: "team:my-repo"},
+		{name: "only first colon splits", id: "3:my:repo", expectOrg: 3, expectUID: "my:repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orgID, uid := splitImportID(tt.id)
+			require.Equal(t, tt.expectOrg, orgID)
+			require.Equal(t, tt.expectUID, uid)
+		})
+	}
+}
+
+func TestOrgIDFromMetadata(t *testing.T) {
+	metaWithOrg := func(org attr.Value) types.Object {
+		return types.ObjectValueMust(metadataAttrTypes, map[string]attr.Value{
+			"uuid":        types.StringNull(),
+			"uid":         types.StringValue("x"),
+			"org_id":      org,
+			"folder_uid":  types.StringNull(),
+			"version":     types.StringNull(),
+			"url":         types.StringNull(),
+			"annotations": types.MapNull(types.StringType),
+		})
+	}
+
+	tests := []struct {
+		name     string
+		metadata types.Object
+		expect   int64
+	}{
+		{name: "null object", metadata: types.ObjectNull(metadataAttrTypes), expect: 0},
+		{name: "unknown object", metadata: types.ObjectUnknown(metadataAttrTypes), expect: 0},
+		{name: "null org_id", metadata: metaWithOrg(types.Int64Null()), expect: 0},
+		{name: "unknown org_id", metadata: metaWithOrg(types.Int64Unknown()), expect: 0},
+		{name: "set org_id", metadata: metaWithOrg(types.Int64Value(7)), expect: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expect, orgIDFromMetadata(tt.metadata))
+		})
+	}
+}
+
+func TestClientForOrgRejectsOrgOverrideOnCloud(t *testing.T) {
+	// A per-resource org_id override is invalid when the provider targets a Cloud stack.
+	r := &Resource[*v0alpha1.Playlist, *v0alpha1.PlaylistList]{providerStackID: 5}
+	_, diags := r.clientForOrg(2)
+	require.True(t, diags.HasError())
+
+	// Without an override (orgID <= 0) it returns the provider-default client and no error,
+	// even when a stack is configured.
+	cli, diags := r.clientForOrg(0)
+	require.False(t, diags.HasError())
+	require.Nil(t, cli) // defaultClient is unset in this unit context
 }
 
 func TestSchemaIncludesSecureBlockWhenConfigured(t *testing.T) {

--- a/internal/resources/appplatform/resource_test.go
+++ b/internal/resources/appplatform/resource_test.go
@@ -468,10 +468,40 @@ func TestOrgIDFromMetadata(t *testing.T) {
 	}
 }
 
-func TestClientForOrgRejectsOrgOverrideOnCloud(t *testing.T) {
+func TestValidateOrgOverride(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerStack  int64
+		usesAPIKey     bool
+		expectErr      bool
+		expectContains string
+	}{
+		{name: "self-hosted basic auth allows override", expectErr: false},
+		{name: "api key rejected", usesAPIKey: true, expectErr: true, expectContains: "basic auth"},
+		{name: "cloud stack rejected", providerStack: 5, expectErr: true, expectContains: "Grafana Cloud stack"},
+		{name: "api key takes precedence over stack", providerStack: 5, usesAPIKey: true, expectErr: true, expectContains: "basic auth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := validateOrgOverride(tt.providerStack, tt.usesAPIKey)
+			require.Equal(t, tt.expectErr, diags.HasError())
+			if tt.expectContains != "" {
+				require.Contains(t, diags.Errors()[0].Detail(), tt.expectContains)
+			}
+		})
+	}
+}
+
+func TestClientForOrgRejectsUnsupportedOverride(t *testing.T) {
 	// A per-resource org_id override is invalid when the provider targets a Cloud stack.
 	r := &Resource[*v0alpha1.Playlist, *v0alpha1.PlaylistList]{providerStackID: 5}
 	_, diags := r.clientForOrg(2)
+	require.True(t, diags.HasError())
+
+	// ...and when the provider authenticates with an API key.
+	r = &Resource[*v0alpha1.Playlist, *v0alpha1.PlaylistList]{providerUsesAPIKey: true}
+	_, diags = r.clientForOrg(2)
 	require.True(t, diags.HasError())
 
 	// Without an override (orgID <= 0) it returns the provider-default client and no error,

--- a/internal/resources/appplatform/secret_keeper_activation_resource.go
+++ b/internal/resources/appplatform/secret_keeper_activation_resource.go
@@ -186,7 +186,7 @@ func (r *keeperActivationResource) ImportState(ctx context.Context, req resource
 		"version":     types.StringType,
 		"url":         types.StringType,
 		"annotations": types.MapType{ElemType: types.StringType},
-	}, ResourceMetadataModel{
+	}, secretMetadataModel{
 		UID:         types.StringValue(req.ID),
 		Annotations: types.MapNull(types.StringType),
 	})

--- a/internal/resources/appplatform/secret_keeper_activation_resource.go
+++ b/internal/resources/appplatform/secret_keeper_activation_resource.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"strings"
 
+	"github.com/grafana/authlib/claims"
 	sdkresource "github.com/grafana/grafana-app-sdk/resource"
 	"github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -21,7 +23,14 @@ import (
 const SystemKeeperName = "system"
 
 type keeperActivationResource struct {
-	client *sdkresource.NamespacedClient[*v1beta1.Keeper, *v1beta1.KeeperList]
+	// typedClient is the namespace-agnostic client; namespaced clients are derived from it
+	// per operation so activation can target a specific org via metadata.org_id.
+	typedClient *sdkresource.TypedClient[*v1beta1.Keeper, *v1beta1.KeeperList]
+	// defaultClient targets the provider-level namespace (from the provider's org_id/stack_id).
+	defaultClient *sdkresource.NamespacedClient[*v1beta1.Keeper, *v1beta1.KeeperList]
+	// providerStackID is the provider-level Grafana Cloud stack ID (0 for self-hosted). When
+	// set, per-resource org_id overrides are rejected because they only apply to self-hosted orgs.
+	providerStackID int64
 }
 
 type keeperActivationModel struct {
@@ -94,7 +103,29 @@ func (r *keeperActivationResource) Configure(ctx context.Context, req resource.C
 		return
 	}
 
-	r.client = sdkresource.NewNamespaced(sdkresource.NewTypedClient[*v1beta1.Keeper, *v1beta1.KeeperList](rcli, v1beta1.KeeperKind()), ns)
+	r.typedClient = sdkresource.NewTypedClient[*v1beta1.Keeper, *v1beta1.KeeperList](rcli, v1beta1.KeeperKind())
+	r.defaultClient = sdkresource.NewNamespaced(r.typedClient, ns)
+	r.providerStackID = client.GrafanaStackID
+}
+
+// clientForOrg resolves the namespaced client for an explicit per-resource org ID override.
+// orgID <= 0 selects the provider-level default client. A non-zero override is only valid
+// for self-hosted Grafana; on Grafana Cloud it is rejected rather than silently ignored.
+func (r *keeperActivationResource) clientForOrg(orgID int64) (*sdkresource.NamespacedClient[*v1beta1.Keeper, *v1beta1.KeeperList], diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if orgID <= 0 {
+		return r.defaultClient, diags
+	}
+	if r.providerStackID > 0 {
+		diags.AddAttributeError(
+			path.Root("metadata").AtName("org_id"),
+			"Invalid metadata.org_id",
+			"metadata.org_id targets a self-hosted Grafana organization, but the provider is configured for a "+
+				"Grafana Cloud stack (stack_id). Remove metadata.org_id, or configure the provider for a self-hosted instance.",
+		)
+		return nil, diags
+	}
+	return sdkresource.NewNamespaced(r.typedClient, claims.OrgNamespaceFormatter(orgID)), diags
 }
 
 func (r *keeperActivationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -110,7 +141,13 @@ func (r *keeperActivationResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	if err := r.activateKeeper(ctx, uid); err != nil {
+	cli, diags := r.clientForOrg(orgIDFromMetadata(data.Metadata))
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.activateKeeper(ctx, cli, uid); err != nil {
 		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionCreate, uid, "grafana_apps_secret_keeper_activation_v1beta1", err)...)
 		return
 	}
@@ -132,7 +169,13 @@ func (r *keeperActivationResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	if _, err := r.client.Get(ctx, uid); err != nil {
+	cli, diags := r.clientForOrg(orgIDFromMetadata(data.Metadata))
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if _, err := cli.Get(ctx, uid); err != nil {
 		if apierrors.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
@@ -158,7 +201,13 @@ func (r *keeperActivationResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	if err := r.activateKeeper(ctx, uid); err != nil {
+	cli, diags := r.clientForOrg(orgIDFromMetadata(data.Metadata))
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.activateKeeper(ctx, cli, uid); err != nil {
 		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionUpdate, uid, "grafana_apps_secret_keeper_activation_v1beta1", err)...)
 		return
 	}
@@ -168,26 +217,41 @@ func (r *keeperActivationResource) Update(ctx context.Context, req resource.Upda
 }
 
 func (r *keeperActivationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	if err := r.activateKeeper(ctx, SystemKeeperName); err != nil {
+	var data keeperActivationModel
+	if diag := req.State.Get(ctx, &data); diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+		return
+	}
+
+	cli, diags := r.clientForOrg(orgIDFromMetadata(data.Metadata))
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.activateKeeper(ctx, cli, SystemKeeperName); err != nil {
 		resp.Diagnostics.Append(ErrorToDiagnostics(ResourceActionDelete, SystemKeeperName, "grafana_apps_secret_keeper_activation_v1beta1", err)...)
 		return
 	}
 }
 
 func (r *keeperActivationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import IDs may be either "<uid>" (provider-default org) or "<orgID>:<uid>" to import an
+	// activation that lives in a specific self-hosted organization.
+	orgID, name := splitImportID(req.ID)
+
+	orgIDValue := types.Int64Null()
+	if orgID > 0 {
+		orgIDValue = types.Int64Value(orgID)
+	}
+
 	data := keeperActivationModel{
 		Metadata: emptyMetadataObject(),
 	}
 
-	meta, diag := types.ObjectValueFrom(ctx, map[string]attr.Type{
-		"uuid":        types.StringType,
-		"uid":         types.StringType,
-		"folder_uid":  types.StringType,
-		"version":     types.StringType,
-		"url":         types.StringType,
-		"annotations": types.MapType{ElemType: types.StringType},
-	}, secretMetadataModel{
-		UID:         types.StringValue(req.ID),
+	meta, diag := types.ObjectValueFrom(ctx, secretMetadataAttrTypes, secretMetadataModel{
+		UID:         types.StringValue(name),
+		OrgID:       orgIDValue,
 		Annotations: types.MapNull(types.StringType),
 	})
 	if diag.HasError() {
@@ -195,14 +259,14 @@ func (r *keeperActivationResource) ImportState(ctx context.Context, req resource
 		return
 	}
 	data.Metadata = meta
-	data.ID = types.StringValue(req.ID)
+	data.ID = types.StringValue(name)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *keeperActivationResource) activateKeeper(ctx context.Context, name string) error {
+func (r *keeperActivationResource) activateKeeper(ctx context.Context, cli *sdkresource.NamespacedClient[*v1beta1.Keeper, *v1beta1.KeeperList], name string) error {
 	body := io.NopCloser(strings.NewReader("{}"))
-	_, err := r.client.SubresourceRequest(ctx, name, sdkresource.CustomRouteRequestOptions{
+	_, err := cli.SubresourceRequest(ctx, name, sdkresource.CustomRouteRequestOptions{
 		Path: "activate",
 		Verb: "POST",
 		Body: body,

--- a/internal/resources/appplatform/secret_keeper_activation_resource.go
+++ b/internal/resources/appplatform/secret_keeper_activation_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/terraform-provider-grafana/v4/internal/common"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -31,6 +30,9 @@ type keeperActivationResource struct {
 	// providerStackID is the provider-level Grafana Cloud stack ID (0 for self-hosted). When
 	// set, per-resource org_id overrides are rejected because they only apply to self-hosted orgs.
 	providerStackID int64
+	// providerUsesAPIKey reports whether the provider authenticates with an API key. API keys
+	// are already org-scoped, so per-resource org_id overrides are rejected in that mode.
+	providerUsesAPIKey bool
 }
 
 type keeperActivationModel struct {
@@ -106,6 +108,7 @@ func (r *keeperActivationResource) Configure(ctx context.Context, req resource.C
 	r.typedClient = sdkresource.NewTypedClient[*v1beta1.Keeper, *v1beta1.KeeperList](rcli, v1beta1.KeeperKind())
 	r.defaultClient = sdkresource.NewNamespaced(r.typedClient, ns)
 	r.providerStackID = client.GrafanaStackID
+	r.providerUsesAPIKey = client.GrafanaAppPlatformUsesAPIKey
 }
 
 // clientForOrg resolves the namespaced client for an explicit per-resource org ID override.
@@ -116,13 +119,7 @@ func (r *keeperActivationResource) clientForOrg(orgID int64) (*sdkresource.Names
 	if orgID <= 0 {
 		return r.defaultClient, diags
 	}
-	if r.providerStackID > 0 {
-		diags.AddAttributeError(
-			path.Root("metadata").AtName("org_id"),
-			"Invalid metadata.org_id",
-			"metadata.org_id targets a self-hosted Grafana organization, but the provider is configured for a "+
-				"Grafana Cloud stack (stack_id). Remove metadata.org_id, or configure the provider for a self-hosted instance.",
-		)
+	if diags.Append(validateOrgOverride(r.providerStackID, r.providerUsesAPIKey)...); diags.HasError() {
 		return nil, diags
 	}
 	return sdkresource.NewNamespaced(r.typedClient, claims.OrgNamespaceFormatter(orgID)), diags

--- a/internal/resources/appplatform/secret_shared.go
+++ b/internal/resources/appplatform/secret_shared.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -13,17 +14,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// secretMetadataModel mirrors the secret metadata block (secretMetadataBlock), which
-// intentionally omits the org_id override present on the generic ResourceMetadataModel.
-// The Terraform framework requires struct fields and object attributes to match exactly,
-// so the secret resources use this dedicated model rather than the generic one.
+// secretMetadataModel mirrors the secret metadata block (secretMetadataBlock). It is kept
+// separate from the generic ResourceMetadataModel because the secret metadata block omits
+// some generic attributes (and the Terraform framework requires struct fields and object
+// attributes to match exactly), but it carries the same org_id override for multi-org use.
 type secretMetadataModel struct {
 	UUID        types.String `tfsdk:"uuid"`
 	UID         types.String `tfsdk:"uid"`
+	OrgID       types.Int64  `tfsdk:"org_id"`
 	FolderUID   types.String `tfsdk:"folder_uid"`
 	Version     types.String `tfsdk:"version"`
 	URL         types.String `tfsdk:"url"`
 	Annotations types.Map    `tfsdk:"annotations"`
+}
+
+// secretMetadataAttrTypes is the attribute-type map for the secret metadata object. It must
+// stay in sync with secretMetadataBlock and secretMetadataModel.
+var secretMetadataAttrTypes = map[string]attr.Type{
+	"uuid":        types.StringType,
+	"uid":         types.StringType,
+	"org_id":      types.Int64Type,
+	"folder_uid":  types.StringType,
+	"version":     types.StringType,
+	"url":         types.StringType,
+	"annotations": types.MapType{ElemType: types.StringType},
 }
 
 func secretMetadataBlock(validators ...validator.String) schema.SingleNestedBlock {
@@ -34,6 +48,16 @@ func secretMetadataBlock(validators ...validator.String) schema.SingleNestedBloc
 				Required:    true,
 				Description: "The unique identifier of the resource.",
 				Validators:  validators,
+			},
+			"org_id": schema.Int64Attribute{
+				Optional: true,
+				Description: "The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. " +
+					"When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration " +
+					"can manage resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with " +
+					"`stack_id` instead). Changing this value forces the resource to be recreated in the new organization.",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
 			"folder_uid": schema.StringAttribute{
 				Optional:    true,
@@ -65,17 +89,11 @@ func secretMetadataBlock(validators ...validator.String) schema.SingleNestedBloc
 
 func emptyMetadataObject() types.Object {
 	return types.ObjectValueMust(
-		map[string]attr.Type{
-			"uuid":        types.StringType,
-			"uid":         types.StringType,
-			"folder_uid":  types.StringType,
-			"version":     types.StringType,
-			"url":         types.StringType,
-			"annotations": types.MapType{ElemType: types.StringType},
-		},
+		secretMetadataAttrTypes,
 		map[string]attr.Value{
 			"uuid":        types.StringNull(),
 			"uid":         types.StringNull(),
+			"org_id":      types.Int64Null(),
 			"folder_uid":  types.StringNull(),
 			"version":     types.StringNull(),
 			"url":         types.StringNull(),

--- a/internal/resources/appplatform/secret_shared.go
+++ b/internal/resources/appplatform/secret_shared.go
@@ -13,6 +13,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+// secretMetadataModel mirrors the secret metadata block (secretMetadataBlock), which
+// intentionally omits the org_id override present on the generic ResourceMetadataModel.
+// The Terraform framework requires struct fields and object attributes to match exactly,
+// so the secret resources use this dedicated model rather than the generic one.
+type secretMetadataModel struct {
+	UUID        types.String `tfsdk:"uuid"`
+	UID         types.String `tfsdk:"uid"`
+	FolderUID   types.String `tfsdk:"folder_uid"`
+	Version     types.String `tfsdk:"version"`
+	URL         types.String `tfsdk:"url"`
+	Annotations types.Map    `tfsdk:"annotations"`
+}
+
 func secretMetadataBlock(validators ...validator.String) schema.SingleNestedBlock {
 	return schema.SingleNestedBlock{
 		Description: "The metadata of the resource.",
@@ -76,7 +89,7 @@ func metadataUID(ctx context.Context, metadata types.Object) (string, diag.Diagn
 		return "", diag.Diagnostics{diag.NewErrorDiagnostic("missing metadata", "metadata.uid is required")}
 	}
 
-	var mod ResourceMetadataModel
+	var mod secretMetadataModel
 	if diag := metadata.As(ctx, &mod, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty:    true,
 		UnhandledUnknownAsEmpty: true,

--- a/internal/resources/appplatform/servicemodel_component_resource_test.go
+++ b/internal/resources/appplatform/servicemodel_component_resource_test.go
@@ -414,6 +414,7 @@ func TestServiceModelComponentResourceName(t *testing.T) {
 var serviceModelTestMetadataAttrTypes = map[string]attr.Type{
 	"uuid":        types.StringType,
 	"uid":         types.StringType,
+	"org_id":      types.Int64Type,
 	"folder_uid":  types.StringType,
 	"version":     types.StringType,
 	"url":         types.StringType,
@@ -425,6 +426,7 @@ func serviceModelTestMetadataObject(t *testing.T, uid attr.Value) types.Object {
 	obj, diags := types.ObjectValue(serviceModelTestMetadataAttrTypes, map[string]attr.Value{
 		"uuid":        types.StringNull(),
 		"uid":         uid,
+		"org_id":      types.Int64Null(),
 		"folder_uid":  types.StringNull(),
 		"version":     types.StringNull(),
 		"url":         types.StringNull(),

--- a/pkg/provider/configure_clients.go
+++ b/pkg/provider/configure_clients.go
@@ -275,6 +275,7 @@ func createGrafanaAppPlatformClient(client *common.Client, cfg ProviderConfig) e
 
 	client.GrafanaOrgID = cfg.OrgID.ValueInt64()
 	client.GrafanaStackID = cfg.StackID.ValueInt64()
+	client.GrafanaAppPlatformUsesAPIKey = apiKey != ""
 	client.GrafanaAppPlatformAPIClientID = appplatform.DefaultManagerIdentity
 	appPlatformTLSConfig, _ := tlsClientConfig.TLSConfig()
 	client.GrafanaHTTPClient = newGrafanaHTTPClient(appPlatformTLSConfig, userInfo, apiKey, client.GrafanaAPIConfig)

--- a/templates/resources/apps_notifications_routingtree_v1beta1.md.tmpl
+++ b/templates/resources/apps_notifications_routingtree_v1beta1.md.tmpl
@@ -106,7 +106,7 @@ blocks are the ones that map to `spec.routes`.
 | `policy.continue`             | `routes.continue` (optional, defaults to false)  |
 | `policy.policy` (deeper nesting) | `routes.routes`                               |
 | `disable_provenance`          | `spec.disable_provenance`                        |
-| `org_id`                      | not a field; the org/stack determines the namespace |
+| `org_id`                      | `metadata.org_id` (optional; self-hosted only — overrides the provider org for this resource) |
 
 -> **Provenance and UI editing:** `disable_provenance` behaves like the legacy
 attribute — `true` leaves the tree editable from other sources (e.g. the Grafana
@@ -137,6 +137,10 @@ attribute, not a top-level resource attribute.
 Required:
 
 - `uid` (String) The unique identifier (Kubernetes name) of the routing tree. The default routing tree is named `default`.
+
+Optional:
+
+- `org_id` (Number) The Grafana organization ID this resource belongs to, for self-hosted OSS or Enterprise Grafana. When set, it overrides the provider's `org_id` for this resource only, so a single provider configuration can manage resources across multiple organizations. Not supported on Grafana Cloud (configure a stack with `stack_id` instead). Changing this value forces the resource to be recreated in the new organization.
 
 Read-Only:
 


### PR DESCRIPTION
Slack thread: https://raintank-corp.slack.com/archives/C04RVCAG9B5/p1787923950659599

## Summary

App Platform resources (e.g. `grafana_apps_provisioning_repository_v0alpha1` / GitSync) currently derive their target Kubernetes namespace **solely from the provider-level `org_id`/`stack_id`**, resolved once at `Configure` time and bound to a single namespaced client (`resource.go` `namespaceForClient` → `NewNamespaced`). As a result, a single provider configuration can only manage resources in **one** Grafana organization.

This is a real pain point for self-hosted Enterprise customers who manage many orgs from one Terraform config (created via a `for_each` over `grafana_organization`). Today the only workaround is one **aliased provider block per org** — which can't be generated dynamically, since Terraform evaluates `provider` blocks statically. The classic SDKv2 resources already solve this with a per-resource `org_id`; App Platform resources never got the equivalent.

This PR adds an optional **`metadata.org_id`** override to the App Platform resources, mirroring that SDKv2 convention.

## What changed

- **Per-operation client resolution.** `Resource[T,L]` now keeps a namespace-agnostic typed client plus the provider-default namespaced client, and each CRUD op resolves the namespaced client via `clientForModel` based on `metadata.org_id`. Omitted/null → provider default (unchanged behavior).
- **Schema.** New `metadata.org_id` (`Optional`, `RequiresReplace`). Because it lives on the generic `Resource[T,L]`, it applies to **all App Platform typed resources** (repository, connection, dashboards, servicemodel, secret keeper/securevalue, rules, …).
- **Custom resources too.** The one non-generic resource, `secret_keeper_activation` (its own client + 6-attribute metadata), gets the same per-operation namespace resolution wired into its custom CRUD, so it is multi-org as well.
- **Self-hosted only.** A non-zero `org_id` is **rejected** (attribute-level diagnostic) when the provider targets a Grafana Cloud stack (`stack_id`), rather than silently ignored. Cross-stack management from one config isn't possible anyway (separate endpoints/tokens).
- **Import.** Import IDs accept `"<orgID>:<uid>"` (in addition to `"<uid>"`) to import a resource from a specific org; the org is reflected back into state.
- **Metadata models.** The framework requires struct/object attribute sets to match **exactly**, so `org_id` was threaded consistently through both the generic `ResourceMetadataModel`/`metadataAttrTypes` and the secret `secretMetadataModel`/`secretMetadataBlock`.
- **Docs** regenerated (`go generate ./...`). **Unit tests** added for `splitImportID`, `orgIDFromMetadata`, and the Cloud-rejection path.

## Usage

```hcl
resource "grafana_organization" "orgs" {
  for_each = toset(["team_a", "team_b"])
  name     = each.key
}

# One provider config, many orgs — no aliases
resource "grafana_apps_provisioning_repository_v0alpha1" "gitsync" {
  for_each = grafana_organization.orgs

  metadata {
    uid    = "gitsync-${each.key}"
    org_id = each.value.org_id
  }
  spec {
    title = each.key
    type  = "github"
    github { url = "https://github.com/acme/${each.key}" branch = "main" }
    sync   { enabled = true target = "folder" }
  }
}
```

## Notes / open questions

- Requires **basic auth** for org switching (API keys are already org-scoped; the provider rejects `org_id > 1` with an API key).
- `provider_schema.json` is regenerated by CI automation (needs the `terraform` CLI, unavailable in my environment) — not included here.
- Draft for design review: does exposing `org_id` on **every** App Platform resource (vs. repository-only) match the intended direction? `org_id` was chosen over a raw `namespace` string for consistency with the rest of the provider and direct `grafana_organization.org_id` wiring.

## Test plan

- [x] `go build ./...`
- [x] `go vet` + `gofmt` clean
- [x] `go test ./internal/resources/appplatform/...`
- [x] `go generate ./...` (docs)
- [ ] Acceptance tests against a multi-org Enterprise instance (needs reviewer env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)