### PR TITLE
fix(grafana_message_template): read back disable_provenance from the API instead of hardcoding false

### DIFF
--- a/internal/resources/grafana/resource_alerting_message_template.go
+++ b/internal/resources/grafana/resource_alerting_message_template.go
@@ -333,7 +333,7 @@ func (r *messageTemplateResource) read(ctx context.Context, id string) (*message
 		OrgID:             types.StringValue(strconv.FormatInt(orgID, 10)),
 		Name:              types.StringValue(tmpl.Name),
 		Template:          templateValue{StringValue: types.StringValue(tmpl.Template)},
-		DisableProvenance: types.BoolValue(false), // API does not return provenance
+		DisableProvenance: types.BoolValue(tmpl.Provenance == ""),
 	}, diags
 }
 

--- a/internal/resources/grafana/resource_alerting_message_template_test.go
+++ b/internal/resources/grafana/resource_alerting_message_template_test.go
@@ -208,3 +208,49 @@ func testAccMessageTemplate_inOrg(name string) string {
 	}
 	`, name)
 }
+
+func TestAccMessageTemplate_disableProvenance(t *testing.T) {
+	// Regression test for https://github.com/grafana/terraform-provider-grafana/issues/2618:
+	// disable_provenance = true previously read back as false after create, which made Terraform
+	// report "Provider produced inconsistent result after apply".
+	testutils.CheckOSSTestsEnabled(t, ">=9.1.0")
+
+	var tmpl models.NotificationTemplate
+
+	config := `
+resource "grafana_message_template" "disable_provenance" {
+  name                = "Disable Provenance Notification Template"
+  disable_provenance  = true
+  template            = "{{define \"custom.message\" }}\n template content\n{{ end }}"
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: testutils.ProtoV5ProviderFactories,
+		// Implicitly tests deletion.
+		CheckDestroy: alertingMessageTemplateCheckExists.destroyed(&tmpl, nil),
+		Steps: []resource.TestStep{
+			// Test creation. The test framework implicitly re-plans after apply and fails if the
+			// plan is non-empty, which is what exposes the original crash.
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					alertingMessageTemplateCheckExists.exists("grafana_message_template.disable_provenance", &tmpl),
+					resource.TestCheckResourceAttr("grafana_message_template.disable_provenance", "disable_provenance", "true"),
+					func(*terraform.State) error {
+						if tmpl.Provenance != "" {
+							return fmt.Errorf("expected template to have no provenance with disable_provenance=true, got %q", tmpl.Provenance)
+						}
+						return nil
+					},
+				),
+			},
+			// Test import: disable_provenance must round-trip, unlike the other tests in this file
+			// which have to ignore it.
+			{
+				ResourceName:      "grafana_message_template.disable_provenance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- `grafana_message_template`'s `read()` always wrote `disable_provenance = false` into state after create/update/read, regardless of what was actually sent to the API. Since `disable_provenance` has a `RequiresReplace` plan modifier and is `Optional+Computed`, this mismatch made Terraform fail apply with:

  ```
  Error: Provider produced inconsistent result after apply
  When applying changes to grafana_message_template.test, provider ... produced an
  unexpected new value: .disable_provenance: was cty.True, but now cty.False.
  ```

  The write path was already correct (`X-Disable-Provenance` was honored server-side); only the read-back was wrong. Once created, the resource is left tainted, so every subsequent `apply` repeats the same crash.

- Fix: read the API's `Provenance` field on the returned template (`tmpl.Provenance == ""` means provisioning provenance tracking is disabled) instead of hardcoding `false`, following the same pattern already used by `grafana_contact_point`.

Fixes #2618

## Test plan

- [x] Added `TestAccMessageTemplate_disableProvenance`, which creates a template with `disable_provenance = true`, asserts the state attribute and the raw API `Provenance` field, and does a full `ImportStateVerify` round-trip (the other tests in this file have to `ImportStateVerifyIgnore` this field due to the bug).
- [x] Confirmed the new test reproduces the exact reported crash against the pre-fix code, and passes against the fix, live against Grafana 13.0.1 via `make testacc-oss-docker`.
- [x] Confirmed `TestAccMessageTemplate_basic` and `TestAccMessageTemplate_heredoc` still pass alongside the fix and the new test.
- [x] `go build ./...` and `go vet` pass.

Note: `TestAccMessageTemplate_inOrg` has a pre-existing, unrelated flake when run in parallel with `TestAccMessageTemplate_heredoc` (an org-enumeration race in the shared test lister, reproduced identically on unmodified `main`) — not introduced or fixed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)