### PR TITLE
feat(grafana_rule_group): support routing notification_settings by policy name

### DIFF
--- a/docs/resources/rule_group.md
+++ b/docs/resources/rule_group.md
@@ -177,17 +177,15 @@ Required:
 <a id="nestedblock--rule--notification_settings"></a>
 ### Nested Schema for `rule.notification_settings`
 
-Required:
-
-- `contact_point` (String) The contact point to route notifications that match this rule to.
-
 Optional:
 
 - `active_timings` (List of String) A list of time interval names to apply to alerts that match this policy to suppress them unless they are sent at the specified time. Supported in Grafana 12.1.0 and later
+- `contact_point` (String) The contact point to route notifications that match this rule to. Exactly one of `contact_point` or `policy` must be set.
 - `group_by` (List of String) A list of alert labels to group alerts into notifications by. Use the special label `...` to group alerts by all labels, effectively disabling grouping. If empty, no grouping is used. If specified, requires labels 'alertname' and 'grafana_folder' to be included.
 - `group_interval` (String) Minimum time interval between two notifications for the same group. Default is 5 minutes.
 - `group_wait` (String) Time to wait to buffer alerts of the same group before sending a notification. Default is 30 seconds.
 - `mute_timings` (List of String) A list of mute timing names to apply to alerts that match this policy.
+- `policy` (String) The name of the notification policy to route notifications that match this rule through. Mutually exclusive with `contact_point` and all other fields in this block. Exactly one of `contact_point` or `policy` must be set.
 - `repeat_interval` (String) Minimum time interval for re-sending a notification if an alert is still firing. Default is 4 hours.
 
 

--- a/internal/resources/grafana/resource_alerting_rule_group.go
+++ b/internal/resources/grafana/resource_alerting_rule_group.go
@@ -236,8 +236,13 @@ This resource requires Grafana 9.1.0 or later.
 								Schema: map[string]*schema.Schema{
 									"contact_point": {
 										Type:        schema.TypeString,
-										Required:    true,
-										Description: "The contact point to route notifications that match this rule to.",
+										Optional:    true,
+										Description: "The contact point to route notifications that match this rule to. Exactly one of `contact_point` or `policy` must be set.",
+									},
+									"policy": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The name of the notification policy to route notifications that match this rule through. Mutually exclusive with `contact_point` and all other fields in this block. Exactly one of `contact_point` or `policy` must be set.",
 									},
 									"group_by": {
 										Type:        schema.TypeList,
@@ -759,13 +764,13 @@ func packNotificationSettings(settings *models.AlertRuleNotificationSettings) (a
 		return nil, nil
 	}
 
-	rec := ""
-	if settings.Receiver != nil {
-		rec = *settings.Receiver
-	}
+	result := map[string]any{}
 
-	result := map[string]any{
-		"contact_point": rec,
+	if settings.Receiver != nil && *settings.Receiver != "" {
+		result["contact_point"] = *settings.Receiver
+	}
+	if settings.Policy != "" {
+		result["policy"] = settings.Policy
 	}
 
 	if len(settings.GroupBy) > 0 {
@@ -812,9 +817,21 @@ func unpackNotificationSettings(p any) (*models.AlertRuleNotificationSettings, e
 
 	jsonData := list[0].(map[string]any)
 
-	receiver := jsonData["contact_point"].(string)
-	result := models.AlertRuleNotificationSettings{
-		Receiver: &receiver,
+	contactPoint, _ := jsonData["contact_point"].(string)
+	policy, _ := jsonData["policy"].(string)
+	switch {
+	case contactPoint == "" && policy == "":
+		return nil, fmt.Errorf("notification_settings: exactly one of \"contact_point\" or \"policy\" must be set")
+	case contactPoint != "" && policy != "":
+		return nil, fmt.Errorf("notification_settings: \"contact_point\" and \"policy\" are mutually exclusive")
+	}
+
+	result := models.AlertRuleNotificationSettings{}
+	if contactPoint != "" {
+		result.Receiver = &contactPoint
+	}
+	if policy != "" {
+		result.Policy = policy
 	}
 
 	if g, ok := jsonData["group_by"]; ok {

--- a/internal/resources/grafana/resource_alerting_rule_group_internal_test.go
+++ b/internal/resources/grafana/resource_alerting_rule_group_internal_test.go
@@ -1,0 +1,91 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+)
+
+func TestUnitUnpackNotificationSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       map[string]any
+		wantErr     string
+		wantPolicy  string
+		wantContact string
+	}{
+		{
+			name:        "contact point only",
+			input:       map[string]any{"contact_point": "my-receiver"},
+			wantContact: "my-receiver",
+		},
+		{
+			name:       "policy only",
+			input:      map[string]any{"policy": "my-policy"},
+			wantPolicy: "my-policy",
+		},
+		{
+			name:    "neither set",
+			input:   map[string]any{},
+			wantErr: `notification_settings: exactly one of "contact_point" or "policy" must be set`,
+		},
+		{
+			name:    "both set",
+			input:   map[string]any{"contact_point": "my-receiver", "policy": "my-policy"},
+			wantErr: `notification_settings: "contact_point" and "policy" are mutually exclusive`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings, err := unpackNotificationSettings([]any{tt.input})
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("expected error %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if settings.Policy != tt.wantPolicy {
+				t.Errorf("Policy = %q, want %q", settings.Policy, tt.wantPolicy)
+			}
+			gotContact := ""
+			if settings.Receiver != nil {
+				gotContact = *settings.Receiver
+			}
+			if gotContact != tt.wantContact {
+				t.Errorf("Receiver = %q, want %q", gotContact, tt.wantContact)
+			}
+		})
+	}
+}
+
+func TestUnitPackNotificationSettings(t *testing.T) {
+	receiver := "my-receiver"
+
+	packed, err := packNotificationSettings(&models.AlertRuleNotificationSettings{Policy: "my-policy"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := packed.([]any)[0].(map[string]any)
+	if _, ok := result["contact_point"]; ok {
+		t.Errorf("expected no contact_point key when routing by policy, got %v", result["contact_point"])
+	}
+	if result["policy"] != "my-policy" {
+		t.Errorf("policy = %v, want %q", result["policy"], "my-policy")
+	}
+
+	packed, err = packNotificationSettings(&models.AlertRuleNotificationSettings{Receiver: &receiver})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result = packed.([]any)[0].(map[string]any)
+	if _, ok := result["policy"]; ok {
+		t.Errorf("expected no policy key when routing by contact point, got %v", result["policy"])
+	}
+	if result["contact_point"] != receiver {
+		t.Errorf("contact_point = %v, want %q", result["contact_point"], receiver)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an optional `policy` attribute to `rule.notification_settings` on `grafana_rule_group`, backed by the API's existing `AlertRuleNotificationSettings.Policy` field, so a rule can route through a named notification policy instead of a contact point.
- `contact_point` is now optional; exactly one of `contact_point` or `policy` must be set (enforced with a client-side error, mirroring the existing pattern used for other mutually-exclusive fields in this schema, since the SDK doesn't support `ConflictsWith` inside `TypeList` blocks).
- Regenerated `docs/resources/rule_group.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)